### PR TITLE
Bump to 0.5.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -793,7 +793,7 @@ dependencies = [
 
 [[package]]
 name = "riperf3"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "base64",
  "libc",
@@ -814,7 +814,7 @@ dependencies = [
 
 [[package]]
 name = "riperf3-cli"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "clap",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.5.3"
+version = "0.5.4"
 authors = ["Evan Henry"]
 edition = "2021"
 homepage = "https://github.com/therealevanhenry/riperf3"

--- a/riperf3-cli/Cargo.toml
+++ b/riperf3-cli/Cargo.toml
@@ -13,7 +13,7 @@ readme = "../README.md"
 
 [dependencies]
 # riperf3 workspace dependencies
-riperf3 = { path = "../riperf3", version = "0.5.3" }
+riperf3 = { path = "../riperf3", version = "0.5.4" }
 
 # external dependencies
 clap.workspace = true


### PR DESCRIPTION
Patch release. Ships the #25 fix already on main (7e30e17): forward UDP now reports the server-measured **receiver** loss in both the text summary and `-J`, matching iperf3 — previously forward printed a sender-only summary and looked loss-free even while the link dropped packets.

Additive output + private-only code changes (no public API change) → patch bump (0.5.3 → 0.5.4). Version-only commit: root `[workspace.package].version`, the CLI path-dep pin, and `Cargo.lock`.