### PR TITLE
Bump to 0.5.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -793,7 +793,7 @@ dependencies = [
 
 [[package]]
 name = "riperf3"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "base64",
  "libc",
@@ -814,7 +814,7 @@ dependencies = [
 
 [[package]]
 name = "riperf3-cli"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "clap",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.5.2"
+version = "0.5.3"
 authors = ["Evan Henry"]
 edition = "2021"
 homepage = "https://github.com/therealevanhenry/riperf3"

--- a/riperf3-cli/Cargo.toml
+++ b/riperf3-cli/Cargo.toml
@@ -13,7 +13,7 @@ readme = "../README.md"
 
 [dependencies]
 # riperf3 workspace dependencies
-riperf3 = { path = "../riperf3", version = "0.5.2" }
+riperf3 = { path = "../riperf3", version = "0.5.3" }
 
 # external dependencies
 clap.workspace = true


### PR DESCRIPTION
Patch release. Ships the #23 fix already on main (ce12407): in reverse/bidir, the client's TCP receiver now drains until the peer closes (EOF) — with a 10s hang-guard — instead of slamming the data socket shut at test end and EPIPE-ing an iperf3 ≤3.12 sender into a fatal `PeerDisconnected`.

Additive, no public API change → patch bump (0.5.2 → 0.5.3). Version-only commit: root `[workspace.package].version`, the CLI path-dep pin, and `Cargo.lock`.