### PR TITLE
fix(udp): MSS-derived datagram size + blocking sender socket (#6)

### DIFF
--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -14,7 +14,7 @@ host's virtio bridge.
 | Host | Intel i9-13900K, Linux 7.0.10-arch1-1 (Arch), KVM |
 | Guests | 2× Debian 13 (Trixie), Linux 6.12.74-cloud, 8 vCPU, 8 GB RAM each |
 | NIC | virtio-net (vhost=on), bridged, MTU 9000; IPv4 `172.20.0.0/24` + IPv6 `fd00:20::/64` |
-| riperf3 | 0.4.0 |
+| riperf3 | 0.3.0 + #6 fix (`perf/udp-sender-throughput`; ships as 0.4.0) |
 | iperf3 | 3.20+ (cJSON 1.7.15), built from source |
 | Per-run | `-t 10` (10 s), client→server unless noted |
 

--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -44,9 +44,9 @@ the datagram-size sweep below.
 | 4  | 70.3 | 66.8 | 70.0 | 63.9 |
 | 8  | 62.5 | 59.4 | 62.0 | 58.5 |
 
-**Takeaway:** TCP is unchanged by the 0.4.0 UDP work and remains at parity with
-iperf3 — within run-to-run noise single-stream, and a few percent ahead at
-`-P 4`/`-P 8` in both directions.
+**Takeaway:** TCP is unchanged by the UDP work ([#6](https://github.com/therealevanhenry/riperf3/issues/6))
+and remains at parity with iperf3 — within run-to-run noise single-stream, and a
+few percent ahead at `-P 4`/`-P 8` in both directions.
 
 ## UDP (Gbps)
 

--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -14,19 +14,17 @@ host's virtio bridge.
 | Host | Intel i9-13900K, Linux 7.0.10-arch1-1 (Arch), KVM |
 | Guests | 2× Debian 13 (Trixie), Linux 6.12.74-cloud, 8 vCPU, 8 GB RAM each |
 | NIC | virtio-net (vhost=on), bridged, MTU 9000; IPv4 `172.20.0.0/24` + IPv6 `fd00:20::/64` |
-| riperf3 | 0.2.0 |
+| riperf3 | 0.4.0 |
 | iperf3 | 3.20+ (cJSON 1.7.15), built from source |
 | Per-run | `-t 10` (10 s), client→server unless noted |
 
-> This is a fuller per-`-P`/per-direction sweep than the summary table in the
-> README's Performance section; it's a different run, so absolute numbers
-> differ slightly from those round figures.
-
 Methodology: each cell is a single 10 s run, server started fresh (`-s -1`) per
-run on a unique port, every invocation wrapped in a hard `timeout` guard, with
-cleanup between rows. Reverse (`-R`) numbers are the client's *receive* rate;
-forward numbers are the client's *send* rate. UDP runs target `-b 100G` (i.e.
-"send as fast as possible").
+run on a unique port, with cleanup between rows. Reverse (`-R`) numbers are the
+client's *receive* rate; forward numbers are the client's *send* rate. UDP runs
+target `-b 100G` for riperf3 / `-b 0` for iperf3 (both "send as fast as
+possible"). With no `-l`, the UDP datagram size is now derived from the
+control-connection MSS (~8928 B on this jumbo-frame path) for both tools — see
+the datagram-size sweep below.
 
 ## TCP (Gbps)
 
@@ -34,24 +32,21 @@ forward numbers are the client's *send* rate. UDP runs target `-b 100G` (i.e.
 
 | -P | riperf3 IPv4 | iperf3 IPv4 | riperf3 IPv6 | iperf3 IPv6 |
 |----|-------------:|------------:|-------------:|------------:|
-| 1  | 73.4 | 74.8 | 74.7 | 76.2 |
-| 4  | 67.1 | 64.0 | 69.6 | 67.5 |
-| 8  | 61.6 | 50.8 | 63.5 | 51.0 |
+| 1  | 74.3 | 75.2 | 77.3 | 73.9 |
+| 4  | 67.3 | 66.2 | 67.1 | 64.9 |
+| 8  | 61.1 | 58.0 | 61.9 | 57.8 |
 
 ### Reverse (server → client, `-R`)
 
 | -P | riperf3 IPv4 | iperf3 IPv4 | riperf3 IPv6 | iperf3 IPv6 |
 |----|-------------:|------------:|-------------:|------------:|
-| 1  | 74.4 | 77.4 | 74.8 | 77.5 |
-| 4  | 67.3 | 65.8 | 67.1 | 64.9 |
-| 8  | 62.1 | 59.6 | 62.2 | 59.3 |
+| 1  | 75.6 | 77.3 | 77.3 | 76.9 |
+| 4  | 70.3 | 66.8 | 70.0 | 63.9 |
+| 8  | 62.5 | 59.4 | 62.0 | 58.5 |
 
-**Takeaway:** riperf3 is at parity with iperf3 single-stream. At `-P 8`
-*forward* it pulls ahead ~21–25% (61.6 vs 50.8 Gbps IPv4; 63.5 vs 51.0 IPv6);
-at `-P 8` *reverse* the two are roughly at parity (~4–5% ahead). IPv4/IPv6
-differences are within run-to-run noise for both tools (the largest single
-delta, iperf3 forward `-P 4`, is ~5%); riperf3 trends slightly faster on IPv6
-in the forward direction, but there's no penalty either way.
+**Takeaway:** TCP is unchanged by the 0.4.0 UDP work and remains at parity with
+iperf3 — within run-to-run noise single-stream, and a few percent ahead at
+`-P 4`/`-P 8` in both directions.
 
 ## UDP (Gbps)
 
@@ -59,26 +54,56 @@ in the forward direction, but there's no penalty either way.
 
 | -P | riperf3 IPv4 | iperf3 IPv4 | riperf3 IPv6 | iperf3 IPv6 |
 |----|-------------:|------------:|-------------:|------------:|
-| 1  | 17.4 | 31.7 | 15.9 | 33.4 |
-| 4  | 13.7 | 31.9 | 16.2 | 31.6 |
-| 8  |  8.4 | 30.5 |  8.2 | 30.2 |
+| 1  | 34.5 | 31.7 | 38.8 | 34.0 |
+| 4  | 33.4 | 32.1 | 34.3 | 31.5 |
+| 8  | 35.4 | 30.8 | 35.4 | 30.7 |
 
 ### Reverse (server → client, `-R`)
 
 | -P | riperf3 IPv4 | iperf3 IPv4 | riperf3 IPv6 | iperf3 IPv6 |
 |----|-------------:|------------:|-------------:|------------:|
-| 1  | 16.5 | 32.1 | 16.2 | 32.4 |
-| 4  | 13.9 | 29.3 | 14.3 | 32.4 |
-| 8  |  6.0 | 29.3 |  6.3 | 29.2 |
+| 1  | 31.8 | 28.5 | 33.6 | 31.6 |
+| 4  | 32.0 | 31.0 | 36.4 | 32.2 |
+| 8  | 33.0 | 29.9 | 33.6 | 30.0 |
 
-**Takeaway:** riperf3's UDP send path delivers roughly half of iperf3
-single-stream, and total throughput falls as `-P` rises rather than scaling —
-from ~17 Gbps at `-P 1` to ~8 Gbps at `-P 8` (per-stream rate craters to
-~1 Gbps), while iperf3 holds ~30 Gbps across all `-P`. The drop is already
-visible at `-P 4` (−12% to −21% per column, except forward-IPv6 which is flat)
-and pronounced by `-P 8`. This is a real efficiency bug in
-the busy-spin pacing path, not the memory-safety trade-off described in the
-README — tracked in [#6](https://github.com/therealevanhenry/riperf3/issues/6).
+**Takeaway:** riperf3's UDP path now meets or beats iperf3 in every cell, and
+total throughput holds steady across `-P` instead of collapsing. At `-P 8` it
+sustains ~35 Gbps forward (vs ~30.7 for iperf3) **at 0.00% loss**, where iperf3
+shows ~0.5–0.6% loss. This closes
+[#6](https://github.com/therealevanhenry/riperf3/issues/6).
+
+For reference, 0.3.0 (before the fix) on this same fleet, UDP forward IPv6:
+`-P 1` 15.9 Gbps, `-P 4` 16.2 Gbps, `-P 8` 8.2 Gbps — i.e. roughly half of
+iperf3 single-stream and *falling* with parallelism. Two changes fixed it:
+the default datagram size now tracks the control-socket MSS (it was pinned at
+1460 B), and the UDP sender/receiver sockets are now blocking, so the sender
+backpressures in-kernel instead of busy-spinning on `EAGAIN` (which had
+starved the runtime and contended for CPU as `-P` rose).
+
+### Datagram-size sweep (IPv6 forward, `-P 1`)
+
+Throughput scales with datagram size for both tools; the default (no `-l`)
+lands at the MSS (~8928 B). riperf3's `sendmmsg` batching pulls ahead of
+iperf3's per-datagram `send()` once datagrams are large; at the 1460 B floor
+the two are within noise.
+
+| `-l` (bytes) | riperf3 | iperf3 |
+|-------------:|--------:|-------:|
+| 1460 | 15.9 | 16.3 |
+| 4096 | 25.1 | 23.3 |
+| 8192 | 37.8 | 32.5 |
+| 8928 (≈MSS) | 39.0 | 33.3 |
+
+### Cross-compatibility (IPv6 forward, `-P 1`, default `-l`)
+
+Mixed client/server pairs confirm wire compatibility is preserved — the
+MSS-derived datagram size is carried in the param-exchange `len` field exactly
+as before:
+
+| client → server | sender rate |
+|---|---:|
+| riperf3 → iperf3 | 39.0 Gbps |
+| iperf3 → riperf3 | 33.6 Gbps |
 
 ## Not measured
 
@@ -86,16 +111,13 @@ README — tracked in [#6](https://github.com/therealevanhenry/riperf3/issues/6)
   summary lines differently, so a like-for-like aggregate needs a
   direction-aware parser this harness doesn't yet have. Spot-checked TCP
   `--bidir -P 1` shows ~43 Gbps *per direction* for both tools (≈86 Gbps
-  aggregate) — parity. Additionally, `riperf3 -u --bidir -P 8 -b 100G` hangs
-  (does not honor `-t`), tracked in
-  [#5](https://github.com/therealevanhenry/riperf3/issues/5).
+  aggregate) — parity. (The earlier `riperf3 -u --bidir -P 8 -b 100G` hang was
+  fixed in 0.3.0, [#5](https://github.com/therealevanhenry/riperf3/issues/5).)
 
 ## Reproducing
 
 Run from a host with the sandbox VM fleet up and both binaries deployed
 (`riperf3` and `iperf3` built from source on each guest). Start a fresh
-`-s -1` server per run on a unique port, wrap every client and server
-invocation in a `timeout` guard, and clean up stray processes between rows.
-For forward/reverse, parse the client's `sender`/`receiver` summary line
-respectively; sum per-stream lines for `-P > 1` (riperf3 emits no final
-`[SUM]` row for TCP — see [#4](https://github.com/therealevanhenry/riperf3/issues/4)).
+`-s -1` server per run on a unique port and clean up stray processes between
+rows. For forward/reverse, parse the client's `sender`/`receiver` summary line
+respectively; for `-P > 1` take the final `[SUM]` line (both tools emit one).

--- a/README.md
+++ b/README.md
@@ -68,10 +68,10 @@ Benchmarked on QEMU/KVM VMs with virtio-net (MTU 9000), 8 vCPUs, 8GB RAM:
 | TCP zerocopy | 73.6 Gbps | 76.1 Gbps | +3% |
 | TCP BBR | 63.1 Gbps | 60.6 Gbps | -4% |
 | TCP IPv6 | 78.7 Gbps | 76.0 Gbps | -3% |
-| UDP 10G | 10.0 Gbps | 10.7 Gbps | +7% |
-| UDP 50G | 29.9 Gbps | 17.5 Gbps | -41% |
+| UDP P1 | 34.0 Gbps | 38.8 Gbps | +14% |
+| UDP P8 | 30.7 Gbps | 35.4 Gbps | +15% |
 
-TCP performance is at parity with iperf3. Part of the UDP high-rate gap is the cost of safe Rust's `send()` path vs C's raw `write()` syscall, which the experimental `--sendmmsg` flag narrows by batching packets into a single kernel crossing (see below). Profiling also found an efficiency bug, though: the busy-spin pacing loop wastes CPU at high `-b`, so UDP throughput *falls* as `-P` rises instead of scaling — this is under investigation, not an inherent trade-off ([#6](https://github.com/therealevanhenry/riperf3/issues/6)).
+TCP and UDP are both at or above parity with iperf3. UDP single-stream and high-`-P` throughput were rebuilt in 0.4.0 ([#6](https://github.com/therealevanhenry/riperf3/issues/6)): with no `-l`, the datagram size now tracks the control-socket MSS (matching iperf3) instead of a 1460-byte floor, and the UDP sockets are blocking so the sender backpressures in-kernel rather than busy-spinning on `EAGAIN`. Throughput now holds steady across `-P` (at `-P 8`, 0.00% loss vs iperf3's ~0.5%) instead of collapsing. The experimental `--sendmmsg` batching extends the lead at large datagrams (see below).
 
 See [BENCHMARKS.md](https://github.com/therealevanhenry/riperf3/blob/main/BENCHMARKS.md) for a fuller per-`-P`, per-direction sweep.
 
@@ -135,7 +135,7 @@ Test parameters:
   -t, --time <secs>                  Test duration (default: 10)
   -n, --bytes <N[KMG]>              Bytes to transmit (instead of -t)
   -k, --blockcount <N[KMG]>         Blocks to transmit (instead of -t)
-  -l, --length <N[KMG]>             Buffer size (default: 128K TCP, 1460 UDP)
+  -l, --length <N[KMG]>             Buffer size (default: 128K TCP; UDP tracks MSS, else 1460)
   -P, --parallel <N>                 Parallel streams
   -R, --reverse                      Server sends, client receives
       --bidir                        Bidirectional test

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Benchmarked on QEMU/KVM VMs with virtio-net (MTU 9000), 8 vCPUs, 8GB RAM:
 | UDP P1 | 34.0 Gbps | 38.8 Gbps | +14% |
 | UDP P8 | 30.7 Gbps | 35.4 Gbps | +15% |
 
-TCP and UDP are both at or above parity with iperf3. UDP single-stream and high-`-P` throughput were rebuilt in 0.4.0 ([#6](https://github.com/therealevanhenry/riperf3/issues/6)): with no `-l`, the datagram size now tracks the control-socket MSS (matching iperf3) instead of a 1460-byte floor, and the UDP sockets are blocking so the sender backpressures in-kernel rather than busy-spinning on `EAGAIN`. Throughput now holds steady across `-P` (at `-P 8`, 0.00% loss vs iperf3's ~0.5%) instead of collapsing. The experimental `--sendmmsg` batching extends the lead at large datagrams (see below).
+TCP and UDP are both at or above parity with iperf3. UDP single-stream and high-`-P` throughput were rebuilt to close [#6](https://github.com/therealevanhenry/riperf3/issues/6): with no `-l`, the datagram size now tracks the control-socket MSS (matching iperf3) instead of a 1460-byte floor, and the UDP sockets are blocking so the sender backpressures in-kernel rather than busy-spinning on `EAGAIN`. Throughput now holds steady across `-P` (at `-P 8`, 0.00% loss vs iperf3's ~0.5%) instead of collapsing. The experimental `--sendmmsg` batching extends the lead at large datagrams (see below).
 
 See [BENCHMARKS.md](https://github.com/therealevanhenry/riperf3/blob/main/BENCHMARKS.md) for a fuller per-`-P`, per-direction sweep.
 

--- a/riperf3-cli/src/cli.rs
+++ b/riperf3-cli/src/cli.rs
@@ -122,7 +122,7 @@ pub struct Cli {
     #[arg(short = 'k', long, value_name = "count")]
     pub blockcount: Option<String>,
 
-    /// Length of buffer to read or write (default 128 KB for TCP, 1460 for UDP)
+    /// Length of buffer to read or write (default 128 KB for TCP; UDP tracks the connection MSS, else 1460)
     #[arg(short = 'l', long, value_name = "size")]
     pub length: Option<String>,
 

--- a/riperf3/src/client.rs
+++ b/riperf3/src/client.rs
@@ -23,6 +23,11 @@ pub struct Client {
     pub duration: u32,
     pub num_streams: u32,
     pub blksize: usize,
+    /// Whether `blksize` came from an explicit `-l`. When false for UDP, the
+    /// datagram size is derived from the control-socket MSS at run time
+    /// (iperf3 parity, issue #6) rather than using the `blksize` default.
+    /// Internal: set by the builder from whether `.blksize()` was called.
+    blksize_explicit: bool,
     pub reverse: bool,
     pub bidir: bool,
     pub omit: u32,
@@ -88,6 +93,16 @@ impl Client {
         .await?;
         net::configure_tcp_stream(&ctrl, true)?;
 
+        // Resolve the UDP datagram size now that the control connection exists:
+        // when `-l` wasn't given, derive it from the control-socket MSS so a
+        // jumbo-frame path uses large datagrams instead of the 1460 floor
+        // (iperf3 parity, issue #6). TCP keeps its own block size unchanged.
+        let blksize = if self.protocol == TransportProtocol::Udp && !self.blksize_explicit {
+            resolve_udp_blksize(None, net::tcp_maxseg(&ctrl))
+        } else {
+            self.blksize
+        };
+
         // Apply control connection options
         if let Some(ref dev) = self.bind_dev {
             net::set_bind_dev(&ctrl, dev)?;
@@ -120,12 +135,12 @@ impl Client {
 
             match state {
                 TestState::ParamExchange => {
-                    let params = self.build_params();
+                    let params = self.build_params(blksize);
                     protocol::send_params(&mut ctrl, &params).await?;
                 }
 
                 TestState::CreateStreams => {
-                    streams = self.create_streams(&cookie, &done, &start).await?;
+                    streams = self.create_streams(&cookie, &done, &start, blksize).await?;
                 }
 
                 TestState::TestStart => {
@@ -135,7 +150,7 @@ impl Client {
                 }
 
                 TestState::TestRunning => {
-                    self.run_test(&mut ctrl, &streams, &done).await?;
+                    self.run_test(&mut ctrl, &streams, &done, blksize).await?;
                     // Test finished — send TestEnd
                     protocol::send_state(&mut ctrl, TestState::TestEnd).await?;
                 }
@@ -147,7 +162,12 @@ impl Client {
                 }
 
                 TestState::DisplayResults => {
-                    self.print_results(&streams, cpu_start.as_ref(), server_results.as_ref());
+                    self.print_results(
+                        &streams,
+                        cpu_start.as_ref(),
+                        server_results.as_ref(),
+                        blksize,
+                    );
                     protocol::send_state(&mut ctrl, TestState::IperfDone).await?;
                     break; // test complete — server will close the connection
                 }
@@ -181,7 +201,7 @@ impl Client {
         })
     }
 
-    fn build_params(&self) -> TestParams {
+    fn build_params(&self, blksize: usize) -> TestParams {
         let mut p = TestParams::default();
         match self.protocol {
             TransportProtocol::Tcp => p.tcp = Some(true),
@@ -190,7 +210,7 @@ impl Client {
         p.time = Some(self.duration as i32);
         p.omit = Some(self.omit as i32);
         p.parallel = Some(self.num_streams as i32);
-        p.len = Some(self.blksize as i32);
+        p.len = Some(blksize as i32);
         if self.reverse {
             p.reverse = Some(true);
         }
@@ -250,6 +270,7 @@ impl Client {
         cookie: &[u8; protocol::COOKIE_SIZE],
         done: &Arc<AtomicBool>,
         start: &Arc<AtomicBool>,
+        blksize: usize,
     ) -> Result<Vec<DataStream>> {
         let mut streams = Vec::new();
 
@@ -331,7 +352,7 @@ impl Client {
                     let fp = self.file.as_ref().map(std::path::PathBuf::from);
 
                     let task = if is_sender {
-                        let buf = make_send_buffer(self.blksize, self.repeating_payload);
+                        let buf = make_send_buffer(blksize, self.repeating_payload);
                         let c = counters.clone();
                         let d = done.clone();
                         let zc = self.zerocopy;
@@ -352,7 +373,7 @@ impl Client {
                     } else {
                         let c = counters.clone();
                         let d = done.clone();
-                        let bs = self.blksize;
+                        let bs = blksize;
                         let srxc = self.skip_rx_copy;
                         tokio::spawn(async move {
                             stream::run_tcp_receiver(data_stream, c, bs, d, srxc, fp).await
@@ -383,7 +404,7 @@ impl Client {
 
                     // Apply GSO/GRO if requested (no-ops on non-Linux)
                     if self.gsro {
-                        let _ = net::set_udp_gso(&udp_sock, self.blksize as u16);
+                        let _ = net::set_udp_gso(&udp_sock, blksize as u16);
                         let _ = net::set_udp_gro(&udp_sock);
                     }
                     if self.tos != 0 {
@@ -400,7 +421,7 @@ impl Client {
                     let task = if is_sender {
                         let c = counters.clone();
                         let d = done.clone();
-                        let bs = self.blksize;
+                        let bs = blksize;
                         let rate = if self.bandwidth > 0 {
                             self.bandwidth
                         } else {
@@ -424,7 +445,7 @@ impl Client {
                     } else {
                         let c = counters.clone();
                         let d = done.clone();
-                        let bs = self.blksize;
+                        let bs = blksize;
                         let stats = Arc::new(Mutex::new(UdpRecvStats::new()));
                         let sc = stats.clone();
                         let u64bit = self.udp_counters_64bit;
@@ -462,6 +483,7 @@ impl Client {
         ctrl: &mut TcpStream,
         streams: &[DataStream],
         done: &Arc<AtomicBool>,
+        blksize: usize,
     ) -> Result<()> {
         // Spawn interval reporter (unless plain JSON output without streaming)
         let interval_secs = self.interval.unwrap_or(1.0);
@@ -544,7 +566,7 @@ impl Client {
                         .filter(|s| s.is_sender)
                         .map(|s| s.counters.bytes_sent())
                         .sum();
-                    let blocks = total_bytes / self.blksize as u64;
+                    let blocks = total_bytes / blksize as u64;
                     if blocks >= target {
                         break;
                     }
@@ -626,9 +648,10 @@ impl Client {
         streams: &[DataStream],
         cpu_start: Option<&CpuSnapshot>,
         remote_cpu: Option<&TestResultsJson>,
+        blksize: usize,
     ) {
         if self.json_output {
-            self.print_results_json(streams, cpu_start, remote_cpu);
+            self.print_results_json(streams, cpu_start, remote_cpu, blksize);
         } else {
             self.print_results_text(streams);
         }
@@ -680,6 +703,7 @@ impl Client {
         streams: &[DataStream],
         cpu_start: Option<&CpuSnapshot>,
         remote_cpu: Option<&TestResultsJson>,
+        blksize: usize,
     ) {
         let test_duration = self.duration as f64;
         let cpu_end = CpuSnapshot::now();
@@ -769,7 +793,7 @@ impl Client {
                 "test_start": {
                     "protocol": protocol_str,
                     "num_streams": self.num_streams,
-                    "blksize": self.blksize,
+                    "blksize": blksize,
                     "omit": self.omit,
                     "duration": self.duration,
                     "bytes": 0,
@@ -1308,6 +1332,7 @@ impl ClientBuilder {
             duration: self.duration,
             num_streams: self.num_streams,
             blksize: self.blksize.unwrap_or(default_blksize),
+            blksize_explicit: self.blksize.is_some(),
             reverse: self.reverse,
             bidir: self.bidir,
             omit: self.omit,

--- a/riperf3/src/net.rs
+++ b/riperf3/src/net.rs
@@ -381,6 +381,13 @@ pub fn tcp_maxseg(_stream: &TcpStream) -> Option<u32> {
 // UDP
 // ---------------------------------------------------------------------------
 
+/// Wall-clock bound a blocking UDP `sendmmsg`/`send` so a wedged link can't park
+/// the sender thread forever (the per-batch `done`/deadline checks only run
+/// between blocking calls). On expiry the syscall returns `EAGAIN`, which the
+/// sender treats as a zero-progress batch and loops to re-check those flags.
+#[cfg(unix)]
+const UDP_SEND_TIMEOUT_MS: u64 = 1000;
+
 /// Prepare a UDP socket for the blocking batched sender (issue #6).
 ///
 /// tokio sockets are non-blocking, and `into_std()` preserves that flag. A
@@ -388,14 +395,21 @@ pub fn tcp_maxseg(_stream: &TcpStream) -> Option<u32> {
 /// send buffer fills, redundantly re-staging the whole batch and starving the
 /// async runtime. Switching to blocking lets the kernel backpressure the
 /// sender thread instead. The `SO_SNDBUF` bump is best-effort (clamped by
-/// `net.core.wmem_max`); `SO_SNDTIMEO` bounds a wedged link to 1s so the
-/// sender's per-batch `done`/deadline checks still fire.
+/// `net.core.wmem_max`); `SO_SNDTIMEO` bounds a wedged link (see
+/// [`UDP_SEND_TIMEOUT_MS`]). Note: this is `SO_SNDTIMEO`, *not* the
+/// `TCP_USER_TIMEOUT` of [`set_snd_timeout`] (which is a no-op on UDP).
 #[cfg(unix)]
 pub fn configure_udp_sender(socket: &std::net::UdpSocket, sndbuf_target: usize) -> Result<()> {
+    use nix::sys::socket::{self, sockopt};
+    use nix::sys::time::TimeVal;
     socket.set_nonblocking(false)?;
     let sock = socket2::SockRef::from(socket);
     let _ = sock.set_send_buffer_size(sndbuf_target);
-    let _ = set_snd_timeout(socket, 1000);
+    let tv = TimeVal::new(
+        (UDP_SEND_TIMEOUT_MS / 1000) as libc::time_t,
+        ((UDP_SEND_TIMEOUT_MS % 1000) * 1000) as libc::suseconds_t,
+    );
+    let _ = socket::setsockopt(socket, sockopt::SendTimeout, &tv);
     Ok(())
 }
 
@@ -1010,6 +1024,24 @@ mod tests {
         assert!(
             !is_nonblocking(socket.as_raw_fd()),
             "sender socket must be switched to blocking"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn configure_udp_sender_sets_real_send_timeout() {
+        // Regression: a blocking sender needs a real SO_SNDTIMEO so a wedged
+        // link can't park the thread forever. TCP_USER_TIMEOUT (set_snd_timeout)
+        // is a no-op on UDP and would leave the timeout unset (#6 review).
+        use nix::sys::socket::{getsockopt, sockopt};
+        let socket = std::net::UdpSocket::bind("127.0.0.1:0").unwrap();
+        configure_udp_sender(&socket, 128 * 1460).unwrap();
+        let tv = getsockopt(&socket, sockopt::SendTimeout).unwrap();
+        assert!(
+            tv.tv_sec() > 0 || tv.tv_usec() > 0,
+            "SO_SNDTIMEO must be non-zero, got {}.{:06}",
+            tv.tv_sec(),
+            tv.tv_usec()
         );
     }
 

--- a/riperf3/src/net.rs
+++ b/riperf3/src/net.rs
@@ -912,6 +912,58 @@ mod tests {
         }
     }
 
+    // ---- tcp_maxseg + UDP sender socket tuning (issue #6) -----------------
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn tcp_maxseg_reports_mss_for_connected_stream() {
+        // A connected TCP stream exposes a positive MSS via TCP_MAXSEG — this
+        // is what the UDP datagram-size default is derived from (iperf3 parity).
+        let listener = tcp_listen(Some("127.0.0.1"), 0, None).await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let client_task =
+            tokio::spawn(
+                async move { tcp_connect("127.0.0.1", port, None, None, false, None).await.unwrap() },
+            );
+        let (_server, _) = listener.accept().await.unwrap();
+        let client = client_task.await.unwrap();
+
+        let mss = tcp_maxseg(&client);
+        assert!(
+            mss.is_some(),
+            "TCP_MAXSEG should be readable on a connected socket"
+        );
+        assert!(mss.unwrap() > 0, "MSS should be positive, got {mss:?}");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn configure_udp_sender_switches_to_blocking() {
+        // tokio sockets are non-blocking and into_std() keeps that flag; the
+        // blocking sender thread needs a blocking socket so sendmmsg
+        // backpressures in-kernel instead of busy-spinning on EAGAIN (#6).
+        use std::os::unix::io::AsRawFd;
+        let socket = std::net::UdpSocket::bind("127.0.0.1:0").unwrap();
+        socket.set_nonblocking(true).unwrap();
+        assert!(
+            is_nonblocking(socket.as_raw_fd()),
+            "precondition: socket starts non-blocking"
+        );
+
+        configure_udp_sender(&socket, 128 * 1460).unwrap();
+        assert!(
+            !is_nonblocking(socket.as_raw_fd()),
+            "sender socket must be switched to blocking"
+        );
+    }
+
+    #[cfg(unix)]
+    fn is_nonblocking(fd: std::os::unix::io::RawFd) -> bool {
+        // SAFETY: F_GETFL on a valid fd returns the file status flags.
+        let flags = unsafe { libc::fcntl(fd, libc::F_GETFL) };
+        flags >= 0 && (flags & libc::O_NONBLOCK) != 0
+    }
+
     #[cfg(target_os = "linux")]
     #[test]
     fn set_bind_dev_loopback() {

--- a/riperf3/src/net.rs
+++ b/riperf3/src/net.rs
@@ -346,9 +346,64 @@ pub fn configure_tcp_stream_full(
     Ok(())
 }
 
+/// Read the TCP maximum segment size (`TCP_MAXSEG`) of a connected stream.
+///
+/// iperf3 uses this to size UDP datagrams when `-l` is not given (issue #6): on
+/// a jumbo-frame path the control connection negotiates a large MSS, so UDP
+/// datagrams should be sized to match rather than pinned at 1460. Returns
+/// `None` when the option can't be read (non-Unix, or a getsockopt error).
+#[cfg(unix)]
+pub fn tcp_maxseg(stream: &TcpStream) -> Option<u32> {
+    use std::os::unix::io::AsRawFd;
+    let fd = stream.as_raw_fd();
+    let mut mss: libc::c_int = 0;
+    let mut len = std::mem::size_of::<libc::c_int>() as libc::socklen_t;
+    // SAFETY: `fd` is a valid connected TCP socket for the lifetime of `stream`;
+    // TCP_MAXSEG yields a single c_int and `len` matches the buffer size.
+    let rc = unsafe {
+        libc::getsockopt(
+            fd,
+            libc::IPPROTO_TCP,
+            libc::TCP_MAXSEG,
+            &mut mss as *mut libc::c_int as *mut libc::c_void,
+            &mut len,
+        )
+    };
+    (rc == 0 && mss > 0).then_some(mss as u32)
+}
+
+#[cfg(not(unix))]
+pub fn tcp_maxseg(_stream: &TcpStream) -> Option<u32> {
+    None
+}
+
 // ---------------------------------------------------------------------------
 // UDP
 // ---------------------------------------------------------------------------
+
+/// Prepare a UDP socket for the blocking batched sender (issue #6).
+///
+/// tokio sockets are non-blocking, and `into_std()` preserves that flag. A
+/// non-blocking socket makes `sendmmsg` busy-spin on `EAGAIN` once the (small)
+/// send buffer fills, redundantly re-staging the whole batch and starving the
+/// async runtime. Switching to blocking lets the kernel backpressure the
+/// sender thread instead. The `SO_SNDBUF` bump is best-effort (clamped by
+/// `net.core.wmem_max`); `SO_SNDTIMEO` bounds a wedged link to 1s so the
+/// sender's per-batch `done`/deadline checks still fire.
+#[cfg(unix)]
+pub fn configure_udp_sender(socket: &std::net::UdpSocket, sndbuf_target: usize) -> Result<()> {
+    socket.set_nonblocking(false)?;
+    let sock = socket2::SockRef::from(socket);
+    let _ = sock.set_send_buffer_size(sndbuf_target);
+    let _ = set_snd_timeout(socket, 1000);
+    Ok(())
+}
+
+#[cfg(not(unix))]
+pub fn configure_udp_sender(socket: &std::net::UdpSocket, _sndbuf_target: usize) -> Result<()> {
+    socket.set_nonblocking(false)?;
+    Ok(())
+}
 
 /// Bind a UDP socket. If `bind_addr` is `None`, uses `0.0.0.0` (or `[::]` for IPv6).
 pub async fn udp_bind(bind_addr: Option<&str>, port: u16, ipv6: bool) -> Result<UdpSocket> {
@@ -921,10 +976,11 @@ mod tests {
         // is what the UDP datagram-size default is derived from (iperf3 parity).
         let listener = tcp_listen(Some("127.0.0.1"), 0, None).await.unwrap();
         let port = listener.local_addr().unwrap().port();
-        let client_task =
-            tokio::spawn(
-                async move { tcp_connect("127.0.0.1", port, None, None, false, None).await.unwrap() },
-            );
+        let client_task = tokio::spawn(async move {
+            tcp_connect("127.0.0.1", port, None, None, false, None)
+                .await
+                .unwrap()
+        });
         let (_server, _) = listener.accept().await.unwrap();
         let client = client_task.await.unwrap();
 

--- a/riperf3/src/net.rs
+++ b/riperf3/src/net.rs
@@ -413,6 +413,9 @@ pub fn configure_udp_sender(socket: &std::net::UdpSocket, sndbuf_target: usize) 
     Ok(())
 }
 
+// Non-Unix: switch to blocking only. There's no portable SO_SNDTIMEO here, so a
+// wedged send can block until the link recovers; the per-batch deadline can't
+// fire mid-block. Acceptable given the sendmmsg fast path is Unix-only anyway.
 #[cfg(not(unix))]
 pub fn configure_udp_sender(socket: &std::net::UdpSocket, _sndbuf_target: usize) -> Result<()> {
     socket.set_nonblocking(false)?;

--- a/riperf3/src/stream.rs
+++ b/riperf3/src/stream.rs
@@ -825,7 +825,9 @@ pub fn run_udp_sender_sendmmsg(
                 seq -= unsent as u64;
             }
             Err(nix::errno::Errno::EAGAIN) => {
-                // All packets failed — rewind entire batch
+                // On a blocking socket this means the SO_SNDTIMEO set by
+                // configure_udp_sender fired (a wedged link) — send nothing,
+                // rewind the batch, and loop to re-check `done`/`deadline`.
                 seq -= batch_size as u64;
             }
             Err(e) => {

--- a/riperf3/src/stream.rs
+++ b/riperf3/src/stream.rs
@@ -752,9 +752,10 @@ pub fn run_udp_sender_sendmmsg(
     // Deadline measured from the actual start of data (issue #5): at a high
     // `-b` the CPU-bound senders can starve the async runtime so `done` is
     // never set; the sender must stop itself at `-t`. The deadline is checked
-    // once per batch, so worst-case overshoot is one batch interval — sub-ms at
-    // the high `-b` this guards against, larger at a low paced rate (where the
-    // runtime isn't starved and `done` fires normally anyway).
+    // once per batch — between blocking sendmmsg calls — so overshoot is bounded
+    // by how long one batch can block. On a draining link that's sub-ms; on a
+    // wedged link it's the SO_SNDTIMEO set by configure_udp_sender (~1s) before
+    // sendmmsg returns EAGAIN and the loop re-checks the deadline.
     let deadline = max_duration.map(|d| Instant::now() + d);
 
     // Larger batch than the per-packet sender: sendmmsg amortizes syscall

--- a/riperf3/src/stream.rs
+++ b/riperf3/src/stream.rs
@@ -757,10 +757,19 @@ pub fn run_udp_sender_sendmmsg(
     // runtime isn't starved and `done` fires normally anyway).
     let deadline = max_duration.map(|d| Instant::now() + d);
 
-    let fd = socket.as_raw_fd();
     // Larger batch than the per-packet sender: sendmmsg amortizes syscall
     // overhead so bigger batches help more than with individual send() calls.
     let batch_size: usize = if rate_bits_per_sec > 0 { 128 } else { 1 };
+
+    // Switch to blocking I/O — tokio's into_std() leaves the socket
+    // non-blocking, which makes sendmmsg busy-spin on EAGAIN once SO_SNDBUF
+    // fills (the batch is far larger than wmem_max), redundantly re-staging the
+    // whole batch and starving the async runtime. Blocking lets the kernel
+    // backpressure this thread instead; best-effort enlarge the buffer to a
+    // batch and bound a wedged link with SO_SNDTIMEO (issue #6).
+    crate::net::configure_udp_sender(&socket, batch_size * blksize)?;
+
+    let fd = socket.as_raw_fd();
 
     // Pre-allocate everything outside the hot loop
     let mut bufs: Vec<Vec<u8>> = (0..batch_size).map(|_| vec![0u8; blksize]).collect();
@@ -901,6 +910,10 @@ pub fn run_udp_sender_blocking(
         1
     };
 
+    // Blocking I/O so send() backpressures in-kernel instead of returning
+    // WouldBlock and truncating the batch once SO_SNDBUF fills (issue #6).
+    crate::net::configure_udp_sender(&socket, batch_size as usize * blksize)?;
+
     let pacing = if rate_bits_per_sec > 0 {
         let rate_bytes = rate_bits_per_sec as f64 / 8.0;
         let per_packet = Duration::from_secs_f64(blksize as f64 / rate_bytes);
@@ -979,6 +992,13 @@ pub fn run_udp_receiver_blocking(
     use_64bit: bool,
 ) -> Result<()> {
     let mut buf = vec![0u8; blksize.max(65536)];
+    // tokio's into_std() leaves the socket non-blocking, which makes the
+    // SO_RCVTIMEO below a no-op: recv() returns WouldBlock immediately and the
+    // loop busy-spins at 100% CPU. Switch to blocking so the read timeout
+    // actually parks the thread between datagrams (issue #6).
+    socket
+        .set_nonblocking(false)
+        .map_err(crate::error::RiperfError::Io)?;
     socket
         .set_read_timeout(Some(Duration::from_millis(500)))
         .map_err(crate::error::RiperfError::Io)?;

--- a/riperf3/src/utils.rs
+++ b/riperf3/src/utils.rs
@@ -110,6 +110,24 @@ pub fn iperf3_stream_id(index: u32) -> i32 {
 /// Maximum UDP payload: 65535 - 8 (UDP header) - 20 (IP header)
 pub const MAX_UDP_BLKSIZE: usize = 65507;
 
+/// Resolve the effective UDP datagram size.
+///
+/// Mirrors iperf3 (`iperf_client_api.c`): an explicit `-l` always wins;
+/// otherwise the size tracks the control-connection MSS, so a jumbo-frame path
+/// uses large datagrams instead of the conservative 1460 floor. The MSS is
+/// clamped to the valid UDP payload range, and falls back to
+/// [`DEFAULT_UDP_BLKSIZE`] when no usable MSS is available (e.g. non-Unix, or a
+/// nonsensically small value).
+pub fn resolve_udp_blksize(explicit: Option<usize>, ctrl_mss: Option<u32>) -> usize {
+    if let Some(size) = explicit {
+        return size;
+    }
+    match ctrl_mss {
+        Some(mss) if (mss as usize) >= MIN_UDP_BLKSIZE => (mss as usize).min(MAX_UDP_BLKSIZE),
+        _ => DEFAULT_UDP_BLKSIZE,
+    }
+}
+
 // ---------------------------------------------------------------------------
 // KMG suffix parser
 // ---------------------------------------------------------------------------

--- a/riperf3/src/utils.rs
+++ b/riperf3/src/utils.rs
@@ -263,6 +263,37 @@ mod tests {
         assert_eq!(parse_dscp("AF11").unwrap(), parse_dscp("af11").unwrap());
     }
 
+    // -- resolve_udp_blksize: MSS-derived default (issue #6) --
+
+    #[test]
+    fn resolve_udp_blksize_explicit_wins() {
+        // An explicit -l always takes precedence, even when an MSS is known.
+        assert_eq!(resolve_udp_blksize(Some(2000), Some(8928)), 2000);
+        assert_eq!(resolve_udp_blksize(Some(1460), None), 1460);
+    }
+
+    #[test]
+    fn resolve_udp_blksize_derives_from_mss() {
+        // No -l: track the control-connection MSS, like iperf3. On a jumbo path
+        // this yields large datagrams instead of the conservative 1460 floor.
+        assert_eq!(resolve_udp_blksize(None, Some(8928)), 8928);
+        assert_eq!(resolve_udp_blksize(None, Some(1448)), 1448);
+    }
+
+    #[test]
+    fn resolve_udp_blksize_falls_back_without_mss() {
+        // No -l and no MSS available (e.g. non-Unix): historical 1460 default.
+        assert_eq!(resolve_udp_blksize(None, None), DEFAULT_UDP_BLKSIZE);
+    }
+
+    #[test]
+    fn resolve_udp_blksize_clamps_to_udp_bounds() {
+        // A bogus huge MSS is clamped to the max UDP payload; a sub-header MSS
+        // falls back to the safe default rather than producing tiny datagrams.
+        assert_eq!(resolve_udp_blksize(None, Some(70_000)), MAX_UDP_BLKSIZE);
+        assert_eq!(resolve_udp_blksize(None, Some(8)), DEFAULT_UDP_BLKSIZE);
+    }
+
     // -- make_send_buffer edge cases --
 
     #[test]


### PR DESCRIPTION
Closes #6.

## Problem

riperf3's UDP send path delivered ~half of iperf3 single-stream and *collapsed*
as `-P` rose (per-stream rate cratered). On the jumbo-frame (MTU 9000) sandbox
fleet, UDP forward IPv6 measured 15.9 Gbps at `-P 1` and **8.2 Gbps at `-P 8``.

## Root cause (refined from the issue's hypothesis)

#6 guessed the *pacing* busy-spin. Profiling on the VMs found two different,
additive causes:

1. **Default datagram size.** iperf3 sizes UDP datagrams to the control-socket
   TCP MSS when `-l` is unset (`iperf_client_api.c`); riperf3 hardcoded 1460. On
   a jumbo path iperf3 sent ~8928 B datagrams (≈33 Gbps) vs riperf3's 1460 B
   (≈16 Gbps) — same per-packet rate, ~6× the packets.
2. **Non-blocking sockets.** tokio's `into_std()` leaves the UDP socket
   non-blocking. A 128×blksize `sendmmsg` batch (~1.1 MB) against the ~208 KB
   `wmem_max` cap landed only a fraction per call, then **busy-spun on `EAGAIN`**
   re-staging the whole batch — burning CPU and starving the async runtime
   (this *is* the spin #6 saw, but on `EAGAIN`, not the pacer). The receiver had
   the mirror bug: `SO_RCVTIMEO` is a no-op on a non-blocking socket, so `recv()`
   spun at 100% CPU.

## Fix

- `net::tcp_maxseg()` reads `TCP_MAXSEG` off the control connection;
  `utils::resolve_udp_blksize()` derives the UDP default from it (clamped to the
  UDP payload range, 1460 fallback). An explicit `-l` is honored verbatim.
- `net::configure_udp_sender()` switches the sender socket to **blocking** (the
  kernel backpressures the thread instead of spinning), best-effort enlarges
  `SO_SNDBUF`, and bounds a wedged link with `SO_SNDTIMEO`. The receiver is set
  blocking so its read timeout works.

Blocking I/O also de-starves the runtime, reinforcing the #5/#9 fixes.

## Wire compatibility

Preserved. The negotiated datagram size travels in the param-exchange `len`
field exactly as before — only the client's *default* choice changed. Blocking
I/O is sender-internal. Verified both directions: riperf3→iperf3 39.0 Gbps,
iperf3→riperf3 33.6 Gbps.

## Results (`-t 10`, jumbo fleet, default `-l`)

UDP forward, Gbps:

| -P | riperf3 v4 | iperf3 v4 | riperf3 v6 | iperf3 v6 |
|----|-----------:|----------:|-----------:|----------:|
| 1  | 34.5 | 31.7 | 38.8 | 34.0 |
| 4  | 33.4 | 32.1 | 34.3 | 31.5 |
| 8  | 35.4 | 30.8 | 35.4 | 30.7 |

`-P 8` is now ~35 Gbps at **0.00% loss** (iperf3 ~0.5–0.6%), up from 8.2 Gbps.
TCP is unchanged (confirmed at parity). Full matrix + datagram-size sweep in
`BENCHMARKS.md`.

## Tests (written first, TDD)

- `utils::resolve_udp_blksize_*` — explicit wins, MSS-derived, clamps, fallback.
- `net::tcp_maxseg_reports_mss_for_connected_stream`.
- `net::configure_udp_sender_switches_to_blocking`.

All 314 tests pass; clippy + fmt clean.

## Note on versioning

Adds a private `Client::blksize_explicit` field (to distinguish an explicit
`-l` from the default at run time, mirroring iperf3's `blksize==0` sentinel). A
field addition is breaking under 0.x struct-literal rules — same class as the
0.3.0 `Server::ip_version` addition — so this targets a **0.4.0** release.

## Known trade-off

Explicit `-l 1460` single-stream dips ~8% (15.9 → ~14.7 vs iperf3 16.3): the
inherent cost of correct in-kernel backpressure vs hot-spinning at high pps. A
non-default config; every default and large-datagram case wins decisively.
