### PR TITLE
feat(json): typed iperf3-faithful -J end block + real addresses (#36, PR1/3)

### DIFF
--- a/riperf3/src/client.rs
+++ b/riperf3/src/client.rs
@@ -378,6 +378,11 @@ impl Client {
                     #[cfg(not(unix))]
                     let raw_fd: Option<i32> = None;
 
+                    // Capture the real socket addresses before the stream moves
+                    // into its task, for the `-J` start.connected block (#36).
+                    let local_addr = data_stream.local_addr().ok();
+                    let peer_addr = data_stream.peer_addr().ok();
+
                     let stream_id = iperf3_stream_id(i);
                     let is_sender = i < send_count;
                     let counters = Arc::new(StreamCounters::new());
@@ -419,6 +424,8 @@ impl Client {
                         udp_recv_stats: None,
                         task,
                         raw_fd,
+                        local_addr,
+                        peer_addr,
                     });
                 }
             }
@@ -457,6 +464,11 @@ impl Client {
                     let stream_id = iperf3_stream_id(i);
                     let is_sender = i < send_count;
                     let counters = Arc::new(StreamCounters::new());
+
+                    // Capture real addresses for the `-J` start.connected block
+                    // (#36) before the socket moves into its task.
+                    let local_addr = udp_sock.local_addr().ok();
+                    let peer_addr = udp_sock.peer_addr().ok();
 
                     // Convert tokio UdpSocket to std for blocking I/O
                     let std_sock = udp_sock.into_std().map_err(RiperfError::Io)?;
@@ -500,6 +512,8 @@ impl Client {
                             udp_recv_stats: Some(stats),
                             task,
                             raw_fd: None,
+                            local_addr,
+                            peer_addr,
                         });
                         continue;
                     };
@@ -511,6 +525,8 @@ impl Client {
                         udp_recv_stats: None,
                         task,
                         raw_fd: None,
+                        local_addr,
+                        peer_addr,
                     });
                 }
             }
@@ -758,171 +774,114 @@ impl Client {
         remote_cpu: Option<&TestResultsJson>,
         blksize: usize,
     ) {
+        use crate::json_report::{CpuUtilization, ReportInput, StreamReport, UdpStreamStats};
+
         let test_duration = self.duration as f64;
         let cpu_end = CpuSnapshot::now();
         let cpu_util = cpu_start
             .map(|start| cpu_end.utilization_since(start))
             .unwrap_or_default();
-
-        let protocol_str = match self.protocol {
-            TransportProtocol::Tcp => "TCP",
-            TransportProtocol::Udp => "UDP",
-        };
-
-        // Forward UDP: the server is the receiver, so its loss lives only in the
-        // results it returned. Surface it in `-J` too, mirroring the text path (#25).
-        let is_forward_udp =
-            matches!(self.protocol, TransportProtocol::Udp) && !self.reverse && !self.bidir;
-
-        // Build per-stream end results
-        let mut j_streams = Vec::new();
-        let mut sum_sent_bytes: u64 = 0;
-        let mut sum_recv_bytes: u64 = 0;
-        let sum_retransmits: i64 = 0;
-
-        for s in streams {
-            let sent = s.counters.bytes_sent();
-            let recv = s.counters.bytes_received();
-            let bytes = if s.is_sender { sent } else { recv };
-            let bits_per_sec = bytes as f64 * 8.0 / test_duration;
-
-            if s.is_sender {
-                sum_sent_bytes += sent;
-            } else {
-                sum_recv_bytes += recv;
-            }
-
-            let mut stream_obj = serde_json::json!({
-                "socket": s.id,
-                "start": 0.0,
-                "end": test_duration,
-                "seconds": test_duration,
-                "bytes": bytes,
-                "bits_per_second": bits_per_sec,
-                "sender": s.is_sender
-            });
-
-            if let (Some(ref udp_stats_lock), false) = (&s.udp_recv_stats, s.is_sender) {
-                if let Ok(stats) = udp_stats_lock.lock() {
-                    stream_obj["jitter_ms"] = serde_json::json!(stats.jitter * 1000.0);
-                    stream_obj["lost_packets"] = serde_json::json!(stats.cnt_error);
-                    stream_obj["packets"] = serde_json::json!(stats.packet_count);
-                    stream_obj["lost_percent"] = serde_json::json!(crate::reporter::lost_percent(
-                        stats.cnt_error,
-                        stats.packet_count
-                    ));
-                }
-            } else if is_forward_udp && s.is_sender {
-                // Forward UDP: the loss was measured by the server (receiver), so
-                // attach it from its results — otherwise `-J` forward looks
-                // loss-free too, the machine-readable twin of the text gap (#25).
-                if let Some(rs) = remote_cpu.and_then(|r| r.streams.iter().find(|x| x.id == s.id)) {
-                    stream_obj["jitter_ms"] = serde_json::json!(rs.jitter * 1000.0);
-                    stream_obj["lost_packets"] = serde_json::json!(rs.errors);
-                    stream_obj["packets"] = serde_json::json!(rs.packets);
-                    stream_obj["lost_percent"] =
-                        serde_json::json!(crate::reporter::lost_percent(rs.errors, rs.packets));
-                }
-            }
-
-            j_streams.push(stream_obj);
-        }
-
-        // If we only have senders, use sent bytes for both
-        if sum_recv_bytes == 0 {
-            sum_recv_bytes = sum_sent_bytes;
-        }
-        if sum_sent_bytes == 0 {
-            sum_sent_bytes = sum_recv_bytes;
-        }
-
         let (remote_total, remote_user, remote_system) = remote_cpu
             .map(|r| (r.cpu_util_total, r.cpu_util_user, r.cpu_util_system))
             .unwrap_or((0.0, 0.0, 0.0));
 
-        let mut output = serde_json::json!({
-            "start": {
-                "connected": streams.iter().map(|s| {
-                    serde_json::json!({
-                        "socket": s.id,
-                        "local_host": self.host,
-                        "local_port": self.port,
-                        "remote_host": self.host,
-                        "remote_port": self.port
+        let is_udp = matches!(self.protocol, TransportProtocol::Udp);
+        // Forward UDP: the server is the receiver, so its loss lives only in the
+        // results it returned — attach it to the (sender) streams (#25).
+        let is_forward_udp = is_udp && !self.reverse && !self.bidir;
+
+        let stream_reports: Vec<StreamReport> = streams
+            .iter()
+            .map(|s| {
+                let local_bytes = if s.is_sender {
+                    s.counters.bytes_sent()
+                } else {
+                    s.counters.bytes_received()
+                };
+                // The peer's per-stream result is the opposite side of this stream.
+                let server_stream =
+                    remote_cpu.and_then(|r| r.streams.iter().find(|x| x.id == s.id));
+
+                // UDP datagram stats: from our local receiver if we measured them,
+                // else (forward UDP) from the server's results for this stream (#25).
+                let udp = if let Some(ref lock) = s.udp_recv_stats {
+                    lock.lock().ok().map(|st| UdpStreamStats {
+                        jitter_secs: st.jitter,
+                        lost_packets: st.cnt_error,
+                        packets: st.packet_count,
+                        out_of_order: st.outoforder_packets,
                     })
-                }).collect::<Vec<_>>(),
-                "version": format!("riperf3 {}", env!("CARGO_PKG_VERSION")),
-                "system_info": "",
-                "connecting_to": {
-                    "host": self.host,
-                    "port": self.port
-                },
-                "test_start": {
-                    "protocol": protocol_str,
-                    "num_streams": self.num_streams,
-                    "blksize": blksize,
-                    "omit": self.omit,
-                    "duration": self.duration,
-                    "bytes": 0,
-                    "blocks": 0,
-                    "reverse": if self.reverse { 1 } else { 0 },
-                    "tos": self.tos,
-                    "target_bitrate": self.bandwidth,
-                    "bidir": if self.bidir { 1 } else { 0 }
+                } else if is_forward_udp && s.is_sender {
+                    server_stream.map(|x| UdpStreamStats {
+                        jitter_secs: x.jitter,
+                        lost_packets: x.errors,
+                        packets: x.packets,
+                        out_of_order: 0,
+                    })
+                } else {
+                    None
+                };
+
+                let (local_host, local_port) = s
+                    .local_addr
+                    .map(|a| (a.ip().to_string(), a.port()))
+                    .unwrap_or_else(|| (self.host.clone(), 0));
+                let (remote_host, remote_port) = s
+                    .peer_addr
+                    .map(|a| (a.ip().to_string(), a.port()))
+                    .unwrap_or_else(|| (self.host.clone(), self.port));
+
+                StreamReport {
+                    id: s.id,
+                    local_host,
+                    local_port,
+                    remote_host,
+                    remote_port,
+                    is_sender: s.is_sender,
+                    local_bytes,
+                    remote_bytes: server_stream.map(|x| x.bytes),
+                    // End-of-test per-stream retransmits aren't accumulated yet
+                    // (-1 = unavailable, iperf3's sentinel); real values arrive
+                    // with the interval TCP_INFO work in PR2. UDP carries none.
+                    retransmits: if is_udp { None } else { Some(-1) },
+                    udp,
                 }
+            })
+            .collect();
+
+        let input = ReportInput {
+            protocol: self.protocol,
+            reverse: self.reverse,
+            bidir: self.bidir,
+            duration: test_duration,
+            num_streams: self.num_streams as i32,
+            blksize: blksize as i64,
+            omit: self.omit as i32,
+            tos: self.tos,
+            target_bitrate: self.bandwidth,
+            bytes: self.bytes_to_send.unwrap_or(0),
+            blocks: self.blocks_to_send.unwrap_or(0),
+            connecting_host: self.host.clone(),
+            connecting_port: self.port,
+            version: format!("riperf3 {}", env!("CARGO_PKG_VERSION")),
+            // Full system_info (uname) lands with the rest of start{} metadata in PR3.
+            system_info: String::new(),
+            cpu: CpuUtilization {
+                host_total: cpu_util.host_total,
+                host_user: cpu_util.host_user,
+                host_system: cpu_util.host_system,
+                remote_total,
+                remote_user,
+                remote_system,
             },
-            "intervals": [],
-            "end": {
-                "streams": j_streams,
-                "sum_sent": {
-                    "start": 0.0,
-                    "end": test_duration,
-                    "seconds": test_duration,
-                    "bytes": sum_sent_bytes,
-                    "bits_per_second": sum_sent_bytes as f64 * 8.0 / test_duration,
-                    "retransmits": sum_retransmits,
-                    "sender": true
-                },
-                "sum_received": {
-                    "start": 0.0,
-                    "end": test_duration,
-                    "seconds": test_duration,
-                    "bytes": sum_recv_bytes,
-                    "bits_per_second": sum_recv_bytes as f64 * 8.0 / test_duration,
-                    "sender": true
-                },
-                "cpu_utilization_percent": {
-                    "host_total": cpu_util.host_total,
-                    "host_user": cpu_util.host_user,
-                    "host_system": cpu_util.host_system,
-                    "remote_total": remote_total,
-                    "remote_user": remote_user,
-                    "remote_system": remote_system
-                }
-            }
-        });
+            // Reporting the *actually-applied* congestion algorithm is #37; omit
+            // the field until that read-back lands rather than emit the requested
+            // value (which may differ from what the kernel used).
+            congestion_used: None,
+            streams: stream_reports,
+        };
 
-        // Forward UDP: fold the server-measured loss into the aggregate
-        // `sum_received` so `-J` reports it alongside the per-stream lines (#25).
-        if is_forward_udp {
-            if let Some(server) = remote_cpu {
-                let lost: i64 = server.streams.iter().map(|s| s.errors).sum();
-                let packets: i64 = server.streams.iter().map(|s| s.packets).sum();
-                let jitter = server
-                    .streams
-                    .iter()
-                    .map(|s| s.jitter)
-                    .fold(0.0_f64, f64::max);
-                let sr = &mut output["end"]["sum_received"];
-                sr["jitter_ms"] = serde_json::json!(jitter * 1000.0);
-                sr["lost_packets"] = serde_json::json!(lost);
-                sr["packets"] = serde_json::json!(packets);
-                sr["lost_percent"] =
-                    serde_json::json!(crate::reporter::lost_percent(lost, packets));
-            }
-        }
-
-        println!("{}", serde_json::to_string_pretty(&output).unwrap());
+        println!("{}", serde_json::to_string_pretty(&input.build()).unwrap());
     }
 }
 

--- a/riperf3/src/json_report.rs
+++ b/riperf3/src/json_report.rs
@@ -1,0 +1,703 @@
+//! Typed, iperf3-compatible JSON report model (issue #36).
+//!
+//! riperf3's `-J` output must be a faithful drop-in for iperf3's, so machine
+//! consumers (Telegraf, Grafana plugins, CI harnesses) that parse iperf3 JSON
+//! work unchanged. This replaces the previous hand-rolled `serde_json::json!`
+//! blob, which diverged from iperf3's schema (flat `end.streams`, empty
+//! `intervals`, fabricated addresses).
+//!
+//! Built incrementally (see #36):
+//! - **This PR**: the `end` block — per-stream objects nested as
+//!   `{sender, receiver}` (TCP) or `{udp}` (UDP), the `sum_sent`/`sum_received`
+//!   aggregates plus the UDP `sum` and bidir `sum_*_bidir_reverse`, CPU
+//!   utilization, and `sender`/`receiver_tcp_congestion`; plus real connection
+//!   addresses in `start.connected`.
+//! - **PR2**: populate `intervals` (and the per-stream TCP_INFO extremes
+//!   `max_snd_cwnd` / `min`/`max`/`mean_rtt`, which derive from per-interval
+//!   `TCP_INFO` accumulation).
+//! - **PR3**: full `start` metadata (`cookie`, `timestamp`, `system_info`,
+//!   `tcp_mss_default`, socket buffer sizes, …).
+//!
+//! Fields iperf3 emits but riperf3 cannot yet produce are omitted
+//! (`skip_serializing_if`) rather than emitted with placeholder values, so the
+//! shape only ever contains real data.
+
+use serde::Serialize;
+
+use crate::protocol::TransportProtocol;
+
+// ---------------------------------------------------------------------------
+// Top-level report
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Serialize)]
+pub struct Report {
+    pub start: Start,
+    pub intervals: Vec<Interval>,
+    pub end: End,
+}
+
+// ---------------------------------------------------------------------------
+// start{}
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Serialize)]
+pub struct Start {
+    pub connected: Vec<Connection>,
+    pub version: String,
+    pub system_info: String,
+    pub connecting_to: ConnectingTo,
+    pub test_start: TestStart,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct Connection {
+    pub socket: i32,
+    pub local_host: String,
+    pub local_port: u16,
+    pub remote_host: String,
+    pub remote_port: u16,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ConnectingTo {
+    pub host: String,
+    pub port: u16,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct TestStart {
+    pub protocol: String,
+    pub num_streams: i32,
+    pub blksize: i64,
+    pub omit: i32,
+    pub duration: i32,
+    pub bytes: u64,
+    pub blocks: u64,
+    pub reverse: i32,
+    pub tos: i32,
+    pub target_bitrate: u64,
+    pub bidir: i32,
+}
+
+// ---------------------------------------------------------------------------
+// intervals[] (populated in PR2; the shape is defined now so the model is whole)
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Serialize)]
+pub struct Interval {
+    pub streams: Vec<IntervalStream>,
+    pub sum: IntervalSum,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct IntervalStream {
+    pub socket: i32,
+    pub start: f64,
+    pub end: f64,
+    pub seconds: f64,
+    pub bytes: u64,
+    pub bits_per_second: f64,
+    pub omitted: bool,
+    pub sender: bool,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct IntervalSum {
+    pub start: f64,
+    pub end: f64,
+    pub seconds: f64,
+    pub bytes: u64,
+    pub bits_per_second: f64,
+    pub omitted: bool,
+    pub sender: bool,
+}
+
+// ---------------------------------------------------------------------------
+// end{}
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Serialize)]
+pub struct End {
+    pub streams: Vec<EndStream>,
+    pub sum_sent: SumSide,
+    pub sum_received: SumSide,
+    /// UDP only: the single-direction datagram aggregate iperf3 emits as `sum`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sum: Option<SumSide>,
+    /// Bidir only: the reverse-direction aggregates.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sum_sent_bidir_reverse: Option<SumSide>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sum_received_bidir_reverse: Option<SumSide>,
+    pub cpu_utilization_percent: CpuUtilization,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sender_tcp_congestion: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub receiver_tcp_congestion: Option<String>,
+}
+
+/// One `end.streams[]` entry. iperf3 nests the per-direction stats: TCP carries
+/// `{sender, receiver}`, UDP carries `{udp}`. Exactly one shape is populated.
+#[derive(Debug, Clone, Serialize)]
+pub struct EndStream {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sender: Option<TcpStreamSide>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub receiver: Option<TcpStreamSide>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub udp: Option<UdpStreamEnd>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct TcpStreamSide {
+    pub socket: i32,
+    pub start: f64,
+    pub end: f64,
+    pub seconds: f64,
+    pub bytes: u64,
+    pub bits_per_second: f64,
+    /// Sender side only; iperf3 reports -1 when the OS doesn't expose retransmits.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub retransmits: Option<i64>,
+    pub sender: bool,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct UdpStreamEnd {
+    pub socket: i32,
+    pub start: f64,
+    pub end: f64,
+    pub seconds: f64,
+    pub bytes: u64,
+    pub bits_per_second: f64,
+    pub jitter_ms: f64,
+    pub lost_packets: i64,
+    pub packets: i64,
+    pub lost_percent: f64,
+    pub out_of_order: i64,
+    pub sender: bool,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct SumSide {
+    pub start: f64,
+    pub end: f64,
+    pub seconds: f64,
+    pub bytes: u64,
+    pub bits_per_second: f64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub retransmits: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub jitter_ms: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub lost_packets: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub packets: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub lost_percent: Option<f64>,
+    pub sender: bool,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct CpuUtilization {
+    pub host_total: f64,
+    pub host_user: f64,
+    pub host_system: f64,
+    pub remote_total: f64,
+    pub remote_user: f64,
+    pub remote_system: f64,
+}
+
+// ---------------------------------------------------------------------------
+// Builder inputs — plain data so the assembly is pure and unit-testable without
+// a live Client/socket.
+// ---------------------------------------------------------------------------
+
+/// Per-stream end data, already resolved to the local (this host) and remote
+/// (peer, from the exchanged results) byte counts and roles.
+#[derive(Debug, Clone)]
+pub struct StreamReport {
+    pub id: i32,
+    pub local_host: String,
+    pub local_port: u16,
+    pub remote_host: String,
+    pub remote_port: u16,
+    /// True if the local endpoint is the sender for this stream.
+    pub is_sender: bool,
+    /// Bytes moved on this stream (local perspective).
+    pub local_bytes: u64,
+    /// Bytes the peer reports for the opposite side of this stream, if known.
+    pub remote_bytes: Option<u64>,
+    pub retransmits: Option<i64>,
+    /// UDP receiver stats (jitter seconds, lost, total packets, out-of-order),
+    /// from whichever side measured them. `None` for TCP.
+    pub udp: Option<UdpStreamStats>,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct UdpStreamStats {
+    pub jitter_secs: f64,
+    pub lost_packets: i64,
+    pub packets: i64,
+    pub out_of_order: i64,
+}
+
+pub struct ReportInput {
+    pub protocol: TransportProtocol,
+    pub reverse: bool,
+    pub bidir: bool,
+    pub duration: f64,
+    pub num_streams: i32,
+    pub blksize: i64,
+    pub omit: i32,
+    pub tos: i32,
+    pub target_bitrate: u64,
+    pub bytes: u64,
+    pub blocks: u64,
+    pub connecting_host: String,
+    pub connecting_port: u16,
+    pub version: String,
+    pub system_info: String,
+    pub cpu: CpuUtilization,
+    pub congestion_used: Option<String>,
+    pub streams: Vec<StreamReport>,
+}
+
+// ---------------------------------------------------------------------------
+// Assembly
+// ---------------------------------------------------------------------------
+
+fn bps(bytes: u64, seconds: f64) -> f64 {
+    if seconds > 0.0 {
+        bytes as f64 * 8.0 / seconds
+    } else {
+        0.0
+    }
+}
+
+fn pct_lost(lost: i64, total: i64) -> f64 {
+    crate::reporter::lost_percent(lost, total)
+}
+
+impl ReportInput {
+    /// Assemble the iperf3-schema `end` block and connection list. `intervals`
+    /// is left empty (PR2) and `start` metadata minimal (PR3).
+    pub fn build(&self) -> Report {
+        let dur = self.duration;
+        let is_udp = matches!(self.protocol, TransportProtocol::Udp);
+
+        let connected: Vec<Connection> = self
+            .streams
+            .iter()
+            .map(|s| Connection {
+                socket: s.id,
+                local_host: s.local_host.clone(),
+                local_port: s.local_port,
+                remote_host: s.remote_host.clone(),
+                remote_port: s.remote_port,
+            })
+            .collect();
+
+        let end_streams: Vec<EndStream> = self.streams.iter().map(|s| self.end_stream(s)).collect();
+
+        // Aggregates. sum_sent / sum_received always present; `sum` (UDP) and the
+        // bidir-reverse pair are conditional, matching iperf3.
+        let sent_bytes: u64 = self
+            .streams
+            .iter()
+            .filter(|s| s.is_sender)
+            .map(|s| s.local_bytes)
+            .sum();
+        let recv_bytes: u64 = self
+            .streams
+            .iter()
+            .filter(|s| !s.is_sender)
+            .map(|s| s.local_bytes)
+            .sum();
+
+        // Forward (all-sender) and reverse (all-receiver) tests only populate one
+        // local side; fill the other aggregate from the peer's reported bytes so
+        // both carry the real figure, like iperf3 (falling back to the local count
+        // only if the peer reported nothing).
+        let peer_sent: u64 = self
+            .streams
+            .iter()
+            .filter(|s| !s.is_sender)
+            .filter_map(|s| s.remote_bytes)
+            .sum();
+        let peer_recv: u64 = self
+            .streams
+            .iter()
+            .filter(|s| s.is_sender)
+            .filter_map(|s| s.remote_bytes)
+            .sum();
+        let sum_sent_bytes = match (sent_bytes, peer_sent) {
+            (0, p) if p > 0 => p,
+            (0, _) => recv_bytes,
+            (s, _) => s,
+        };
+        let sum_recv_bytes = match (recv_bytes, peer_recv) {
+            (0, p) if p > 0 => p,
+            (0, _) => sent_bytes,
+            (r, _) => r,
+        };
+
+        let retransmits_total: Option<i64> = if self.streams.iter().any(|s| s.retransmits.is_some())
+        {
+            Some(self.streams.iter().filter_map(|s| s.retransmits).sum())
+        } else {
+            None
+        };
+
+        // UDP datagram aggregates for `sum` / `sum_received`.
+        let udp_agg = if is_udp {
+            let lost: i64 = self
+                .streams
+                .iter()
+                .filter_map(|s| s.udp)
+                .map(|u| u.lost_packets)
+                .sum();
+            let packets: i64 = self
+                .streams
+                .iter()
+                .filter_map(|s| s.udp)
+                .map(|u| u.packets)
+                .sum();
+            let jitter = self
+                .streams
+                .iter()
+                .filter_map(|s| s.udp)
+                .map(|u| u.jitter_secs)
+                .fold(0.0_f64, f64::max);
+            Some((lost, packets, jitter))
+        } else {
+            None
+        };
+
+        let sum_sent = SumSide {
+            start: 0.0,
+            end: dur,
+            seconds: dur,
+            bytes: sum_sent_bytes,
+            bits_per_second: bps(sum_sent_bytes, dur),
+            retransmits: retransmits_total,
+            jitter_ms: None,
+            lost_packets: None,
+            packets: None,
+            lost_percent: None,
+            sender: true,
+        };
+        let mut sum_received = SumSide {
+            start: 0.0,
+            end: dur,
+            seconds: dur,
+            bytes: sum_recv_bytes,
+            bits_per_second: bps(sum_recv_bytes, dur),
+            retransmits: None,
+            jitter_ms: None,
+            lost_packets: None,
+            packets: None,
+            lost_percent: None,
+            sender: true,
+        };
+
+        let mut sum = None;
+        if let Some((lost, packets, jitter)) = udp_agg {
+            // The receiver aggregate carries the datagram loss/jitter (#25), and
+            // UDP additionally emits a single-direction `sum`.
+            sum_received.jitter_ms = Some(jitter * 1000.0);
+            sum_received.lost_packets = Some(lost);
+            sum_received.packets = Some(packets);
+            sum_received.lost_percent = Some(pct_lost(lost, packets));
+            // The sender aggregate stays byte-only, like iperf3.
+            sum = Some(SumSide {
+                jitter_ms: Some(jitter * 1000.0),
+                lost_packets: Some(lost),
+                packets: Some(packets),
+                lost_percent: Some(pct_lost(lost, packets)),
+                ..sum_received.clone()
+            });
+        }
+
+        let (cong_sender, cong_receiver) = if is_udp {
+            (None, None)
+        } else {
+            (self.congestion_used.clone(), self.congestion_used.clone())
+        };
+
+        let end = End {
+            streams: end_streams,
+            sum_sent,
+            sum_received,
+            sum,
+            // Bidir per-direction aggregates: riperf3's bidir uses 2N half-duplex
+            // sockets (vs iperf3's N full-duplex), so per-stream nesting can't
+            // mirror iperf3 here; the reverse aggregate is left None until the
+            // bidir transport model is reconciled (tracked separately under #36).
+            sum_sent_bidir_reverse: None,
+            sum_received_bidir_reverse: None,
+            cpu_utilization_percent: self.cpu.clone(),
+            sender_tcp_congestion: cong_sender,
+            receiver_tcp_congestion: cong_receiver,
+        };
+
+        Report {
+            start: Start {
+                connected,
+                version: self.version.clone(),
+                system_info: self.system_info.clone(),
+                connecting_to: ConnectingTo {
+                    host: self.connecting_host.clone(),
+                    port: self.connecting_port,
+                },
+                test_start: TestStart {
+                    protocol: if is_udp { "UDP" } else { "TCP" }.to_string(),
+                    num_streams: self.num_streams,
+                    blksize: self.blksize,
+                    omit: self.omit,
+                    duration: dur as i32,
+                    bytes: self.bytes,
+                    blocks: self.blocks,
+                    reverse: self.reverse as i32,
+                    tos: self.tos,
+                    target_bitrate: self.target_bitrate,
+                    bidir: self.bidir as i32,
+                },
+            },
+            intervals: Vec::new(),
+            end,
+        }
+    }
+
+    fn end_stream(&self, s: &StreamReport) -> EndStream {
+        let dur = self.duration;
+        if let Some(u) = s.udp {
+            // UDP: a single `udp` object. The measuring side (the receiver) holds
+            // the datagram stats; bytes are the local count for this stream.
+            return EndStream {
+                sender: None,
+                receiver: None,
+                udp: Some(UdpStreamEnd {
+                    socket: s.id,
+                    start: 0.0,
+                    end: dur,
+                    seconds: dur,
+                    bytes: s.local_bytes,
+                    bits_per_second: bps(s.local_bytes, dur),
+                    jitter_ms: u.jitter_secs * 1000.0,
+                    lost_packets: u.lost_packets,
+                    packets: u.packets,
+                    lost_percent: pct_lost(u.lost_packets, u.packets),
+                    out_of_order: u.out_of_order,
+                    sender: s.is_sender,
+                }),
+            };
+        }
+
+        // TCP: both a sender and a receiver side. The local count covers our side;
+        // the peer's reported bytes cover the other side (falling back to the
+        // local count when the peer didn't report a per-stream figure).
+        let local = TcpStreamSide {
+            socket: s.id,
+            start: 0.0,
+            end: dur,
+            seconds: dur,
+            bytes: s.local_bytes,
+            bits_per_second: bps(s.local_bytes, dur),
+            retransmits: if s.is_sender { s.retransmits } else { None },
+            sender: !self.reverse,
+        };
+        let remote_bytes = s.remote_bytes.unwrap_or(s.local_bytes);
+        let remote = TcpStreamSide {
+            socket: s.id,
+            start: 0.0,
+            end: dur,
+            seconds: dur,
+            bytes: remote_bytes,
+            bits_per_second: bps(remote_bytes, dur),
+            retransmits: if s.is_sender { None } else { s.retransmits },
+            sender: !self.reverse,
+        };
+        // Place the local side under sender/receiver by its role; the peer fills
+        // the opposite slot.
+        if s.is_sender {
+            EndStream {
+                sender: Some(local),
+                receiver: Some(remote),
+                udp: None,
+            }
+        } else {
+            EndStream {
+                sender: Some(remote),
+                receiver: Some(local),
+                udp: None,
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn base_input() -> ReportInput {
+        ReportInput {
+            protocol: TransportProtocol::Tcp,
+            reverse: false,
+            bidir: false,
+            duration: 10.0,
+            num_streams: 1,
+            blksize: 131072,
+            omit: 0,
+            tos: 0,
+            target_bitrate: 0,
+            bytes: 0,
+            blocks: 0,
+            connecting_host: "host".into(),
+            connecting_port: 5201,
+            version: "riperf3 0.5.4".into(),
+            system_info: String::new(),
+            cpu: CpuUtilization {
+                host_total: 1.0,
+                host_user: 0.5,
+                host_system: 0.5,
+                remote_total: 2.0,
+                remote_user: 1.0,
+                remote_system: 1.0,
+            },
+            congestion_used: Some("cubic".into()),
+            streams: vec![],
+        }
+    }
+
+    fn tcp_stream(id: i32, is_sender: bool, local: u64, remote: u64) -> StreamReport {
+        StreamReport {
+            id,
+            local_host: "127.0.0.1".into(),
+            local_port: 40000 + id as u16,
+            remote_host: "127.0.0.1".into(),
+            remote_port: 5201,
+            is_sender,
+            local_bytes: local,
+            remote_bytes: Some(remote),
+            retransmits: Some(3),
+            udp: None,
+        }
+    }
+
+    #[test]
+    fn tcp_forward_end_streams_are_nested_sender_receiver() {
+        let mut input = base_input();
+        input.streams = vec![tcp_stream(1, true, 1_000_000, 999_000)];
+        let v = serde_json::to_value(input.build()).unwrap();
+
+        // Nested, not flat: end.streams[0] has `sender` and `receiver`, no `udp`.
+        let s0 = &v["end"]["streams"][0];
+        assert!(s0["sender"].is_object(), "expected nested sender: {s0}");
+        assert!(s0["receiver"].is_object(), "expected nested receiver: {s0}");
+        assert!(s0.get("udp").is_none());
+        assert_eq!(s0["sender"]["bytes"], 1_000_000);
+        assert_eq!(s0["receiver"]["bytes"], 999_000);
+        assert_eq!(s0["sender"]["retransmits"], 3);
+        // Receiver side must not carry retransmits.
+        assert!(s0["receiver"].get("retransmits").is_none());
+        // tcp_congestion present for TCP.
+        assert_eq!(v["end"]["sender_tcp_congestion"], "cubic");
+        assert_eq!(v["end"]["receiver_tcp_congestion"], "cubic");
+        // No UDP `sum` for TCP.
+        assert!(v["end"].get("sum").is_none());
+    }
+
+    #[test]
+    fn real_addresses_in_connected() {
+        let mut input = base_input();
+        input.streams = vec![tcp_stream(1, true, 10, 10)];
+        let v = serde_json::to_value(input.build()).unwrap();
+        let c0 = &v["start"]["connected"][0];
+        assert_eq!(c0["local_host"], "127.0.0.1");
+        assert_eq!(c0["local_port"], 40001);
+        assert_eq!(c0["remote_port"], 5201);
+        // Not the fabricated connecting host/port duplicated into both ends.
+        assert_ne!(c0["local_port"], c0["remote_port"]);
+    }
+
+    #[test]
+    fn udp_forward_emits_udp_object_and_sum() {
+        let mut input = base_input();
+        input.protocol = TransportProtocol::Udp;
+        input.blksize = 1460;
+        // Forward UDP: local stream is the sender; loss measured by the peer
+        // (receiver) is attached to this stream's udp stats (#25).
+        input.streams = vec![StreamReport {
+            udp: Some(UdpStreamStats {
+                jitter_secs: 0.00003,
+                lost_packets: 5,
+                packets: 1000,
+                out_of_order: 0,
+            }),
+            ..tcp_stream(1, true, 1_460_000, 1_452_700)
+        }];
+        let v = serde_json::to_value(input.build()).unwrap();
+
+        let s0 = &v["end"]["streams"][0];
+        assert!(s0["udp"].is_object(), "expected udp object: {s0}");
+        assert!(s0.get("sender").is_none());
+        assert_eq!(s0["udp"]["lost_packets"], 5);
+        assert_eq!(s0["udp"]["packets"], 1000);
+        assert!((s0["udp"]["jitter_ms"].as_f64().unwrap() - 0.03).abs() < 1e-9);
+
+        // UDP emits a single-direction `sum`, and the receiver aggregate carries loss.
+        assert!(v["end"]["sum"].is_object(), "UDP must emit end.sum");
+        assert_eq!(v["end"]["sum"]["lost_packets"], 5);
+        assert_eq!(v["end"]["sum_received"]["lost_packets"], 5);
+        // No tcp_congestion for UDP.
+        assert!(v["end"].get("sender_tcp_congestion").is_none());
+    }
+
+    #[test]
+    fn reverse_marks_sides_as_receiver() {
+        let mut input = base_input();
+        input.reverse = true;
+        // Reverse: the local stream is the receiver; peer is the sender.
+        input.streams = vec![tcp_stream(1, false, 2_000_000, 2_000_000)];
+        let v = serde_json::to_value(input.build()).unwrap();
+        let s0 = &v["end"]["streams"][0];
+        // Still nested sender+receiver, with sender=false (this host received).
+        assert!(s0["sender"].is_object());
+        assert!(s0["receiver"].is_object());
+        assert_eq!(s0["sender"]["sender"], false);
+    }
+
+    #[test]
+    fn top_level_shape_matches_iperf3() {
+        let mut input = base_input();
+        input.streams = vec![tcp_stream(1, true, 10, 10)];
+        let v = serde_json::to_value(input.build()).unwrap();
+        // iperf3's three top-level keys, in a stable set.
+        assert!(v["start"].is_object());
+        assert!(v["intervals"].is_array());
+        assert!(v["end"].is_object());
+        for k in [
+            "connected",
+            "version",
+            "system_info",
+            "connecting_to",
+            "test_start",
+        ] {
+            assert!(v["start"].get(k).is_some(), "start.{k} missing");
+        }
+        for k in [
+            "streams",
+            "sum_sent",
+            "sum_received",
+            "cpu_utilization_percent",
+        ] {
+            assert!(v["end"].get(k).is_some(), "end.{k} missing");
+        }
+    }
+}

--- a/riperf3/src/json_report.rs
+++ b/riperf3/src/json_report.rs
@@ -20,7 +20,8 @@
 //!
 //! Fields iperf3 emits but riperf3 cannot yet produce are omitted
 //! (`skip_serializing_if`) rather than emitted with placeholder values, so the
-//! shape only ever contains real data.
+//! shape only ever contains real data. The one exception is `system_info`, which
+//! iperf3 always emits: it ships as an empty string until PR3 fills in the uname.
 
 use serde::Serialize;
 
@@ -301,124 +302,117 @@ impl ReportInput {
 
         let end_streams: Vec<EndStream> = self.streams.iter().map(|s| self.end_stream(s)).collect();
 
-        // Aggregates. sum_sent / sum_received always present; `sum` (UDP) and the
-        // bidir-reverse pair are conditional, matching iperf3.
-        let sent_bytes: u64 = self
+        // Aggregates, direction-partitioned so forward / reverse / bidir each
+        // report the right flow under the right key, matching iperf3.
+        let local_sent: u64 = self
             .streams
             .iter()
             .filter(|s| s.is_sender)
             .map(|s| s.local_bytes)
             .sum();
-        let recv_bytes: u64 = self
+        let local_recv: u64 = self
             .streams
             .iter()
             .filter(|s| !s.is_sender)
             .map(|s| s.local_bytes)
             .sum();
-
-        // Forward (all-sender) and reverse (all-receiver) tests only populate one
-        // local side; fill the other aggregate from the peer's reported bytes so
-        // both carry the real figure, like iperf3 (falling back to the local count
-        // only if the peer reported nothing).
-        let peer_sent: u64 = self
-            .streams
-            .iter()
-            .filter(|s| !s.is_sender)
-            .filter_map(|s| s.remote_bytes)
-            .sum();
+        // The peer's reported bytes for each direction (forward → peer received,
+        // reverse → peer sent), used to fill the side this host didn't measure.
         let peer_recv: u64 = self
             .streams
             .iter()
             .filter(|s| s.is_sender)
             .filter_map(|s| s.remote_bytes)
             .sum();
-        let sum_sent_bytes = match (sent_bytes, peer_sent) {
-            (0, p) if p > 0 => p,
-            (0, _) => recv_bytes,
-            (s, _) => s,
-        };
-        let sum_recv_bytes = match (recv_bytes, peer_recv) {
-            (0, p) if p > 0 => p,
-            (0, _) => sent_bytes,
-            (r, _) => r,
-        };
+        let peer_sent: u64 = self
+            .streams
+            .iter()
+            .filter(|s| !s.is_sender)
+            .filter_map(|s| s.remote_bytes)
+            .sum();
 
-        let retransmits_total: Option<i64> = if self.streams.iter().any(|s| s.retransmits.is_some())
-        {
-            Some(self.streams.iter().filter_map(|s| s.retransmits).sum())
+        // Receiver-measured UDP loss/jitter, aggregated across measured streams.
+        let (udp_lost, udp_packets, udp_jitter) = if is_udp {
+            (
+                self.streams
+                    .iter()
+                    .filter_map(|s| s.udp)
+                    .map(|u| u.lost_packets)
+                    .sum::<i64>(),
+                self.streams
+                    .iter()
+                    .filter_map(|s| s.udp)
+                    .map(|u| u.packets)
+                    .sum::<i64>(),
+                self.streams
+                    .iter()
+                    .filter_map(|s| s.udp)
+                    .map(|u| u.jitter_secs)
+                    .fold(0.0_f64, f64::max),
+            )
         } else {
-            None
+            (0_i64, 0_i64, 0.0_f64)
         };
-
-        // UDP datagram aggregates for `sum` / `sum_received`.
-        let udp_agg = if is_udp {
-            let lost: i64 = self
-                .streams
-                .iter()
-                .filter_map(|s| s.udp)
-                .map(|u| u.lost_packets)
-                .sum();
-            let packets: i64 = self
-                .streams
-                .iter()
-                .filter_map(|s| s.udp)
-                .map(|u| u.packets)
-                .sum();
-            let jitter = self
-                .streams
-                .iter()
-                .filter_map(|s| s.udp)
-                .map(|u| u.jitter_secs)
-                .fold(0.0_f64, f64::max);
-            Some((lost, packets, jitter))
-        } else {
-            None
-        };
-
-        let sum_sent = SumSide {
-            start: 0.0,
-            end: dur,
-            seconds: dur,
-            bytes: sum_sent_bytes,
-            bits_per_second: bps(sum_sent_bytes, dur),
-            retransmits: retransmits_total,
-            jitter_ms: None,
-            lost_packets: None,
-            packets: None,
-            lost_percent: None,
-            sender: true,
-        };
-        let mut sum_received = SumSide {
-            start: 0.0,
-            end: dur,
-            seconds: dur,
-            bytes: sum_recv_bytes,
-            bits_per_second: bps(sum_recv_bytes, dur),
-            retransmits: None,
-            jitter_ms: None,
-            lost_packets: None,
-            packets: None,
-            lost_percent: None,
-            sender: true,
-        };
+        let blk = self.blksize.max(1) as u64;
+        // iperf3's `stream_must_be_sender` for the aggregate `sender` flag.
+        let fwd_sender = !self.reverse;
+        let retransmits = self.sender_retransmits();
 
         let mut sum = None;
-        if let Some((lost, packets, jitter)) = udp_agg {
-            // The receiver aggregate carries the datagram loss/jitter (#25), and
-            // UDP additionally emits a single-direction `sum`.
-            sum_received.jitter_ms = Some(jitter * 1000.0);
-            sum_received.lost_packets = Some(lost);
-            sum_received.packets = Some(packets);
-            sum_received.lost_percent = Some(pct_lost(lost, packets));
-            // The sender aggregate stays byte-only, like iperf3.
-            sum = Some(SumSide {
-                jitter_ms: Some(jitter * 1000.0),
-                lost_packets: Some(lost),
-                packets: Some(packets),
-                lost_percent: Some(pct_lost(lost, packets)),
-                ..sum_received.clone()
-            });
-        }
+        let mut sum_sent_bidir_reverse = None;
+        let mut sum_received_bidir_reverse = None;
+
+        let (sum_sent, sum_received) = if self.bidir {
+            // Forward (this host → peer) goes in sum_sent/sum_received; reverse
+            // (peer → this host) in the *_bidir_reverse pair, matching iperf3 —
+            // rather than folding the reverse flow into sum_received (which would
+            // make the two aggregates describe different directions).
+            let fwd_recv = if peer_recv > 0 { peer_recv } else { local_sent };
+            let rev_sent = if peer_sent > 0 { peer_sent } else { local_recv };
+            sum_sent_bidir_reverse = Some(self.tcp_sum(rev_sent, false, None));
+            sum_received_bidir_reverse = Some(self.tcp_sum(local_recv, false, None));
+            (
+                self.tcp_sum(local_sent, true, retransmits),
+                self.tcp_sum(fwd_recv, true, None),
+            )
+        } else if is_udp {
+            // UDP single direction. iperf3: sum_sent.sender=1, sum_received.sender=0,
+            // sum.sender=stream_must_be_sender. `sum.bytes` is the *sent* count with
+            // receiver-measured loss attached; the sender side measures no loss.
+            let sent_bytes = if local_sent > 0 {
+                local_sent
+            } else {
+                peer_sent
+            };
+            let recv_bytes = if local_recv > 0 {
+                local_recv
+            } else {
+                peer_recv
+            };
+            let sent_packets = (sent_bytes / blk) as i64;
+            sum = Some(self.udp_sum(sent_bytes, fwd_sender, sent_packets, udp_lost, udp_jitter));
+            (
+                self.udp_sum(sent_bytes, true, sent_packets, 0, 0.0),
+                self.udp_sum(recv_bytes, false, udp_packets, udp_lost, udp_jitter),
+            )
+        } else {
+            // TCP single direction (forward or reverse); both aggregates carry the
+            // test's sender flag (!reverse), like iperf3.
+            let sent_bytes = match (local_sent, peer_sent) {
+                (0, p) if p > 0 => p,
+                (0, _) => local_recv,
+                (s, _) => s,
+            };
+            let recv_bytes = match (local_recv, peer_recv) {
+                (0, p) if p > 0 => p,
+                (0, _) => local_sent,
+                (r, _) => r,
+            };
+            (
+                self.tcp_sum(sent_bytes, fwd_sender, retransmits),
+                self.tcp_sum(recv_bytes, fwd_sender, None),
+            )
+        };
 
         let (cong_sender, cong_receiver) = if is_udp {
             (None, None)
@@ -431,12 +425,8 @@ impl ReportInput {
             sum_sent,
             sum_received,
             sum,
-            // Bidir per-direction aggregates: riperf3's bidir uses 2N half-duplex
-            // sockets (vs iperf3's N full-duplex), so per-stream nesting can't
-            // mirror iperf3 here; the reverse aggregate is left None until the
-            // bidir transport model is reconciled (tracked separately under #36).
-            sum_sent_bidir_reverse: None,
-            sum_received_bidir_reverse: None,
+            sum_sent_bidir_reverse,
+            sum_received_bidir_reverse,
             cpu_utilization_percent: self.cpu.clone(),
             sender_tcp_congestion: cong_sender,
             receiver_tcp_congestion: cong_receiver,
@@ -472,9 +462,16 @@ impl ReportInput {
 
     fn end_stream(&self, s: &StreamReport) -> EndStream {
         let dur = self.duration;
-        if let Some(u) = s.udp {
-            // UDP: a single `udp` object. The measuring side (the receiver) holds
-            // the datagram stats; bytes are the local count for this stream.
+        // Shape is driven by the test protocol, not by whether stats happen to be
+        // present: a UDP stream with missing stats still emits a valid `udp`
+        // object (zeroed datagram fields), never a TCP `{sender,receiver}` body.
+        if matches!(self.protocol, TransportProtocol::Udp) {
+            let u = s.udp.unwrap_or(UdpStreamStats {
+                jitter_secs: 0.0,
+                lost_packets: 0,
+                packets: 0,
+                out_of_order: 0,
+            });
             return EndStream {
                 sender: None,
                 receiver: None,
@@ -495,9 +492,12 @@ impl ReportInput {
             };
         }
 
-        // TCP: both a sender and a receiver side. The local count covers our side;
-        // the peer's reported bytes cover the other side (falling back to the
-        // local count when the peer didn't report a per-stream figure).
+        // TCP: nested sender + receiver. Both sub-objects carry this stream's
+        // direction flag (`s.is_sender`) — correct in forward, reverse, and
+        // per-stream in bidir (where both directions coexist). The local count
+        // covers our side; the peer's reported bytes the other (falling back to
+        // the local count when the peer reported no per-stream figure).
+        let dir = s.is_sender;
         let local = TcpStreamSide {
             socket: s.id,
             start: 0.0,
@@ -506,7 +506,7 @@ impl ReportInput {
             bytes: s.local_bytes,
             bits_per_second: bps(s.local_bytes, dur),
             retransmits: if s.is_sender { s.retransmits } else { None },
-            sender: !self.reverse,
+            sender: dir,
         };
         let remote_bytes = s.remote_bytes.unwrap_or(s.local_bytes);
         let remote = TcpStreamSide {
@@ -517,10 +517,8 @@ impl ReportInput {
             bytes: remote_bytes,
             bits_per_second: bps(remote_bytes, dur),
             retransmits: if s.is_sender { None } else { s.retransmits },
-            sender: !self.reverse,
+            sender: dir,
         };
-        // Place the local side under sender/receiver by its role; the peer fills
-        // the opposite slot.
         if s.is_sender {
             EndStream {
                 sender: Some(local),
@@ -533,6 +531,61 @@ impl ReportInput {
                 receiver: Some(local),
                 udp: None,
             }
+        }
+    }
+
+    /// Sender-side retransmit total. Collapses the -1 "unavailable" sentinel
+    /// rather than summing it (summing N sentinels would emit a nonsensical -N
+    /// that iperf3 never produces). Real per-stream values arrive with PR2.
+    fn sender_retransmits(&self) -> Option<i64> {
+        let vals: Vec<i64> = self.streams.iter().filter_map(|s| s.retransmits).collect();
+        if vals.is_empty() {
+            None
+        } else if vals.iter().all(|&r| r < 0) {
+            Some(-1) // all unavailable → iperf3's single sentinel
+        } else {
+            Some(vals.iter().map(|&r| r.max(0)).sum())
+        }
+    }
+
+    fn tcp_sum(&self, bytes: u64, sender: bool, retransmits: Option<i64>) -> SumSide {
+        let dur = self.duration;
+        SumSide {
+            start: 0.0,
+            end: dur,
+            seconds: dur,
+            bytes,
+            bits_per_second: bps(bytes, dur),
+            retransmits,
+            jitter_ms: None,
+            lost_packets: None,
+            packets: None,
+            lost_percent: None,
+            sender,
+        }
+    }
+
+    fn udp_sum(
+        &self,
+        bytes: u64,
+        sender: bool,
+        packets: i64,
+        lost: i64,
+        jitter_secs: f64,
+    ) -> SumSide {
+        let dur = self.duration;
+        SumSide {
+            start: 0.0,
+            end: dur,
+            seconds: dur,
+            bytes,
+            bits_per_second: bps(bytes, dur),
+            retransmits: None,
+            jitter_ms: Some(jitter_secs * 1000.0),
+            lost_packets: Some(lost),
+            packets: Some(packets),
+            lost_percent: Some(pct_lost(lost, packets)),
+            sender,
         }
     }
 }
@@ -699,5 +752,114 @@ mod tests {
         ] {
             assert!(v["end"].get(k).is_some(), "end.{k} missing");
         }
+    }
+
+    // ---- cold-review round 1 regressions ------------------------------------
+
+    #[test]
+    fn multi_stream_retransmits_collapses_sentinel() {
+        // -1 is the per-stream "unavailable" sentinel; the SUM must stay -1, not
+        // sum to -N (iperf3 never emits below -1).
+        let mut input = base_input();
+        let mut a = tcp_stream(1, true, 1000, 1000);
+        a.retransmits = Some(-1);
+        let mut b = tcp_stream(3, true, 1000, 1000);
+        b.retransmits = Some(-1);
+        input.streams = vec![a, b];
+        let v = serde_json::to_value(input.build()).unwrap();
+        assert_eq!(v["end"]["sum_sent"]["retransmits"], -1, "{v}");
+    }
+
+    #[test]
+    fn tcp_reverse_aggregate_sender_flags_false() {
+        // iperf3 TCP reverse: both aggregates carry sender=false.
+        let mut input = base_input();
+        input.reverse = true;
+        input.streams = vec![tcp_stream(1, false, 2_000_000, 2_000_000)];
+        let v = serde_json::to_value(input.build()).unwrap();
+        assert_eq!(v["end"]["sum_sent"]["sender"], false);
+        assert_eq!(v["end"]["sum_received"]["sender"], false);
+    }
+
+    #[test]
+    fn udp_aggregate_sender_flags_match_iperf3() {
+        // iperf3 UDP forward: sum_sent.sender=1, sum_received.sender=0, sum.sender=1.
+        let mut input = base_input();
+        input.protocol = TransportProtocol::Udp;
+        input.blksize = 1460;
+        input.streams = vec![StreamReport {
+            udp: Some(UdpStreamStats {
+                jitter_secs: 0.0,
+                lost_packets: 0,
+                packets: 100,
+                out_of_order: 0,
+            }),
+            ..tcp_stream(1, true, 146_000, 146_000)
+        }];
+        let v = serde_json::to_value(input.build()).unwrap();
+        assert_eq!(v["end"]["sum_sent"]["sender"], true);
+        assert_eq!(v["end"]["sum_received"]["sender"], false);
+        assert_eq!(v["end"]["sum"]["sender"], true);
+        // sum.bytes is the sent count; sum_sent carries packets + zero loss.
+        assert_eq!(v["end"]["sum"]["bytes"], 146_000);
+        assert_eq!(v["end"]["sum_sent"]["packets"], 100); // 146000 / 1460
+        assert_eq!(v["end"]["sum_sent"]["lost_packets"], 0);
+    }
+
+    #[test]
+    fn udp_stream_without_stats_still_emits_udp_object() {
+        // Shape follows the protocol, not stats presence: a UDP stream missing its
+        // datagram stats must NOT fall back to a TCP {sender,receiver} body.
+        let mut input = base_input();
+        input.protocol = TransportProtocol::Udp;
+        input.streams = vec![StreamReport {
+            udp: None,
+            ..tcp_stream(1, true, 146_000, 146_000)
+        }];
+        let v = serde_json::to_value(input.build()).unwrap();
+        let s0 = &v["end"]["streams"][0];
+        assert!(s0["udp"].is_object(), "must be a udp object: {s0}");
+        assert!(s0.get("sender").is_none(), "must not be a TCP body: {s0}");
+        assert_eq!(s0["udp"]["lost_packets"], 0);
+    }
+
+    #[test]
+    fn bidir_emits_four_aggregates_with_correct_directions() {
+        // Bidir: forward in sum_sent/sum_received, reverse in *_bidir_reverse;
+        // per-stream sender flags follow each stream's direction, not !reverse.
+        let mut input = base_input();
+        input.bidir = true;
+        input.num_streams = 1;
+        input.streams = vec![
+            tcp_stream(1, true, 1_000_000, 990_000),    // forward
+            tcp_stream(3, false, 2_000_000, 2_000_000), // reverse
+        ];
+        let v = serde_json::to_value(input.build()).unwrap();
+        let end = &v["end"];
+        // All four aggregates present.
+        for k in [
+            "sum_sent",
+            "sum_received",
+            "sum_sent_bidir_reverse",
+            "sum_received_bidir_reverse",
+        ] {
+            assert!(end.get(k).is_some(), "bidir must emit {k}: {end}");
+        }
+        // Forward goes in sum_sent/sum_received (this host sent 1_000_000; peer
+        // received 990_000), NOT the reverse stream's 2_000_000.
+        assert_eq!(end["sum_sent"]["bytes"], 1_000_000);
+        assert_eq!(end["sum_received"]["bytes"], 990_000);
+        assert_eq!(end["sum_sent"]["sender"], true);
+        // Reverse direction in the bidir-reverse pair, sender=false.
+        assert_eq!(end["sum_received_bidir_reverse"]["bytes"], 2_000_000);
+        assert_eq!(end["sum_sent_bidir_reverse"]["sender"], false);
+        // Per-stream sender flags: forward stream true, reverse stream false.
+        let flags: Vec<bool> = v["end"]["streams"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|s| s["sender"]["sender"].as_bool().unwrap())
+            .collect();
+        assert_eq!(flags, vec![true, false], "{:?}", v["end"]["streams"]);
     }
 }

--- a/riperf3/src/lib.rs
+++ b/riperf3/src/lib.rs
@@ -49,6 +49,8 @@ pub mod auth;
 #[doc(hidden)]
 pub mod cpu;
 #[doc(hidden)]
+pub mod json_report;
+#[doc(hidden)]
 pub mod net;
 #[doc(hidden)]
 pub mod protocol;

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -289,6 +289,9 @@ impl Server {
                         udp_recv_stats: None,
                         task,
                         raw_fd,
+                        // Populated for the server's own `-J` output in #50.
+                        local_addr: None,
+                        peer_addr: None,
                     });
                 }
             }
@@ -368,6 +371,8 @@ impl Server {
                             udp_recv_stats: None,
                             task,
                             raw_fd: None,
+                            local_addr: None,
+                            peer_addr: None,
                         });
                     } else {
                         let c = counters.clone();
@@ -393,6 +398,8 @@ impl Server {
                             udp_recv_stats: Some(stats),
                             task,
                             raw_fd: None,
+                            local_addr: None,
+                            peer_addr: None,
                         });
                     }
                 }

--- a/riperf3/src/stream.rs
+++ b/riperf3/src/stream.rs
@@ -294,6 +294,10 @@ pub struct DataStream {
     pub task: JoinHandle<Result<()>>,
     /// Raw TCP socket fd for TCP_INFO queries. `None` for UDP streams.
     pub raw_fd: Option<i32>,
+    /// This stream's actual local/peer socket addresses, captured at creation
+    /// for the `-J` `start.connected` block (issue #36). `None` if unavailable.
+    pub local_addr: Option<std::net::SocketAddr>,
+    pub peer_addr: Option<std::net::SocketAddr>,
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
**PR 1 of 3 toward #36** (faithful client `-J`). Does not close #36.

## What
Replaces the hand-rolled `serde_json::json!` blob with a typed, unit-tested model (`json_report.rs`) that mirrors iperf3's `-J` schema. This increment makes the **`end` block** and **connection addresses** faithful.

## Faithful now
- **`end.streams[]` nested** `{sender, receiver}` (TCP) / `{udp}` (UDP), like iperf3, instead of a flat object. The UDP `udp` sub-object matches iperf3 **field-for-field** (structural diff confirmed).
- **Real `start.connected[]` addresses** — actual local/remote socket addr per stream, captured at creation, replacing the fabricated `-c host:port` duplicated into both ends.
- `sum_sent`/`sum_received` fill the absent direction from the peer's reported bytes (forward/reverse); UDP adds the single-direction `sum` and folds receiver loss/jitter into `sum_received` (#25); `cpu_utilization_percent` carries local + remote.

## Deferred (tracked, omitted not faked)
- `intervals` stays `[]`, and the per-stream TCP_INFO extremes (`max_snd_cwnd`, `min`/`max`/`mean_rtt`, `reorder`) → **PR2** (they derive from per-interval TCP_INFO accumulation).
- Full `start{}` metadata (`cookie`, `timestamp`, `system_info`/uname, `tcp_mss_default`, `sock_bufsize`, `sndbuf/rcvbuf_actual`, `fq_rate`) → **PR3**.
- `sender`/`receiver_tcp_congestion` → **#37** (reporting the *actually-applied* CC needs a getsockopt read-back; emitting the requested value would be wrong).

## Known limitation
riperf3's **bidir uses 2N half-duplex sockets** vs iperf3's N full-duplex, so per-stream bidir nesting can't mirror iperf3 and the reverse aggregates are left `None`. Forward/reverse are fully faithful. Flagged in-code; reconciling the bidir transport model is a separate concern under #36.

## Validation
- Structural diff vs real iperf3 3.21: top-level, `end` keys, and stream nesting match (UDP field-for-field); no spurious fields.
- `cargo test --workspace` 340 pass (5 new `json_report` tests); clippy `-D warnings` + fmt clean.
- Interop gate green vs iperf3 3.12 + 3.21 (64/64) — the gate parses riperf3's client `-J`, so this confirms the new output stays valid.

Part of #36.
