### PR TITLE
ci: real-iperf3 wire-interop gate (#38)

### DIFF
--- a/.github/workflows/interop.yml
+++ b/.github/workflows/interop.yml
@@ -1,0 +1,52 @@
+name: Interop
+
+# Wire-compatibility gate against a real iperf3, built from source at pinned
+# versions. The in-repo tests are riperf3<->riperf3 loopback only and cannot
+# catch a wire/JSON value that is wrong against actual iperf3 (issue #38); this
+# job can. Loopback, so it asserts protocol interop + data transfer, not speed.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  interop:
+    name: iperf3 ${{ matrix.iperf3 }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # Legacy target (exercises riperf3's iperf3<=3.12 compat shims:
+        # issues #23, #24, the legacy UDP connect reply) + latest release.
+        iperf3: ["3.12", "3.21"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Install iperf3 build dependencies
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends automake autoconf libtool
+
+      - name: Build iperf3 ${{ matrix.iperf3 }} from source
+        run: echo "IPERF3_BIN=$(bash scripts/build-iperf3.sh '${{ matrix.iperf3 }}' "$RUNNER_TEMP/iperf3")" >> "$GITHUB_ENV"
+
+      - name: Build riperf3 (release)
+        run: cargo build --release --bin riperf3
+
+      - name: Run interop matrix
+        env:
+          INTEROP_DURATION: "1"
+        run: |
+          # iperf3 <=3.12 aborts the control connection on the late UDP send
+          # error at reverse/bidir teardown (issue #48, UDP analog of #23).
+          # Tracked as xfail until fixed; the gate flips red if it starts passing.
+          if [ "${{ matrix.iperf3 }}" = "3.12" ]; then
+            export XFAIL="udp_rev|[r->i] udp_bidir|[r->i]"
+            export XFAIL_REASON="#48 UDP reverse/bidir teardown resets iperf3<=3.12"
+          fi
+          bash scripts/interop.sh target/release/riperf3 "$IPERF3_BIN"

--- a/.github/workflows/interop.yml
+++ b/.github/workflows/interop.yml
@@ -1,15 +1,19 @@
 name: Interop
 
-# Wire-compatibility gate against a real iperf3, built from source at pinned
-# versions. The in-repo tests are riperf3<->riperf3 loopback only and cannot
-# catch a wire/JSON value that is wrong against actual iperf3 (issue #38); this
-# job can. Loopback, so it asserts protocol interop + data transfer, not speed.
+# Wire-interop gate: builds a real iperf3 from source at pinned versions and runs
+# the client<->server matrix over loopback. The in-repo tests are riperf3<->riperf3
+# only and cannot catch a wire value that is wrong against actual iperf3 (#38);
+# this can. Scope: proves protocol interop + bidirectional transfer, NOT JSON
+# field-level parity (that's #36) and NOT throughput (meaningless on loopback).
 
 on:
   push:
     branches: [main]
   pull_request:
     branches: [main]
+
+permissions:
+  contents: read
 
 env:
   CARGO_TERM_COLOR: always
@@ -21,19 +25,31 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Legacy target (exercises riperf3's iperf3<=3.12 compat shims:
-        # issues #23, #24, the legacy UDP connect reply) + latest release.
-        iperf3: ["3.12", "3.21"]
+        include:
+          # Legacy target — exercises riperf3's iperf3<=3.12 compat shims (#23,
+          # #24, the legacy UDP connect reply). SHA-pinned (the tag is mutable)
+          # so the "known iperf3" can't silently change under the gate.
+          - iperf3: "3.12"
+            sha: e61aaf8c95df956cefbc54fab7b3d78914664180
+          # Latest release.
+          - iperf3: "3.21"
+            sha: d39cf41526626b4e5a130f115d931cd6cbdffc19
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
 
+      # build-essential + git for the iperf3 source build; automake/autoconf/
+      # libtool for its bootstrap. python3 and iproute2 (`ss`) — used by
+      # interop.sh — are preinstalled on the ubuntu-latest image.
       - name: Install iperf3 build dependencies
-        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends automake autoconf libtool
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends build-essential git automake autoconf libtool
 
-      - name: Build iperf3 ${{ matrix.iperf3 }} from source
-        run: echo "IPERF3_BIN=$(bash scripts/build-iperf3.sh '${{ matrix.iperf3 }}' "$RUNNER_TEMP/iperf3")" >> "$GITHUB_ENV"
+      - name: Build iperf3 ${{ matrix.iperf3 }} from source (pinned SHA)
+        run: |
+          BIN="$(bash scripts/build-iperf3.sh '${{ matrix.iperf3 }}' "$RUNNER_TEMP/iperf3" '${{ matrix.sha }}')"
+          [ -x "$BIN" ] || { echo "iperf3 build did not produce a binary"; exit 1; }
+          echo "IPERF3_BIN=$BIN" >> "$GITHUB_ENV"
 
       - name: Build riperf3 (release)
         run: cargo build --release --bin riperf3
@@ -42,9 +58,10 @@ jobs:
         env:
           INTEROP_DURATION: "1"
         run: |
-          # iperf3 <=3.12 aborts the control connection on the late UDP send
-          # error at reverse/bidir teardown (issue #48, UDP analog of #23).
-          # Tracked as xfail until fixed; the gate flips red if it starts passing.
+          # iperf3 <=3.12 aborts the control connection on the late UDP send error
+          # at reverse/bidir teardown (#48, the UDP analog of #23) — a timing race,
+          # so these cells pass/fail nondeterministically. Tracked as a soft xfail
+          # (tolerated either way, never reds the gate); remove once #48 is fixed.
           if [ "${{ matrix.iperf3 }}" = "3.12" ]; then
             export XFAIL="udp_rev|[r->i] udp_bidir|[r->i]"
             export XFAIL_REASON="#48 UDP reverse/bidir teardown resets iperf3<=3.12"

--- a/scripts/build-iperf3.sh
+++ b/scripts/build-iperf3.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Build a pinned iperf3 from source — per the project's build-from-source policy
+# (never distro packages), so the interop gate tests an exact, known iperf3.
+#
+# Clones the given tag, bootstraps autotools, and compiles a static-libiperf
+# binary (no shared-lib wrapper, so it runs from the build tree). All build
+# chatter goes to stderr; the absolute path to the built `iperf3` is printed to
+# stdout so callers can `BIN=$(build-iperf3.sh ...)`.
+#
+# Usage:   build-iperf3.sh <version-tag> <workdir>
+# Example: build-iperf3.sh 3.12 /tmp/iperf3
+set -euo pipefail
+
+version="${1:?usage: build-iperf3.sh <version-tag> <workdir>}"
+workdir="${2:?usage: build-iperf3.sh <version-tag> <workdir>}"
+src="$workdir/iperf-$version"
+bin="$src/src/iperf3"
+
+if [ ! -x "$bin" ]; then
+    rm -rf "$src"
+    mkdir -p "$workdir"
+    git clone --depth 1 --branch "$version" https://github.com/esnet/iperf.git "$src" >&2
+    (
+        cd "$src"
+        ./bootstrap.sh
+        ./configure --disable-shared
+        make -j"$(nproc 2>/dev/null || echo 2)"
+    ) >&2
+fi
+
+echo "$bin"

--- a/scripts/build-iperf3.sh
+++ b/scripts/build-iperf3.sh
@@ -2,17 +2,20 @@
 # Build a pinned iperf3 from source — per the project's build-from-source policy
 # (never distro packages), so the interop gate tests an exact, known iperf3.
 #
-# Clones the given tag, bootstraps autotools, and compiles a static-libiperf
-# binary (no shared-lib wrapper, so it runs from the build tree). All build
-# chatter goes to stderr; the absolute path to the built `iperf3` is printed to
-# stdout so callers can `BIN=$(build-iperf3.sh ...)`.
+# Clones the given tag, verifies the checkout against an expected commit SHA when
+# one is supplied (a tag is mutable; pinning the SHA keeps the "known iperf3"
+# from silently changing under the gate), bootstraps autotools, and compiles a
+# static-libiperf binary (no shared-lib wrapper, so it runs from the build tree).
+# All build chatter and the resolved SHA go to stderr; the absolute path to the
+# built `iperf3` is printed to stdout so callers can `BIN=$(build-iperf3.sh ...)`.
 #
-# Usage:   build-iperf3.sh <version-tag> <workdir>
-# Example: build-iperf3.sh 3.12 /tmp/iperf3
+# Usage:   build-iperf3.sh <version-tag> <workdir> [expected-commit-sha]
+# Example: build-iperf3.sh 3.12 /tmp/iperf3 e61aaf8c95df956cefbc54fab7b3d78914664180
 set -euo pipefail
 
-version="${1:?usage: build-iperf3.sh <version-tag> <workdir>}"
-workdir="${2:?usage: build-iperf3.sh <version-tag> <workdir>}"
+version="${1:?usage: build-iperf3.sh <version-tag> <workdir> [expected-sha]}"
+workdir="${2:?usage: build-iperf3.sh <version-tag> <workdir> [expected-sha]}"
+expected_sha="${3:-}"
 src="$workdir/iperf-$version"
 bin="$src/src/iperf3"
 
@@ -20,6 +23,17 @@ if [ ! -x "$bin" ]; then
     rm -rf "$src"
     mkdir -p "$workdir"
     git clone --depth 1 --branch "$version" https://github.com/esnet/iperf.git "$src" >&2
+fi
+
+# Verify the checkout BEFORE the (expensive) build, so a moved tag fails fast.
+sha="$(git -C "$src" rev-parse HEAD)"
+echo "iperf3 $version checked out at $sha" >&2
+if [ -n "$expected_sha" ] && [ "$sha" != "$expected_sha" ]; then
+    echo "ERROR: iperf3 $version resolved to $sha, expected $expected_sha (tag moved?)" >&2
+    exit 1
+fi
+
+if [ ! -x "$bin" ]; then
     (
         cd "$src"
         ./bootstrap.sh
@@ -28,4 +42,7 @@ if [ ! -x "$bin" ]; then
     ) >&2
 fi
 
+# Sanity: the binary must actually run (catches a partial/corrupt build that
+# still left an executable behind).
+"$bin" --version >&2
 echo "$bin"

--- a/scripts/build-iperf3.sh
+++ b/scripts/build-iperf3.sh
@@ -26,7 +26,10 @@ if [ ! -x "$bin" ]; then
 fi
 
 # Verify the checkout BEFORE the (expensive) build, so a moved tag fails fast.
-sha="$(git -C "$src" rev-parse HEAD)"
+if ! sha="$(git -C "$src" rev-parse HEAD 2>/dev/null)"; then
+    echo "ERROR: $src is not a usable git checkout — remove it and re-run" >&2
+    exit 1
+fi
 echo "iperf3 $version checked out at $sha" >&2
 if [ -n "$expected_sha" ] && [ "$sha" != "$expected_sha" ]; then
     echo "ERROR: iperf3 $version resolved to $sha, expected $expected_sha (tag moved?)" >&2

--- a/scripts/interop.sh
+++ b/scripts/interop.sh
@@ -2,12 +2,14 @@
 # riperf3 <-> iperf3 wire-interop matrix over loopback.
 #
 # Runs every client->server pairing of {riperf3, iperf3} across protocol x
-# direction x parallel x feature spot-checks, asserting each test COMPLETES with
-# a valid (non-zero-byte) result. This is the correctness gate the in-repo
-# loopback tests cannot provide: those are riperf3<->riperf3 only, so a wire
-# constant that is wrong against real iperf3 still passes them. The interop-
-# relevant pairings are r->i and i->r; r->r and i->i are controls. Throughput is
-# meaningless here (loopback) — only completion + data transfer is asserted.
+# direction x parallel x feature spot-checks, asserting each test COMPLETES and
+# moves data in both aggregates (sum_sent and sum_received > 0). This catches the
+# protocol-interop regressions the in-repo tests cannot: those are riperf3<->
+# riperf3 only, so a wire constant wrong against real iperf3 still passes them.
+# Scope: it proves the handshake / param-exchange / transfer path interoperates;
+# it does NOT assert JSON field-level parity (counter/schema fidelity is #36).
+# Interop pairings are r->i and i->r; r->r and i->i are controls. Throughput is
+# meaningless here (loopback).
 #
 # Exit status is non-zero if any case fails.
 #
@@ -17,17 +19,34 @@ set -uo pipefail
 
 RIPERF3="${1:?usage: interop.sh <riperf3-bin> <iperf3-bin>}"
 IPERF3="${2:?usage: interop.sh <riperf3-bin> <iperf3-bin>}"
+# The two binaries must differ — tag() maps each path to its r/i column, so the
+# same path twice would silently render every pairing as a control.
+if [ "$RIPERF3" = "$IPERF3" ]; then
+    echo "error: riperf3 and iperf3 binaries must differ (got '$RIPERF3' twice)" >&2
+    exit 2
+fi
 DUR="${INTEROP_DURATION:-2}"
-# Space-separated list of "name|col" keys (e.g. "udp_rev|[r->i]") that are known
-# to fail against this peer and should be tolerated. An xfail that unexpectedly
-# PASSES is reported as UPASS and fails the run, forcing promotion to required
-# once the underlying bug is fixed. Set per iperf3 version by the CI workflow.
+# Space-separated list of "name|col" keys (e.g. "udp_rev|[r->i]") for cells with a
+# tracked, KNOWN-broken interop bug. Their outcome (pass OR fail) never reds the
+# gate: the #48 teardown reset is a timing race, so a pass doesn't mean "fixed" —
+# just that the race went the other way this run. When the underlying issue is
+# fixed these pass deterministically; remove them here then so the cell becomes
+# required again. Set per iperf3 version by the CI workflow.
 XFAIL="${XFAIL:-}"
 XFAIL_REASON="${XFAIL_REASON:-tracked}"
 HOST=127.0.0.1
 port=5202
 workdir="$(mktemp -d)"
 trap 'rm -rf "$workdir"' EXIT
+
+# Per-attempt I/O sinks (fixed paths, reused per case). -J JSON (stdout) and
+# diagnostics (stderr) stay SEPARATE: a stray stderr line merged into the JSON
+# sink would make the parser choke and score a good transfer as a false FAIL.
+# The server's output (sj/serr) is kept for failure diagnostics only; it is NOT
+# validated as JSON — the riperf3 server emits text, not JSON yet (#50). Once it
+# gains a -J path, validate sj for the interop pairings too (#49 review).
+cj="$workdir/c.json"; cerr="$workdir/c.err"
+sj="$workdir/s.json"; serr="$workdir/s.err"
 
 pass=0
 fail=0
@@ -69,9 +88,13 @@ wait_port() {
     return 1
 }
 
-# Succeeds (exit 0) iff the client JSON shows no error and a positive byte count
-# in any end-of-test aggregate. Kept dependency-free (python3, no jq) so it runs
-# the same locally and in CI.
+# Succeeds (exit 0) iff the client JSON shows no error AND both end-of-test
+# aggregates moved data (sum_sent.bytes > 0 and sum_received.bytes > 0). Requiring
+# both — not "some bytes somewhere" — catches a one-sided transfer (a real interop
+# break) instead of scoring it green. The per-direction bidir split
+# (sum_*_bidir_reverse) is intentionally NOT required: riperf3 doesn't emit it yet
+# (#36), while the sender/receiver aggregates are populated by both tools in every
+# direction. Dependency-free (python3, no jq) so it runs the same locally and in CI.
 valid_result() {
     python3 - "$1" <<'PY'
 import json, sys
@@ -84,52 +107,73 @@ if isinstance(d, dict) and d.get("error"):
     print("  reported error:", d["error"], file=sys.stderr)
     sys.exit(1)
 end = d.get("end", {}) if isinstance(d, dict) else {}
-best = 0
-for k, v in end.items():
-    if isinstance(v, dict) and isinstance(v.get("bytes"), (int, float)):
-        best = max(best, v["bytes"])
-sys.exit(0 if best > 0 else 2)
+def aggregate_bytes(key):
+    v = end.get(key)
+    return v["bytes"] if isinstance(v, dict) and isinstance(v.get("bytes"), (int, float)) else 0
+sent = aggregate_bytes("sum_sent")
+recv = aggregate_bytes("sum_received")
+if sent > 0 and recv > 0:
+    sys.exit(0)
+print(f"  no bidirectional transfer: sum_sent={sent} sum_received={recv}", file=sys.stderr)
+sys.exit(2)
 PY
+}
+
+# attempt <client-bin> <server-bin> <client-opts...>
+# One server/client round on a fresh port. Returns 0 iff the test completed with
+# bidirectional transfer. Writes cj/cerr (client) and sj/serr (server).
+attempt() {
+    local client="$1" server="$2"
+    shift 2
+    local p=$((port++))
+    "$server" -s -1 -p "$p" -J >"$sj" 2>"$serr" &
+    local spid=$!
+    if ! wait_port "$p"; then
+        kill "$spid" 2>/dev/null
+        wait "$spid" 2>/dev/null
+        echo "server never listened on port $p" >"$cerr"
+        return 1
+    fi
+    # -k escalates to SIGKILL if the client ignores SIGTERM; the budget scales
+    # with the test duration so a hang costs seconds rather than a fixed ceiling.
+    timeout -k 5 "$((DUR + 15))" "$client" -c "$HOST" -p "$p" -J "$@" >"$cj" 2>"$cerr"
+    local rc=$?
+    kill "$spid" 2>/dev/null
+    wait "$spid" 2>/dev/null
+    [ "$rc" -eq 0 ] && valid_result "$cj"
 }
 
 # run_case <name> <client-bin> <server-bin> <client-opts...>
 run_case() {
     local name="$1" client="$2" server="$3"
     shift 3
-    local copts=("$@")
-    local p=$((port++))
-    local sj="$workdir/s.json" cj="$workdir/c.json"
     local col="[$(tag "$client")->$(tag "$server")]"
 
-    "$server" -s -1 -p "$p" -J >"$sj" 2>&1 &
-    local spid=$!
+    local ok=1
+    if attempt "$client" "$server" "$@"; then ok=0; fi
 
-    if ! wait_port "$p"; then
-        kill "$spid" 2>/dev/null
-        wait "$spid" 2>/dev/null
-        printf 'FAIL  %-26s %s  (server never listened)\n' "$name" "$col"
-        fail=$((fail + 1))
-        failed_cases+=("$name $col")
-        return
+    # Retry a single transient failure once: UDP -b0 floods on loopback are
+    # inherently lossy/racy under back-to-back load, so an isolated failure may
+    # not reproduce. A deterministic failure — a real interop break, or a tracked
+    # xfail — fails both attempts. Don't spend the retry on a known xfail.
+    if [ "$ok" -ne 0 ] && ! is_xfail "$name|$col"; then
+        printf 'RETRY %-26s %s  (transient failure — re-running once)\n' "$name" "$col"
+        if attempt "$client" "$server" "$@"; then ok=0; fi
     fi
 
-    timeout 40 "$client" -c "$HOST" -p "$p" -J "${copts[@]}" >"$cj" 2>&1
-    local rc=$?
-    kill "$spid" 2>/dev/null
-    wait "$spid" 2>/dev/null
-
-    local ok=1
-    if [ "$rc" -eq 0 ] && valid_result "$cj"; then ok=0; fi
-
     if is_xfail "$name|$col"; then
+        # Tolerated known-broken cell: report the outcome but never red the gate.
+        # The bug is racy (the #48 teardown reset is timing-dependent), so a pass
+        # doesn't mean "fixed", just that the race went the other way. NOTE this
+        # also means a NEW, unrelated breakage in the cell stays hidden — keep the
+        # XFAIL list minimal, tied to a tracked issue, and removed once fixed (so
+        # a regression reds the gate again).
         if [ "$ok" -eq 0 ]; then
-            printf 'UPASS %-26s %s  (xfail but PASSED — bug fixed? promote to required)\n' "$name" "$col"
-            fail=$((fail + 1))
-            failed_cases+=("UPASS $name $col")
+            printf 'XPASS %-26s %s  (known-flaky %s; passed this run)\n' "$name" "$col" "$XFAIL_REASON"
         else
             printf 'XFAIL %-26s %s  (known: %s)\n' "$name" "$col" "$XFAIL_REASON"
-            xfail=$((xfail + 1))
         fi
+        xfail=$((xfail + 1))
         return
     fi
 
@@ -137,8 +181,11 @@ run_case() {
         printf 'PASS  %-26s %s\n' "$name" "$col"
         pass=$((pass + 1))
     else
-        printf 'FAIL  %-26s %s  (rc=%s)\n' "$name" "$col" "$rc"
-        sed 's/^/    | /' "$cj" | tail -4
+        printf 'FAIL  %-26s %s\n' "$name" "$col"
+        sed 's/^/    client    | /' "$cj" | tail -4
+        sed 's/^/    client-err| /' "$cerr" | tail -4
+        sed 's/^/    server    | /' "$sj" | tail -4
+        sed 's/^/    server-err| /' "$serr" | tail -4
         fail=$((fail + 1))
         failed_cases+=("$name $col")
     fi

--- a/scripts/interop.sh
+++ b/scripts/interop.sh
@@ -1,0 +1,186 @@
+#!/usr/bin/env bash
+# riperf3 <-> iperf3 wire-interop matrix over loopback.
+#
+# Runs every client->server pairing of {riperf3, iperf3} across protocol x
+# direction x parallel x feature spot-checks, asserting each test COMPLETES with
+# a valid (non-zero-byte) result. This is the correctness gate the in-repo
+# loopback tests cannot provide: those are riperf3<->riperf3 only, so a wire
+# constant that is wrong against real iperf3 still passes them. The interop-
+# relevant pairings are r->i and i->r; r->r and i->i are controls. Throughput is
+# meaningless here (loopback) — only completion + data transfer is asserted.
+#
+# Exit status is non-zero if any case fails.
+#
+# Usage:   interop.sh <riperf3-bin> <iperf3-bin>
+# Env:     INTEROP_DURATION  seconds per test (default 2)
+set -uo pipefail
+
+RIPERF3="${1:?usage: interop.sh <riperf3-bin> <iperf3-bin>}"
+IPERF3="${2:?usage: interop.sh <riperf3-bin> <iperf3-bin>}"
+DUR="${INTEROP_DURATION:-2}"
+# Space-separated list of "name|col" keys (e.g. "udp_rev|[r->i]") that are known
+# to fail against this peer and should be tolerated. An xfail that unexpectedly
+# PASSES is reported as UPASS and fails the run, forcing promotion to required
+# once the underlying bug is fixed. Set per iperf3 version by the CI workflow.
+XFAIL="${XFAIL:-}"
+XFAIL_REASON="${XFAIL_REASON:-tracked}"
+HOST=127.0.0.1
+port=5202
+workdir="$(mktemp -d)"
+trap 'rm -rf "$workdir"' EXIT
+
+pass=0
+fail=0
+xfail=0
+failed_cases=()
+
+echo "riperf3: $("$RIPERF3" -v 2>&1 | head -1)"
+echo "iperf3:  $("$IPERF3" --version 2>&1 | head -1)"
+echo
+
+# Single-letter tag for the matrix column.
+tag() {
+    case "$1" in
+        "$RIPERF3") echo r ;;
+        "$IPERF3") echo i ;;
+        *) echo "?" ;;
+    esac
+}
+
+# True if "name|col" is in the known-xfail list for this peer.
+is_xfail() {
+    case " $XFAIL " in
+        *" $1 "*) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+# Wait until the server's TCP control port is in LISTEN state. Uses `ss`, not a
+# connect probe: a probe would consume the single connection a `-s -1` one-off
+# server accepts, leaving the real client to see "connection refused".
+wait_port() {
+    local p="$1" i
+    for i in $(seq 1 100); do
+        if ss -ltn 2>/dev/null | grep -qE ":${p} "; then
+            return 0
+        fi
+        sleep 0.1
+    done
+    return 1
+}
+
+# Succeeds (exit 0) iff the client JSON shows no error and a positive byte count
+# in any end-of-test aggregate. Kept dependency-free (python3, no jq) so it runs
+# the same locally and in CI.
+valid_result() {
+    python3 - "$1" <<'PY'
+import json, sys
+try:
+    d = json.load(open(sys.argv[1]))
+except Exception as e:
+    print("  json parse failed:", e, file=sys.stderr)
+    sys.exit(1)
+if isinstance(d, dict) and d.get("error"):
+    print("  reported error:", d["error"], file=sys.stderr)
+    sys.exit(1)
+end = d.get("end", {}) if isinstance(d, dict) else {}
+best = 0
+for k, v in end.items():
+    if isinstance(v, dict) and isinstance(v.get("bytes"), (int, float)):
+        best = max(best, v["bytes"])
+sys.exit(0 if best > 0 else 2)
+PY
+}
+
+# run_case <name> <client-bin> <server-bin> <client-opts...>
+run_case() {
+    local name="$1" client="$2" server="$3"
+    shift 3
+    local copts=("$@")
+    local p=$((port++))
+    local sj="$workdir/s.json" cj="$workdir/c.json"
+    local col="[$(tag "$client")->$(tag "$server")]"
+
+    "$server" -s -1 -p "$p" -J >"$sj" 2>&1 &
+    local spid=$!
+
+    if ! wait_port "$p"; then
+        kill "$spid" 2>/dev/null
+        wait "$spid" 2>/dev/null
+        printf 'FAIL  %-26s %s  (server never listened)\n' "$name" "$col"
+        fail=$((fail + 1))
+        failed_cases+=("$name $col")
+        return
+    fi
+
+    timeout 40 "$client" -c "$HOST" -p "$p" -J "${copts[@]}" >"$cj" 2>&1
+    local rc=$?
+    kill "$spid" 2>/dev/null
+    wait "$spid" 2>/dev/null
+
+    local ok=1
+    if [ "$rc" -eq 0 ] && valid_result "$cj"; then ok=0; fi
+
+    if is_xfail "$name|$col"; then
+        if [ "$ok" -eq 0 ]; then
+            printf 'UPASS %-26s %s  (xfail but PASSED — bug fixed? promote to required)\n' "$name" "$col"
+            fail=$((fail + 1))
+            failed_cases+=("UPASS $name $col")
+        else
+            printf 'XFAIL %-26s %s  (known: %s)\n' "$name" "$col" "$XFAIL_REASON"
+            xfail=$((xfail + 1))
+        fi
+        return
+    fi
+
+    if [ "$ok" -eq 0 ]; then
+        printf 'PASS  %-26s %s\n' "$name" "$col"
+        pass=$((pass + 1))
+    else
+        printf 'FAIL  %-26s %s  (rc=%s)\n' "$name" "$col" "$rc"
+        sed 's/^/    | /' "$cj" | tail -4
+        fail=$((fail + 1))
+        failed_cases+=("$name $col")
+    fi
+}
+
+# Client option-sets. The server is always plain `-s` — iperf3 negotiates
+# protocol/direction/parallel/features from the client's param exchange.
+order=(
+    tcp_fwd tcp_rev tcp_bidir tcp_p4 tcp_len128k tcp_win256k tcp_mss1400
+    tcp_omit tcp_zerocopy tcp_get_output
+    udp_fwd udp_rev udp_bidir udp_p4 udp_len8192 udp_64bit
+)
+declare -A opts=(
+    [tcp_fwd]="-t $DUR"
+    [tcp_rev]="-R -t $DUR"
+    [tcp_bidir]="--bidir -t $DUR"
+    [tcp_p4]="-P 4 -t $DUR"
+    [tcp_len128k]="-l 128K -t $DUR"
+    [tcp_win256k]="-w 256K -t $DUR"
+    [tcp_mss1400]="-M 1400 -t $DUR"
+    [tcp_omit]="-O 1 -t $DUR"
+    [tcp_zerocopy]="-Z -t $DUR"
+    [tcp_get_output]="--get-server-output -t $DUR"
+    [udp_fwd]="-u -b 0 -t $DUR"
+    [udp_rev]="-u -R -b 0 -t $DUR"
+    [udp_bidir]="-u --bidir -b 0 -t $DUR"
+    [udp_p4]="-u -P 4 -b 0 -t $DUR"
+    [udp_len8192]="-u -l 8192 -b 0 -t $DUR"
+    [udp_64bit]="-u --udp-counters-64bit -b 0 -t $DUR"
+)
+
+for name in "${order[@]}"; do
+    read -ra o <<<"${opts[$name]}"
+    run_case "$name" "$RIPERF3" "$IPERF3" "${o[@]}"  # r->i  (interop)
+    run_case "$name" "$IPERF3" "$RIPERF3" "${o[@]}"  # i->r  (interop)
+    run_case "$name" "$RIPERF3" "$RIPERF3" "${o[@]}" # r->r  (control)
+    run_case "$name" "$IPERF3" "$IPERF3" "${o[@]}"   # i->i  (control)
+done
+
+echo
+echo "==== interop summary: $pass passed, $xfail xfail, $fail failed ===="
+if [ "$fail" -gt 0 ]; then
+    printf '  FAIL: %s\n' "${failed_cases[@]}"
+    exit 1
+fi


### PR DESCRIPTION
## What

Adds a **real-iperf3 wire-interop gate** to CI — the check that actually backs the "wire-compatible with iperf3" claim. Closes #38.

The in-repo integration tests are riperf3↔riperf3 loopback only, so a wire/JSON constant that's wrong against *real* iperf3 still passes all 334 of them. This gate builds iperf3 from source at pinned, SHA-verified versions and runs the full client→server matrix over loopback, asserting each test completes and moves data in both aggregates. Loopback ⇒ it gates **protocol interop + bidirectional transfer**, not throughput, and not JSON field-level parity (#36).

## How
- **`scripts/build-iperf3.sh <tag> <dir> [sha]`** — clone + bootstrap + build a pinned iperf3 from source (build-from-source policy). Verifies the checkout against an expected **commit SHA** (a tag is mutable) and fails fast on drift; prints the binary path.
- **`scripts/interop.sh <riperf3> <iperf3>`** — `r→i` / `i→r` (interop) + `r→r` / `i→i` (controls) across TCP/UDP × fwd/rev/bidir × P1/P4 + feature spot-checks (`-l`, `-w`, `-M`, `-O`, `-Z`, `--get-server-output`, UDP `-l 8192`, `--udp-counters-64bit`). Results parsed with `python3` (no `jq`); `-J` JSON and stderr kept in separate files; success requires **both** `sum_sent` and `sum_received` > 0. A single transient non-xfail failure is retried once (loopback UDP `-b0` floods are racy), logged as `RETRY`.
- **`.github/workflows/interop.yml`** — matrix over iperf3 **3.12** (legacy) and **3.21** (latest), SHA-pinned.

Runs identically locally: `bash scripts/interop.sh target/release/riperf3 $(which iperf3)`.

## Local validation
| iperf3 | result |
|---|---|
| 3.21 | **64/64 pass** |
| 3.12 | **62 pass + 2 soft-xfail**, exit 0 across repeated runs |

## Bugs/gaps the gate surfaced
- **#48** — UDP reverse/bidir teardown resets the iperf3 ≤3.12 server (UDP analog of #23). It's a **timing race**, so those two cells are tracked as a **soft xfail**: tolerated whether they pass or fail (never reds the gate), removed once #48 is fixed (then they pass deterministically and become required again). 3.21 tolerates the late send and passes.
- **#50** — the riperf3 **server emits no JSON** (`-J` is client-only). The interop gate therefore validates only the client JSON today; once #50 lands, it'll validate the server side of each pairing too (tracked via an in-code TODO).

## Cold review
Two independent round-1 reviews applied (robustness + reproducibility): stderr/JSON separation, both-aggregate validation, SHA pinning + drift check, build-failure propagation, `timeout -k`, transient retry, soft-xfail, `permissions: contents: read`, explicit apt deps. (Reviewer-supplied SHAs were the annotated-tag objects; corrected to the peeled-commit SHAs.) Round 2 pending.

## Follow-ups (not in this PR)
- Promote `Interop / iperf3 3.12` and `Interop / iperf3 3.21` to **required checks** in the branch ruleset.
- Remove the two soft-xfail entries once **#48** is fixed.
- Extend the gate to validate the **server** JSON once **#50** lands.
- Optional: cache the iperf3 source build; a nightly job floating to iperf3's newest tag.
- A deep `-J` schema diff vs iperf3 belongs with #36.
