### PR TITLE
fix(report): report forward UDP receiver loss, matching iperf3 (#25)

### DIFF
--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -91,20 +91,29 @@ p<0.05.
   p<1e-4), the result of the 0.4.0 UDP rebuild ([#6](https://github.com/therealevanhenry/riperf3/issues/6): MSS-derived datagram size + blocking sockets).
 - No cell where iperf3 is significantly faster.
 
-### UDP loss (%) — directional asymmetry
+### UDP loss (%) at `-b 0`
 
 | direction | riperf3 | iperf3 |
 |---|--:|--:|
-| forward (server receives) | **0.00** (P8) | 0.8–1.2 |
-| reverse (server sends) | **1.2–1.8** | 0.4–0.8 |
+| forward (server receives), P8 | 2.4–2.8 | 0.9–1.0 |
+| reverse (server sends), P8 | 1.2–1.6 | 0.6–0.7 |
 
-Forward, riperf3 is faster **and** loss-free even at P8. Reverse, riperf3 is
-faster but drops 2–3× more than iperf3. The asymmetry tracks the sender: forward
-uses the client's `sendmmsg` path (loss-free); reverse uses the server's
-per-packet blocking sender, which bursts harder into the receiver. Goodput still
-favors riperf3 (≈31.1 vs 28.3 Gbps reverse P8 v6), so it's a characteristic, not
-a regression — tracked in
-[#25](https://github.com/therealevanhenry/riperf3/issues/25).
+UDP loss at `-b 0` is receiver-side socket-buffer overflow on a saturated link —
+kernel `RcvbufErrors` on the receiving host, while sender `SndbufErrors` stay 0
+(the sender never drops). It is roughly symmetric by direction; if anything,
+forward drops a touch more. riperf3 loses somewhat more than iperf3 in both
+directions because it pushes ~10–15% more throughput, so it overruns the
+receiver's buffer harder — higher goodput, slightly higher loss, a
+characteristic rather than a regression.
+
+> **Correction (0.5.4).** Earlier editions reported forward as "0.00 / loss-free"
+> and attributed the gap to a `sendmmsg`-vs-per-packet sender split. Both were
+> wrong. riperf3 had a reporting bug — forward UDP never printed the
+> server-measured receiver loss, so it *looked* loss-free
+> ([#25](https://github.com/therealevanhenry/riperf3/issues/25), fixed in 0.5.4)
+> — and the campaign never passed `--sendmmsg`, so both directions used the same
+> per-packet sender. Kernel counters confirm forward drops the same ~2–3% as
+> reverse; the "asymmetry" was measurement, not packet loss.
 
 ## Single-run supplements
 
@@ -122,7 +131,9 @@ TCP bidir is at parity (~80 Gbps aggregate); UDP bidir aggregate is comparable.
 ### UDP datagram-size sweep (IPv6 forward, P1)
 
 Throughput scales with datagram size; the default (no `-l`) lands at the MSS
-(~8928 B). riperf3's `sendmmsg` batching pulls ahead once datagrams are large.
+(~8928 B). riperf3's UDP path — blocking sockets and MSS-derived datagram sizing
+([#6](https://github.com/therealevanhenry/riperf3/issues/6)) — pulls ahead once
+datagrams are large.
 
 | `-l` (bytes) | riperf3 | iperf3 |
 |-------------:|--------:|-------:|

--- a/riperf3/src/client.rs
+++ b/riperf3/src/client.rs
@@ -78,6 +78,34 @@ pub struct Client {
     pub use_pkcs1_padding: bool,
 }
 
+/// Build receiver-perspective summaries from the server's results. In a forward
+/// test the local streams are senders, so the receiver's view — most importantly
+/// UDP loss — lives only in the results the server returned. Surfacing it as a
+/// `receiver` line matches iperf3; without it, forward UDP looks loss-free even
+/// when the link is dropping packets (issue #25). `is_udp` gates the datagram
+/// loss/jitter columns so a forward TCP run shows a plain receiver byte line.
+fn server_receiver_summaries(
+    server: &TestResultsJson,
+    end: f64,
+    is_udp: bool,
+) -> Vec<crate::reporter::StreamSummary> {
+    server
+        .streams
+        .iter()
+        .map(|s| crate::reporter::StreamSummary {
+            stream_id: s.id,
+            start: 0.0,
+            end,
+            bytes: s.bytes,
+            is_sender: false,
+            retransmits: None,
+            jitter: is_udp.then_some(s.jitter),
+            lost: is_udp.then_some(s.errors),
+            total_packets: is_udp.then_some(s.packets),
+        })
+        .collect()
+}
+
 impl Client {
     pub async fn run(&self) -> Result<TestResultsJson> {
         // ---- Generate cookie and connect ----
@@ -666,15 +694,15 @@ impl Client {
         if self.json_output {
             self.print_results_json(streams, cpu_start, remote_cpu, blksize);
         } else {
-            self.print_results_text(streams);
+            self.print_results_text(streams, remote_cpu);
         }
     }
 
-    fn print_results_text(&self, streams: &[DataStream]) {
+    fn print_results_text(&self, streams: &[DataStream], server_results: Option<&TestResultsJson>) {
         let test_duration = self.duration as f64;
         crate::reporter::print_separator();
 
-        let summaries: Vec<crate::reporter::StreamSummary> = streams
+        let mut summaries: Vec<crate::reporter::StreamSummary> = streams
             .iter()
             .map(|s| {
                 let bytes = if s.is_sender {
@@ -706,6 +734,18 @@ impl Client {
             })
             .collect();
 
+        // Forward: the server is the receiver, so its loss/throughput lives only
+        // in the results it returned — surface it as the receiver line iperf3
+        // prints, otherwise forward UDP looks loss-free even when the link drops
+        // packets (issue #25). Reverse already reports the receiver locally;
+        // bidir's server-receive half isn't split out of the aggregate results.
+        if !self.reverse && !self.bidir {
+            if let Some(server) = server_results {
+                let is_udp = matches!(self.protocol, TransportProtocol::Udp);
+                summaries.extend(server_receiver_summaries(server, test_duration, is_udp));
+            }
+        }
+
         // Per-stream lines plus aggregate [SUM] row(s) for parallel streams
         // (issue #4), via the shared path the server also uses.
         crate::reporter::print_final_summaries(&summaries, self.format_char);
@@ -728,6 +768,11 @@ impl Client {
             TransportProtocol::Tcp => "TCP",
             TransportProtocol::Udp => "UDP",
         };
+
+        // Forward UDP: the server is the receiver, so its loss lives only in the
+        // results it returned. Surface it in `-J` too, mirroring the text path (#25).
+        let is_forward_udp =
+            matches!(self.protocol, TransportProtocol::Udp) && !self.reverse && !self.bidir;
 
         // Build per-stream end results
         let mut j_streams = Vec::new();
@@ -769,6 +814,21 @@ impl Client {
                     };
                     stream_obj["lost_percent"] = serde_json::json!(pct);
                 }
+            } else if is_forward_udp && s.is_sender {
+                // Forward UDP: the loss was measured by the server (receiver), so
+                // attach it from its results — otherwise `-J` forward looks
+                // loss-free too, the machine-readable twin of the text gap (#25).
+                if let Some(rs) = remote_cpu.and_then(|r| r.streams.iter().find(|x| x.id == s.id)) {
+                    stream_obj["jitter_ms"] = serde_json::json!(rs.jitter * 1000.0);
+                    stream_obj["lost_packets"] = serde_json::json!(rs.errors);
+                    stream_obj["packets"] = serde_json::json!(rs.packets);
+                    let pct = if rs.packets > 0 {
+                        rs.errors as f64 / rs.packets as f64 * 100.0
+                    } else {
+                        0.0
+                    };
+                    stream_obj["lost_percent"] = serde_json::json!(pct);
+                }
             }
 
             j_streams.push(stream_obj);
@@ -786,7 +846,7 @@ impl Client {
             .map(|r| (r.cpu_util_total, r.cpu_util_user, r.cpu_util_system))
             .unwrap_or((0.0, 0.0, 0.0));
 
-        let output = serde_json::json!({
+        let mut output = serde_json::json!({
             "start": {
                 "connected": streams.iter().map(|s| {
                     serde_json::json!({
@@ -847,6 +907,29 @@ impl Client {
                 }
             }
         });
+
+        // Forward UDP: fold the server-measured loss into the aggregate
+        // `sum_received` so `-J` reports it alongside the per-stream lines (#25).
+        if is_forward_udp {
+            if let Some(server) = remote_cpu {
+                let lost: i64 = server.streams.iter().map(|s| s.errors).sum();
+                let packets: i64 = server.streams.iter().map(|s| s.packets).sum();
+                let jitter = server
+                    .streams
+                    .iter()
+                    .map(|s| s.jitter)
+                    .fold(0.0_f64, f64::max);
+                let sr = &mut output["end"]["sum_received"];
+                sr["jitter_ms"] = serde_json::json!(jitter * 1000.0);
+                sr["lost_packets"] = serde_json::json!(lost);
+                sr["packets"] = serde_json::json!(packets);
+                sr["lost_percent"] = serde_json::json!(if packets > 0 {
+                    lost as f64 / packets as f64 * 100.0
+                } else {
+                    0.0
+                });
+            }
+        }
 
         println!("{}", serde_json::to_string_pretty(&output).unwrap());
     }
@@ -1551,6 +1634,53 @@ mod tests {
                 .build()
                 .unwrap();
             assert_eq!(c.build_params(1460).bandwidth, Some(0));
+        }
+
+        // -- forward UDP receiver-loss reporting (issue #25) --
+
+        #[test]
+        fn forward_udp_surfaces_server_receiver_loss() {
+            // Forward UDP: the client is the sender, so the receiver's loss lives
+            // only in the server's results. riperf3 must surface it as a receiver
+            // line, like iperf3 — otherwise forward looks artificially loss-free
+            // even when the link drops packets (issue #25).
+            let server = TestResultsJson {
+                cpu_util_total: 0.0,
+                cpu_util_user: 0.0,
+                cpu_util_system: 0.0,
+                sender_has_retransmits: -1,
+                congestion_used: None,
+                streams: vec![protocol::StreamResultJson {
+                    id: 1,
+                    bytes: 2_000_000,
+                    retransmits: -1,
+                    jitter: 0.000_03,
+                    errors: 4258,
+                    omitted_errors: 0,
+                    packets: 267_190,
+                    omitted_packets: 0,
+                    start_time: 0.0,
+                    end_time: 5.0,
+                }],
+            };
+
+            let recv = server_receiver_summaries(&server, 5.0, true);
+            assert_eq!(recv.len(), 1);
+            assert!(!recv[0].is_sender, "server is the receiver in forward mode");
+            assert_eq!(recv[0].lost, Some(4258));
+            assert_eq!(recv[0].total_packets, Some(267_190));
+            assert_eq!(recv[0].jitter, Some(0.000_03));
+
+            // Renders as a receiver line carrying the loss iperf3 would print.
+            let line = crate::reporter::format_summary_line(&recv[0], 'a');
+            assert!(line.contains("receiver"), "{line}");
+            assert!(line.contains("4258/267190"), "{line}");
+
+            // TCP forward: no datagram-loss columns, just a receiver byte line.
+            let tcp = server_receiver_summaries(&server, 5.0, false);
+            assert_eq!(tcp[0].lost, None);
+            assert_eq!(tcp[0].total_packets, None);
+            assert_eq!(tcp[0].jitter, None);
         }
 
         // -- client -B vs -4/-6 build-time validation (issue #15) --

--- a/riperf3/src/client.rs
+++ b/riperf3/src/client.rs
@@ -807,12 +807,10 @@ impl Client {
                     stream_obj["jitter_ms"] = serde_json::json!(stats.jitter * 1000.0);
                     stream_obj["lost_packets"] = serde_json::json!(stats.cnt_error);
                     stream_obj["packets"] = serde_json::json!(stats.packet_count);
-                    let pct = if stats.packet_count > 0 {
-                        stats.cnt_error as f64 / stats.packet_count as f64 * 100.0
-                    } else {
-                        0.0
-                    };
-                    stream_obj["lost_percent"] = serde_json::json!(pct);
+                    stream_obj["lost_percent"] = serde_json::json!(crate::reporter::lost_percent(
+                        stats.cnt_error,
+                        stats.packet_count
+                    ));
                 }
             } else if is_forward_udp && s.is_sender {
                 // Forward UDP: the loss was measured by the server (receiver), so
@@ -822,12 +820,8 @@ impl Client {
                     stream_obj["jitter_ms"] = serde_json::json!(rs.jitter * 1000.0);
                     stream_obj["lost_packets"] = serde_json::json!(rs.errors);
                     stream_obj["packets"] = serde_json::json!(rs.packets);
-                    let pct = if rs.packets > 0 {
-                        rs.errors as f64 / rs.packets as f64 * 100.0
-                    } else {
-                        0.0
-                    };
-                    stream_obj["lost_percent"] = serde_json::json!(pct);
+                    stream_obj["lost_percent"] =
+                        serde_json::json!(crate::reporter::lost_percent(rs.errors, rs.packets));
                 }
             }
 
@@ -923,11 +917,8 @@ impl Client {
                 sr["jitter_ms"] = serde_json::json!(jitter * 1000.0);
                 sr["lost_packets"] = serde_json::json!(lost);
                 sr["packets"] = serde_json::json!(packets);
-                sr["lost_percent"] = serde_json::json!(if packets > 0 {
-                    lost as f64 / packets as f64 * 100.0
-                } else {
-                    0.0
-                });
+                sr["lost_percent"] =
+                    serde_json::json!(crate::reporter::lost_percent(lost, packets));
             }
         }
 

--- a/riperf3/src/reporter.rs
+++ b/riperf3/src/reporter.rs
@@ -90,11 +90,7 @@ pub fn print_interval(interval: &StreamInterval, format_char: char) {
     if let (Some(jitter), Some(lost), Some(total)) =
         (interval.jitter, interval.lost, interval.total_packets)
     {
-        let pct = if total > 0 {
-            lost as f64 / total as f64 * 100.0
-        } else {
-            0.0
-        };
+        let pct = lost_percent(lost, total);
         println!(
             "[{id}] {:5.2}-{:<5.2} sec  {:>10}  {:>12}  {:7.3} ms  {}/{} ({:.2}%)  {}",
             interval.start,
@@ -126,6 +122,17 @@ pub fn print_separator() {
     println!("- - - - - - - - - - - - - - - - - - - - - - - - -");
 }
 
+/// UDP loss as a percentage of total datagrams, guarding the zero-total case
+/// (no packets ⇒ 0%, not NaN). Single source of truth for the `(x.xx%)` figure
+/// across interval lines, final summaries, and JSON output.
+pub fn lost_percent(lost: i64, total: i64) -> f64 {
+    if total > 0 {
+        lost as f64 / total as f64 * 100.0
+    } else {
+        0.0
+    }
+}
+
 /// Format a single final-summary line (no trailing newline). Pure, so the
 /// rendered output can be unit-tested without capturing stdout.
 pub fn format_summary_line(summary: &StreamSummary, format_char: char) -> String {
@@ -147,11 +154,7 @@ pub fn format_summary_line(summary: &StreamSummary, format_char: char) -> String
     if let (Some(jitter), Some(lost), Some(total)) =
         (summary.jitter, summary.lost, summary.total_packets)
     {
-        let pct = if total > 0 {
-            lost as f64 / total as f64 * 100.0
-        } else {
-            0.0
-        };
+        let pct = lost_percent(lost, total);
         format!(
             "[{id}] {:5.2}-{:<5.2} sec  {:>10}  {:>12}  {:7.3} ms  {}/{} ({:.2}%)  {}",
             summary.start,
@@ -621,6 +624,15 @@ mod tests {
         // Bidir -P 1: one sender + one receiver → neither direction gets a SUM.
         let streams = vec![tcp_summary(1, true, 1_000), tcp_summary(3, false, 2_000)];
         assert!(sum_summaries(&streams).is_empty());
+    }
+
+    #[test]
+    fn lost_percent_guards_zero_total() {
+        assert_eq!(lost_percent(0, 0), 0.0, "no datagrams ⇒ 0%, not NaN");
+        assert_eq!(lost_percent(5, 0), 0.0, "zero total never divides");
+        assert_eq!(lost_percent(0, 1000), 0.0, "loss-free");
+        assert!((lost_percent(4258, 267_190) - 1.5936).abs() < 1e-3);
+        assert_eq!(lost_percent(1000, 1000), 100.0, "total loss");
     }
 
     #[test]


### PR DESCRIPTION
Closes #25.

## What #25 actually is (reframed by fleet profiling)
The issue reported that UDP **reverse/bidir** drops 2–3× more than iperf3 and attributed it to the server's per-packet sender (vs the client's `sendmmsg` path). Profiling on the sandbox fleet showed both claims are wrong:

- **`--sendmmsg` was never used** in the campaign (`bench.sh` doesn't pass it), so forward (client) and reverse (server) used the **same** `run_udp_sender_blocking` per-packet sender. The sender wasn't the variable.
- **Kernel UDP counters** (`/proc/net/snmp` `RcvbufErrors`) show forward drops the *same* ~2–3% as reverse — all **receiver recv-buffer overflow** at `-b 0` (`SndbufErrors` = 0 both ways; the sender never drops).

The real defect was **reporting**: in forward UDP the client is the sender, so the receiver's loss is measured by the *server* and only arrives in the results it returns. riperf3 built its final report solely from local streams, so forward UDP printed a **sender-only** summary and looked loss-free even while the link dropped packets. That produced the phantom "reverse is worse" asymmetry (forward read 0.00%, reverse 1.2–1.8%). Reverse was unaffected because there the client *is* the receiver.

## Fix
Surface the server's receiver results in the forward path:
- **Text** — append receiver-perspective summaries from the server's per-stream results (loss/jitter for UDP, bytes for TCP); `print_final_summaries` then emits the per-stream `receiver` lines and `[SUM] receiver` iperf3 prints.
- **`-J`** — parallel treatment: per-stream loss fields + a `sum_received` aggregate. Additive only (no existing field changed).
- Gated to `!reverse && !bidir` (reverse already reports the receiver locally; bidir's server-receive half isn't split out of the aggregate — noted as a follow-up).
- Shared `reporter::lost_percent` helper dedups the `(x.xx%)` formula across all five call sites.

Sender path untouched. riperf3 still delivers ~10–15% higher UDP throughput than iperf3 in every cell; the somewhat-higher loss tracks that higher throughput (more overrun at the same buffer), a characteristic not a regression.

## Verification (sandbox fleet, iperf 3.20+, N=30)
- **Post-fix campaign**: 480/480 runs, 0 FAILs. Forward P8 riperf3 loss now **2.4–2.8%** (was 0.00, matching the kernel drop count); reverse 1.2–1.6%. Throughput unchanged — riperf3 FASTER in all 8 UDP cells (+7–15%), no regression.
- **`compat.sh`**: 48/48 PASS (TCP/UDP × forward/reverse/bidir × r/i pairs, param-exchange features, and the 3.12 cross-pairs).
- Unit tests: `forward_udp_surfaces_server_receiver_loss`, `lost_percent_guards_zero_total`. Full suite (334) green; clippy + fmt clean.
- Two cold-review rounds.

## Note for output consumers
Forward UDP text output gains a `receiver` line, so a parser doing `grep '(%)' | tail -1` on forward output now sees the receiver loss instead of a sender `0/0` interval line. Behavior change in CLI text output, not a Rust API break.

`BENCHMARKS.md` updated to the measured reality (the old "forward 0.00 / sendmmsg" section was wrong).