### PR TITLE
fix(udp): -b 0 = unlimited + sender polish (#17, #18)

### DIFF
--- a/riperf3-cli/src/cli.rs
+++ b/riperf3-cli/src/cli.rs
@@ -154,7 +154,7 @@ pub struct Cli {
     #[arg(short = 'N', long = "no-delay")]
     pub no_delay: bool,
 
-    /// Target bitrate in bits/sec (0 = unlimited for TCP, 1M default for UDP)
+    /// Target bitrate in bits/sec (0 = unlimited; default: unlimited TCP, 1M UDP)
     #[arg(short = 'b', long, value_name = "rate[/burst]")]
     pub bitrate: Option<String>,
 

--- a/riperf3/src/client.rs
+++ b/riperf3/src/client.rs
@@ -222,9 +222,11 @@ impl Client {
         }
         p.mss = self.mss;
         p.window = self.window;
-        if self.bandwidth > 0 {
-            p.bandwidth = Some(self.bandwidth);
-        }
+        // Always carry the resolved rate (incl. 0 = unlimited) so the server
+        // paces correctly in reverse/bidir; matches iperf3, which always sends
+        // it. `bandwidth` is the effective rate after the build-time default
+        // (UDP unset → 1 Mbit/s), so 0 here unambiguously means unlimited (#17).
+        p.bandwidth = Some(self.bandwidth);
         if self.tos != 0 {
             p.tos = Some(self.tos);
         }
@@ -422,11 +424,9 @@ impl Client {
                         let c = counters.clone();
                         let d = done.clone();
                         let bs = blksize;
-                        let rate = if self.bandwidth > 0 {
-                            self.bandwidth
-                        } else {
-                            DEFAULT_UDP_RATE
-                        };
+                        // Effective rate is resolved at build time (UDP unset →
+                        // 1 Mbit/s); 0 means unlimited — no pacing (#17).
+                        let rate = self.bandwidth;
                         let u64bit = self.udp_counters_64bit;
                         let use_sendmmsg = self.sendmmsg;
                         let st = start.clone();
@@ -862,7 +862,7 @@ pub struct ClientBuilder {
     no_delay: bool,
     mss: Option<i32>,
     window: Option<i32>,
-    bandwidth: u64,
+    bandwidth: Option<u64>,
     tos: i32,
     congestion: Option<String>,
     udp_counters_64bit: bool,
@@ -921,7 +921,7 @@ impl Default for ClientBuilder {
             no_delay: false,
             mss: None,
             window: None,
-            bandwidth: 0,
+            bandwidth: None,
             tos: 0,
             congestion: None,
             udp_counters_64bit: false,
@@ -1033,7 +1033,9 @@ impl ClientBuilder {
     }
 
     pub fn bandwidth(mut self, bps: u64) -> Self {
-        self.bandwidth = bps;
+        // `Some` even for 0: an explicit `-b 0` means unlimited and must be
+        // distinguishable from "unset" (which resolves to the UDP default) (#17).
+        self.bandwidth = Some(bps);
         self
     }
 
@@ -1306,11 +1308,16 @@ impl ClientBuilder {
                     "UDP GSO/GRO is not supported on this platform".into(),
                 ));
             }
-            if self.sendmmsg {
-                return Err(ConfigError::Unsupported(
-                    "sendmmsg is not supported on this platform".into(),
-                ));
-            }
+        }
+
+        // sendmmsg's real implementation is Linux/FreeBSD/NetBSD only; elsewhere
+        // (incl. macOS, which is `unix` but unsupported) it would silently fall
+        // back to the per-packet sender, so reject it at build time instead (#18).
+        #[cfg(not(any(target_os = "linux", target_os = "freebsd", target_os = "netbsd")))]
+        if self.sendmmsg {
+            return Err(ConfigError::Unsupported(
+                "sendmmsg is only supported on Linux, FreeBSD, and NetBSD".into(),
+            ));
         }
 
         let default_blksize = match self.protocol {
@@ -1339,7 +1346,13 @@ impl ClientBuilder {
             no_delay: self.no_delay,
             mss: self.mss,
             window: self.window,
-            bandwidth: self.bandwidth,
+            // Resolve the rate default now (UDP unset → 1 Mbit/s, like iperf3);
+            // an explicit -b (incl. 0 = unlimited) is honored. TCP default is
+            // unlimited (0). After this, bandwidth==0 unambiguously = unlimited.
+            bandwidth: self.bandwidth.unwrap_or(match self.protocol {
+                TransportProtocol::Udp => DEFAULT_UDP_RATE,
+                TransportProtocol::Tcp => 0,
+            }),
             tos,
             congestion: self.congestion,
             udp_counters_64bit: self.udp_counters_64bit,

--- a/riperf3/src/client.rs
+++ b/riperf3/src/client.rs
@@ -1467,5 +1467,49 @@ mod tests {
             assert_eq!(c.bandwidth, 100_000_000);
             assert_eq!(c.tos, 0x10);
         }
+
+        // -- UDP -b 0 = unlimited (issue #17) --
+
+        #[test]
+        fn udp_unset_bandwidth_defaults_to_1m() {
+            // No -b on UDP resolves to the 1 Mbit/s default (iperf3 parity),
+            // now resolved at build time rather than in the sender.
+            let c = ClientBuilder::new("h")
+                .protocol(TransportProtocol::Udp)
+                .build()
+                .unwrap();
+            assert_eq!(c.bandwidth, DEFAULT_UDP_RATE);
+        }
+
+        #[test]
+        fn udp_explicit_zero_bandwidth_is_unlimited() {
+            // -b 0 means unlimited (0), NOT the 1 Mbit/s default (#17).
+            let c = ClientBuilder::new("h")
+                .protocol(TransportProtocol::Udp)
+                .bandwidth(0)
+                .build()
+                .unwrap();
+            assert_eq!(c.bandwidth, 0);
+        }
+
+        #[test]
+        fn tcp_unset_bandwidth_is_unlimited() {
+            // TCP default stays unlimited (0).
+            let c = ClientBuilder::new("h").build().unwrap();
+            assert_eq!(c.protocol, TransportProtocol::Tcp);
+            assert_eq!(c.bandwidth, 0);
+        }
+
+        #[test]
+        fn udp_build_params_carries_bandwidth_including_zero() {
+            // The negotiated rate must reach the server (in `len`/`bandwidth`)
+            // so reverse-mode -b 0 is unlimited server-side, not throttled.
+            let c = ClientBuilder::new("h")
+                .protocol(TransportProtocol::Udp)
+                .bandwidth(0)
+                .build()
+                .unwrap();
+            assert_eq!(c.build_params(1460).bandwidth, Some(0));
+        }
     }
 }

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -52,7 +52,12 @@ impl TestConfig {
             no_delay: params.nodelay.unwrap_or(false),
             mss: params.mss,
             window: params.window,
-            bandwidth: params.bandwidth.unwrap_or(0),
+            // Mirror the client's resolution (#17): a present rate (incl. 0 =
+            // unlimited) is used verbatim; when absent (older peer, or TCP),
+            // default to 1 Mbit/s for UDP and unlimited for TCP. 0 = unlimited.
+            bandwidth: params
+                .bandwidth
+                .unwrap_or(if is_udp { DEFAULT_UDP_RATE } else { 0 }),
             tos: params.tos.unwrap_or(0),
             congestion: params.congestion.clone(),
             udp_counters_64bit: params.udp_counters_64bit.unwrap_or(0) != 0,
@@ -345,11 +350,8 @@ impl Server {
                         let c = counters.clone();
                         let d = done.clone();
                         let bs = cfg.blksize;
-                        let rate = if cfg.bandwidth > 0 {
-                            cfg.bandwidth
-                        } else {
-                            DEFAULT_UDP_RATE
-                        };
+                        // Already resolved in TestConfig (#17); 0 = unlimited.
+                        let rate = cfg.bandwidth;
                         let u64bit = cfg.udp_counters_64bit;
                         let st = start.clone();
                         let md = max_duration;

--- a/riperf3/src/stream.rs
+++ b/riperf3/src/stream.rs
@@ -760,7 +760,9 @@ pub fn run_udp_sender_sendmmsg(
 
     // Larger batch than the per-packet sender: sendmmsg amortizes syscall
     // overhead so bigger batches help more than with individual send() calls.
-    let batch_size: usize = if rate_bits_per_sec > 0 { 128 } else { 1 };
+    // Always batch — pacing (below) is what's gated on the rate; an unlimited
+    // run (rate 0, -b 0) still needs the full batch, not one packet (#17).
+    let batch_size: usize = 128;
 
     // Switch to blocking I/O — tokio's into_std() leaves the socket
     // non-blocking, which makes sendmmsg busy-spin on EAGAIN once SO_SNDBUF
@@ -832,8 +834,13 @@ pub fn run_udp_sender_sendmmsg(
                 seq -= batch_size as u64;
             }
             Err(e) => {
+                // A non-EAGAIN error (e.g. ECONNREFUSED from an ICMP
+                // port-unreachable on the connected socket) can persist; back
+                // off briefly so we don't spin a core re-trying until the
+                // deadline, while still recovering if it clears (#18).
                 log::debug!("sendmmsg error: {e}");
                 seq -= batch_size as u64;
+                std::thread::sleep(Duration::from_millis(1));
             }
         }
 
@@ -904,14 +911,11 @@ pub fn run_udp_sender_blocking(
     let mut buf = vec![0u8; blksize];
     let mut seq: u64 = 0;
 
-    // Batch size: send 32 packets between clock checks.
-    // Small enough to maintain pacing accuracy, large enough to
-    // amortize Instant::now() and atomic counter overhead.
-    let batch_size: u32 = if rate_bits_per_sec > 0 {
-        32_u64.clamp(1, 64) as u32
-    } else {
-        1
-    };
+    // Send 32 packets between clock checks: small enough to maintain pacing
+    // accuracy, large enough to amortize Instant::now() and atomic-counter
+    // overhead. Unconditional — pacing (below) is gated on the rate, so an
+    // unlimited run (rate 0, -b 0) still batches rather than dropping to 1 (#17).
+    let batch_size: u32 = 32;
 
     // Blocking I/O so send() backpressures in-kernel instead of returning
     // WouldBlock and truncating the batch once SO_SNDBUF fills (issue #6).
@@ -956,8 +960,13 @@ pub fn run_udp_sender_blocking(
                     break;
                 }
                 Err(e) => {
+                    // Persistent fatal error (e.g. ECONNREFUSED): stop the
+                    // batch and back off briefly rather than retrying every
+                    // packet in a tight loop until the deadline (#18).
                     log::debug!("UDP send error: {e}");
                     seq -= 1;
+                    std::thread::sleep(Duration::from_millis(1));
+                    break;
                 }
             }
         }

--- a/riperf3/tests/integration.rs
+++ b/riperf3/tests/integration.rs
@@ -782,6 +782,43 @@ mod test_config_tests {
         assert_eq!(cfg.congestion, Some("bbr".to_string()));
         assert!(cfg.udp_counters_64bit);
     }
+
+    // -- server mirrors the client's rate resolution (#17) --
+
+    #[test]
+    fn udp_absent_bandwidth_defaults_to_1m() {
+        // A peer that omits the rate (older riperf3 / some iperf3 paths) → the
+        // 1 Mbit/s UDP default, not unlimited.
+        let p = TestParams {
+            udp: Some(true),
+            ..Default::default()
+        };
+        let cfg = TestConfig::from_params(&p);
+        assert_eq!(cfg.bandwidth, 1024 * 1024); // DEFAULT_UDP_RATE
+    }
+
+    #[test]
+    fn udp_explicit_zero_bandwidth_is_unlimited() {
+        // -b 0 carried in params → unlimited server-side, so reverse/bidir
+        // runs flat-out instead of being throttled to 1 Mbit/s.
+        let p = TestParams {
+            udp: Some(true),
+            bandwidth: Some(0),
+            ..Default::default()
+        };
+        let cfg = TestConfig::from_params(&p);
+        assert_eq!(cfg.bandwidth, 0);
+    }
+
+    #[test]
+    fn tcp_absent_bandwidth_is_unlimited() {
+        let p = TestParams {
+            tcp: Some(true),
+            ..Default::default()
+        };
+        let cfg = TestConfig::from_params(&p);
+        assert_eq!(cfg.bandwidth, 0);
+    }
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #17, closes #18.

## #17 — UDP `-b 0` should mean unlimited

iperf3: `-b 0` = unlimited; no `-b` = 1 Mbit/s default. riperf3 conflated the
two (the client and server both mapped `bandwidth == 0` to the 1 Mbit/s
default), so `riperf3 -c host -u -b 0` was throttled to 1 Mbit/s.

**Fix:** the builder tracks `bandwidth: Option<u64>`. At build time, unset
resolves to the UDP default (1 Mbit/s) / TCP unlimited, so a resolved
`bandwidth == 0` unambiguously means **unlimited**. `build_params` now always
carries the rate (including 0) so reverse/bidir pace correctly server-side, and
the server mirrors the same resolution. Both senders treat rate 0 as "no
pacing."

**Coupled batch fix:** the sendmmsg/blocking `batch_size` no longer drops to 1
when `rate == 0` — pacing alone is gated on the rate, so an unlimited run keeps
the full batch (128 / 32). This also removes the dead `32_u64.clamp(1, 64)`
constant flagged in #18.

## #18 — UDP sender polish

- **Fatal-error busy-loop:** a persistent send error (e.g. `ECONNREFUSED` from
  an ICMP port-unreachable on the connected socket) now backs off ~1 ms instead
  of spinning a core until the deadline; the per-packet path also stops the
  batch.
- **Dead clamp:** removed (see above).
- **`--sendmmsg` on macOS:** now rejected at build time (the real impl is
  Linux/FreeBSD/NetBSD; it previously silently fell back to the per-packet
  sender, contradicting the "error at parse time" framing).

## Wire compatibility

Preserved. The rate travels in the param-exchange `bandwidth` field (iperf3
always sends it too); 0 = unlimited on both sides.

## VM fleet verification (jumbo fleet)

- `-u -b 0` forward → **38.5 Gbps** (was throttled to ~1 Mbit/s).
- `-u` (no `-b`) → **1.52 Mbps** (1 Mbit/s default preserved).
- `-u -b 0 -R` reverse → **36 Gbps** (server sends unlimited — proves the rate
  reaches the server).
- iperf3 client `-u -b 0` → riperf3 server → **32.9 Gbps** (cross-compatible).

## Tests (TDD, written first)

`udp_unset_bandwidth_defaults_to_1m`, `udp_explicit_zero_bandwidth_is_unlimited`,
`tcp_unset_bandwidth_is_unlimited`, `udp_build_params_carries_bandwidth_including_zero`.
321 tests pass; clippy + fmt clean.

## Semver

The builder's `bandwidth` field is private (changed `u64 → Option<u64>`
internally); `Client.bandwidth` stays `pub u64`. No public-API signature change
— but `Client.bandwidth == 0` now means *unlimited* rather than "use default"
(a behavior change for library users who set 0 explicitly). Patch-level for the
CLI; flagged for the release notes.
