### PR TITLE
fix(protocol): tolerate iperf3 <=3.12 results-JSON sentinels (#24)

### DIFF
--- a/riperf3/src/protocol.rs
+++ b/riperf3/src/protocol.rs
@@ -282,16 +282,45 @@ pub struct TestParams {
 // Test results — exchanged as JSON during ExchangeResults
 // ---------------------------------------------------------------------------
 
+/// Deserialize an integer that iperf3 may report as a "-1 = unavailable"
+/// sentinel (e.g. retransmit info when the OS doesn't expose it). iperf3 ≤ 3.12
+/// serializes that -1 as `u64::MAX` in the results JSON, which overflows the
+/// signed Rust type and would otherwise fail the whole test at result decode
+/// (issue #24). Normalize any value past `i64::MAX` (incl. `u64::MAX`) to -1.
+fn de_retransmit_sentinel<'de, D>(deserializer: D) -> std::result::Result<i64, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    struct SentinelVisitor;
+    impl serde::de::Visitor<'_> for SentinelVisitor {
+        type Value = i64;
+        fn expecting(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+            f.write_str("an integer (iperf3 may send u64::MAX or -1 for \"unavailable\")")
+        }
+        fn visit_i64<E: serde::de::Error>(self, v: i64) -> std::result::Result<i64, E> {
+            Ok(v)
+        }
+        fn visit_u64<E: serde::de::Error>(self, v: u64) -> std::result::Result<i64, E> {
+            Ok(if v > i64::MAX as u64 { -1 } else { v as i64 })
+        }
+    }
+    deserializer.deserialize_any(SentinelVisitor)
+}
+
 /// Per-stream result data included in the results JSON.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct StreamResultJson {
     pub id: i32,
     pub bytes: u64,
+    #[serde(deserialize_with = "de_retransmit_sentinel")]
     pub retransmits: i64,
     pub jitter: f64,
     pub errors: i64,
+    // iperf 3.12 omits the omitted_* fields from the stream object (#24).
+    #[serde(default)]
     pub omitted_errors: i64,
     pub packets: i64,
+    #[serde(default)]
     pub omitted_packets: i64,
     pub start_time: f64,
     pub end_time: f64,
@@ -303,7 +332,8 @@ pub struct TestResultsJson {
     pub cpu_util_total: f64,
     pub cpu_util_user: f64,
     pub cpu_util_system: f64,
-    pub sender_has_retransmits: i32,
+    #[serde(deserialize_with = "de_retransmit_sentinel")]
+    pub sender_has_retransmits: i64,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub congestion_used: Option<String>,
     pub streams: Vec<StreamResultJson>,
@@ -596,7 +626,10 @@ mod tests {
         assert_eq!(r.streams[0].retransmits, -1, "u64::MAX sentinel maps to -1");
         assert_eq!(r.streams[0].bytes, 25_371_082_752);
         assert_eq!(r.streams[0].omitted_errors, 0, "absent field defaults to 0");
-        assert_eq!(r.streams[0].omitted_packets, 0, "absent field defaults to 0");
+        assert_eq!(
+            r.streams[0].omitted_packets, 0,
+            "absent field defaults to 0"
+        );
     }
 
     #[tokio::test]

--- a/riperf3/src/protocol.rs
+++ b/riperf3/src/protocol.rs
@@ -287,6 +287,8 @@ pub struct TestParams {
 /// serializes that -1 as `u64::MAX` in the results JSON, which overflows the
 /// signed Rust type and would otherwise fail the whole test at result decode
 /// (issue #24). Normalize any value past `i64::MAX` (incl. `u64::MAX`) to -1.
+/// No `visit_u128` is needed: these counts derive from a `u32`
+/// (`tcpi_total_retrans`), so a JSON integer above `u64::MAX` never occurs.
 fn de_retransmit_sentinel<'de, D>(deserializer: D) -> std::result::Result<i64, D::Error>
 where
     D: serde::Deserializer<'de>,
@@ -629,6 +631,39 @@ mod tests {
         assert_eq!(
             r.streams[0].omitted_packets, 0,
             "absent field defaults to 0"
+        );
+    }
+
+    #[test]
+    fn results_json_serializes_sentinel_as_signed_minus_one() {
+        // When riperf3 is the server sending results to an (older) iperf3 client,
+        // the -1 "unavailable" sentinel must go on the wire as signed -1 (what
+        // iperf3's reader expects), never u64::MAX — the send side of #24.
+        let results = TestResultsJson {
+            cpu_util_total: 0.0,
+            cpu_util_user: 0.0,
+            cpu_util_system: 0.0,
+            sender_has_retransmits: -1,
+            congestion_used: None,
+            streams: vec![StreamResultJson {
+                id: 1,
+                bytes: 0,
+                retransmits: -1,
+                jitter: 0.0,
+                errors: 0,
+                omitted_errors: 0,
+                packets: 0,
+                omitted_packets: 0,
+                start_time: 0.0,
+                end_time: 1.0,
+            }],
+        };
+        let json = serde_json::to_string(&results).unwrap();
+        assert!(json.contains("\"sender_has_retransmits\":-1"), "{json}");
+        assert!(json.contains("\"retransmits\":-1"), "{json}");
+        assert!(
+            !json.contains("18446744073709551615"),
+            "must serialize -1 signed, not as u64::MAX: {json}"
         );
     }
 

--- a/riperf3/src/protocol.rs
+++ b/riperf3/src/protocol.rs
@@ -582,6 +582,23 @@ mod tests {
         assert_eq!(decoded.streams[0].bytes, 1_000_000);
     }
 
+    #[test]
+    fn results_json_from_iperf_3_12_decodes() {
+        // iperf 3.12 (e.g. the networkstatic/iperf3 Docker image) serializes its
+        // -1 "retransmit info unavailable" sentinel as u64::MAX, and omits
+        // omitted_errors/omitted_packets from the stream object. riperf3 must
+        // tolerate both rather than failing the whole test at result decode
+        // (issue #24). Verbatim results JSON captured from the 3.12 server.
+        let json = r#"{"congestion_used":"bbr","cpu_util_system":78.41548529516153,"cpu_util_total":85.9062232248101,"cpu_util_user":7.490704603857994,"sender_has_retransmits":18446744073709551615,"streams":[{"bytes":25371082752,"end_time":3.000672,"errors":0,"id":1,"jitter":0,"packets":0,"retransmits":18446744073709551615,"start_time":0}]}"#;
+        let r: TestResultsJson =
+            serde_json::from_str(json).expect("must decode iperf 3.12 results JSON");
+        assert_eq!(r.sender_has_retransmits, -1, "u64::MAX sentinel maps to -1");
+        assert_eq!(r.streams[0].retransmits, -1, "u64::MAX sentinel maps to -1");
+        assert_eq!(r.streams[0].bytes, 25_371_082_752);
+        assert_eq!(r.streams[0].omitted_errors, 0, "absent field defaults to 0");
+        assert_eq!(r.streams[0].omitted_packets, 0, "absent field defaults to 0");
+    }
+
     #[tokio::test]
     async fn json_framing_round_trip() {
         let (client, server) = tokio::io::duplex(1024);


### PR DESCRIPTION
Closes #24.

## Problem (reported by @Sean-Bartie, reproduced)

`riperf3 -c <host>` against `networkstatic/iperf3` (= **iperf 3.12**) runs the
full data phase, then errors at result decode:
```
Error: Json(Error("invalid value: integer `18446744073709551615`, expected i32"))
```

## Root cause (captured the wire JSON)

iperf 3.12's results exchange serializes its `-1` "retransmit info unavailable"
sentinel as **`u64::MAX`**, and **omits** `omitted_errors`/`omitted_packets`
from the stream object:
```json
{ "sender_has_retransmits": 18446744073709551615,
  "streams":[{ "id":1, "bytes":..., "retransmits": 18446744073709551615,
               "errors":0, "jitter":0, "packets":0, "start_time":0, "end_time":3.0 }] }
```
riperf3 typed `sender_has_retransmits` as `i32` and `retransmits` as `i64` (both
required, all stream fields required), so deserialization failed — after a fully
successful transfer. Our fleet iperf3 is 3.20+, which doesn't emit the sentinel,
so the compatibility matrix missed it.

## Fix (deserialize-only, wire-compatible)

- `de_retransmit_sentinel`: a tolerant deserializer that maps any value past
  `i64::MAX` (incl. `u64::MAX`) back to `-1`; applied to `retransmits` and
  `sender_has_retransmits` (now `i64`).
- `#[serde(default)]` on `omitted_errors`/`omitted_packets`.

The send side and 3.20+ decode are unchanged (no-op for valid values).

## Tests (TDD)

`results_json_from_iperf_3_12_decodes` deserializes the **verbatim** 3.12 JSON
and asserts it decodes with the sentinels mapped to `-1` and the absent fields
defaulted to `0`. Red before the fix. Existing round-trip test still passes.
329 tests; clippy + fmt clean.

## Verification

Against `networkstatic/iperf3` (3.12) on Docker: `riperf3 -c 127.0.0.1` (default
TCP) now completes cleanly (was the crash). Comprehensive 3.12 + 3.20 matrix run
to follow (adding 3.12 as a standing compat target).

Patch release: 0.5.2. (TCP `--reverse` vs 3.12 still hits `PeerDisconnected` —
that's #23, separate.)
