### PR TITLE
fix(server): bind dual-stack by default; wire -4/-6 flags

### DIFF
--- a/riperf3-cli/src/cli.rs
+++ b/riperf3-cli/src/cli.rs
@@ -203,7 +203,7 @@ pub struct Cli {
     pub pacing_timer: Option<u32>,
 
     /// Only use IPv4
-    #[arg(short = '4', long)]
+    #[arg(short = '4', long, conflicts_with = "version6")]
     pub version4: bool,
 
     /// Only use IPv6
@@ -862,6 +862,13 @@ mod cli_tests {
             let cli = Cli::parse_from(["riperf3", "-c", "h", "-6"]);
             let c = build_client_from_cli(&cli);
             assert_eq!(c.ip_version, Some(6));
+        }
+
+        #[test]
+        fn version4_and_version6_conflict() {
+            // -4 and -6 are mutually exclusive (matches iperf3).
+            let err = Cli::try_parse_from(["riperf3", "-c", "h", "-4", "-6"]);
+            assert!(err.is_err(), "-4 -6 together should be rejected");
         }
 
         #[test]

--- a/riperf3-cli/src/main.rs
+++ b/riperf3-cli/src/main.rs
@@ -266,6 +266,11 @@ async fn async_main(cli: Cli) -> std::result::Result<(), Box<dyn std::error::Err
         if let Some(ref addr) = cli.bind {
             builder = builder.bind_address(addr);
         }
+        if cli.version4 {
+            builder = builder.ip_version(Some(4));
+        } else if cli.version6 {
+            builder = builder.ip_version(Some(6));
+        }
         if let Some(ref fmt) = cli.timestamps {
             builder = builder.timestamps(fmt);
         }

--- a/riperf3-cli/src/main.rs
+++ b/riperf3-cli/src/main.rs
@@ -267,9 +267,9 @@ async fn async_main(cli: Cli) -> std::result::Result<(), Box<dyn std::error::Err
             builder = builder.bind_address(addr);
         }
         if cli.version4 {
-            builder = builder.ip_version(Some(4));
+            builder = builder.ip_version(4);
         } else if cli.version6 {
-            builder = builder.ip_version(Some(6));
+            builder = builder.ip_version(6);
         }
         if let Some(ref fmt) = cli.timestamps {
             builder = builder.timestamps(fmt);

--- a/riperf3/src/net.rs
+++ b/riperf3/src/net.rs
@@ -212,10 +212,12 @@ pub async fn tcp_listen(
     };
     let socket = Socket::new(domain, Type::STREAM, None)?;
     socket.set_reuse_address(true)?;
-    if addr.is_ipv6() && bind_addr.is_none() {
-        // Explicit dual-stack control: only-v6 when the caller asked for it,
-        // dual-stack otherwise. BSDs default V6ONLY=1, so we can't rely on
-        // /proc/sys/net/ipv6/bindv6only.
+    if addr.is_ipv6() {
+        // Set V6ONLY explicitly on every IPv6 bind, including when an explicit
+        // `-B` address is given: `-6 -B ::` must be IPv6-only and `-B ::` alone
+        // must be dual-stack. BSDs default V6ONLY=1 and Linux defaults 0, so we
+        // can't rely on the platform default. For a non-wildcard IPv6 address
+        // (e.g. `::1`) the flag is moot but harmless.
         socket.set_only_v6(ip_version == Some(6))?;
     }
     socket.set_nonblocking(true)?;
@@ -595,7 +597,8 @@ pub async fn udp_bind_reusable(
     };
     let socket = Socket::new(domain, Type::DGRAM, None)?;
     socket.set_reuse_address(true)?;
-    if addr.is_ipv6() && bind_addr.is_none() {
+    if addr.is_ipv6() {
+        // Set V6ONLY on every IPv6 bind, explicit `-B` included — see tcp_listen.
         socket.set_only_v6(ip_version == Some(6))?;
     }
     socket.set_nonblocking(true)?;
@@ -718,7 +721,12 @@ mod tests {
                 let _ = listener.accept().await.unwrap();
             }
             Err(RiperfError::Io(ref e)) if e.kind() == std::io::ErrorKind::AddrNotAvailable => {
-                // No IPv6 loopback available — soft-skip.
+                // No IPv6 loopback on this host — the IPv6 half can't be
+                // exercised. Make the skip visible so it isn't a silent vacuous
+                // pass (run with `--nocapture` to see it).
+                eprintln!(
+                    "SKIP tcp_listen_dual_stack_default: ::1 unavailable, IPv6 path not exercised"
+                );
             }
             Err(e) => panic!("IPv6 connect to default listener failed: {e:?}"),
         }
@@ -735,9 +743,15 @@ mod tests {
         // IPv6 connect must be refused.
         let v6 = tcp_connect("::1", port, None, None, false).await;
         match v6 {
-            Err(RiperfError::Io(ref e))
-                if e.kind() == std::io::ErrorKind::ConnectionRefused
-                    || e.kind() == std::io::ErrorKind::AddrNotAvailable => {}
+            Err(RiperfError::Io(ref e)) if e.kind() == std::io::ErrorKind::ConnectionRefused => {}
+            Err(RiperfError::Io(ref e)) if e.kind() == std::io::ErrorKind::AddrNotAvailable => {
+                // ::1 unavailable: this confirms "no IPv6 reach" but not
+                // specifically that the listener rejected it. Flag the weaker
+                // assertion rather than pass silently.
+                eprintln!(
+                    "SKIP tcp_listen_ipv4_only: ::1 unavailable, refusal not specifically verified"
+                );
+            }
             Ok(_) => panic!("IPv6 connect should fail against IPv4-only listener"),
             Err(e) => panic!("unexpected error from IPv6 connect: {e:?}"),
         }
@@ -759,6 +773,37 @@ mod tests {
             Err(RiperfError::Io(ref e)) if e.kind() == std::io::ErrorKind::ConnectionRefused => {}
             Ok(_) => panic!("IPv4 connect should fail against IPv6-only listener"),
             Err(e) => panic!("unexpected error from IPv4 connect: {e:?}"),
+        }
+    }
+
+    /// Regression for the cold-review should-fix: `-6`/`-4` must be honored
+    /// even when an explicit `-B` bind address is given. `-B :: -6` is
+    /// IPv6-only; `-B ::` alone is dual-stack. Previously V6ONLY was only set
+    /// on the implicit-default path, so `-B :: -6` silently stayed dual-stack.
+    #[tokio::test]
+    async fn tcp_listen_explicit_bind_respects_ip_version() {
+        // `-B :: -6`  → IPv6-only: an IPv4 client must be refused.
+        let v6only = tcp_listen(Some("::"), 0, Some(6)).await.unwrap();
+        let port = v6only.local_addr().unwrap().port();
+        let v4 = tcp_connect("127.0.0.1", port, None, None, false).await;
+        assert!(
+            matches!(&v4, Err(RiperfError::Io(e)) if e.kind() == std::io::ErrorKind::ConnectionRefused),
+            "`-B :: -6` must refuse IPv4, got {v4:?}"
+        );
+        drop(v6only);
+
+        // `-B ::` alone → dual-stack: an IPv4 client connects via v4-mapped.
+        let dual = tcp_listen(Some("::"), 0, None).await.unwrap();
+        let port = dual.local_addr().unwrap().port();
+        let v4 = tcp_connect("127.0.0.1", port, None, None, false).await;
+        match v4 {
+            Ok(_) => {
+                let _ = dual.accept().await.unwrap();
+            }
+            Err(RiperfError::Io(ref e)) if e.kind() == std::io::ErrorKind::AddrNotAvailable => {
+                eprintln!("SKIP tcp_listen_explicit_bind: v4-mapped unavailable on this host");
+            }
+            Err(e) => panic!("`-B ::` (dual-stack) must accept IPv4, got {e:?}"),
         }
     }
 

--- a/riperf3/src/net.rs
+++ b/riperf3/src/net.rs
@@ -699,8 +699,11 @@ mod tests {
 
     // ---- Regression tests for issue #1: server binds IPv4 only ------------
     //
-    // These tests are written before the implementation. They MUST fail on
-    // `main`'s default-IPv4 behavior and pass after the dual-stack fix lands.
+    // `tcp_listen_dual_stack_default` and `tcp_listen_ipv6_only` are genuine
+    // regressions: they fail on `main`'s default-IPv4 behavior and pass after
+    // the dual-stack fix. `tcp_listen_ipv4_only` is a guard for behavior that
+    // was already correct on `main` (`Some(4)` always meant `0.0.0.0`); it's
+    // kept to lock that in.
 
     /// Default listener (`ip_version=None`) must accept both IPv4 and IPv6
     /// clients on the same port — matches iperf3's dual-stack default.
@@ -771,6 +774,10 @@ mod tests {
         let v4 = tcp_connect("127.0.0.1", port, None, None, false).await;
         match v4 {
             Err(RiperfError::Io(ref e)) if e.kind() == std::io::ErrorKind::ConnectionRefused => {}
+            Err(RiperfError::Io(ref e)) if e.kind() == std::io::ErrorKind::AddrNotAvailable => {
+                // No IPv4 loopback on this host — can't exercise the refusal.
+                eprintln!("SKIP tcp_listen_ipv6_only: 127.0.0.1 unavailable");
+            }
             Ok(_) => panic!("IPv4 connect should fail against IPv6-only listener"),
             Err(e) => panic!("unexpected error from IPv4 connect: {e:?}"),
         }

--- a/riperf3/src/net.rs
+++ b/riperf3/src/net.rs
@@ -679,6 +679,77 @@ mod tests {
         assert_eq!(val, libc::IP_PMTUDISC_DO, "IP_MTU_DISCOVER should be DO");
     }
 
+    // ---- Regression tests for issue #1: server binds IPv4 only ------------
+    //
+    // These tests are written before the implementation. They MUST fail on
+    // `main`'s default-IPv4 behavior and pass after the dual-stack fix lands.
+
+    /// Default listener (`ip_version=None`) must accept both IPv4 and IPv6
+    /// clients on the same port — matches iperf3's dual-stack default.
+    #[tokio::test]
+    async fn tcp_listen_dual_stack_default() {
+        let listener = tcp_listen(None, 0, None).await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+
+        // IPv4 connect must succeed.
+        let v4 = tcp_connect("127.0.0.1", port, None, None, false).await;
+        assert!(v4.is_ok(), "IPv4 connect failed: {v4:?}");
+        let _ = listener.accept().await.unwrap();
+
+        // IPv6 connect must also succeed against the same listener.
+        let v6 = tcp_connect("::1", port, None, None, false).await;
+        match v6 {
+            Ok(_) => {
+                let _ = listener.accept().await.unwrap();
+            }
+            Err(RiperfError::Io(ref e))
+                if e.kind() == std::io::ErrorKind::AddrNotAvailable =>
+            {
+                // No IPv6 loopback available — soft-skip.
+            }
+            Err(e) => panic!("IPv6 connect to default listener failed: {e:?}"),
+        }
+    }
+
+    /// `ip_version=Some(4)` restricts the listener to IPv4 only.
+    #[tokio::test]
+    async fn tcp_listen_ipv4_only() {
+        let listener = tcp_listen(None, 0, Some(4)).await.unwrap();
+        let local = listener.local_addr().unwrap();
+        assert!(local.is_ipv4(), "expected IPv4 local_addr, got {local}");
+        let port = local.port();
+
+        // IPv6 connect must be refused.
+        let v6 = tcp_connect("::1", port, None, None, false).await;
+        match v6 {
+            Err(RiperfError::Io(ref e))
+                if e.kind() == std::io::ErrorKind::ConnectionRefused
+                    || e.kind() == std::io::ErrorKind::AddrNotAvailable => {}
+            Ok(_) => panic!("IPv6 connect should fail against IPv4-only listener"),
+            Err(e) => panic!("unexpected error from IPv6 connect: {e:?}"),
+        }
+    }
+
+    /// `ip_version=Some(6)` restricts the listener to IPv6 only (sets
+    /// IPV6_V6ONLY). On Linux without this, `::` accepts IPv4 via v4-mapped
+    /// addresses; the test guards against that regression.
+    #[tokio::test]
+    async fn tcp_listen_ipv6_only() {
+        let listener = tcp_listen(None, 0, Some(6)).await.unwrap();
+        let local = listener.local_addr().unwrap();
+        assert!(local.is_ipv6(), "expected IPv6 local_addr, got {local}");
+        let port = local.port();
+
+        // IPv4 connect must be refused.
+        let v4 = tcp_connect("127.0.0.1", port, None, None, false).await;
+        match v4 {
+            Err(RiperfError::Io(ref e))
+                if e.kind() == std::io::ErrorKind::ConnectionRefused => {}
+            Ok(_) => panic!("IPv4 connect should fail against IPv6-only listener"),
+            Err(e) => panic!("unexpected error from IPv4 connect: {e:?}"),
+        }
+    }
+
     #[cfg(target_os = "linux")]
     #[test]
     fn set_bind_dev_loopback() {

--- a/riperf3/src/net.rs
+++ b/riperf3/src/net.rs
@@ -108,10 +108,12 @@ mod custom_sockopt {
 // ---------------------------------------------------------------------------
 
 /// Resolve the default bind address for the given IP version preference.
+/// `None` → `::` (dual-stack via IPV6_V6ONLY=0); `Some(4)` → IPv4 only;
+/// `Some(6)` → IPv6 only.
 fn default_bind_addr(ip_version: Option<u8>) -> &'static str {
     match ip_version {
-        Some(6) => "::",
-        _ => "0.0.0.0",
+        Some(4) => "0.0.0.0",
+        _ => "::",
     }
 }
 
@@ -189,7 +191,10 @@ pub async fn tcp_connect(
 }
 
 /// Create a TCP listener with SO_REUSEADDR.
-/// If `bind_addr` is `None`, binds to 0.0.0.0 (or :: if `ip_version` is 6).
+/// If `bind_addr` is `None`, binds dual-stack (`::` with IPV6_V6ONLY=0) by
+/// default, matching iperf3's `getaddrinfo`+`AI_PASSIVE` behavior.
+/// `ip_version=Some(4)` restricts to IPv4 (`0.0.0.0`); `Some(6)` restricts to
+/// IPv6 only (sets IPV6_V6ONLY=1).
 pub async fn tcp_listen(
     bind_addr: Option<&str>,
     port: u16,
@@ -207,6 +212,12 @@ pub async fn tcp_listen(
     };
     let socket = Socket::new(domain, Type::STREAM, None)?;
     socket.set_reuse_address(true)?;
+    if addr.is_ipv6() && bind_addr.is_none() {
+        // Explicit dual-stack control: only-v6 when the caller asked for it,
+        // dual-stack otherwise. BSDs default V6ONLY=1, so we can't rely on
+        // /proc/sys/net/ipv6/bindv6only.
+        socket.set_only_v6(ip_version == Some(6))?;
+    }
     socket.set_nonblocking(true)?;
     socket.bind(&addr.into())?;
     socket.listen(128)?;
@@ -565,13 +576,14 @@ pub fn set_tos<F>(_fd: &F, _tos: u32) -> Result<()> {
 
 /// Bind a UDP socket with SO_REUSEADDR, allowing multiple sockets on the same port.
 /// Used by the server to recycle the UDP listener after each stream connect.
+/// `ip_version=None` binds dual-stack (`::` with IPV6_V6ONLY=0); `Some(4)`
+/// restricts to IPv4; `Some(6)` restricts to IPv6 only.
 pub async fn udp_bind_reusable(
     bind_addr: Option<&str>,
     port: u16,
-    ipv6: bool,
+    ip_version: Option<u8>,
 ) -> Result<UdpSocket> {
-    let default = if ipv6 { "::" } else { "0.0.0.0" };
-    let host = bind_addr.unwrap_or(default);
+    let host = bind_addr.unwrap_or(default_bind_addr(ip_version));
     let addr: SocketAddr = format_addr(host, port)
         .parse()
         .map_err(|e| RiperfError::Protocol(format!("bad bind address: {e}")))?;
@@ -583,6 +595,9 @@ pub async fn udp_bind_reusable(
     };
     let socket = Socket::new(domain, Type::DGRAM, None)?;
     socket.set_reuse_address(true)?;
+    if addr.is_ipv6() && bind_addr.is_none() {
+        socket.set_only_v6(ip_version == Some(6))?;
+    }
     socket.set_nonblocking(true)?;
     socket.bind(&addr.into())?;
 
@@ -702,9 +717,7 @@ mod tests {
             Ok(_) => {
                 let _ = listener.accept().await.unwrap();
             }
-            Err(RiperfError::Io(ref e))
-                if e.kind() == std::io::ErrorKind::AddrNotAvailable =>
-            {
+            Err(RiperfError::Io(ref e)) if e.kind() == std::io::ErrorKind::AddrNotAvailable => {
                 // No IPv6 loopback available — soft-skip.
             }
             Err(e) => panic!("IPv6 connect to default listener failed: {e:?}"),
@@ -743,8 +756,7 @@ mod tests {
         // IPv4 connect must be refused.
         let v4 = tcp_connect("127.0.0.1", port, None, None, false).await;
         match v4 {
-            Err(RiperfError::Io(ref e))
-                if e.kind() == std::io::ErrorKind::ConnectionRefused => {}
+            Err(RiperfError::Io(ref e)) if e.kind() == std::io::ErrorKind::ConnectionRefused => {}
             Ok(_) => panic!("IPv4 connect should fail against IPv6-only listener"),
             Err(e) => panic!("unexpected error from IPv4 connect: {e:?}"),
         }

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -76,6 +76,7 @@ pub struct Server {
     pub logfile: Option<String>,
     pub forceflush: bool,
     pub bind_address: Option<String>,
+    pub ip_version: Option<u8>,
     pub timestamps: Option<String>,
     pub file: Option<String>,
     pub rsa_private_key_path: Option<String>,
@@ -98,7 +99,8 @@ impl Server {
             }
         }
 
-        let listener = net::tcp_listen(self.bind_address.as_deref(), self.port, None).await?;
+        let listener =
+            net::tcp_listen(self.bind_address.as_deref(), self.port, self.ip_version).await?;
         let sep = "-----------------------------------------------------------";
         println!("{sep}");
         println!("Server listening on {}", self.port);
@@ -283,8 +285,12 @@ impl Server {
                 // For each stream: accept the connect handshake on the listener,
                 // which locks that socket to the client. Then create a fresh
                 // listener for the next stream (iperf3's recycling pattern).
-                let mut udp_listener =
-                    net::udp_bind_reusable(self.bind_address.as_deref(), self.port, None).await?;
+                let mut udp_listener = net::udp_bind_reusable(
+                    self.bind_address.as_deref(),
+                    self.port,
+                    self.ip_version,
+                )
+                .await?;
 
                 protocol::send_state(&mut ctrl, TestState::CreateStreams).await?;
 
@@ -296,9 +302,12 @@ impl Server {
 
                     // Create a fresh listener for the next stream (if any)
                     if i + 1 < total {
-                        udp_listener =
-                            net::udp_bind_reusable(self.bind_address.as_deref(), self.port, None)
-                                .await?;
+                        udp_listener = net::udp_bind_reusable(
+                            self.bind_address.as_deref(),
+                            self.port,
+                            self.ip_version,
+                        )
+                        .await?;
                     } else {
                         // Last stream — create a dummy that won't be used
                         udp_listener = net::udp_bind(None, 0, false).await?;
@@ -578,6 +587,7 @@ pub struct ServerBuilder {
     logfile: Option<String>,
     forceflush: bool,
     bind_address: Option<String>,
+    ip_version: Option<u8>,
     timestamps: Option<String>,
     file: Option<String>,
     rsa_private_key_path: Option<String>,
@@ -600,6 +610,7 @@ impl Default for ServerBuilder {
             logfile: None,
             forceflush: false,
             bind_address: None,
+            ip_version: None,
             timestamps: None,
             file: None,
             rsa_private_key_path: None,
@@ -670,6 +681,13 @@ impl ServerBuilder {
         self
     }
 
+    /// Restrict the listener to a specific IP version. `Some(4)` → IPv4 only,
+    /// `Some(6)` → IPv6 only, `None` → dual-stack (default).
+    pub fn ip_version(mut self, version: Option<u8>) -> Self {
+        self.ip_version = version;
+        self
+    }
+
     pub fn timestamps(mut self, fmt: &str) -> Self {
         self.timestamps = Some(fmt.to_string());
         self
@@ -725,6 +743,7 @@ impl ServerBuilder {
             logfile: self.logfile,
             forceflush: self.forceflush,
             bind_address: self.bind_address,
+            ip_version: self.ip_version,
             timestamps: self.timestamps,
             file: self.file,
             rsa_private_key_path: self.rsa_private_key_path,

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -283,12 +283,8 @@ impl Server {
                 // For each stream: accept the connect handshake on the listener,
                 // which locks that socket to the client. Then create a fresh
                 // listener for the next stream (iperf3's recycling pattern).
-                let mut udp_listener = net::udp_bind_reusable(
-                    self.bind_address.as_deref(),
-                    self.port,
-                    self.bind_address.as_ref().is_some_and(|a| a.contains(':')),
-                )
-                .await?;
+                let mut udp_listener =
+                    net::udp_bind_reusable(self.bind_address.as_deref(), self.port, None).await?;
 
                 protocol::send_state(&mut ctrl, TestState::CreateStreams).await?;
 
@@ -300,12 +296,9 @@ impl Server {
 
                     // Create a fresh listener for the next stream (if any)
                     if i + 1 < total {
-                        udp_listener = net::udp_bind_reusable(
-                            self.bind_address.as_deref(),
-                            self.port,
-                            self.bind_address.as_ref().is_some_and(|a| a.contains(':')),
-                        )
-                        .await?;
+                        udp_listener =
+                            net::udp_bind_reusable(self.bind_address.as_deref(), self.port, None)
+                                .await?;
                     } else {
                         // Last stream — create a dummy that won't be used
                         udp_listener = net::udp_bind(None, 0, false).await?;

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -681,10 +681,11 @@ impl ServerBuilder {
         self
     }
 
-    /// Restrict the listener to a specific IP version. `Some(4)` → IPv4 only,
-    /// `Some(6)` → IPv6 only, `None` → dual-stack (default).
-    pub fn ip_version(mut self, version: Option<u8>) -> Self {
-        self.ip_version = version;
+    /// Restrict the listener to a specific IP version: `4` → IPv4 only, `6` →
+    /// IPv6 only. Leave unset for dual-stack (the default). Signature matches
+    /// `ClientBuilder::ip_version` for consistency.
+    pub fn ip_version(mut self, version: u8) -> Self {
+        self.ip_version = Some(version);
         self
     }
 

--- a/riperf3/tests/integration.rs
+++ b/riperf3/tests/integration.rs
@@ -102,6 +102,68 @@ async fn server_accepts_ipv6_client_by_default() {
     let _ = server_task.await;
 }
 
+/// Default server accepts an IPv6 UDP client too (dual-stack covers UDP).
+#[tokio::test]
+async fn server_accepts_ipv6_udp_client_by_default() {
+    let port = next_port();
+    let server = ServerBuilder::new()
+        .port(Some(port))
+        .one_off(true)
+        .build()
+        .unwrap();
+    let server_task = tokio::spawn(async move { server.run().await });
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    let client = ClientBuilder::new("::1")
+        .port(Some(port))
+        .protocol(TransportProtocol::Udp)
+        .duration(1)
+        .bandwidth(10_000_000)
+        .build()
+        .unwrap();
+    let result = client.run().await;
+    assert!(
+        result.is_ok(),
+        "IPv6 UDP client to default server: {result:?}"
+    );
+    let _ = server_task.await;
+}
+
+/// `ServerBuilder::ip_version(6)` must restrict the listener to IPv6, so an
+/// IPv4 client is refused — exercises the builder→net pass-through end-to-end.
+#[tokio::test]
+async fn server_ipv6_only_refuses_ipv4_client() {
+    let port = next_port();
+    let server = ServerBuilder::new()
+        .port(Some(port))
+        .one_off(true)
+        .ip_version(6)
+        .build()
+        .unwrap();
+    let server_task = tokio::spawn(async move { server.run().await });
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    let client = ClientBuilder::new("127.0.0.1")
+        .port(Some(port))
+        .duration(1)
+        .connect_timeout(Duration::from_millis(500))
+        .build()
+        .unwrap();
+    let result = client.run().await;
+    assert!(
+        result.is_err(),
+        "IPv4 client must be refused by an IPv6-only server"
+    );
+    // The one-off server is still waiting; drain it with a matching IPv6 client.
+    let v6 = ClientBuilder::new("::1")
+        .port(Some(port))
+        .duration(1)
+        .build()
+        .unwrap();
+    let _ = v6.run().await;
+    let _ = server_task.await;
+}
+
 // ---------------------------------------------------------------------------
 // TCP loopback tests
 // ---------------------------------------------------------------------------

--- a/riperf3/tests/integration.rs
+++ b/riperf3/tests/integration.rs
@@ -72,6 +72,37 @@ async fn regression_udp_default_path() {
 }
 
 // ---------------------------------------------------------------------------
+// Issue #1: dual-stack server bind regression
+// ---------------------------------------------------------------------------
+
+/// Server must accept IPv6 clients by default (matches iperf3's dual-stack
+/// `getaddrinfo`+`AI_PASSIVE` behavior). Pre-fix the server binds `0.0.0.0`
+/// only, so this fails with ConnectionRefused.
+#[tokio::test]
+async fn server_accepts_ipv6_client_by_default() {
+    let port = next_port();
+    let server = ServerBuilder::new()
+        .port(Some(port))
+        .one_off(true)
+        .build()
+        .unwrap();
+    let server_task = tokio::spawn(async move { server.run().await });
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    let client = ClientBuilder::new("::1")
+        .port(Some(port))
+        .duration(1)
+        .build()
+        .unwrap();
+    let result = client.run().await;
+    assert!(
+        result.is_ok(),
+        "IPv6 client to default server failed: {result:?}"
+    );
+    let _ = server_task.await;
+}
+
+// ---------------------------------------------------------------------------
 // TCP loopback tests
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Server now binds dual-stack (`::` with `IPV6_V6ONLY=0`) by default, matching iperf3. IPv6 clients no longer get `ConnectionRefused`.
- `-4` / `-6` server flags are wired through `ServerBuilder::ip_version` (previously parsed but ignored). `-4` → bind `0.0.0.0`; `-6` → bind `::` with `IPV6_V6ONLY=1`. `V6ONLY` is set explicitly on **every** IPv6 bind, including with an explicit `-B` address (`-6 -B ::` is IPv6-only; `-B ::` alone is dual-stack), so behavior is identical across Linux and BSD.
- `-4`/`-6` are mutually exclusive (clap `conflicts_with`); `ServerBuilder::ip_version` takes `u8` to match `ClientBuilder`.

Closes #1.

> **Scope note:** this fixes the *server*. The *client* `-4`/`-6` is a separate, pre-existing no-op (the value is stored but never used for connection) — tracked in #10.

## Test plan

### Automated
- [x] `cargo test --workspace` (98 lib / 122 integration / 59 CLI — all green; the tests-only commit is genuinely red on `main`)
- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace -- -D warnings`

New tests: `tcp_listen_dual_stack_default`, `tcp_listen_ipv6_only`, `tcp_listen_explicit_bind_respects_ip_version` (the `-B` V6ONLY case); integration `server_ipv6_only_refuses_ipv4_client`, `server_accepts_ipv6_udp_client_by_default`; CLI `version4_and_version6_conflict`.

### Manual (localhost + Gandalf sandbox VMs)
- [x] Default `-s` binds `[::]`; IPv4 + IPv6 clients both connect.
- [x] `-s -4` binds `0.0.0.0`; IPv6 client refused. `-s -6` binds `[::]` v6only; IPv4 client refused.
- [x] `-s -6 -B ::` refuses IPv4 (the explicit-bind V6ONLY fix).
- [x] `-4 -6` together is rejected by the CLI.
- [x] VM fleet: default server accepts IPv6 client (the reported bug) at ~74 Gbps; iperf3 parity confirmed.