### PR TITLE
fix: honor client -4/-6; reject contradictory -4/-6 + -B (#10, #12)

### DIFF
--- a/riperf3/src/client.rs
+++ b/riperf3/src/client.rs
@@ -1134,6 +1134,10 @@ impl ClientBuilder {
     }
 
     pub fn ip_version(mut self, version: u8) -> Self {
+        debug_assert!(
+            matches!(version, 4 | 6),
+            "ip_version must be 4 or 6, got {version}"
+        );
         self.ip_version = Some(version);
         self
     }

--- a/riperf3/src/client.rs
+++ b/riperf3/src/client.rs
@@ -83,6 +83,7 @@ impl Client {
             self.connect_timeout,
             None,
             self.mptcp,
+            self.ip_version,
         )
         .await?;
         net::configure_tcp_stream(&ctrl, true)?;
@@ -281,6 +282,7 @@ impl Client {
                         self.connect_timeout,
                         self.cport,
                         self.mptcp,
+                        self.ip_version,
                     )
                     .await?;
                     protocol::send_cookie(&mut data_stream, cookie).await?;
@@ -368,15 +370,15 @@ impl Client {
                 }
             }
             TransportProtocol::Udp => {
+                // Resolve once, honoring -4/-6, so the bind family matches the
+                // peer and the connection respects the version preference (#10).
+                let remote = net::resolve_host(&self.host, self.port, self.ip_version).await?;
                 for i in 0..total {
-                    let is_ipv6 = self.host.contains(':');
-                    let udp_sock = net::udp_bind(None, 0, is_ipv6).await?;
+                    let udp_sock = net::udp_bind(None, 0, remote.is_ipv6()).await?;
                     if let Some(ref dev) = self.bind_dev {
                         net::set_bind_dev(&udp_sock, dev)?;
                     }
-                    udp_sock
-                        .connect(net::format_addr(&self.host, self.port))
-                        .await?;
+                    udp_sock.connect(remote).await?;
                     protocol::udp_connect_client(&udp_sock).await?;
 
                     // Apply GSO/GRO if requested (no-ops on non-Linux)

--- a/riperf3/src/net.rs
+++ b/riperf3/src/net.rs
@@ -148,12 +148,18 @@ pub async fn resolve_host(host: &str, port: u16, ip_version: Option<u8>) -> Resu
 
     if let Ok(ip) = host.parse::<std::net::IpAddr>() {
         let addr = SocketAddr::new(ip, port);
-        if !family_ok(&addr) {
-            return Err(RiperfError::Protocol(format!(
-                "address {host} is not {} (conflicts with -{})",
-                want(),
-                ip_version.unwrap_or(0)
-            )));
+        match ip_version {
+            Some(4) if !addr.is_ipv4() => {
+                return Err(RiperfError::Protocol(format!(
+                    "address {host} is not IPv4 (conflicts with -4)"
+                )))
+            }
+            Some(6) if !addr.is_ipv6() => {
+                return Err(RiperfError::Protocol(format!(
+                    "address {host} is not IPv6 (conflicts with -6)"
+                )))
+            }
+            _ => {}
         }
         return Ok(addr);
     }

--- a/riperf3/src/net.rs
+++ b/riperf3/src/net.rs
@@ -129,19 +129,57 @@ pub fn format_addr(host: &str, port: u16) -> String {
 /// MPTCP protocol number (not in libc/socket2 yet).
 const IPPROTO_MPTCP: i32 = 262;
 
+/// Resolve `host:port` to a single `SocketAddr`, honoring an IP-version
+/// preference. For an IP literal it validates the family matches `ip_version`
+/// (rejecting e.g. `-6` against an IPv4 literal). For a hostname it resolves
+/// and returns the first address of the requested family — this is how `-4`/
+/// `-6` constrain the connection (issue #10).
+pub async fn resolve_host(host: &str, port: u16, ip_version: Option<u8>) -> Result<SocketAddr> {
+    let family_ok = |a: &SocketAddr| match ip_version {
+        Some(4) => a.is_ipv4(),
+        Some(6) => a.is_ipv6(),
+        _ => true,
+    };
+    let want = || match ip_version {
+        Some(4) => "IPv4",
+        Some(6) => "IPv6",
+        _ => "any",
+    };
+
+    if let Ok(ip) = host.parse::<std::net::IpAddr>() {
+        let addr = SocketAddr::new(ip, port);
+        if !family_ok(&addr) {
+            return Err(RiperfError::Protocol(format!(
+                "address {host} is not {} (conflicts with -{})",
+                want(),
+                ip_version.unwrap_or(0)
+            )));
+        }
+        return Ok(addr);
+    }
+
+    let mut addrs = tokio::net::lookup_host((host, port))
+        .await
+        .map_err(RiperfError::Io)?;
+    addrs
+        .find(family_ok)
+        .ok_or_else(|| RiperfError::Protocol(format!("no {} address found for {host}", want())))
+}
+
 /// Connect to a TCP (or MPTCP) endpoint.
-/// Uses socket2 when local_port or mptcp is set; tokio's built-in connect otherwise.
+/// Uses socket2 when local_port or mptcp is set; tokio's built-in connect
+/// otherwise. `ip_version` constrains address-family selection for hostnames
+/// (`-4`/`-6`); when `None`, the OS resolver's full address list is tried.
 pub async fn tcp_connect(
     host: &str,
     port: u16,
     timeout: Option<Duration>,
     local_port: Option<u16>,
     mptcp: bool,
+    ip_version: Option<u8>,
 ) -> Result<TcpStream> {
     if local_port.is_some() || mptcp {
-        let remote: SocketAddr = format_addr(host, port)
-            .parse()
-            .map_err(|e| RiperfError::Protocol(format!("bad address: {e}")))?;
+        let remote = resolve_host(host, port, ip_version).await?;
         let domain = if remote.is_ipv6() {
             Domain::IPV6
         } else {
@@ -175,7 +213,19 @@ pub async fn tcp_connect(
             return Err(RiperfError::Io(e));
         }
         Ok(stream)
+    } else if ip_version.is_some() {
+        // Honor -4/-6: connect to a single resolved address of the chosen
+        // family rather than letting the resolver try every family.
+        let remote = resolve_host(host, port, ip_version).await?;
+        match timeout {
+            Some(dur) => Ok(tokio::time::timeout(dur, TcpStream::connect(remote))
+                .await
+                .map_err(|_| RiperfError::ConnectionTimeout)?
+                .map_err(RiperfError::Io)?),
+            None => Ok(TcpStream::connect(remote).await?),
+        }
     } else {
+        // No version preference: let the OS resolver try all addresses.
         let addr = format_addr(host, port);
         match timeout {
             Some(dur) => {
@@ -622,7 +672,7 @@ mod tests {
         let port = listener.local_addr().unwrap().port();
 
         let client_task = tokio::spawn(async move {
-            tcp_connect("127.0.0.1", port, None, None, false)
+            tcp_connect("127.0.0.1", port, None, None, false, None)
                 .await
                 .unwrap()
         });
@@ -643,6 +693,7 @@ mod tests {
             Some(Duration::from_millis(50)),
             None,
             false,
+            None,
         )
         .await;
         assert!(result.is_err());
@@ -652,6 +703,47 @@ mod tests {
     async fn udp_bind_ephemeral() {
         let socket = udp_bind(Some("127.0.0.1"), 0, false).await.unwrap();
         assert!(socket.local_addr().is_ok());
+    }
+
+    // ---- resolve_host: honoring -4/-6 (issue #10) -------------------------
+
+    #[tokio::test]
+    async fn resolve_host_literal_no_preference() {
+        let a = resolve_host("127.0.0.1", 5201, None).await.unwrap();
+        assert!(a.is_ipv4() && a.port() == 5201);
+        let a = resolve_host("::1", 5201, None).await.unwrap();
+        assert!(a.is_ipv6());
+    }
+
+    #[tokio::test]
+    async fn resolve_host_literal_matching_family_ok() {
+        assert!(resolve_host("127.0.0.1", 0, Some(4))
+            .await
+            .unwrap()
+            .is_ipv4());
+        assert!(resolve_host("::1", 0, Some(6)).await.unwrap().is_ipv6());
+    }
+
+    #[tokio::test]
+    async fn resolve_host_literal_family_mismatch_errors() {
+        // -6 against an IPv4 literal (and vice versa) must be rejected, not
+        // silently connected to the wrong family.
+        assert!(resolve_host("127.0.0.1", 0, Some(6)).await.is_err());
+        assert!(resolve_host("::1", 0, Some(4)).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn resolve_host_hostname_filters_by_family() {
+        // localhost typically resolves to 127.0.0.1 and/or ::1; assert the
+        // requested family is honored when available, soft-skip if not.
+        match resolve_host("localhost", 5201, Some(4)).await {
+            Ok(a) => assert!(a.is_ipv4(), "Some(4) must yield IPv4, got {a}"),
+            Err(_) => eprintln!("SKIP: localhost has no IPv4 address on this host"),
+        }
+        match resolve_host("localhost", 5201, Some(6)).await {
+            Ok(a) => assert!(a.is_ipv6(), "Some(6) must yield IPv6, got {a}"),
+            Err(_) => eprintln!("SKIP: localhost has no IPv6 address on this host"),
+        }
     }
 
     #[test]
@@ -713,12 +805,12 @@ mod tests {
         let port = listener.local_addr().unwrap().port();
 
         // IPv4 connect must succeed.
-        let v4 = tcp_connect("127.0.0.1", port, None, None, false).await;
+        let v4 = tcp_connect("127.0.0.1", port, None, None, false, None).await;
         assert!(v4.is_ok(), "IPv4 connect failed: {v4:?}");
         let _ = listener.accept().await.unwrap();
 
         // IPv6 connect must also succeed against the same listener.
-        let v6 = tcp_connect("::1", port, None, None, false).await;
+        let v6 = tcp_connect("::1", port, None, None, false, None).await;
         match v6 {
             Ok(_) => {
                 let _ = listener.accept().await.unwrap();
@@ -744,7 +836,7 @@ mod tests {
         let port = local.port();
 
         // IPv6 connect must be refused.
-        let v6 = tcp_connect("::1", port, None, None, false).await;
+        let v6 = tcp_connect("::1", port, None, None, false, None).await;
         match v6 {
             Err(RiperfError::Io(ref e)) if e.kind() == std::io::ErrorKind::ConnectionRefused => {}
             Err(RiperfError::Io(ref e)) if e.kind() == std::io::ErrorKind::AddrNotAvailable => {
@@ -771,7 +863,7 @@ mod tests {
         let port = local.port();
 
         // IPv4 connect must be refused.
-        let v4 = tcp_connect("127.0.0.1", port, None, None, false).await;
+        let v4 = tcp_connect("127.0.0.1", port, None, None, false, None).await;
         match v4 {
             Err(RiperfError::Io(ref e)) if e.kind() == std::io::ErrorKind::ConnectionRefused => {}
             Err(RiperfError::Io(ref e)) if e.kind() == std::io::ErrorKind::AddrNotAvailable => {
@@ -792,7 +884,7 @@ mod tests {
         // `-B :: -6`  → IPv6-only: an IPv4 client must be refused.
         let v6only = tcp_listen(Some("::"), 0, Some(6)).await.unwrap();
         let port = v6only.local_addr().unwrap().port();
-        let v4 = tcp_connect("127.0.0.1", port, None, None, false).await;
+        let v4 = tcp_connect("127.0.0.1", port, None, None, false, None).await;
         assert!(
             matches!(&v4, Err(RiperfError::Io(e)) if e.kind() == std::io::ErrorKind::ConnectionRefused),
             "`-B :: -6` must refuse IPv4, got {v4:?}"
@@ -802,7 +894,7 @@ mod tests {
         // `-B ::` alone → dual-stack: an IPv4 client connects via v4-mapped.
         let dual = tcp_listen(Some("::"), 0, None).await.unwrap();
         let port = dual.local_addr().unwrap().port();
-        let v4 = tcp_connect("127.0.0.1", port, None, None, false).await;
+        let v4 = tcp_connect("127.0.0.1", port, None, None, false, None).await;
         match v4 {
             Ok(_) => {
                 let _ = dual.accept().await.unwrap();

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -707,6 +707,10 @@ impl ServerBuilder {
     /// IPv6 only. Leave unset for dual-stack (the default). Signature matches
     /// `ClientBuilder::ip_version` for consistency.
     pub fn ip_version(mut self, version: u8) -> Self {
+        debug_assert!(
+            matches!(version, 4 | 6),
+            "ip_version must be 4 or 6, got {version}"
+        );
         self.ip_version = Some(version);
         self
     }

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -754,6 +754,20 @@ impl ServerBuilder {
             ));
         }
 
+        // Reject -4/-6 contradicting an explicit -B of the opposite family,
+        // instead of silently letting the bind address win (issue #12).
+        if let (Some(v), Some(addr)) = (self.ip_version, self.bind_address.as_deref()) {
+            if let Ok(ip) = addr.parse::<std::net::IpAddr>() {
+                let mismatch = (v == 4 && ip.is_ipv6()) || (v == 6 && ip.is_ipv4());
+                if mismatch {
+                    return Err(ConfigError::InvalidValue(
+                        "bind_address",
+                        format!("-{v} conflicts with bind address {addr}"),
+                    ));
+                }
+            }
+        }
+
         Ok(Server {
             port: self.port.unwrap_or(DEFAULT_PORT),
             one_off: self.one_off,

--- a/riperf3/tests/integration.rs
+++ b/riperf3/tests/integration.rs
@@ -129,6 +129,25 @@ async fn server_accepts_ipv6_udp_client_by_default() {
     let _ = server_task.await;
 }
 
+/// Client `-6` against an IPv4-literal host must fail fast at address
+/// resolution rather than silently connecting over IPv4 (issue #10). No
+/// server needed — it errors before any connection is attempted.
+#[tokio::test]
+async fn client_ip_version_conflicts_with_literal_host() {
+    let client = ClientBuilder::new("127.0.0.1")
+        .port(Some(next_port()))
+        .ip_version(6)
+        .duration(1)
+        .connect_timeout(Duration::from_millis(500))
+        .build()
+        .unwrap();
+    let result = client.run().await;
+    assert!(
+        result.is_err(),
+        "-6 against an IPv4-literal host must error, not connect over IPv4"
+    );
+}
+
 /// `ServerBuilder::ip_version(6)` must restrict the listener to IPv6, so an
 /// IPv4 client is refused — exercises the builder→net pass-through end-to-end.
 #[tokio::test]
@@ -659,6 +678,33 @@ mod builder_tests {
     fn server_builder_verbose() {
         let s = ServerBuilder::new().verbose(true).build().unwrap();
         assert!(s.verbose);
+    }
+
+    #[test]
+    fn server_builder_rejects_version_bind_conflict() {
+        // -4/-6 contradicting an explicit -B of the opposite family is an
+        // error, not silently honored (issue #12).
+        assert!(ServerBuilder::new()
+            .ip_version(6)
+            .bind_address("127.0.0.1")
+            .build()
+            .is_err());
+        assert!(ServerBuilder::new()
+            .ip_version(4)
+            .bind_address("::")
+            .build()
+            .is_err());
+        // Matching family, or a non-literal bind, is fine.
+        assert!(ServerBuilder::new()
+            .ip_version(6)
+            .bind_address("::")
+            .build()
+            .is_ok());
+        assert!(ServerBuilder::new()
+            .ip_version(4)
+            .bind_address("0.0.0.0")
+            .build()
+            .is_ok());
     }
 }
 

--- a/riperf3/tests/integration.rs
+++ b/riperf3/tests/integration.rs
@@ -141,11 +141,17 @@ async fn client_ip_version_conflicts_with_literal_host() {
         .connect_timeout(Duration::from_millis(500))
         .build()
         .unwrap();
-    let result = client.run().await;
-    assert!(
-        result.is_err(),
-        "-6 against an IPv4-literal host must error, not connect over IPv4"
-    );
+    // Assert the *family-conflict* path fired, not just any connect error
+    // (no server is listening, so a bare is_err() could pass vacuously).
+    match client.run().await {
+        Err(riperf3::RiperfError::Protocol(msg)) => {
+            assert!(
+                msg.contains("is not IPv6"),
+                "expected a family-conflict error, got: {msg}"
+            );
+        }
+        other => panic!("expected a family-conflict Protocol error, got {other:?}"),
+    }
 }
 
 /// `ServerBuilder::ip_version(6)` must restrict the listener to IPv6, so an


### PR DESCRIPTION
Two related IP-version correctness fixes, targeting 0.3.0.

## #10 — client `-4`/`-6` was a no-op
The client stored `ip_version` but never consulted it, so `-4`/`-6` had no effect when connecting to a dual-stack hostname (the OS resolver picked the family).

- New `net::resolve_host(host, port, ip_version)` resolves a hostname with address-family filtering, and validates an IP literal against the requested family.
- `tcp_connect` takes `ip_version` (wired into the control + TCP data connections); when `None`, the resolver's full address list is still tried (no behavior change). The UDP client path resolves once, binds the matching family, and connects to the resolved address.
- An IP literal of the wrong family (`-6 -c 127.0.0.1`) now errors instead of silently connecting over the other family.

## #12 — contradictory `-4`/`-6` + `-B` silently mis-honored
`ServerBuilder::build()` now rejects `-4`/`-6` against an explicit `-B` of the opposite family (e.g. `-6 -B 127.0.0.1`) instead of letting the bind address silently win.

## Tests
- Unit (`resolve_host`): literal no-preference, matching-family OK, family-mismatch errors, hostname family filter (soft-skips if a family is unavailable).
- Integration: `client_ip_version_conflicts_with_literal_host`, `server_builder_rejects_version_bind_conflict`.
- Full workspace green; `clippy`/`fmt` clean.

## Verified live
- `riperf3 -c localhost -4` → server sees `::ffff:127.0.0.1` (IPv4); `-6` → `::1` (IPv6).
- `riperf3 -c 127.0.0.1 -6` → `Error: address 127.0.0.1 is not IPv6 (conflicts with -6)`.

Closes #10, closes #12.


## Notes / behavior changes
- Side-effect improvement: `--cport`/`--mptcp` previously required an IP literal (a hostname errored with "bad address"); routing them through `resolve_host` now accepts hostnames too.
- Out of scope, tracked separately: client `-B` (local bind address) is still ignored entirely (#15) — the #12 validation here covers the server bind only.