### PR TITLE
fix(server): absent UDP bandwidth = unlimited, matching iperf3 (#21)

### DIFF
--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -52,12 +52,13 @@ impl TestConfig {
             no_delay: params.nodelay.unwrap_or(false),
             mss: params.mss,
             window: params.window,
-            // Mirror the client's resolution (#17): a present rate (incl. 0 =
-            // unlimited) is used verbatim; when absent (older peer, or TCP),
-            // default to 1 Mbit/s for UDP and unlimited for TCP. 0 = unlimited.
-            bandwidth: params
-                .bandwidth
-                .unwrap_or(if is_udp { DEFAULT_UDP_RATE } else { 0 }),
+            // A present rate (incl. 0 = unlimited) is used verbatim. An ABSENT
+            // rate means unlimited (0), matching iperf3: it omits the param only
+            // for -b 0 and sends it explicitly otherwise (incl. its 1 Mbit/s UDP
+            // default), as do riperf3 clients. Defaulting an absent UDP rate to
+            // 1 Mbit/s throttled an iperf3 -b 0 reverse/bidir sender (#21). The
+            // 1 Mbit/s UDP default is a client-side concern, resolved at build.
+            bandwidth: params.bandwidth.unwrap_or(0),
             tos: params.tos.unwrap_or(0),
             congestion: params.congestion.clone(),
             udp_counters_64bit: params.udp_counters_64bit.unwrap_or(0) != 0,

--- a/riperf3/tests/integration.rs
+++ b/riperf3/tests/integration.rs
@@ -786,15 +786,18 @@ mod test_config_tests {
     // -- server mirrors the client's rate resolution (#17) --
 
     #[test]
-    fn udp_absent_bandwidth_defaults_to_1m() {
-        // A peer that omits the rate (older riperf3 / some iperf3 paths) → the
-        // 1 Mbit/s UDP default, not unlimited.
+    fn udp_absent_bandwidth_is_unlimited() {
+        // iperf3 omits the `bandwidth` param only for -b 0 (unlimited) and sends
+        // it explicitly otherwise (incl. its 1 Mbit/s default); riperf3 clients
+        // always send it. So an ABSENT bandwidth means unlimited (0), matching
+        // iperf3 — NOT the 1 Mbit/s default. Defaulting to 1M throttled an
+        // iperf3 `-b 0` reverse/bidir client's server-side sender (#21).
         let p = TestParams {
             udp: Some(true),
             ..Default::default()
         };
         let cfg = TestConfig::from_params(&p);
-        assert_eq!(cfg.bandwidth, 1024 * 1024); // DEFAULT_UDP_RATE
+        assert_eq!(cfg.bandwidth, 0);
     }
 
     #[test]


### PR DESCRIPTION
Closes #21.

## Problem

Found by the 0.5.0 cross-tool compatibility matrix: an **iperf3 client** doing
**reverse/bidir UDP at `-b 0`** (unlimited) against a **riperf3 server** was
throttled to **1 Mbit/s** server-side.

```
iperf3 -c <riperf3-server> -u -b 5G -R  → 4.98 Gbit/s   (explicit rate: OK)
iperf3 -c <riperf3-server> -u -b 0  -R  → 1.29 Mbit/s   (unlimited: BUG)
```

## Root cause

iperf3 omits the `bandwidth` param when the rate is 0 (`iperf_api.c`):

```c
if (test->settings->rate)
    cJSON_AddNumberToObject(j, "bandwidth", test->settings->rate);
```

So `-b 0` sends *no* `bandwidth` field — meaning unlimited — and iperf3's own
server defaults an absent rate to 0. riperf3's server (`TestConfig::from_params`,
#17) instead defaulted an absent UDP `bandwidth` to `DEFAULT_UDP_RATE` (1 Mbit/s).
Since iperf3 always sends the rate explicitly otherwise (incl. its 1 Mbit/s
default) and riperf3 clients always send it, the *only* peer that omits the field
is an iperf3 client requesting unlimited — so absent must mean unlimited.

## Fix

`TestConfig::from_params`: `bandwidth: params.bandwidth.unwrap_or(0)` (absent =
unlimited, both protocols). One line. The 1 Mbit/s UDP default is unchanged — it's
resolved client-side at build and sent explicitly.

## Tests (TDD)

Flipped the `udp_absent_bandwidth_*` unit test (added in #17, which encoded the
wrong expectation) to assert absent → 0. 328 tests pass; clippy + fmt clean.
VM cross-tool re-verification to follow.

## Scope / severity

Medium. Forward UDP (common case) and explicit rates were unaffected; only an
iperf3 `-b 0` reverse/bidir client against a riperf3 server. Regression class
from #17's server default. Patch release (0.5.1).
