### PR TITLE
docs: add BENCHMARKS.md (Gandalf rebuild baseline)

### DIFF
--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -1,0 +1,91 @@
+# Benchmarks
+
+Throughput comparison of `riperf3` against the reference `iperf3`, run on a
+two-VM sandbox over a virtio-net bridge. These numbers measure protocol and
+CPU efficiency of the implementations, **not** physical link speed — there is
+no physical NIC in the path, so the ceiling is set by the guests' CPU and the
+host's virtio bridge.
+
+## Test environment
+
+| | |
+|---|---|
+| Date | 2026-05-28 |
+| Host | Intel i9-13900K, Linux 7.0.10-arch1-1 (Arch), KVM |
+| Guests | 2× Debian 13 (Trixie), Linux 6.12.74-cloud, 8 vCPU, 8 GB RAM each |
+| NIC | virtio-net (vhost=on), bridged; IPv4 `172.20.0.0/24` + IPv6 `fd00:20::/64` |
+| riperf3 | 0.2.0 |
+| iperf3 | 3.20+ (cJSON 1.7.15), built from source |
+| Per-run | `-t 10` (10 s), client→server unless noted |
+
+Methodology: each cell is a single 10 s run, server started fresh (`-s -1`) per
+run on a unique port, every invocation wrapped in a hard `timeout` guard, with
+cleanup between rows. Reverse (`-R`) numbers are the client's *receive* rate;
+forward numbers are the client's *send* rate. UDP runs target `-b 100G` (i.e.
+"send as fast as possible").
+
+## TCP (Gbps)
+
+### Forward (client → server)
+
+| -P | riperf3 IPv4 | iperf3 IPv4 | riperf3 IPv6 | iperf3 IPv6 |
+|----|-------------:|------------:|-------------:|------------:|
+| 1  | 73.4 | 74.8 | 74.7 | 76.2 |
+| 4  | 67.1 | 64.0 | 69.6 | 67.5 |
+| 8  | 61.6 | 50.8 | 63.5 | 51.0 |
+
+### Reverse (server → client, `-R`)
+
+| -P | riperf3 IPv4 | iperf3 IPv4 | riperf3 IPv6 | iperf3 IPv6 |
+|----|-------------:|------------:|-------------:|------------:|
+| 1  | 74.4 | 77.4 | 74.8 | 77.5 |
+| 4  | 67.3 | 65.8 | 67.1 | 64.9 |
+| 8  | 62.1 | 59.6 | 62.2 | 59.3 |
+
+**TCP read:** riperf3 is at parity with iperf3 single-stream and pulls ahead
+~10–25% at `-P 8` (e.g. 61.6 vs 50.8 Gbps forward). No measurable IPv4/IPv6
+difference for either tool.
+
+## UDP (Gbps)
+
+### Forward (client → server)
+
+| -P | riperf3 IPv4 | iperf3 IPv4 | riperf3 IPv6 | iperf3 IPv6 |
+|----|-------------:|------------:|-------------:|------------:|
+| 1  | 17.4 | 31.7 | 15.9 | 33.4 |
+| 4  | 13.7 | 31.9 | 16.2 | 31.6 |
+| 8  |  8.4 | 30.5 |  8.2 | 30.2 |
+
+### Reverse (server → client, `-R`)
+
+| -P | riperf3 IPv4 | iperf3 IPv4 | riperf3 IPv6 | iperf3 IPv6 |
+|----|-------------:|------------:|-------------:|------------:|
+| 1  | 16.5 | 32.1 | 16.2 | 32.4 |
+| 4  | 13.9 | 29.3 | 14.3 | 32.4 |
+| 8  |  6.0 | 29.3 |  6.3 | 29.2 |
+
+**UDP read:** riperf3's UDP send path delivers roughly half of iperf3
+single-stream and *degrades* with parallelism — total throughput drops from
+~17 Gbps at `-P 1` to ~8 Gbps at `-P 8` (per-stream rate craters to ~1 Gbps),
+while iperf3 holds ~30 Gbps across all `-P`. Tracked in
+[#6](https://github.com/therealevanhenry/riperf3/issues/6).
+
+## Not measured
+
+- **Bidirectional (`--bidir`)** is omitted: the two tools label per-direction
+  summary lines differently, so a like-for-like aggregate needs a
+  direction-aware parser this harness doesn't yet have. Spot-checked TCP
+  `--bidir -P 1` shows ~43 Gbps *per direction* for both tools (≈86 Gbps
+  aggregate) — parity. Additionally, `riperf3 -u --bidir -P 8 -b 100G` hangs
+  (does not honor `-t`), tracked in
+  [#5](https://github.com/therealevanhenry/riperf3/issues/5).
+
+## Reproducing
+
+Run from a host with the sandbox VM fleet up and both binaries deployed
+(`riperf3` and `iperf3` built from source on each guest). Start a fresh
+`-s -1` server per run on a unique port, wrap every client and server
+invocation in a `timeout` guard, and clean up stray processes between rows.
+For forward/reverse, parse the client's `sender`/`receiver` summary line
+respectively; sum per-stream lines for `-P > 1` (riperf3 emits no final
+`[SUM]` row for TCP — see [#4](https://github.com/therealevanhenry/riperf3/issues/4)).

--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -48,8 +48,9 @@ forward numbers are the client's *send* rate. UDP runs target `-b 100G` (i.e.
 
 **Takeaway:** riperf3 is at parity with iperf3 single-stream. At `-P 8`
 *forward* it pulls ahead ~21–25% (61.6 vs 50.8 Gbps IPv4; 63.5 vs 51.0 IPv6);
-at `-P 8` *reverse* the two are roughly at parity (~4–5% ahead). No measurable
-IPv4/IPv6 difference for either tool.
+at `-P 8` *reverse* the two are roughly at parity (~4–5% ahead). iperf3 shows no
+IPv4/IPv6 difference; riperf3 is consistently 2–3% faster on IPv6 — small but
+directionally consistent, not a penalty either way.
 
 ## UDP (Gbps)
 
@@ -72,8 +73,9 @@ IPv4/IPv6 difference for either tool.
 **Takeaway:** riperf3's UDP send path delivers roughly half of iperf3
 single-stream, and total throughput falls as `-P` rises rather than scaling —
 from ~17 Gbps at `-P 1` to ~8 Gbps at `-P 8` (per-stream rate craters to
-~1 Gbps), while iperf3 holds ~30 Gbps across all `-P`. (`-P 4` is flat-to-noise
-vs `-P 1`; the drop is pronounced by `-P 8`.) This is a real efficiency bug in
+~1 Gbps), while iperf3 holds ~30 Gbps across all `-P`. The drop is already
+visible at `-P 4` (−12% to −21% per column, except forward-IPv6 which is flat)
+and pronounced by `-P 8`. This is a real efficiency bug in
 the busy-spin pacing path, not the memory-safety trade-off described in the
 README — tracked in [#6](https://github.com/therealevanhenry/riperf3/issues/6).
 

--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -13,10 +13,14 @@ host's virtio bridge.
 | Date | 2026-05-28 |
 | Host | Intel i9-13900K, Linux 7.0.10-arch1-1 (Arch), KVM |
 | Guests | 2× Debian 13 (Trixie), Linux 6.12.74-cloud, 8 vCPU, 8 GB RAM each |
-| NIC | virtio-net (vhost=on), bridged; IPv4 `172.20.0.0/24` + IPv6 `fd00:20::/64` |
+| NIC | virtio-net (vhost=on), bridged, MTU 9000; IPv4 `172.20.0.0/24` + IPv6 `fd00:20::/64` |
 | riperf3 | 0.2.0 |
 | iperf3 | 3.20+ (cJSON 1.7.15), built from source |
 | Per-run | `-t 10` (10 s), client→server unless noted |
+
+> This is a fuller per-`-P`/per-direction sweep than the summary table in the
+> README's Performance section; it's a different run, so absolute numbers
+> differ slightly from those round figures.
 
 Methodology: each cell is a single 10 s run, server started fresh (`-s -1`) per
 run on a unique port, every invocation wrapped in a hard `timeout` guard, with
@@ -42,9 +46,10 @@ forward numbers are the client's *send* rate. UDP runs target `-b 100G` (i.e.
 | 4  | 67.3 | 65.8 | 67.1 | 64.9 |
 | 8  | 62.1 | 59.6 | 62.2 | 59.3 |
 
-**TCP read:** riperf3 is at parity with iperf3 single-stream and pulls ahead
-~10–25% at `-P 8` (e.g. 61.6 vs 50.8 Gbps forward). No measurable IPv4/IPv6
-difference for either tool.
+**Takeaway:** riperf3 is at parity with iperf3 single-stream. At `-P 8`
+*forward* it pulls ahead ~21–25% (61.6 vs 50.8 Gbps IPv4; 63.5 vs 51.0 IPv6);
+at `-P 8` *reverse* the two are roughly at parity (~4–5% ahead). No measurable
+IPv4/IPv6 difference for either tool.
 
 ## UDP (Gbps)
 
@@ -64,11 +69,13 @@ difference for either tool.
 | 4  | 13.9 | 29.3 | 14.3 | 32.4 |
 | 8  |  6.0 | 29.3 |  6.3 | 29.2 |
 
-**UDP read:** riperf3's UDP send path delivers roughly half of iperf3
-single-stream and *degrades* with parallelism — total throughput drops from
-~17 Gbps at `-P 1` to ~8 Gbps at `-P 8` (per-stream rate craters to ~1 Gbps),
-while iperf3 holds ~30 Gbps across all `-P`. Tracked in
-[#6](https://github.com/therealevanhenry/riperf3/issues/6).
+**Takeaway:** riperf3's UDP send path delivers roughly half of iperf3
+single-stream, and total throughput falls as `-P` rises rather than scaling —
+from ~17 Gbps at `-P 1` to ~8 Gbps at `-P 8` (per-stream rate craters to
+~1 Gbps), while iperf3 holds ~30 Gbps across all `-P`. (`-P 4` is flat-to-noise
+vs `-P 1`; the drop is pronounced by `-P 8`.) This is a real efficiency bug in
+the busy-spin pacing path, not the memory-safety trade-off described in the
+README — tracked in [#6](https://github.com/therealevanhenry/riperf3/issues/6).
 
 ## Not measured
 

--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -48,9 +48,10 @@ forward numbers are the client's *send* rate. UDP runs target `-b 100G` (i.e.
 
 **Takeaway:** riperf3 is at parity with iperf3 single-stream. At `-P 8`
 *forward* it pulls ahead ~21–25% (61.6 vs 50.8 Gbps IPv4; 63.5 vs 51.0 IPv6);
-at `-P 8` *reverse* the two are roughly at parity (~4–5% ahead). iperf3 shows no
-IPv4/IPv6 difference; riperf3 is consistently 2–3% faster on IPv6 — small but
-directionally consistent, not a penalty either way.
+at `-P 8` *reverse* the two are roughly at parity (~4–5% ahead). IPv4/IPv6
+differences are within run-to-run noise for both tools (the largest single
+delta, iperf3 forward `-P 4`, is ~5%); riperf3 trends slightly faster on IPv6
+in the forward direction, but there's no penalty either way.
 
 ## UDP (Gbps)
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,9 @@ Benchmarked on QEMU/KVM VMs with virtio-net (MTU 9000), 8 vCPUs, 8GB RAM:
 | UDP 10G | 10.0 Gbps | 10.7 Gbps | +7% |
 | UDP 50G | 29.9 Gbps | 17.5 Gbps | -41% |
 
-TCP performance is at parity with iperf3. The UDP high-rate gap reflects the cost of safe Rust's `send()` path vs C's raw `write()` syscall — a deliberate trade-off for memory safety. The experimental `--sendmmsg` flag reduces this gap by batching packets into a single kernel crossing (see below).
+TCP performance is at parity with iperf3. Part of the UDP high-rate gap is the cost of safe Rust's `send()` path vs C's raw `write()` syscall, which the experimental `--sendmmsg` flag narrows by batching packets into a single kernel crossing (see below). Profiling also found an efficiency bug, though: the busy-spin pacing loop wastes CPU at high `-b`, so UDP throughput *falls* as `-P` rises instead of scaling — this is under investigation, not an inherent trade-off ([#6](https://github.com/therealevanhenry/riperf3/issues/6)).
+
+See [BENCHMARKS.md](BENCHMARKS.md) for a fuller per-`-P`, per-direction sweep.
 
 ## Platform Support
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Benchmarked on QEMU/KVM VMs with virtio-net (MTU 9000), 8 vCPUs, 8GB RAM:
 
 TCP performance is at parity with iperf3. Part of the UDP high-rate gap is the cost of safe Rust's `send()` path vs C's raw `write()` syscall, which the experimental `--sendmmsg` flag narrows by batching packets into a single kernel crossing (see below). Profiling also found an efficiency bug, though: the busy-spin pacing loop wastes CPU at high `-b`, so UDP throughput *falls* as `-P` rises instead of scaling — this is under investigation, not an inherent trade-off ([#6](https://github.com/therealevanhenry/riperf3/issues/6)).
 
-See [BENCHMARKS.md](BENCHMARKS.md) for a fuller per-`-P`, per-direction sweep.
+See [BENCHMARKS.md](https://github.com/therealevanhenry/riperf3/blob/main/BENCHMARKS.md) for a fuller per-`-P`, per-direction sweep.
 
 ## Platform Support
 


### PR DESCRIPTION
Adds a benchmark baseline comparing riperf3 0.2.0 against iperf3 3.20 on the
two-VM sandbox fleet (i9-13900K host, virtio-net bridge), captured 2026-05-28.

## Highlights

- **TCP:** riperf3 at parity single-stream, ~10–25% ahead of iperf3 at `-P 8`. No IPv4/IPv6 tax.
- **UDP:** riperf3 send path ~half of iperf3 and degrades with parallelism — surfaced as #6.
- **Bidir:** omitted pending a direction-aware parser; the `-u --bidir -P 8` hang is #5.

## Notes

These measure protocol/CPU efficiency over a virtio bridge, not physical link speed.
Findings from this run opened #4 (missing TCP `[SUM]` row), #5 (UDP bidir hang / `-t` not enforced), #6 (UDP throughput gap).

Refs #4, #5, #6.