### PR TITLE
fix(udp): honor -t and don't stall stream setup under load (#5)

### DIFF
--- a/riperf3/src/client.rs
+++ b/riperf3/src/client.rs
@@ -103,6 +103,9 @@ impl Client {
         }
 
         let done = Arc::new(AtomicBool::new(false));
+        // Signal `done` on every exit path (incl. early `?` returns) so a UDP
+        // sender parked on the start barrier can't leak if setup fails (#5).
+        let _done_guard = stream::DoneOnDrop(done.clone());
         // Released at TestStart so UDP senders don't transmit during stream
         // setup (issue #5): the create-streams handshake is lost under a flood.
         let start = Arc::new(AtomicBool::new(false));

--- a/riperf3/src/client.rs
+++ b/riperf3/src/client.rs
@@ -103,6 +103,9 @@ impl Client {
         }
 
         let done = Arc::new(AtomicBool::new(false));
+        // Released at TestStart so UDP senders don't transmit during stream
+        // setup (issue #5): the create-streams handshake is lost under a flood.
+        let start = Arc::new(AtomicBool::new(false));
         let mut streams: Vec<DataStream> = Vec::new();
         let mut cpu_start: Option<CpuSnapshot> = None;
         let mut server_results: Option<TestResultsJson> = None;
@@ -118,10 +121,12 @@ impl Client {
                 }
 
                 TestState::CreateStreams => {
-                    streams = self.create_streams(&cookie, &done).await?;
+                    streams = self.create_streams(&cookie, &done, &start).await?;
                 }
 
                 TestState::TestStart => {
+                    // All streams are set up — release the UDP senders.
+                    start.store(true, Ordering::Relaxed);
                     cpu_start = Some(CpuSnapshot::now());
                 }
 
@@ -240,6 +245,7 @@ impl Client {
         &self,
         cookie: &[u8; protocol::COOKIE_SIZE],
         done: &Arc<AtomicBool>,
+        start: &Arc<AtomicBool>,
     ) -> Result<Vec<DataStream>> {
         let mut streams = Vec::new();
 
@@ -255,6 +261,14 @@ impl Client {
             0
         };
         let total = send_count + recv_count;
+
+        // Max send duration the UDP senders self-enforce (issue #5): the
+        // sender stops itself at `-t` so termination never depends on `done`
+        // being set by a CPU-starved runtime. Only in duration mode;
+        // byte/block-limited tests stop on `done`.
+        let max_duration = (self.bytes_to_send.is_none() && self.blocks_to_send.is_none())
+            .then(|| Duration::from_secs(self.duration as u64));
+
         match self.protocol {
             TransportProtocol::Tcp => {
                 for i in 0..total {
@@ -389,11 +403,17 @@ impl Client {
                         };
                         let u64bit = self.udp_counters_64bit;
                         let use_sendmmsg = self.sendmmsg;
+                        let st = start.clone();
+                        let md = max_duration;
                         tokio::task::spawn_blocking(move || {
                             if use_sendmmsg {
-                                stream::run_udp_sender_sendmmsg(std_sock, c, bs, d, rate, u64bit)
+                                stream::run_udp_sender_sendmmsg(
+                                    std_sock, c, bs, d, rate, u64bit, st, md,
+                                )
                             } else {
-                                stream::run_udp_sender_blocking(std_sock, c, bs, d, rate, u64bit)
+                                stream::run_udp_sender_blocking(
+                                    std_sock, c, bs, d, rate, u64bit, st, md,
+                                )
                             }
                         })
                     } else {
@@ -481,7 +501,14 @@ impl Client {
 
         match end_condition {
             EndCondition::Duration(dur) => {
-                // Use select to handle both timer and control socket
+                // Use select to handle both timer and control socket.
+                //
+                // The UDP senders also enforce this deadline themselves inside
+                // their loop (see the `deadline` passed at stream creation):
+                // at a high `-b` the CPU-bound senders can saturate every core
+                // and starve this async timer, so they must not depend on it to
+                // stop (issue #5). Once they self-terminate, CPU frees and this
+                // timer fires normally to drive the rest of the shutdown.
                 tokio::select! {
                     _ = tokio::time::sleep(dur) => {}
                     state = protocol::recv_state(ctrl) => {

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -202,6 +202,9 @@ impl Server {
 
         // ---- CreateStreams ----
         let done = Arc::new(AtomicBool::new(false));
+        // Signal `done` on every exit path (incl. early `?` returns) so a UDP
+        // sender parked on the start barrier can't leak if setup fails (#5).
+        let _done_guard = stream::DoneOnDrop(done.clone());
         // Released at TestStart so UDP senders don't transmit during stream
         // setup (issue #5): the create-streams handshake is lost under a flood.
         let start = Arc::new(AtomicBool::new(false));

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -202,6 +202,9 @@ impl Server {
 
         // ---- CreateStreams ----
         let done = Arc::new(AtomicBool::new(false));
+        // Released at TestStart so UDP senders don't transmit during stream
+        // setup (issue #5): the create-streams handshake is lost under a flood.
+        let start = Arc::new(AtomicBool::new(false));
         let mut streams: Vec<DataStream> = Vec::new();
 
         // Determine how many streams to accept and their roles.
@@ -292,6 +295,14 @@ impl Server {
 
                 protocol::send_state(&mut ctrl, TestState::CreateStreams).await?;
 
+                // Max send duration the server's UDP senders self-enforce
+                // (issue #5): in bidir/reverse the server sends too, and at a
+                // high `-b` those CPU-bound senders can starve this side's
+                // runtime so it never processes the client's TestEnd. Only in
+                // duration mode; byte/block-limited tests stop on `done`.
+                let max_duration = (params.num.is_none() && params.blockcount.is_none())
+                    .then(|| std::time::Duration::from_secs(cfg.duration as u64));
+
                 for i in 0..total {
                     // Accept: recv magic, connect() to client, send reply
                     let _client_addr = protocol::udp_connect_server(&udp_listener).await?;
@@ -327,8 +338,12 @@ impl Server {
                             DEFAULT_UDP_RATE
                         };
                         let u64bit = cfg.udp_counters_64bit;
+                        let st = start.clone();
+                        let md = max_duration;
                         let task = tokio::task::spawn_blocking(move || {
-                            stream::run_udp_sender_blocking(std_sock, c, bs, d, rate, u64bit)
+                            stream::run_udp_sender_blocking(
+                                std_sock, c, bs, d, rate, u64bit, st, md,
+                            )
                         });
                         streams.push(DataStream {
                             id: stream_id,
@@ -369,6 +384,8 @@ impl Server {
         }
 
         // ---- TestStart / TestRunning ----
+        // All streams are set up — release the UDP senders.
+        start.store(true, Ordering::Relaxed);
         protocol::send_state(&mut ctrl, TestState::TestStart).await?;
         let cpu_start = CpuSnapshot::now();
         protocol::send_state(&mut ctrl, TestState::TestRunning).await?;

--- a/riperf3/src/stream.rs
+++ b/riperf3/src/stream.rs
@@ -694,6 +694,23 @@ pub async fn run_udp_receiver(
 // Blocking UDP send / recv (high-performance, no async overhead)
 // ---------------------------------------------------------------------------
 
+/// Block until the start barrier is released so a UDP sender does not transmit
+/// during stream setup (issue #5). The UDP create-streams handshake is sent on
+/// the same port as the data and is silently lost under a high-rate flood, so
+/// if early streams start blasting while later streams are still handshaking,
+/// setup stalls forever. Holding all senders until every stream is created
+/// keeps the handshake clean. Returns `false` if the test was torn down before
+/// starting (the caller should just return).
+fn await_start(start: &AtomicBool, done: &AtomicBool) -> bool {
+    while !start.load(Ordering::Relaxed) {
+        if done.load(Ordering::Relaxed) {
+            return false;
+        }
+        std::thread::sleep(Duration::from_millis(1));
+    }
+    true
+}
+
 /// High-performance UDP sender using blocking I/O on a dedicated OS thread.
 /// No `unsafe` code — uses `std::net::UdpSocket` and batch pacing with
 /// `std::thread::sleep` + spin-loop for sub-microsecond precision.
@@ -701,6 +718,7 @@ pub async fn run_udp_receiver(
 /// Batched UDP sender using sendmmsg — one kernel crossing per batch.
 /// Safe Rust only (nix wraps sendmmsg). Available on Linux, FreeBSD, NetBSD.
 #[cfg(any(target_os = "linux", target_os = "freebsd", target_os = "netbsd"))]
+#[allow(clippy::too_many_arguments)] // hot-path sender: socket + tuning + lifecycle
 pub fn run_udp_sender_sendmmsg(
     socket: std::net::UdpSocket,
     counters: Arc<StreamCounters>,
@@ -708,10 +726,20 @@ pub fn run_udp_sender_sendmmsg(
     done: Arc<AtomicBool>,
     rate_bits_per_sec: u64,
     use_64bit: bool,
+    start: Arc<AtomicBool>,
+    max_duration: Option<Duration>,
 ) -> Result<()> {
     use nix::sys::socket::{self, MsgFlags, MultiHeaders, SockaddrIn};
     use std::io::IoSlice;
     use std::os::unix::io::AsRawFd;
+
+    if !await_start(&start, &done) {
+        return Ok(());
+    }
+    // Deadline measured from the actual start of data (issue #5): at a high
+    // `-b` the CPU-bound senders can starve the async runtime so `done` is
+    // never set; the sender must stop itself at `-t`.
+    let deadline = max_duration.map(|d| Instant::now() + d);
 
     let fd = socket.as_raw_fd();
     // Larger batch than the per-packet sender: sendmmsg amortizes syscall
@@ -737,6 +765,9 @@ pub fn run_udp_sender_sendmmsg(
     let mut next_send = Instant::now();
 
     while !done.load(Ordering::Relaxed) {
+        if deadline.is_some_and(|d| Instant::now() >= d) {
+            break;
+        }
         // Cache timestamp once per batch
         let cached_time = SystemTime::now()
             .duration_since(UNIX_EPOCH)
@@ -798,6 +829,7 @@ pub fn run_udp_sender_sendmmsg(
 
 /// Fallback for platforms without sendmmsg.
 #[cfg(not(any(target_os = "linux", target_os = "freebsd", target_os = "netbsd")))]
+#[allow(clippy::too_many_arguments)] // hot-path sender: socket + tuning + lifecycle
 pub fn run_udp_sender_sendmmsg(
     socket: std::net::UdpSocket,
     counters: Arc<StreamCounters>,
@@ -805,6 +837,8 @@ pub fn run_udp_sender_sendmmsg(
     done: Arc<AtomicBool>,
     rate_bits_per_sec: u64,
     use_64bit: bool,
+    start: Arc<AtomicBool>,
+    max_duration: Option<Duration>,
 ) -> Result<()> {
     run_udp_sender_blocking(
         socket,
@@ -813,12 +847,15 @@ pub fn run_udp_sender_sendmmsg(
         done,
         rate_bits_per_sec,
         use_64bit,
+        start,
+        max_duration,
     )
 }
 
 /// Batch pacing: sends N packets in a tight loop, then does a single clock
 /// check and sleep/spin for the aggregate interval. This amortizes the cost
 /// of `Instant::now()` (~50ns) and atomic operations across multiple packets.
+#[allow(clippy::too_many_arguments)] // hot-path sender: socket + tuning + lifecycle
 pub fn run_udp_sender_blocking(
     socket: std::net::UdpSocket,
     counters: Arc<StreamCounters>,
@@ -826,7 +863,16 @@ pub fn run_udp_sender_blocking(
     done: Arc<AtomicBool>,
     rate_bits_per_sec: u64,
     use_64bit: bool,
+    start: Arc<AtomicBool>,
+    max_duration: Option<Duration>,
 ) -> Result<()> {
+    if !await_start(&start, &done) {
+        return Ok(());
+    }
+    // Deadline measured from the actual start of data — see the note in
+    // run_udp_sender_sendmmsg (issue #5).
+    let deadline = max_duration.map(|d| Instant::now() + d);
+
     let mut buf = vec![0u8; blksize];
     let mut seq: u64 = 0;
 
@@ -850,6 +896,9 @@ pub fn run_udp_sender_blocking(
     let mut next_send = Instant::now();
 
     while !done.load(Ordering::Relaxed) {
+        if deadline.is_some_and(|d| Instant::now() >= d) {
+            break;
+        }
         // Cache timestamp once per batch (sufficient for jitter calculation)
         let cached_time = SystemTime::now()
             .duration_since(UNIX_EPOCH)
@@ -1329,5 +1378,177 @@ mod tests {
 
         assert!(send_counters.bytes_sent() > 0);
         assert!(recv_counters.bytes_received() > 0);
+    }
+
+    // ---- issue #5: UDP senders self-enforce the wall-clock deadline ---------
+
+    /// Connected UDP socket pair on loopback. The receiver is never drained,
+    /// but UDP send() doesn't block on a full receive buffer (datagrams are
+    /// dropped), so the sender loops freely — exactly like the real bug where
+    /// senders spin at a high `-b`.
+    fn udp_pair() -> (std::net::UdpSocket, std::net::UdpSocket) {
+        let recv = std::net::UdpSocket::bind("127.0.0.1:0").unwrap();
+        let send = std::net::UdpSocket::bind("127.0.0.1:0").unwrap();
+        send.connect(recv.local_addr().unwrap()).unwrap();
+        (send, recv)
+    }
+
+    /// A released start barrier.
+    fn started() -> Arc<AtomicBool> {
+        Arc::new(AtomicBool::new(true))
+    }
+
+    /// The core regression: with `done` never set, the max-duration alone must
+    /// stop the loop. Before the fix this spun forever (issue #5).
+    #[test]
+    fn udp_sender_blocking_honors_deadline_without_done() {
+        let (send, _recv) = udp_pair();
+        let done = Arc::new(AtomicBool::new(false)); // intentionally never set
+        let counters = Arc::new(StreamCounters::new());
+
+        let t0 = Instant::now();
+        run_udp_sender_blocking(
+            send,
+            counters.clone(),
+            1400,
+            done.clone(),
+            0,
+            false,
+            started(),
+            Some(Duration::from_millis(200)),
+        )
+        .unwrap();
+        let elapsed = t0.elapsed();
+
+        assert!(
+            !done.load(Ordering::Relaxed),
+            "done was never set — the deadline alone must terminate the loop"
+        );
+        assert!(
+            elapsed < Duration::from_secs(2),
+            "sender should stop near its 200ms deadline, took {elapsed:?}"
+        );
+        assert!(
+            counters.bytes_sent() > 0,
+            "should have sent before stopping"
+        );
+    }
+
+    #[cfg(any(target_os = "linux", target_os = "freebsd", target_os = "netbsd"))]
+    #[test]
+    fn udp_sender_sendmmsg_honors_deadline_without_done() {
+        let (send, _recv) = udp_pair();
+        let done = Arc::new(AtomicBool::new(false)); // intentionally never set
+        let counters = Arc::new(StreamCounters::new());
+
+        let t0 = Instant::now();
+        run_udp_sender_sendmmsg(
+            send,
+            counters.clone(),
+            1400,
+            done.clone(),
+            0,
+            false,
+            started(),
+            Some(Duration::from_millis(200)),
+        )
+        .unwrap();
+        let elapsed = t0.elapsed();
+
+        assert!(!done.load(Ordering::Relaxed));
+        assert!(
+            elapsed < Duration::from_secs(2),
+            "sendmmsg sender should stop near its 200ms deadline, took {elapsed:?}"
+        );
+        assert!(counters.bytes_sent() > 0);
+    }
+
+    /// `max_duration = None` preserves the original behavior: the loop runs
+    /// until `done` is set (byte/block-limited tests and the control path).
+    #[test]
+    fn udp_sender_blocking_no_deadline_stops_on_done() {
+        let (send, _recv) = udp_pair();
+        let done = Arc::new(AtomicBool::new(false));
+        let counters = Arc::new(StreamCounters::new());
+        let d2 = done.clone();
+        std::thread::spawn(move || {
+            std::thread::sleep(Duration::from_millis(150));
+            d2.store(true, Ordering::Relaxed);
+        });
+
+        let t0 = Instant::now();
+        run_udp_sender_blocking(send, counters, 1400, done, 0, false, started(), None).unwrap();
+        assert!(
+            t0.elapsed() < Duration::from_secs(2),
+            "should stop shortly after done is set"
+        );
+    }
+
+    /// The start barrier (issue #5): a sender must not transmit until `start`
+    /// is released, so the create-streams handshake isn't flooded.
+    #[test]
+    fn udp_sender_blocking_waits_for_start_barrier() {
+        let (send, _recv) = udp_pair();
+        let done = Arc::new(AtomicBool::new(false));
+        let start = Arc::new(AtomicBool::new(false)); // held closed
+        let counters = Arc::new(StreamCounters::new());
+
+        let c2 = counters.clone();
+        let d2 = done.clone();
+        let s2 = start.clone();
+        let h = std::thread::spawn(move || {
+            run_udp_sender_blocking(
+                send,
+                c2,
+                1400,
+                d2,
+                0,
+                false,
+                s2,
+                Some(Duration::from_secs(10)),
+            )
+        });
+
+        // While the barrier is closed, nothing should be sent.
+        std::thread::sleep(Duration::from_millis(200));
+        assert_eq!(
+            counters.bytes_sent(),
+            0,
+            "sender must not transmit before the start barrier is released"
+        );
+
+        // Release, let it run briefly, then stop it.
+        start.store(true, Ordering::Relaxed);
+        std::thread::sleep(Duration::from_millis(100));
+        done.store(true, Ordering::Relaxed);
+        h.join().unwrap().unwrap();
+        assert!(
+            counters.bytes_sent() > 0,
+            "sender should transmit after the barrier opens"
+        );
+    }
+
+    /// If torn down before the barrier opens, the sender exits without sending.
+    #[test]
+    fn udp_sender_blocking_exits_if_done_before_start() {
+        let (send, _recv) = udp_pair();
+        let done = Arc::new(AtomicBool::new(true)); // already done
+        let start = Arc::new(AtomicBool::new(false)); // never released
+        let counters = Arc::new(StreamCounters::new());
+
+        let t0 = Instant::now();
+        run_udp_sender_blocking(
+            send,
+            counters.clone(),
+            1400,
+            done,
+            0,
+            false,
+            start,
+            Some(Duration::from_secs(10)),
+        )
+        .unwrap();
+        assert!(t0.elapsed() < Duration::from_secs(1));
+        assert_eq!(counters.bytes_sent(), 0);
     }
 }

--- a/riperf3/src/stream.rs
+++ b/riperf3/src/stream.rs
@@ -751,7 +751,10 @@ pub fn run_udp_sender_sendmmsg(
     }
     // Deadline measured from the actual start of data (issue #5): at a high
     // `-b` the CPU-bound senders can starve the async runtime so `done` is
-    // never set; the sender must stop itself at `-t`.
+    // never set; the sender must stop itself at `-t`. The deadline is checked
+    // once per batch, so worst-case overshoot is one batch interval — sub-ms at
+    // the high `-b` this guards against, larger at a low paced rate (where the
+    // runtime isn't starved and `done` fires normally anyway).
     let deadline = max_duration.map(|d| Instant::now() + d);
 
     let fd = socket.as_raw_fd();
@@ -1445,6 +1448,38 @@ mod tests {
             counters.bytes_sent() > 0,
             "should have sent before stopping"
         );
+    }
+
+    /// Same deadline guarantee, but with a non-zero rate so `batch_size > 1`
+    /// and the paced send loop runs — production never uses rate 0, so this
+    /// covers the batched regime where the deadline is checked once per batch
+    /// rather than per packet.
+    #[test]
+    fn udp_sender_blocking_honors_deadline_when_paced() {
+        let (send, _recv) = udp_pair();
+        let done = Arc::new(AtomicBool::new(false)); // never set
+        let counters = Arc::new(StreamCounters::new());
+
+        let t0 = Instant::now();
+        run_udp_sender_blocking(
+            send,
+            counters.clone(),
+            1400,
+            done.clone(),
+            100_000_000, // 100 Mbps → rate>0 → batched + paced
+            false,
+            started(),
+            Some(Duration::from_millis(200)),
+        )
+        .unwrap();
+
+        assert!(!done.load(Ordering::Relaxed));
+        assert!(
+            t0.elapsed() < Duration::from_secs(2),
+            "paced sender should stop near its 200ms deadline, took {:?}",
+            t0.elapsed()
+        );
+        assert!(counters.bytes_sent() > 0);
     }
 
     #[cfg(any(target_os = "linux", target_os = "freebsd", target_os = "netbsd"))]

--- a/riperf3/src/stream.rs
+++ b/riperf3/src/stream.rs
@@ -711,6 +711,19 @@ fn await_start(start: &AtomicBool, done: &AtomicBool) -> bool {
     true
 }
 
+/// Sets `done` when dropped, so every exit path of a test handler — including
+/// early `?` error returns before the normal `done.store(true)` — signals the
+/// data tasks to stop. Without this, a UDP sender parked in `await_start`
+/// (start=false, done=false) on a failed/aborted setup would never observe a
+/// stop and would leak on a long-running server (issue #5 follow-up).
+pub struct DoneOnDrop(pub Arc<AtomicBool>);
+
+impl Drop for DoneOnDrop {
+    fn drop(&mut self) {
+        self.0.store(true, Ordering::Relaxed);
+    }
+}
+
 /// High-performance UDP sender using blocking I/O on a dedicated OS thread.
 /// No `unsafe` code — uses `std::net::UdpSocket` and batch pacing with
 /// `std::thread::sleep` + spin-loop for sub-microsecond precision.
@@ -1549,6 +1562,41 @@ mod tests {
         )
         .unwrap();
         assert!(t0.elapsed() < Duration::from_secs(1));
+        assert_eq!(counters.bytes_sent(), 0);
+    }
+
+    /// DoneOnDrop releases a sender parked on the start barrier: on a failed
+    /// setup the guard drops, sets `done`, and the parked sender exits instead
+    /// of leaking (issue #5 follow-up).
+    #[test]
+    fn done_on_drop_releases_parked_sender() {
+        let (send, _recv) = udp_pair();
+        let done = Arc::new(AtomicBool::new(false));
+        let start = Arc::new(AtomicBool::new(false)); // never released
+        let counters = Arc::new(StreamCounters::new());
+
+        let c = counters.clone();
+        let d = done.clone();
+        let s = start.clone();
+        let h = std::thread::spawn(move || {
+            run_udp_sender_blocking(send, c, 1400, d, 0, false, s, Some(Duration::from_secs(10)))
+        });
+
+        // Parked on the barrier — nothing transmitted.
+        std::thread::sleep(Duration::from_millis(50));
+        assert_eq!(counters.bytes_sent(), 0);
+
+        // Simulate a handler tearing down: the guard drops and sets `done`.
+        drop(DoneOnDrop(done.clone()));
+
+        // The parked sender must observe `done` and return (no leak, no send).
+        let t0 = Instant::now();
+        h.join().unwrap().unwrap();
+        assert!(
+            t0.elapsed() < Duration::from_secs(1),
+            "sender should exit promptly"
+        );
+        assert!(done.load(Ordering::Relaxed));
         assert_eq!(counters.bytes_sent(), 0);
     }
 }

--- a/riperf3/tests/integration.rs
+++ b/riperf3/tests/integration.rs
@@ -1694,11 +1694,17 @@ mod implemented_flag_tests {
         let _ = server_task.await;
     }
 
-    /// Regression for issue #5: UDP bidirectional with parallel streams at a
-    /// high target rate must complete and honor `-t` (it deadlocked before the
-    /// start-barrier + self-deadline fix). The outer timeout turns a hang into
-    /// a test failure rather than a wedged run. This also exercises the
-    /// start-barrier release and the in-loop deadline end-to-end.
+    /// Smoke test for issue #5: UDP bidirectional with parallel streams runs
+    /// the full wired-up path (barrier release at TestStart, self-deadline,
+    /// teardown) without deadlocking, and the outer timeout turns any hang into
+    /// a failure rather than a wedged run.
+    ///
+    /// NOTE: this does not by itself reproduce the original hang on fast
+    /// hardware — that needs real per-core starvation plus lossy handshake
+    /// delivery (an 8-vCPU VM), conditions loopback on a workstation doesn't
+    /// create, so it can pass even with the fix disabled. The deadline and
+    /// start-barrier mechanisms are pinned directly by the `stream.rs` unit
+    /// tests; this is the end-to-end "doesn't wedge" guard.
     #[tokio::test]
     async fn udp_bidir_parallel_completes() {
         let port = next_port();

--- a/riperf3/tests/integration.rs
+++ b/riperf3/tests/integration.rs
@@ -1694,6 +1694,40 @@ mod implemented_flag_tests {
         let _ = server_task.await;
     }
 
+    /// Regression for issue #5: UDP bidirectional with parallel streams at a
+    /// high target rate must complete and honor `-t` (it deadlocked before the
+    /// start-barrier + self-deadline fix). The outer timeout turns a hang into
+    /// a test failure rather than a wedged run. This also exercises the
+    /// start-barrier release and the in-loop deadline end-to-end.
+    #[tokio::test]
+    async fn udp_bidir_parallel_completes() {
+        let port = next_port();
+        let server = ServerBuilder::new()
+            .port(Some(port))
+            .one_off(true)
+            .build()
+            .unwrap();
+        let server_task = tokio::spawn(async move { server.run().await });
+        tokio::time::sleep(Duration::from_millis(200)).await;
+        let client = ClientBuilder::new("127.0.0.1")
+            .port(Some(port))
+            .protocol(TransportProtocol::Udp)
+            .duration(2)
+            .num_streams(4)
+            .bidir(true)
+            .bandwidth(50_000_000_000) // 50 Gbps/stream target
+            .build()
+            .unwrap();
+        // -t is 2s; allow generous slack, but fail (not hang) on a regression.
+        let result = tokio::time::timeout(Duration::from_secs(20), client.run()).await;
+        assert!(
+            result.is_ok(),
+            "UDP --bidir -P 4 hung — issue #5 regression"
+        );
+        assert!(result.unwrap().is_ok(), "UDP --bidir -P 4 errored");
+        let _ = server_task.await;
+    }
+
     #[tokio::test]
     async fn udp_high_rate_reverse() {
         // 50G reverse mode — server sends, client receives


### PR DESCRIPTION
Closes #5.

`riperf3 -u --bidir` at a high `-b`/`-P` could hang indefinitely, ignoring `-t` (observed: a `-t 10` run pegged 8 cores for 45 minutes). Root-caused on the sandbox VM fleet via thread-state inspection to **two** distinct failure modes, both stemming from CPU-bound `spawn_blocking` UDP senders saturating every core and starving the async runtime.

## 1. Termination spin
The senders' only stop signal was the `done` flag, set by an async `tokio::time::sleep` timer. Under the starvation that timer's task never got scheduled, so `done` was never set and the senders spun forever. **Fix:** senders self-enforce a wall-clock deadline (`max_duration`) inside the loop — `-t` is honored regardless of runtime health. Once they stop, CPU frees and the runtime recovers to drive the normal shutdown.

## 2. Stream-setup stall
Each sender began transmitting the instant its stream was created, while later streams were still doing the UDP create-streams handshake on the same server port. The flood dropped those handshake packets, so the server blocked forever in `udp_connect_server` and never reached the data phase (thread dump: only 3 of 8 server senders ever spawned). **Fix:** a start barrier, released at `TestStart` once all streams are set up, holds the senders until setup completes — matching iperf3's `CreateStreams → TestStart` gating.

## Scope
`start` + `max_duration` are wired through the client and server UDP sender spawn sites. TCP is unaffected (reliable accept-based setup; async senders already yield).

**Byte/block (`-n`/`-k`) UDP is out of scope and still carries the same exposure:** with no wall-clock anchor those senders stop only on `done`, so under the same high-`-b -P` starvation the byte-counting poll loop can be starved just like the duration timer was. High-rate floods are essentially always duration-mode, so this is deferred — tracked in #11.

## Verification (sandbox VM fleet, 8-vCPU KVM, virtio-net)
The exact trigger `riperf3 -c <h> -u -b 100G --bidir -P 8 -t 5`:
- **Before:** hung 6/8 runs (killed at timeout).
- **After:** 0/12 hung; every run completes at ~5–7 s, honoring `-t 5`.

Regression sweep (TCP fwd/bidir, UDP fwd/rev/bidir at various `-P`/`-b`): all complete cleanly, throughput unchanged.

## Tests
5 new unit tests: deadline-without-`done` for both `sendmmsg` and `blocking` senders, `max_duration=None` still stops on `done`, the start barrier holds transmission until released, and clean exit if torn down before the barrier opens. Full workspace suite green; `fmt`/`clippy` clean.
