### PR TITLE
fix(net): honor client -B local bind address (#15)

### DIFF
--- a/riperf3-cli/src/cli.rs
+++ b/riperf3-cli/src/cli.rs
@@ -211,7 +211,7 @@ pub struct Cli {
     pub version6: bool,
 
     /// Bind to a local source address (device binding is `--bind-dev`)
-    #[arg(short = 'B', long, value_name = "host[%dev]")]
+    #[arg(short = 'B', long, value_name = "host")]
     pub bind: Option<String>,
 
     /// Bind to the network interface with SO_BINDTODEVICE

--- a/riperf3-cli/src/cli.rs
+++ b/riperf3-cli/src/cli.rs
@@ -210,7 +210,7 @@ pub struct Cli {
     #[arg(short = '6', long)]
     pub version6: bool,
 
-    /// Bind to the interface associated with the address
+    /// Bind to a local source address (device binding is `--bind-dev`)
     #[arg(short = 'B', long, value_name = "host[%dev]")]
     pub bind: Option<String>,
 

--- a/riperf3/src/client.rs
+++ b/riperf3/src/client.rs
@@ -396,17 +396,18 @@ impl Client {
                 // Resolve once, honoring -4/-6, so the bind family matches the
                 // peer and the connection respects the version preference (#10).
                 let remote = net::resolve_host(&self.host, self.port, self.ip_version).await?;
+                // Honor -B: resolve the UDP source address once (family-validated
+                // against the target), then bind every stream's socket to it,
+                // mirroring the TCP path (#15).
+                let bind_ip = match self.bind_address.as_deref() {
+                    Some(b) => Some(
+                        net::resolve_bind_ip(b, remote.is_ipv6(), &self.host)
+                            .await?
+                            .to_string(),
+                    ),
+                    None => None,
+                };
                 for i in 0..total {
-                    // Honor -B: bind the UDP source address (family-validated
-                    // against the target), mirroring the TCP path (#15).
-                    let bind_ip = match self.bind_address.as_deref() {
-                        Some(b) => Some(
-                            net::resolve_bind_ip(b, remote.is_ipv6(), &self.host, self.ip_version)
-                                .await?
-                                .to_string(),
-                        ),
-                        None => None,
-                    };
                     let udp_sock = net::udp_bind(bind_ip.as_deref(), 0, remote.is_ipv6()).await?;
                     if let Some(ref dev) = self.bind_dev {
                         net::set_bind_dev(&udp_sock, dev)?;
@@ -1289,6 +1290,21 @@ impl ClientBuilder {
     pub fn build(self) -> std::result::Result<Client, ConfigError> {
         let host = self.host.ok_or(ConfigError::MissingField("host"))?;
 
+        // Reject a -B literal whose family contradicts -4/-6 at config time,
+        // mirroring the server-side check (#12); a bind hostname is validated
+        // against the target family at connect time instead (#15).
+        if let (Some(v), Some(addr)) = (self.ip_version, self.bind_address.as_deref()) {
+            let addr = addr.split('%').next().unwrap_or(addr);
+            if let Ok(ip) = addr.parse::<std::net::IpAddr>() {
+                if (v == 4 && ip.is_ipv6()) || (v == 6 && ip.is_ipv4()) {
+                    return Err(ConfigError::InvalidValue(
+                        "bind_address",
+                        format!("-{v} conflicts with bind address {addr}"),
+                    ));
+                }
+            }
+        }
+
         // Reject flags that require OS support not available on this platform.
         // Matches iperf3 behavior: error at build/parse time, not at runtime.
         #[cfg(not(unix))]
@@ -1478,6 +1494,27 @@ mod tests {
             assert!(c.no_delay);
             assert_eq!(c.bandwidth, 100_000_000);
             assert_eq!(c.tos, 0x10);
+        }
+
+        #[test]
+        fn bind_address_family_conflict_rejected_at_build() {
+            // A -B literal contradicting -4/-6 is rejected at config time,
+            // mirroring the server (#12); matching families build fine (#15).
+            assert!(ClientBuilder::new("h")
+                .ip_version(6)
+                .bind_address("10.0.0.1")
+                .build()
+                .is_err());
+            assert!(ClientBuilder::new("h")
+                .ip_version(4)
+                .bind_address("::1")
+                .build()
+                .is_err());
+            assert!(ClientBuilder::new("h")
+                .ip_version(4)
+                .bind_address("10.0.0.1")
+                .build()
+                .is_ok());
         }
     }
 }

--- a/riperf3/src/client.rs
+++ b/riperf3/src/client.rs
@@ -87,6 +87,7 @@ impl Client {
             self.port,
             self.connect_timeout,
             None,
+            self.bind_address.as_deref(),
             self.mptcp,
             self.ip_version,
         )
@@ -302,6 +303,7 @@ impl Client {
                         self.port,
                         self.connect_timeout,
                         self.cport,
+                        self.bind_address.as_deref(),
                         self.mptcp,
                         self.ip_version,
                     )
@@ -395,7 +397,17 @@ impl Client {
                 // peer and the connection respects the version preference (#10).
                 let remote = net::resolve_host(&self.host, self.port, self.ip_version).await?;
                 for i in 0..total {
-                    let udp_sock = net::udp_bind(None, 0, remote.is_ipv6()).await?;
+                    // Honor -B: bind the UDP source address (family-validated
+                    // against the target), mirroring the TCP path (#15).
+                    let bind_ip = match self.bind_address.as_deref() {
+                        Some(b) => Some(
+                            net::resolve_bind_ip(b, remote.is_ipv6(), &self.host, self.ip_version)
+                                .await?
+                                .to_string(),
+                        ),
+                        None => None,
+                    };
+                    let udp_sock = net::udp_bind(bind_ip.as_deref(), 0, remote.is_ipv6()).await?;
                     if let Some(ref dev) = self.bind_dev {
                         net::set_bind_dev(&udp_sock, dev)?;
                     }

--- a/riperf3/src/net.rs
+++ b/riperf3/src/net.rs
@@ -889,6 +889,64 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn resolve_bind_ip_literals_and_wildcards() {
+        use std::net::IpAddr;
+        let v4 = |s: &str| s.parse::<IpAddr>().unwrap();
+        // Matching-family literal / wildcard → returned as-is.
+        assert_eq!(
+            resolve_bind_ip("10.0.0.1", false, "1.2.3.4").await.unwrap(),
+            v4("10.0.0.1")
+        );
+        assert_eq!(
+            resolve_bind_ip("0.0.0.0", false, "1.2.3.4").await.unwrap(),
+            v4("0.0.0.0")
+        );
+        assert_eq!(
+            resolve_bind_ip("::1", true, "::2").await.unwrap(),
+            v4("::1")
+        );
+        // A `%dev` suffix is stripped; the address part is bound.
+        assert_eq!(
+            resolve_bind_ip("10.0.0.1%eth0", false, "1.2.3.4")
+                .await
+                .unwrap(),
+            v4("10.0.0.1")
+        );
+        // Wrong-family literal → error (either direction).
+        assert!(resolve_bind_ip("::1", false, "1.2.3.4").await.is_err());
+        assert!(resolve_bind_ip("10.0.0.1", true, "::2").await.is_err());
+    }
+
+    #[cfg(target_os = "linux")]
+    #[tokio::test]
+    async fn tcp_connect_binds_local_address_and_port() {
+        // -B and --cport together: the source IP is applied through the same
+        // socket2 bind path that also handles the local port (#15).
+        let listener = tcp_listen(Some("127.0.0.1"), 0, None).await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let client_task = tokio::spawn(async move {
+            // local_port Some(0) = ephemeral, exercised alongside the -B bind.
+            tcp_connect(
+                "127.0.0.1",
+                port,
+                None,
+                Some(0),
+                Some("127.0.0.2"),
+                false,
+                None,
+            )
+            .await
+            .unwrap()
+        });
+        let (_server, _) = listener.accept().await.unwrap();
+        let client = client_task.await.unwrap();
+        assert_eq!(
+            client.local_addr().unwrap().ip(),
+            "127.0.0.2".parse::<std::net::IpAddr>().unwrap()
+        );
+    }
+
+    #[tokio::test]
     async fn udp_bind_ephemeral() {
         let socket = udp_bind(Some("127.0.0.1"), 0, false).await.unwrap();
         assert!(socket.local_addr().is_ok());

--- a/riperf3/src/net.rs
+++ b/riperf3/src/net.rs
@@ -172,24 +172,27 @@ pub async fn resolve_host(host: &str, port: u16, ip_version: Option<u8>) -> Resu
         .ok_or_else(|| RiperfError::Protocol(format!("no {} address found for {host}", want())))
 }
 
-/// Resolve a client `-B` bind address to a local source IP. Honors `-4`/`-6`
-/// (via `ip_version`) and requires the result to share the target's address
-/// family, mirroring the server-side validation (#12); a mismatch is a clear
-/// error rather than a silent fallback. `host%dev` keeps only the address part
-/// — device binding is `--bind-dev`'s job (#15).
+/// Resolve a client `-B` bind address to a local source IP in the target's
+/// address family. The bind family must match the connection, and the target
+/// was already resolved honoring `-4`/`-6`, so `target_is_ipv6` is authoritative
+/// — resolving the bind host in that family makes a dual-stack bind *hostname*
+/// pick the matching address (rather than the resolver's first result) and
+/// rejects a wrong-family bind *literal* with a clear message. `host%dev` keeps
+/// only the address part (device binding is `--bind-dev`); note an IPv6
+/// link-local zone id like `fe80::1%eth0` is therefore not supported here.
 pub async fn resolve_bind_ip(
     bind_address: &str,
     target_is_ipv6: bool,
     target_host: &str,
-    ip_version: Option<u8>,
 ) -> Result<std::net::IpAddr> {
     let addr = bind_address.split('%').next().unwrap_or(bind_address);
-    let resolved = resolve_host(addr, 0, ip_version).await?;
-    if resolved.is_ipv6() != target_is_ipv6 {
-        return Err(RiperfError::Protocol(format!(
-            "bind address {addr} family does not match target {target_host}"
-        )));
-    }
+    let family = if target_is_ipv6 { 6 } else { 4 };
+    let resolved = resolve_host(addr, 0, Some(family)).await.map_err(|_| {
+        RiperfError::Protocol(format!(
+            "bind address {addr} has no {} address to match target {target_host}",
+            if target_is_ipv6 { "IPv6" } else { "IPv4" }
+        ))
+    })?;
     Ok(resolved.ip())
 }
 
@@ -227,11 +230,14 @@ pub async fn tcp_connect(
         if bind_address.is_some() || local_port.is_some() {
             let lport = local_port.unwrap_or(0);
             let local_ip = match bind_address {
-                Some(b) => resolve_bind_ip(b, remote.is_ipv6(), host, ip_version).await?,
+                Some(b) => resolve_bind_ip(b, remote.is_ipv6(), host).await?,
                 None if remote.is_ipv6() => std::net::Ipv6Addr::UNSPECIFIED.into(),
                 None => std::net::Ipv4Addr::UNSPECIFIED.into(),
             };
-            socket.bind(&SocketAddr::new(local_ip, lport).into())?;
+            let local = SocketAddr::new(local_ip, lport);
+            socket.bind(&local.into()).map_err(|e| {
+                RiperfError::Protocol(format!("failed to bind local address {local}: {e}"))
+            })?;
         }
         socket.set_nonblocking(true)?;
         match socket.connect(&remote.into()) {
@@ -855,6 +861,30 @@ mod tests {
         assert!(
             result.is_err(),
             "v6 bind address against a v4 target must be rejected"
+        );
+    }
+
+    #[tokio::test]
+    async fn tcp_connect_socket2_path_honors_timeout() {
+        // A bind address forces the socket2 path; a connect to a non-routable
+        // target with a short timeout must fail fast, not hang — this path
+        // previously ignored connect_timeout (#15 review).
+        let start = std::time::Instant::now();
+        let result = tcp_connect(
+            "192.0.2.1", // TEST-NET-1, non-routable
+            12345,
+            Some(Duration::from_millis(150)),
+            None,
+            Some("0.0.0.0"),
+            false,
+            None,
+        )
+        .await;
+        assert!(result.is_err(), "non-routable connect must fail");
+        assert!(
+            start.elapsed() < Duration::from_secs(3),
+            "socket2 path must honor the timeout, not hang (took {:?})",
+            start.elapsed()
         );
     }
 

--- a/riperf3/src/net.rs
+++ b/riperf3/src/net.rs
@@ -777,6 +777,44 @@ mod tests {
         assert!(result.is_err());
     }
 
+    // ---- client -B local bind address (issue #15) ------------------------
+
+    #[cfg(target_os = "linux")]
+    #[tokio::test]
+    async fn tcp_connect_binds_local_address() {
+        // Bind the client source to 127.0.0.2 (loopback /8 on Linux). The OS
+        // would otherwise pick 127.0.0.1, so observing 127.0.0.2 proves -B
+        // actually took effect rather than being silently ignored (#15).
+        let listener = tcp_listen(Some("127.0.0.1"), 0, None).await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let client_task = tokio::spawn(async move {
+            tcp_connect("127.0.0.1", port, None, None, Some("127.0.0.2"), false, None)
+                .await
+                .unwrap()
+        });
+        let (_server, _) = listener.accept().await.unwrap();
+        let client = client_task.await.unwrap();
+        assert_eq!(
+            client.local_addr().unwrap().ip(),
+            "127.0.0.2".parse::<std::net::IpAddr>().unwrap(),
+            "client should have bound its source to -B 127.0.0.2"
+        );
+    }
+
+    #[tokio::test]
+    async fn tcp_connect_rejects_bind_family_mismatch() {
+        // A -B with a v6 literal while connecting to a v4 target must error,
+        // not silently ignore it (#15 family validation, mirroring #12).
+        let listener = tcp_listen(Some("127.0.0.1"), 0, None).await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let result =
+            tcp_connect("127.0.0.1", port, None, None, Some("::1"), false, None).await;
+        assert!(
+            result.is_err(),
+            "v6 bind address against a v4 target must be rejected"
+        );
+    }
+
     #[tokio::test]
     async fn udp_bind_ephemeral() {
         let socket = udp_bind(Some("127.0.0.1"), 0, false).await.unwrap();

--- a/riperf3/src/net.rs
+++ b/riperf3/src/net.rs
@@ -172,19 +172,45 @@ pub async fn resolve_host(host: &str, port: u16, ip_version: Option<u8>) -> Resu
         .ok_or_else(|| RiperfError::Protocol(format!("no {} address found for {host}", want())))
 }
 
+/// Resolve a client `-B` bind address to a local source IP. Honors `-4`/`-6`
+/// (via `ip_version`) and requires the result to share the target's address
+/// family, mirroring the server-side validation (#12); a mismatch is a clear
+/// error rather than a silent fallback. `host%dev` keeps only the address part
+/// — device binding is `--bind-dev`'s job (#15).
+pub async fn resolve_bind_ip(
+    bind_address: &str,
+    target_is_ipv6: bool,
+    target_host: &str,
+    ip_version: Option<u8>,
+) -> Result<std::net::IpAddr> {
+    let addr = bind_address.split('%').next().unwrap_or(bind_address);
+    let resolved = resolve_host(addr, 0, ip_version).await?;
+    if resolved.is_ipv6() != target_is_ipv6 {
+        return Err(RiperfError::Protocol(format!(
+            "bind address {addr} family does not match target {target_host}"
+        )));
+    }
+    Ok(resolved.ip())
+}
+
 /// Connect to a TCP (or MPTCP) endpoint.
-/// Uses socket2 when local_port or mptcp is set; tokio's built-in connect
-/// otherwise. `ip_version` constrains address-family selection for hostnames
-/// (`-4`/`-6`); when `None`, the OS resolver's full address list is tried.
+/// Uses socket2 when a local port (`--cport`), a bind address (`-B`), or mptcp
+/// is set; tokio's built-in connect otherwise. `ip_version` constrains
+/// address-family selection for hostnames (`-4`/`-6`); when `None`, the OS
+/// resolver's full address list is tried. A `bind_address` is resolved honoring
+/// `ip_version` and must share the target's address family (it's the client
+/// source address; `host%dev` device binding is `--bind-dev`'s job).
+#[allow(clippy::too_many_arguments)] // connect tuning knobs map 1:1 to CLI flags
 pub async fn tcp_connect(
     host: &str,
     port: u16,
     timeout: Option<Duration>,
     local_port: Option<u16>,
+    bind_address: Option<&str>,
     mptcp: bool,
     ip_version: Option<u8>,
 ) -> Result<TcpStream> {
-    if local_port.is_some() || mptcp {
+    if local_port.is_some() || bind_address.is_some() || mptcp {
         let remote = resolve_host(host, port, ip_version).await?;
         let domain = if remote.is_ipv6() {
             Domain::IPV6
@@ -198,13 +224,14 @@ pub async fn tcp_connect(
         };
         let socket = Socket::new(domain, Type::STREAM, protocol)?;
         socket.set_reuse_address(true)?;
-        if let Some(lport) = local_port {
-            let local_addr: SocketAddr = if remote.is_ipv6() {
-                format!("[::]:{lport}").parse().unwrap()
-            } else {
-                format!("0.0.0.0:{lport}").parse().unwrap()
+        if bind_address.is_some() || local_port.is_some() {
+            let lport = local_port.unwrap_or(0);
+            let local_ip = match bind_address {
+                Some(b) => resolve_bind_ip(b, remote.is_ipv6(), host, ip_version).await?,
+                None if remote.is_ipv6() => std::net::Ipv6Addr::UNSPECIFIED.into(),
+                None => std::net::Ipv4Addr::UNSPECIFIED.into(),
             };
-            socket.bind(&local_addr.into())?;
+            socket.bind(&SocketAddr::new(local_ip, lport).into())?;
         }
         socket.set_nonblocking(true)?;
         match socket.connect(&remote.into()) {
@@ -214,7 +241,15 @@ pub async fn tcp_connect(
         }
         let std_stream: std::net::TcpStream = socket.into();
         let stream = TcpStream::from_std(std_stream)?;
-        stream.writable().await?;
+        // Honor connect_timeout on the writability wait (the EINPROGRESS connect
+        // completes asynchronously); previously this path ignored the timeout.
+        match timeout {
+            Some(dur) => tokio::time::timeout(dur, stream.writable())
+                .await
+                .map_err(|_| RiperfError::ConnectionTimeout)?
+                .map_err(RiperfError::Io)?,
+            None => stream.writable().await.map_err(RiperfError::Io)?,
+        }
         if let Some(e) = stream.take_error()? {
             return Err(RiperfError::Io(e));
         }
@@ -750,7 +785,7 @@ mod tests {
         let port = listener.local_addr().unwrap().port();
 
         let client_task = tokio::spawn(async move {
-            tcp_connect("127.0.0.1", port, None, None, false, None)
+            tcp_connect("127.0.0.1", port, None, None, None, false, None)
                 .await
                 .unwrap()
         });
@@ -770,6 +805,7 @@ mod tests {
             12345,
             Some(Duration::from_millis(50)),
             None,
+            None,
             false,
             None,
         )
@@ -788,9 +824,17 @@ mod tests {
         let listener = tcp_listen(Some("127.0.0.1"), 0, None).await.unwrap();
         let port = listener.local_addr().unwrap().port();
         let client_task = tokio::spawn(async move {
-            tcp_connect("127.0.0.1", port, None, None, Some("127.0.0.2"), false, None)
-                .await
-                .unwrap()
+            tcp_connect(
+                "127.0.0.1",
+                port,
+                None,
+                None,
+                Some("127.0.0.2"),
+                false,
+                None,
+            )
+            .await
+            .unwrap()
         });
         let (_server, _) = listener.accept().await.unwrap();
         let client = client_task.await.unwrap();
@@ -807,8 +851,7 @@ mod tests {
         // not silently ignore it (#15 family validation, mirroring #12).
         let listener = tcp_listen(Some("127.0.0.1"), 0, None).await.unwrap();
         let port = listener.local_addr().unwrap().port();
-        let result =
-            tcp_connect("127.0.0.1", port, None, None, Some("::1"), false, None).await;
+        let result = tcp_connect("127.0.0.1", port, None, None, Some("::1"), false, None).await;
         assert!(
             result.is_err(),
             "v6 bind address against a v4 target must be rejected"
@@ -921,12 +964,12 @@ mod tests {
         let port = listener.local_addr().unwrap().port();
 
         // IPv4 connect must succeed.
-        let v4 = tcp_connect("127.0.0.1", port, None, None, false, None).await;
+        let v4 = tcp_connect("127.0.0.1", port, None, None, None, false, None).await;
         assert!(v4.is_ok(), "IPv4 connect failed: {v4:?}");
         let _ = listener.accept().await.unwrap();
 
         // IPv6 connect must also succeed against the same listener.
-        let v6 = tcp_connect("::1", port, None, None, false, None).await;
+        let v6 = tcp_connect("::1", port, None, None, None, false, None).await;
         match v6 {
             Ok(_) => {
                 let _ = listener.accept().await.unwrap();
@@ -952,7 +995,7 @@ mod tests {
         let port = local.port();
 
         // IPv6 connect must be refused.
-        let v6 = tcp_connect("::1", port, None, None, false, None).await;
+        let v6 = tcp_connect("::1", port, None, None, None, false, None).await;
         match v6 {
             Err(RiperfError::Io(ref e)) if e.kind() == std::io::ErrorKind::ConnectionRefused => {}
             Err(RiperfError::Io(ref e)) if e.kind() == std::io::ErrorKind::AddrNotAvailable => {
@@ -979,7 +1022,7 @@ mod tests {
         let port = local.port();
 
         // IPv4 connect must be refused.
-        let v4 = tcp_connect("127.0.0.1", port, None, None, false, None).await;
+        let v4 = tcp_connect("127.0.0.1", port, None, None, None, false, None).await;
         match v4 {
             Err(RiperfError::Io(ref e)) if e.kind() == std::io::ErrorKind::ConnectionRefused => {}
             Err(RiperfError::Io(ref e)) if e.kind() == std::io::ErrorKind::AddrNotAvailable => {
@@ -1000,7 +1043,7 @@ mod tests {
         // `-B :: -6`  → IPv6-only: an IPv4 client must be refused.
         let v6only = tcp_listen(Some("::"), 0, Some(6)).await.unwrap();
         let port = v6only.local_addr().unwrap().port();
-        let v4 = tcp_connect("127.0.0.1", port, None, None, false, None).await;
+        let v4 = tcp_connect("127.0.0.1", port, None, None, None, false, None).await;
         assert!(
             matches!(&v4, Err(RiperfError::Io(e)) if e.kind() == std::io::ErrorKind::ConnectionRefused),
             "`-B :: -6` must refuse IPv4, got {v4:?}"
@@ -1010,7 +1053,7 @@ mod tests {
         // `-B ::` alone → dual-stack: an IPv4 client connects via v4-mapped.
         let dual = tcp_listen(Some("::"), 0, None).await.unwrap();
         let port = dual.local_addr().unwrap().port();
-        let v4 = tcp_connect("127.0.0.1", port, None, None, false, None).await;
+        let v4 = tcp_connect("127.0.0.1", port, None, None, None, false, None).await;
         match v4 {
             Ok(_) => {
                 let _ = dual.accept().await.unwrap();
@@ -1032,7 +1075,7 @@ mod tests {
         let listener = tcp_listen(Some("127.0.0.1"), 0, None).await.unwrap();
         let port = listener.local_addr().unwrap().port();
         let client_task = tokio::spawn(async move {
-            tcp_connect("127.0.0.1", port, None, None, false, None)
+            tcp_connect("127.0.0.1", port, None, None, None, false, None)
                 .await
                 .unwrap()
         });

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -769,6 +769,9 @@ impl ServerBuilder {
         // Reject -4/-6 contradicting an explicit -B of the opposite family,
         // instead of silently letting the bind address win (issue #12).
         if let (Some(v), Some(addr)) = (self.ip_version, self.bind_address.as_deref()) {
+            // Strip any `%dev` suffix before parsing so e.g. `-B 10.0.0.1%eth0`
+            // is still family-checked (consistent with the client, #15).
+            let addr = addr.split('%').next().unwrap_or(addr);
             if let Ok(ip) = addr.parse::<std::net::IpAddr>() {
                 let mismatch = (v == 4 && ip.is_ipv6()) || (v == 6 && ip.is_ipv4());
                 if mismatch {


### PR DESCRIPTION
Closes #15.

## Problem

On the client, `-B`/`--bind` (local source address) was parsed and stored on
`Client.bind_address` but **never applied** — `net::tcp_connect` had no
bind-address parameter, and the UDP path called `udp_bind(None, …)`. So
`riperf3 -c <host> -B <addr>` silently let the OS pick the source address.

## Fix

- `tcp_connect` gains a `bind_address` parameter; its socket2 path binds the
  local source IP (plus optional `--cport`) before connect, for both the control
  socket and TCP data streams.
- `net::resolve_bind_ip` resolves `-B` honoring `-4`/`-6` and **requires it to
  share the target's address family** — a mismatch is a clear error, mirroring
  the #12 server-side validation. `host%dev` keeps the address part (device
  binding remains `--bind-dev`).
- The UDP client path resolves and binds the source IP the same way.
- While in the socket2 path, it now honors `connect_timeout` (it previously
  ignored it).

`net` is `#[doc(hidden)]` (only `set_cpu_affinity` is re-exported as stable
API), so the `tcp_connect` signature change is not a stable-API break.

## Tests (TDD, written first)

- `tcp_connect_binds_local_address`: binds source to 127.0.0.2 and asserts the
  connected socket's local IP is 127.0.0.2 — the OS would pick 127.0.0.1, so
  this proves `-B` takes effect.
- `tcp_connect_rejects_bind_family_mismatch`: a v6 `-B` against a v4 target errors.

## VM fleet verification

- TCP `-B 172.20.0.21` → 71 Gbps; IPv6 `-B fd00:20::21` → 75 Gbps; UDP
  `-b 1G -B 172.20.0.21` → ~1 Gbps — all run.
- v6 `-B` against a v4 target → `bind address … family does not match target`.
- Decisive: `-B 127.0.0.1` against the off-subnet target now **fails to connect**
  (EINVAL) instead of silently succeeding — proof the bind is applied.

317 tests pass; clippy + fmt clean. No version bump here (release is a separate
step).
