### PR TITLE
fix(reporter): emit final [SUM] row for -P > 1 (#4)

### DIFF
--- a/riperf3/src/client.rs
+++ b/riperf3/src/client.rs
@@ -606,24 +606,25 @@ impl Client {
         let test_duration = self.duration as f64;
         crate::reporter::print_separator();
 
-        for s in streams {
-            let bytes = if s.is_sender {
-                s.counters.bytes_sent()
-            } else {
-                s.counters.bytes_received()
-            };
+        let summaries: Vec<crate::reporter::StreamSummary> = streams
+            .iter()
+            .map(|s| {
+                let bytes = if s.is_sender {
+                    s.counters.bytes_sent()
+                } else {
+                    s.counters.bytes_received()
+                };
 
-            let (jitter, lost, total) = if let Some(ref udp_stats) = s.udp_recv_stats {
-                udp_stats
-                    .lock()
-                    .map(|st| (Some(st.jitter), Some(st.cnt_error), Some(st.packet_count)))
-                    .unwrap_or((None, None, None))
-            } else {
-                (None, None, None)
-            };
+                let (jitter, lost, total) = if let Some(ref udp_stats) = s.udp_recv_stats {
+                    udp_stats
+                        .lock()
+                        .map(|st| (Some(st.jitter), Some(st.cnt_error), Some(st.packet_count)))
+                        .unwrap_or((None, None, None))
+                } else {
+                    (None, None, None)
+                };
 
-            crate::reporter::print_summary(
-                &crate::reporter::StreamSummary {
+                crate::reporter::StreamSummary {
                     stream_id: s.id,
                     start: 0.0,
                     end: test_duration,
@@ -633,9 +634,18 @@ impl Client {
                     jitter,
                     lost,
                     total_packets: total,
-                },
-                self.format_char,
-            );
+                }
+            })
+            .collect();
+
+        for summary in &summaries {
+            crate::reporter::print_summary(summary, self.format_char);
+        }
+
+        // Aggregate [SUM] row(s) for parallel streams (issue #4), matching
+        // iperf3. One per direction; omitted for single-stream directions.
+        for sum in crate::reporter::sum_summaries(&summaries) {
+            crate::reporter::print_summary(&sum, self.format_char);
         }
     }
 

--- a/riperf3/src/client.rs
+++ b/riperf3/src/client.rs
@@ -638,15 +638,9 @@ impl Client {
             })
             .collect();
 
-        for summary in &summaries {
-            crate::reporter::print_summary(summary, self.format_char);
-        }
-
-        // Aggregate [SUM] row(s) for parallel streams (issue #4), matching
-        // iperf3. One per direction; omitted for single-stream directions.
-        for sum in crate::reporter::sum_summaries(&summaries) {
-            crate::reporter::print_summary(&sum, self.format_char);
-        }
+        // Per-stream lines plus aggregate [SUM] row(s) for parallel streams
+        // (issue #4), via the shared path the server also uses.
+        crate::reporter::print_final_summaries(&summaries, self.format_char);
     }
 
     fn print_results_json(

--- a/riperf3/src/reporter.rs
+++ b/riperf3/src/reporter.rs
@@ -126,8 +126,9 @@ pub fn print_separator() {
     println!("- - - - - - - - - - - - - - - - - - - - - - - - -");
 }
 
-/// Print a final summary line.
-pub fn print_summary(summary: &StreamSummary, format_char: char) {
+/// Format a single final-summary line (no trailing newline). Pure, so the
+/// rendered output can be unit-tested without capturing stdout.
+pub fn format_summary_line(summary: &StreamSummary, format_char: char) -> String {
     let id = fmt_id(summary.stream_id);
     let transfer = units::format_bytes(summary.bytes as f64, format_char.to_ascii_uppercase());
     let seconds = summary.end - summary.start;
@@ -151,7 +152,7 @@ pub fn print_summary(summary: &StreamSummary, format_char: char) {
         } else {
             0.0
         };
-        println!(
+        format!(
             "[{id}] {:5.2}-{:<5.2} sec  {:>10}  {:>12}  {:7.3} ms  {}/{} ({:.2}%)  {}",
             summary.start,
             summary.end,
@@ -162,17 +163,45 @@ pub fn print_summary(summary: &StreamSummary, format_char: char) {
             total,
             pct,
             role,
-        );
+        )
     } else if let Some(retr) = summary.retransmits {
-        println!(
+        format!(
             "[{id}] {:5.2}-{:<5.2} sec  {:>10}  {:>12}  {:4}             {}",
             summary.start, summary.end, transfer, rate, retr, role,
-        );
+        )
     } else {
-        println!(
+        format!(
             "[{id}] {:5.2}-{:<5.2} sec  {:>10}  {:>12}                    {}",
             summary.start, summary.end, transfer, rate, role,
-        );
+        )
+    }
+}
+
+/// Print a single final summary line.
+pub fn print_summary(summary: &StreamSummary, format_char: char) {
+    println!("{}", format_summary_line(summary, format_char));
+}
+
+/// Build the full set of final-report lines for a set of per-stream summaries:
+/// the per-stream lines followed by aggregate `[SUM]` rows. Pure and testable.
+/// Both the client and the server route their final report through this so the
+/// two sides stay consistent (issue #4 was caused by the server omitting the
+/// SUM row that the client emitted).
+pub fn final_report_lines(per_stream: &[StreamSummary], format_char: char) -> Vec<String> {
+    let mut lines: Vec<String> = per_stream
+        .iter()
+        .map(|s| format_summary_line(s, format_char))
+        .collect();
+    for sum in sum_summaries(per_stream) {
+        lines.push(format_summary_line(&sum, format_char));
+    }
+    lines
+}
+
+/// Print the final report (per-stream summaries + aggregate `[SUM]` rows).
+pub fn print_final_summaries(per_stream: &[StreamSummary], format_char: char) {
+    for line in final_report_lines(per_stream, format_char) {
+        println!("{line}");
     }
 }
 
@@ -206,6 +235,10 @@ pub fn sum_summaries(streams: &[StreamSummary]) -> Vec<StreamSummary> {
         } else {
             (None, None, None)
         };
+        // Aggregate per-stream retransmits when present. The final per-stream
+        // summaries don't yet carry retransmits (the producers pass `None`, so
+        // this is dormant today), but the math is kept correct and tested so
+        // the SUM stays right if/when end-of-test TCP_INFO is plumbed in.
         let retransmits = if group.iter().any(|s| s.retransmits.is_some()) {
             Some(group.iter().filter_map(|s| s.retransmits).sum())
         } else {
@@ -622,5 +655,72 @@ mod tests {
         assert_eq!(s.lost, Some(7), "lost datagrams summed");
         assert_eq!(s.total_packets, Some(3000), "total datagrams summed");
         assert_eq!(s.jitter, Some(0.025), "SUM carries worst-case jitter");
+    }
+
+    #[test]
+    fn sum_summaries_aggregates_retransmits() {
+        // Forward-compat: when per-stream summaries carry retransmits, the SUM
+        // must sum them (the producers don't set this yet — see sum_summaries).
+        let mut a = tcp_summary(1, true, 1_000);
+        a.retransmits = Some(3);
+        let mut b = tcp_summary(3, true, 1_000);
+        b.retransmits = Some(4);
+        let sums = sum_summaries(&[a, b]);
+        assert_eq!(sums.len(), 1);
+        assert_eq!(sums[0].retransmits, Some(7), "retransmits summed on SUM");
+    }
+
+    // ---- final_report_lines: the rendered output both client & server emit ---
+
+    /// The blocker behind issue #4: parallel streams must produce a rendered
+    /// `[SUM]` line. Both the client and server route through final_report_lines,
+    /// so this pins the rendered behavior for both sides without stdout capture.
+    #[test]
+    fn final_report_lines_includes_sum_for_multistream() {
+        let streams = vec![
+            tcp_summary(1, true, 1_000),
+            tcp_summary(3, true, 2_000),
+            tcp_summary(4, true, 3_000),
+        ];
+        let lines = final_report_lines(&streams, 'm');
+        assert_eq!(lines.len(), 4, "3 per-stream lines + 1 SUM");
+        assert_eq!(
+            lines.iter().filter(|l| l.contains("[SUM]")).count(),
+            1,
+            "exactly one [SUM] line; got:\n{}",
+            lines.join("\n")
+        );
+        assert!(lines.last().unwrap().contains("[SUM]"));
+    }
+
+    #[test]
+    fn final_report_lines_no_sum_for_single_stream() {
+        let lines = final_report_lines(&[tcp_summary(1, true, 1_000)], 'm');
+        assert_eq!(lines.len(), 1);
+        assert!(!lines[0].contains("[SUM]"));
+    }
+
+    #[test]
+    fn final_report_lines_bidir_has_two_sums() {
+        let streams = vec![
+            tcp_summary(1, true, 1_000),
+            tcp_summary(3, true, 1_000),
+            tcp_summary(5, false, 2_000),
+            tcp_summary(7, false, 2_000),
+        ];
+        let lines = final_report_lines(&streams, 'm');
+        let sum_lines: Vec<&String> = lines.iter().filter(|l| l.contains("[SUM]")).collect();
+        assert_eq!(sum_lines.len(), 2, "one SUM per direction");
+        assert!(sum_lines.iter().any(|l| l.ends_with("sender")));
+        assert!(sum_lines.iter().any(|l| l.ends_with("receiver")));
+    }
+
+    #[test]
+    fn format_summary_line_renders_retransmits_column() {
+        let mut s = tcp_summary(1, true, 1_000_000);
+        s.retransmits = Some(12);
+        let line = format_summary_line(&s, 'm');
+        assert!(line.contains(" 12 "), "Retr value should appear: {line}");
+        assert!(line.ends_with("sender"));
     }
 }

--- a/riperf3/src/reporter.rs
+++ b/riperf3/src/reporter.rs
@@ -176,6 +176,56 @@ pub fn print_summary(summary: &StreamSummary, format_char: char) {
     }
 }
 
+/// Derive the aggregate `[SUM]` rows for the final report from the per-stream
+/// summaries. Returns one SUM per direction (sender / receiver) that has more
+/// than one stream — matching iperf3, which prints a `[SUM]` for parallel
+/// streams and omits it for a single stream. Bidir runs yield up to two SUM
+/// rows (one per direction). UDP SUM rows aggregate lost/total datagrams and
+/// carry the worst-case (max) jitter across the grouped streams.
+pub fn sum_summaries(streams: &[StreamSummary]) -> Vec<StreamSummary> {
+    let mut out = Vec::new();
+    for is_sender in [true, false] {
+        let group: Vec<&StreamSummary> = streams
+            .iter()
+            .filter(|s| s.is_sender == is_sender)
+            .collect();
+        if group.len() <= 1 {
+            continue;
+        }
+        let bytes = group.iter().map(|s| s.bytes).sum();
+        let is_udp = group.iter().any(|s| s.total_packets.is_some());
+        let (jitter, lost, total_packets) = if is_udp {
+            let lost = group.iter().filter_map(|s| s.lost).sum();
+            let total = group.iter().filter_map(|s| s.total_packets).sum();
+            // Jitter doesn't sum; report the worst stream's jitter on the SUM.
+            let jitter = group
+                .iter()
+                .filter_map(|s| s.jitter)
+                .fold(None, |acc, j| Some(acc.map_or(j, |a: f64| a.max(j))));
+            (jitter, Some(lost), Some(total))
+        } else {
+            (None, None, None)
+        };
+        let retransmits = if group.iter().any(|s| s.retransmits.is_some()) {
+            Some(group.iter().filter_map(|s| s.retransmits).sum())
+        } else {
+            None
+        };
+        out.push(StreamSummary {
+            stream_id: -1, // renders as "SUM"
+            start: group[0].start,
+            end: group[0].end,
+            bytes,
+            is_sender,
+            retransmits,
+            jitter,
+            lost,
+            total_packets,
+        });
+    }
+    out
+}
+
 // ---------------------------------------------------------------------------
 // Interval reporter — spawned async task for periodic stats
 // ---------------------------------------------------------------------------
@@ -474,5 +524,103 @@ mod tests {
         };
         // Should print [SUM] instead of a number
         print_interval(&interval, 'm');
+    }
+
+    // ---- sum_summaries (issue #4: final [SUM] row for -P > 1) ----------------
+
+    fn tcp_summary(id: i32, is_sender: bool, bytes: u64) -> StreamSummary {
+        StreamSummary {
+            stream_id: id,
+            start: 0.0,
+            end: 10.0,
+            bytes,
+            is_sender,
+            retransmits: None,
+            jitter: None,
+            lost: None,
+            total_packets: None,
+        }
+    }
+
+    #[test]
+    fn sum_summaries_single_stream_no_sum() {
+        // One stream → no [SUM] row, matching iperf3.
+        let streams = vec![tcp_summary(1, true, 1_000_000)];
+        assert!(sum_summaries(&streams).is_empty());
+    }
+
+    #[test]
+    fn sum_summaries_multi_sender_aggregates_bytes() {
+        let streams = vec![
+            tcp_summary(1, true, 1_000),
+            tcp_summary(3, true, 2_000),
+            tcp_summary(4, true, 3_000),
+        ];
+        let sums = sum_summaries(&streams);
+        assert_eq!(sums.len(), 1, "one SUM row for the sender group");
+        assert_eq!(sums[0].stream_id, -1, "SUM renders from id -1");
+        assert!(sums[0].is_sender);
+        assert_eq!(sums[0].bytes, 6_000, "bytes summed across streams");
+        assert_eq!(sums[0].start, 0.0);
+        assert_eq!(sums[0].end, 10.0);
+    }
+
+    #[test]
+    fn sum_summaries_bidir_yields_two_rows() {
+        // Bidir: senders and receivers each >1 → one SUM per direction.
+        let streams = vec![
+            tcp_summary(1, true, 1_000),
+            tcp_summary(3, true, 1_000),
+            tcp_summary(5, false, 2_000),
+            tcp_summary(7, false, 2_000),
+        ];
+        let sums = sum_summaries(&streams);
+        assert_eq!(sums.len(), 2);
+        let sender = sums.iter().find(|s| s.is_sender).unwrap();
+        let receiver = sums.iter().find(|s| !s.is_sender).unwrap();
+        assert_eq!(sender.bytes, 2_000);
+        assert_eq!(receiver.bytes, 4_000);
+    }
+
+    #[test]
+    fn sum_summaries_bidir_single_per_direction_no_sum() {
+        // Bidir -P 1: one sender + one receiver → neither direction gets a SUM.
+        let streams = vec![tcp_summary(1, true, 1_000), tcp_summary(3, false, 2_000)];
+        assert!(sum_summaries(&streams).is_empty());
+    }
+
+    #[test]
+    fn sum_summaries_udp_aggregates_loss_and_max_jitter() {
+        let streams = vec![
+            StreamSummary {
+                stream_id: 1,
+                start: 0.0,
+                end: 10.0,
+                bytes: 100_000,
+                is_sender: false,
+                retransmits: None,
+                jitter: Some(0.010),
+                lost: Some(2),
+                total_packets: Some(1000),
+            },
+            StreamSummary {
+                stream_id: 3,
+                start: 0.0,
+                end: 10.0,
+                bytes: 200_000,
+                is_sender: false,
+                retransmits: None,
+                jitter: Some(0.025),
+                lost: Some(5),
+                total_packets: Some(2000),
+            },
+        ];
+        let sums = sum_summaries(&streams);
+        assert_eq!(sums.len(), 1);
+        let s = &sums[0];
+        assert_eq!(s.bytes, 300_000);
+        assert_eq!(s.lost, Some(7), "lost datagrams summed");
+        assert_eq!(s.total_packets, Some(3000), "total datagrams summed");
+        assert_eq!(s.jitter, Some(0.025), "SUM carries worst-case jitter");
     }
 }

--- a/riperf3/src/reporter.rs
+++ b/riperf3/src/reporter.rs
@@ -185,8 +185,9 @@ pub fn print_summary(summary: &StreamSummary, format_char: char) {
 /// Build the full set of final-report lines for a set of per-stream summaries:
 /// the per-stream lines followed by aggregate `[SUM]` rows. Pure and testable.
 /// Both the client and the server route their final report through this so the
-/// two sides stay consistent (issue #4 was caused by the server omitting the
-/// SUM row that the client emitted).
+/// two sides stay consistent: issue #4 was the final `[SUM]` row being omitted
+/// for `-P > 1` (the client fix landed first, then the server), and a single
+/// shared path keeps either side from regressing independently.
 pub fn final_report_lines(per_stream: &[StreamSummary], format_char: char) -> Vec<String> {
     let mut lines: Vec<String> = per_stream
         .iter()
@@ -690,7 +691,16 @@ mod tests {
             "exactly one [SUM] line; got:\n{}",
             lines.join("\n")
         );
-        assert!(lines.last().unwrap().contains("[SUM]"));
+        let sum_line = lines.last().unwrap();
+        assert!(sum_line.contains("[SUM]"));
+        // Pin the rendered aggregate value, not just the presence of a SUM
+        // row: the SUM line must render the summed bytes (6000), so a
+        // regression that printed a per-stream or zero value would be caught.
+        let expected_transfer = units::format_bytes(6_000.0, 'M');
+        assert!(
+            sum_line.contains(&expected_transfer),
+            "SUM must render summed transfer {expected_transfer:?}; got {sum_line:?}"
+        );
     }
 
     #[test]

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -527,25 +527,27 @@ impl Server {
             }
         }
 
-        // Print summary
-        for s in &streams {
-            let bytes = if s.is_sender {
-                s.counters.bytes_sent()
-            } else {
-                s.counters.bytes_received()
-            };
+        // Print summary: per-stream lines plus aggregate [SUM] row(s) for
+        // parallel streams (issue #4), via the shared path the client uses.
+        let summaries: Vec<crate::reporter::StreamSummary> = streams
+            .iter()
+            .map(|s| {
+                let bytes = if s.is_sender {
+                    s.counters.bytes_sent()
+                } else {
+                    s.counters.bytes_received()
+                };
 
-            let (jitter, lost, total) = if let Some(ref udp_stats) = s.udp_recv_stats {
-                udp_stats
-                    .lock()
-                    .map(|st| (Some(st.jitter), Some(st.cnt_error), Some(st.packet_count)))
-                    .unwrap_or((None, None, None))
-            } else {
-                (None, None, None)
-            };
+                let (jitter, lost, total) = if let Some(ref udp_stats) = s.udp_recv_stats {
+                    udp_stats
+                        .lock()
+                        .map(|st| (Some(st.jitter), Some(st.cnt_error), Some(st.packet_count)))
+                        .unwrap_or((None, None, None))
+                } else {
+                    (None, None, None)
+                };
 
-            crate::reporter::print_summary(
-                &crate::reporter::StreamSummary {
+                crate::reporter::StreamSummary {
                     stream_id: s.id,
                     start: 0.0,
                     end: test_duration,
@@ -555,10 +557,10 @@ impl Server {
                     jitter,
                     lost,
                     total_packets: total,
-                },
-                'a',
-            );
-        }
+                }
+            })
+            .collect();
+        crate::reporter::print_final_summaries(&summaries, 'a');
 
         // Join stream tasks (best-effort, they should be done)
         for s in streams {


### PR DESCRIPTION
Closes #4.

The text final summary printed per-stream `sender`/`receiver` lines but omitted the aggregate `[SUM]` row for parallel streams — unlike iperf3, and unlike riperf3's own *interval* reporter which already prints one. Tools parsing the binary's output had to sum streams by hand (this bit the benchmark harness in #7). Both the client **and** the server omitted the row.

## Change

- New pure helpers in `reporter`: `sum_summaries` (one `[SUM]` per direction with >1 stream — bidir → two rows, single-stream → none; UDP SUM aggregates lost/total datagrams + worst-case jitter), `format_summary_line` (pure, so rendered output is testable), and `final_report_lines`/`print_final_summaries` (the per-stream + SUM rows).
- **Both** `Client::print_results_text` and the server's final summary route through the shared `print_final_summaries` path, so the two sides can't diverge.

## Tests

Unit tests on the helpers: single-stream (no SUM), multi-sender byte aggregation (incl. pinning the rendered SUM value), bidir (two rows), bidir `-P 1` (no SUM), UDP loss/jitter aggregation, retransmit aggregation, and `format_summary_line` rendering. Full workspace suite green; `clippy`/`fmt` clean. Verified live that the **server** now prints `[SUM]` for `-P > 1`.

## Notes

The retransmit-aggregation branch is correct but dormant (final per-stream summaries don't yet carry retransmits — that needs end-of-test TCP_INFO capture); kept tested and documented as such.