### PR TITLE
feat(json): -J intervals + per-stream TCP_INFO extremes (#36, PR2/3)

### DIFF
--- a/riperf3/src/client.rs
+++ b/riperf3/src/client.rs
@@ -576,6 +576,7 @@ impl Client {
                     timestamp_format: self.timestamps.clone(),
                     json_stream: self.json_stream,
                     print: print_intervals,
+                    blksize,
                 },
                 stream_refs,
                 done.clone(),
@@ -871,11 +872,17 @@ impl Client {
                 let retransmits = if is_udp {
                     None
                 } else {
-                    // Real cumulative total when TCP_INFO gave us one; otherwise
-                    // -1 (iperf3's "unavailable" sentinel).
+                    // Real cumulative total when TCP_INFO gave us one (forward
+                    // sender). Otherwise (reverse, or a stream we didn't send) use
+                    // iperf3's defaults: 0 on a platform that supports retransmit
+                    // info, -1 where it doesn't.
                     ext.and_then(|e| e.total_retransmits)
                         .map(|r| r as i64)
-                        .or(Some(-1))
+                        .or(Some(if crate::tcp_info::has_retransmit_info() {
+                            0
+                        } else {
+                            -1
+                        }))
                 };
 
                 StreamReport {

--- a/riperf3/src/client.rs
+++ b/riperf3/src/client.rs
@@ -154,6 +154,9 @@ impl Client {
         // Released at TestStart so UDP senders don't transmit during stream
         // setup (issue #5): the create-streams handshake is lost under a flood.
         let start = Arc::new(AtomicBool::new(false));
+        // Interval samples + TCP_INFO extremes the reporter collects during the
+        // run, read back at DisplayResults for the `-J` blob (#36 PR2).
+        let interval_data = Arc::new(Mutex::new(crate::reporter::CollectedIntervals::default()));
         let mut streams: Vec<DataStream> = Vec::new();
         let mut cpu_start: Option<CpuSnapshot> = None;
         let mut server_results: Option<TestResultsJson> = None;
@@ -179,7 +182,8 @@ impl Client {
                 }
 
                 TestState::TestRunning => {
-                    self.run_test(&mut ctrl, &streams, &done, blksize).await?;
+                    self.run_test(&mut ctrl, &streams, &done, blksize, interval_data.clone())
+                        .await?;
                     // Test finished — send TestEnd
                     protocol::send_state(&mut ctrl, TestState::TestEnd).await?;
                 }
@@ -196,6 +200,7 @@ impl Client {
                         cpu_start.as_ref(),
                         server_results.as_ref(),
                         blksize,
+                        &interval_data,
                     );
                     protocol::send_state(&mut ctrl, TestState::IperfDone).await?;
                     break; // test complete — server will close the connection
@@ -541,11 +546,15 @@ impl Client {
         streams: &[DataStream],
         done: &Arc<AtomicBool>,
         blksize: usize,
+        collector: Arc<Mutex<crate::reporter::CollectedIntervals>>,
     ) -> Result<()> {
-        // Spawn interval reporter (unless plain JSON output without streaming)
+        // Run the interval reporter whenever intervals are enabled. It prints
+        // live for text / json-stream; for plain -J it runs silently to collect
+        // intervals for the final blob (#36 PR2).
         let interval_secs = self.interval.unwrap_or(1.0);
-        let use_intervals = interval_secs > 0.0 && (!self.json_output || self.json_stream);
-        let interval_handle = if use_intervals {
+        let print_intervals = !self.json_output || self.json_stream;
+        let collect_intervals = self.json_output && !self.json_stream;
+        let interval_handle = if interval_secs > 0.0 {
             let stream_refs: Vec<_> = streams
                 .iter()
                 .map(|s| crate::reporter::IntervalStreamRef {
@@ -566,9 +575,11 @@ impl Client {
                     forceflush: self.forceflush,
                     timestamp_format: self.timestamps.clone(),
                     json_stream: self.json_stream,
+                    print: print_intervals,
                 },
                 stream_refs,
                 done.clone(),
+                collect_intervals.then(|| collector.clone()),
             )
         } else {
             None
@@ -706,9 +717,10 @@ impl Client {
         cpu_start: Option<&CpuSnapshot>,
         remote_cpu: Option<&TestResultsJson>,
         blksize: usize,
+        interval_data: &Arc<Mutex<crate::reporter::CollectedIntervals>>,
     ) {
         if self.json_output {
-            self.print_results_json(streams, cpu_start, remote_cpu, blksize);
+            self.print_results_json(streams, cpu_start, remote_cpu, blksize, interval_data);
         } else {
             self.print_results_text(streams, remote_cpu);
         }
@@ -773,8 +785,21 @@ impl Client {
         cpu_start: Option<&CpuSnapshot>,
         remote_cpu: Option<&TestResultsJson>,
         blksize: usize,
+        interval_data: &Arc<Mutex<crate::reporter::CollectedIntervals>>,
     ) {
-        use crate::json_report::{CpuUtilization, ReportInput, StreamReport, UdpStreamStats};
+        use crate::json_report::{
+            CpuUtilization, ReportInput, StreamReport, TcpEndExtras, UdpStreamStats,
+        };
+
+        // Take the interval samples + per-stream extremes the reporter collected.
+        // Its task has been joined by now (run_test awaits it), so this is final.
+        let (collected_intervals, extremes) = match interval_data.lock() {
+            Ok(mut g) => (
+                std::mem::take(&mut g.intervals),
+                std::mem::take(&mut g.extremes),
+            ),
+            Err(_) => (Vec::new(), Vec::new()),
+        };
 
         let test_duration = self.duration as f64;
         let cpu_end = CpuSnapshot::now();
@@ -831,6 +856,28 @@ impl Client {
                     .map(|a| (a.ip().to_string(), a.port()))
                     .unwrap_or_else(|| (self.host.clone(), self.port));
 
+                // Sender-side TCP_INFO extremes + real retransmit total collected
+                // across intervals (#36 PR2); only present for streams we sent.
+                let ext = extremes
+                    .iter()
+                    .find(|e| e.stream_id == s.id && e.has_samples());
+                let tcp_end = ext.map(|e| TcpEndExtras {
+                    max_snd_cwnd: e.max_snd_cwnd,
+                    max_rtt: e.max_rtt,
+                    min_rtt: e.min_rtt,
+                    mean_rtt: e.mean_rtt(),
+                    reorder: e.reorder,
+                });
+                let retransmits = if is_udp {
+                    None
+                } else {
+                    // Real cumulative total when TCP_INFO gave us one; otherwise
+                    // -1 (iperf3's "unavailable" sentinel).
+                    ext.and_then(|e| e.total_retransmits)
+                        .map(|r| r as i64)
+                        .or(Some(-1))
+                };
+
                 StreamReport {
                     id: s.id,
                     local_host,
@@ -840,10 +887,8 @@ impl Client {
                     is_sender: s.is_sender,
                     local_bytes,
                     remote_bytes: server_stream.map(|x| x.bytes),
-                    // End-of-test per-stream retransmits aren't accumulated yet
-                    // (-1 = unavailable, iperf3's sentinel); real values arrive
-                    // with the interval TCP_INFO work in PR2. UDP carries none.
-                    retransmits: if is_udp { None } else { Some(-1) },
+                    retransmits,
+                    tcp_end,
                     udp,
                 }
             })
@@ -878,6 +923,7 @@ impl Client {
             // the field until that read-back lands rather than emit the requested
             // value (which may differ from what the kernel used).
             congestion_used: None,
+            intervals: collected_intervals,
             streams: stream_reports,
         };
 

--- a/riperf3/src/json_report.rs
+++ b/riperf3/src/json_report.rs
@@ -99,6 +99,29 @@ pub struct IntervalStream {
     pub seconds: f64,
     pub bytes: u64,
     pub bits_per_second: f64,
+    // TCP per-interval detail (sender side); omitted where TCP_INFO is
+    // unavailable. `snd_wnd` is absent — see TcpStreamSide.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub retransmits: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub snd_cwnd: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rtt: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rttvar: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pmtu: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reorder: Option<u32>,
+    // UDP per-interval detail (receiver side).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub jitter_ms: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub lost_packets: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub packets: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub lost_percent: Option<f64>,
     pub omitted: bool,
     pub sender: bool,
 }
@@ -110,6 +133,16 @@ pub struct IntervalSum {
     pub seconds: f64,
     pub bytes: u64,
     pub bits_per_second: f64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub retransmits: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub jitter_ms: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub lost_packets: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub packets: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub lost_percent: Option<f64>,
     pub omitted: bool,
     pub sender: bool,
 }
@@ -161,6 +194,20 @@ pub struct TcpStreamSide {
     /// Sender side only; iperf3 reports -1 when the OS doesn't expose retransmits.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub retransmits: Option<i64>,
+    // Sender-side TCP_INFO extremes, accumulated across the test's intervals
+    // (PR2). Omitted on the receiver side and where TCP_INFO is unavailable.
+    // `max_snd_wnd` is intentionally absent: libc's `tcp_info` doesn't expose
+    // `tcpi_snd_wnd` on Linux, so riperf3 can't produce it (omit, don't fake).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_snd_cwnd: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_rtt: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub min_rtt: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mean_rtt: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reorder: Option<u32>,
     pub sender: bool,
 }
 
@@ -231,9 +278,21 @@ pub struct StreamReport {
     /// Bytes the peer reports for the opposite side of this stream, if known.
     pub remote_bytes: Option<u64>,
     pub retransmits: Option<i64>,
+    /// Sender-side TCP_INFO extremes for the `end.streams[].sender` object (PR2).
+    /// Only set for streams this host sent (local TCP_INFO); `None` otherwise.
+    pub tcp_end: Option<TcpEndExtras>,
     /// UDP receiver stats (jitter seconds, lost, total packets, out-of-order),
     /// from whichever side measured them. `None` for TCP.
     pub udp: Option<UdpStreamStats>,
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct TcpEndExtras {
+    pub max_snd_cwnd: u64,
+    pub max_rtt: u32,
+    pub min_rtt: u32,
+    pub mean_rtt: u32,
+    pub reorder: u32,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -262,6 +321,9 @@ pub struct ReportInput {
     pub system_info: String,
     pub cpu: CpuUtilization,
     pub congestion_used: Option<String>,
+    /// Per-interval samples collected during the run (PR2). Empty if interval
+    /// reporting was disabled (`-i 0`).
+    pub intervals: Vec<Interval>,
     pub streams: Vec<StreamReport>,
 }
 
@@ -282,8 +344,8 @@ fn pct_lost(lost: i64, total: i64) -> f64 {
 }
 
 impl ReportInput {
-    /// Assemble the iperf3-schema `end` block and connection list. `intervals`
-    /// is left empty (PR2) and `start` metadata minimal (PR3).
+    /// Assemble the iperf3-schema report: `start`, the collected `intervals`, and
+    /// the `end` block. `start` metadata stays minimal (PR3).
     pub fn build(&self) -> Report {
         let dur = self.duration;
         let is_udp = matches!(self.protocol, TransportProtocol::Udp);
@@ -455,7 +517,7 @@ impl ReportInput {
                     bidir: self.bidir as i32,
                 },
             },
-            intervals: Vec::new(),
+            intervals: self.intervals.clone(),
             end,
         }
     }
@@ -498,6 +560,19 @@ impl ReportInput {
         // covers our side; the peer's reported bytes the other (falling back to
         // the local count when the peer reported no per-stream figure).
         let dir = s.is_sender;
+        // Sender-side TCP_INFO extremes go on whichever sub-object is the local
+        // sender (forward). The peer's extremes aren't exchanged, so the sender
+        // sub-object of a reverse stream omits them.
+        let (cwnd, maxr, minr, meanr, reord) = match s.tcp_end {
+            Some(e) => (
+                Some(e.max_snd_cwnd),
+                Some(e.max_rtt),
+                Some(e.min_rtt),
+                Some(e.mean_rtt),
+                Some(e.reorder),
+            ),
+            None => (None, None, None, None, None),
+        };
         let local = TcpStreamSide {
             socket: s.id,
             start: 0.0,
@@ -506,6 +581,11 @@ impl ReportInput {
             bytes: s.local_bytes,
             bits_per_second: bps(s.local_bytes, dur),
             retransmits: if s.is_sender { s.retransmits } else { None },
+            max_snd_cwnd: cwnd,
+            max_rtt: maxr,
+            min_rtt: minr,
+            mean_rtt: meanr,
+            reorder: reord,
             sender: dir,
         };
         let remote_bytes = s.remote_bytes.unwrap_or(s.local_bytes);
@@ -517,6 +597,11 @@ impl ReportInput {
             bytes: remote_bytes,
             bits_per_second: bps(remote_bytes, dur),
             retransmits: if s.is_sender { None } else { s.retransmits },
+            max_snd_cwnd: None,
+            max_rtt: None,
+            min_rtt: None,
+            mean_rtt: None,
+            reorder: None,
             sender: dir,
         };
         if s.is_sender {
@@ -624,6 +709,7 @@ mod tests {
                 remote_system: 1.0,
             },
             congestion_used: Some("cubic".into()),
+            intervals: vec![],
             streams: vec![],
         }
     }
@@ -639,6 +725,7 @@ mod tests {
             local_bytes: local,
             remote_bytes: Some(remote),
             retransmits: Some(3),
+            tcp_end: None,
             udp: None,
         }
     }
@@ -861,5 +948,79 @@ mod tests {
             .map(|s| s["sender"]["sender"].as_bool().unwrap())
             .collect();
         assert_eq!(flags, vec![true, false], "{:?}", v["end"]["streams"]);
+    }
+
+    // ---- PR2: intervals + sender extremes -----------------------------------
+
+    #[test]
+    fn intervals_and_sender_extremes_are_emitted() {
+        let mut input = base_input();
+        input.intervals = vec![Interval {
+            streams: vec![IntervalStream {
+                socket: 1,
+                start: 0.0,
+                end: 1.0,
+                seconds: 1.0,
+                bytes: 1000,
+                bits_per_second: 8000.0,
+                retransmits: Some(2),
+                snd_cwnd: Some(64000),
+                rtt: Some(15),
+                rttvar: Some(3),
+                pmtu: Some(1500),
+                reorder: Some(0),
+                jitter_ms: None,
+                lost_packets: None,
+                packets: None,
+                lost_percent: None,
+                omitted: false,
+                sender: true,
+            }],
+            sum: IntervalSum {
+                start: 0.0,
+                end: 1.0,
+                seconds: 1.0,
+                bytes: 1000,
+                bits_per_second: 8000.0,
+                retransmits: Some(2),
+                jitter_ms: None,
+                lost_packets: None,
+                packets: None,
+                lost_percent: None,
+                omitted: false,
+                sender: true,
+            },
+        }];
+        let mut s = tcp_stream(1, true, 1000, 1000);
+        s.retransmits = Some(2);
+        s.tcp_end = Some(TcpEndExtras {
+            max_snd_cwnd: 64000,
+            max_rtt: 17,
+            min_rtt: 14,
+            mean_rtt: 15,
+            reorder: 0,
+        });
+        input.streams = vec![s];
+        let v = serde_json::to_value(input.build()).unwrap();
+
+        // intervals populated with TCP per-interval detail.
+        assert_eq!(v["intervals"].as_array().unwrap().len(), 1);
+        let i0 = &v["intervals"][0]["streams"][0];
+        assert_eq!(i0["snd_cwnd"], 64000);
+        assert_eq!(i0["rtt"], 15);
+        assert_eq!(i0["retransmits"], 2);
+        assert_eq!(v["intervals"][0]["sum"]["retransmits"], 2);
+
+        // end.sender carries the accumulated extremes.
+        let snd = &v["end"]["streams"][0]["sender"];
+        assert_eq!(snd["max_snd_cwnd"], 64000);
+        assert_eq!(snd["min_rtt"], 14);
+        assert_eq!(snd["max_rtt"], 17);
+        assert_eq!(snd["mean_rtt"], 15);
+        assert_eq!(snd["reorder"], 0);
+
+        // snd_wnd / max_snd_wnd are intentionally absent (Linux libc gap).
+        assert!(i0.get("snd_wnd").is_none(), "{i0}");
+        assert!(snd.get("max_snd_wnd").is_none(), "{snd}");
     }
 }

--- a/riperf3/src/json_report.rs
+++ b/riperf3/src/json_report.rs
@@ -106,6 +106,8 @@ pub struct IntervalStream {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub snd_cwnd: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub snd_wnd: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub rtt: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub rttvar: Option<u32>,
@@ -194,12 +196,16 @@ pub struct TcpStreamSide {
     /// Sender side only; iperf3 reports -1 when the OS doesn't expose retransmits.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub retransmits: Option<i64>,
-    // Sender-side TCP_INFO extremes, accumulated across the test's intervals
-    // (PR2). Omitted on the receiver side and where TCP_INFO is unavailable.
-    // `max_snd_wnd` is intentionally absent: libc's `tcp_info` doesn't expose
-    // `tcpi_snd_wnd` on Linux, so riperf3 can't produce it (omit, don't fake).
+    // Sender-side TCP_INFO fields. iperf3 ALWAYS emits these on the sender
+    // sub-object (0 when it couldn't measure them), so riperf3 does too for
+    // drop-in schema parity; they're omitted on the receiver sub-object.
+    // `max_snd_wnd` and `reorder` are always 0 on Linux — libc's `tcp_info`
+    // exposes neither `tcpi_snd_wnd` nor `tcpi_reord_seen` — matching what iperf3
+    // emits when those are unavailable.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub max_snd_cwnd: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_snd_wnd: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub max_rtt: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -563,41 +569,39 @@ impl ReportInput {
         // Sender-side TCP_INFO extremes go on whichever sub-object is the local
         // sender (forward). The peer's extremes aren't exchanged, so the sender
         // sub-object of a reverse stream omits them.
-        let (cwnd, maxr, minr, meanr, reord) = match s.tcp_end {
-            Some(e) => (
-                Some(e.max_snd_cwnd),
-                Some(e.max_rtt),
-                Some(e.min_rtt),
-                Some(e.mean_rtt),
-                Some(e.reorder),
-            ),
-            None => (None, None, None, None, None),
-        };
-        let local = TcpStreamSide {
+        let remote_bytes = s.remote_bytes.unwrap_or(s.local_bytes);
+        // iperf3 always emits the sender sub-object's TCP_INFO keys (0 when
+        // unmeasured). The local sender's extremes (forward) are real; the peer's
+        // (reverse) aren't exchanged, so they default to 0 — exactly what iperf3
+        // emits for a reverse stream's sender block. The receiver sub-object omits
+        // them, like iperf3.
+        let e = s.tcp_end.unwrap_or_default();
+        let sender_side = |bytes: u64, retransmits: Option<i64>| TcpStreamSide {
             socket: s.id,
             start: 0.0,
             end: dur,
             seconds: dur,
-            bytes: s.local_bytes,
-            bits_per_second: bps(s.local_bytes, dur),
-            retransmits: if s.is_sender { s.retransmits } else { None },
-            max_snd_cwnd: cwnd,
-            max_rtt: maxr,
-            min_rtt: minr,
-            mean_rtt: meanr,
-            reorder: reord,
+            bytes,
+            bits_per_second: bps(bytes, dur),
+            retransmits,
+            max_snd_cwnd: Some(e.max_snd_cwnd),
+            max_snd_wnd: Some(0), // tcpi_snd_wnd unavailable via libc; 0 like iperf3
+            max_rtt: Some(e.max_rtt),
+            min_rtt: Some(e.min_rtt),
+            mean_rtt: Some(e.mean_rtt),
+            reorder: Some(e.reorder),
             sender: dir,
         };
-        let remote_bytes = s.remote_bytes.unwrap_or(s.local_bytes);
-        let remote = TcpStreamSide {
+        let receiver_side = |bytes: u64| TcpStreamSide {
             socket: s.id,
             start: 0.0,
             end: dur,
             seconds: dur,
-            bytes: remote_bytes,
-            bits_per_second: bps(remote_bytes, dur),
-            retransmits: if s.is_sender { None } else { s.retransmits },
+            bytes,
+            bits_per_second: bps(bytes, dur),
+            retransmits: None,
             max_snd_cwnd: None,
+            max_snd_wnd: None,
             max_rtt: None,
             min_rtt: None,
             mean_rtt: None,
@@ -606,14 +610,14 @@ impl ReportInput {
         };
         if s.is_sender {
             EndStream {
-                sender: Some(local),
-                receiver: Some(remote),
+                sender: Some(sender_side(s.local_bytes, s.retransmits)),
+                receiver: Some(receiver_side(remote_bytes)),
                 udp: None,
             }
         } else {
             EndStream {
-                sender: Some(remote),
-                receiver: Some(local),
+                sender: Some(sender_side(remote_bytes, s.retransmits)),
+                receiver: Some(receiver_side(s.local_bytes)),
                 udp: None,
             }
         }
@@ -965,6 +969,7 @@ mod tests {
                 bits_per_second: 8000.0,
                 retransmits: Some(2),
                 snd_cwnd: Some(64000),
+                snd_wnd: Some(0),
                 rtt: Some(15),
                 rttvar: Some(3),
                 pmtu: Some(1500),
@@ -1019,8 +1024,38 @@ mod tests {
         assert_eq!(snd["mean_rtt"], 15);
         assert_eq!(snd["reorder"], 0);
 
-        // snd_wnd / max_snd_wnd are intentionally absent (Linux libc gap).
-        assert!(i0.get("snd_wnd").is_none(), "{i0}");
-        assert!(snd.get("max_snd_wnd").is_none(), "{snd}");
+        // snd_wnd / max_snd_wnd are emitted as 0 — libc can't read tcpi_snd_wnd,
+        // and iperf3 likewise emits 0 when the field is unavailable.
+        assert_eq!(i0["snd_wnd"], 0);
+        assert_eq!(snd["max_snd_wnd"], 0);
+    }
+
+    #[test]
+    fn reverse_sender_block_emits_zeroed_extremes_not_omitted() {
+        // iperf3 always emits the sender sub-object's TCP_INFO keys; for a reverse
+        // stream (peer is the sender, its TCP_INFO isn't exchanged) they're 0, not
+        // absent. A consumer reading e.g. sender.max_snd_cwnd must not hit a gap.
+        let mut input = base_input();
+        input.reverse = true;
+        let mut s = tcp_stream(1, false, 2_000_000, 2_000_000);
+        s.tcp_end = None; // reverse: no local sender TCP_INFO
+        s.retransmits = Some(0); // iperf3 emits 0 here on a retransmit-capable OS
+        input.streams = vec![s];
+        let snd =
+            serde_json::to_value(input.build()).unwrap()["end"]["streams"][0]["sender"].clone();
+        for key in [
+            "max_snd_cwnd",
+            "max_snd_wnd",
+            "max_rtt",
+            "min_rtt",
+            "mean_rtt",
+            "reorder",
+            "retransmits",
+        ] {
+            assert_eq!(
+                snd[key], 0,
+                "reverse sender.{key} must be 0, not absent: {snd}"
+            );
+        }
     }
 }

--- a/riperf3/src/reporter.rs
+++ b/riperf3/src/reporter.rs
@@ -287,6 +287,44 @@ pub struct IntervalReporterConfig {
     pub forceflush: bool,
     pub timestamp_format: Option<String>,
     pub json_stream: bool,
+    /// Print interval lines live (text or json-stream). When false the reporter
+    /// runs purely to collect intervals for the final `-J` blob (issue #36 PR2).
+    pub print: bool,
+}
+
+/// Per-stream sender-side TCP_INFO extremes accumulated across the run (#36 PR2),
+/// for the `end.streams[].sender` object. Only meaningful for TCP sender streams.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct StreamExtremes {
+    pub stream_id: i32,
+    pub max_snd_cwnd: u64,
+    pub max_rtt: u32,
+    pub min_rtt: u32,
+    pub reorder: u32,
+    rtt_sum: u64,
+    rtt_samples: u64,
+    /// Final cumulative retransmit total; `None` until a TCP_INFO read succeeds.
+    pub total_retransmits: Option<u32>,
+}
+
+impl StreamExtremes {
+    pub fn mean_rtt(&self) -> u32 {
+        self.rtt_sum.checked_div(self.rtt_samples).unwrap_or(0) as u32
+    }
+
+    /// True once at least one TCP_INFO sample was recorded.
+    pub fn has_samples(&self) -> bool {
+        self.rtt_samples > 0
+    }
+}
+
+/// Interval samples plus per-stream extremes collected during a run, for the
+/// final `-J` report (#36 PR2). Written once when the reporter task finishes;
+/// the client reads it after joining that task.
+#[derive(Debug, Default)]
+pub struct CollectedIntervals {
+    pub intervals: Vec<crate::json_report::Interval>,
+    pub extremes: Vec<StreamExtremes>,
 }
 
 /// Spawn an async task that prints interval reports periodically.
@@ -297,6 +335,7 @@ pub fn spawn_interval_reporter(
     config: IntervalReporterConfig,
     streams: Vec<IntervalStreamRef>,
     done: Arc<AtomicBool>,
+    collector: Option<Arc<Mutex<CollectedIntervals>>>,
 ) -> Option<JoinHandle<()>> {
     if config.interval_secs <= 0.0 {
         return None;
@@ -306,6 +345,8 @@ pub fn spawn_interval_reporter(
     let has_retransmits = tcp_info::has_retransmit_info()
         && config.protocol == TransportProtocol::Tcp
         && streams.iter().any(|s| s.is_sender);
+    let collecting = collector.is_some();
+    let is_udp = config.protocol == TransportProtocol::Udp;
 
     Some(tokio::spawn(async move {
         let mut ticker = tokio::time::interval(interval_dur);
@@ -325,6 +366,18 @@ pub fn spawn_interval_reporter(
         let mut prev_cnt_error: Vec<i64> = vec![0; streams.len()];
         let mut prev_packet_count: Vec<i64> = vec![0; streams.len()];
 
+        // Accumulated state for the final `-J` report (#36 PR2). Written to the
+        // collector once the loop ends; the client reads it after joining us.
+        let mut collected: Vec<crate::json_report::Interval> = Vec::new();
+        let mut acc_extremes: Vec<StreamExtremes> = streams
+            .iter()
+            .map(|s| StreamExtremes {
+                stream_id: s.id,
+                min_rtt: u32::MAX,
+                ..Default::default()
+            })
+            .collect();
+
         loop {
             ticker.tick().await;
 
@@ -336,9 +389,10 @@ pub fn spawn_interval_reporter(
             let omitted = interval_num <= omit_intervals;
             let start = (interval_num - 1) as f64 * config.interval_secs;
             let end = interval_num as f64 * config.interval_secs;
+            let seconds = end - start;
 
             // Timestamp prefix for this tick
-            if config.timestamp_format.is_some() {
+            if config.print && config.timestamp_format.is_some() {
                 // Use libc strftime for iperf3-compatible timestamp formatting
                 let now = std::time::SystemTime::now()
                     .duration_since(std::time::UNIX_EPOCH)
@@ -351,7 +405,7 @@ pub fn spawn_interval_reporter(
                 print!("{hours:02}:{mins:02}:{s:02} ");
             }
 
-            if !header_printed {
+            if config.print && !header_printed {
                 print_header(config.protocol, has_retransmits);
                 header_printed = true;
             }
@@ -362,6 +416,7 @@ pub fn spawn_interval_reporter(
             let mut sum_lost: i64 = 0;
             let mut sum_packets: i64 = 0;
             let mut last_jitter: f64 = 0.0;
+            let mut collected_streams: Vec<crate::json_report::IntervalStream> = Vec::new();
 
             for (i, stream) in streams.iter().enumerate() {
                 let bytes = if stream.is_sender {
@@ -370,21 +425,41 @@ pub fn spawn_interval_reporter(
                     stream.counters.take_received_interval()
                 };
 
-                // TCP_INFO for retransmits and cwnd
-                let (retransmits, snd_cwnd, rtt) = if has_retransmits && stream.is_sender {
+                // TCP_INFO for the interval detail and the end extremes.
+                let (retransmits, snd_cwnd, rtt, rttvar, pmtu, reorder_iv) = if has_retransmits
+                    && stream.is_sender
+                {
                     if let Some(fd) = stream.raw_fd {
                         if let Some(info) = tcp_info::get_tcp_info(fd) {
                             let delta = info.total_retransmits.saturating_sub(prev_retransmits[i]);
                             prev_retransmits[i] = info.total_retransmits;
-                            (Some(delta as i64), Some(info.snd_cwnd), Some(info.rtt))
+                            // Accumulate sender-side extremes for the end report.
+                            let e = &mut acc_extremes[i];
+                            e.max_snd_cwnd = e.max_snd_cwnd.max(info.snd_cwnd);
+                            e.reorder = e.reorder.max(info.reorder);
+                            if info.rtt > 0 {
+                                e.max_rtt = e.max_rtt.max(info.rtt);
+                                e.min_rtt = e.min_rtt.min(info.rtt);
+                                e.rtt_sum += info.rtt as u64;
+                                e.rtt_samples += 1;
+                            }
+                            e.total_retransmits = Some(info.total_retransmits);
+                            (
+                                Some(delta as i64),
+                                Some(info.snd_cwnd),
+                                Some(info.rtt),
+                                Some(info.rttvar),
+                                Some(info.pmtu),
+                                Some(info.reorder),
+                            )
                         } else {
-                            (None, None, None)
+                            (None, None, None, None, None, None)
                         }
                     } else {
-                        (None, None, None)
+                        (None, None, None, None, None, None)
                     }
                 } else {
-                    (None, None, None)
+                    (None, None, None, None, None, None)
                 };
 
                 // UDP stats (compute deltas for loss/packets)
@@ -403,56 +478,85 @@ pub fn spawn_interval_reporter(
                     (None, None, None)
                 };
 
-                let interval = StreamInterval {
-                    stream_id: stream.id,
-                    start,
-                    end,
-                    bytes,
-                    is_sender: stream.is_sender,
-                    retransmits,
-                    snd_cwnd,
-                    rtt,
-                    jitter,
-                    lost,
-                    total_packets: total,
-                    omitted,
+                let bps_val = if seconds > 0.0 {
+                    bytes as f64 * 8.0 / seconds
+                } else {
+                    0.0
                 };
 
-                if config.json_stream {
-                    let seconds = end - start;
-                    let bps = if seconds > 0.0 {
-                        bytes as f64 * 8.0 / seconds
-                    } else {
-                        0.0
+                if config.print {
+                    let interval = StreamInterval {
+                        stream_id: stream.id,
+                        start,
+                        end,
+                        bytes,
+                        is_sender: stream.is_sender,
+                        retransmits,
+                        snd_cwnd,
+                        rtt,
+                        jitter,
+                        lost,
+                        total_packets: total,
+                        omitted,
                     };
-                    let mut j = serde_json::json!({
-                        "socket": stream.id,
-                        "start": start,
-                        "end": end,
-                        "seconds": seconds,
-                        "bytes": bytes,
-                        "bits_per_second": bps,
-                        "omitted": omitted,
-                        "sender": stream.is_sender,
+
+                    if config.json_stream {
+                        let mut j = serde_json::json!({
+                            "socket": stream.id,
+                            "start": start,
+                            "end": end,
+                            "seconds": seconds,
+                            "bytes": bytes,
+                            "bits_per_second": bps_val,
+                            "omitted": omitted,
+                            "sender": stream.is_sender,
+                        });
+                        if let Some(r) = retransmits {
+                            j["retransmits"] = serde_json::json!(r);
+                        }
+                        if let Some(c) = snd_cwnd {
+                            j["snd_cwnd"] = serde_json::json!(c);
+                        }
+                        if let Some(ji) = jitter {
+                            j["jitter_ms"] = serde_json::json!(ji * 1000.0);
+                        }
+                        if let Some(l) = lost {
+                            j["lost_packets"] = serde_json::json!(l);
+                        }
+                        if let Some(p) = total {
+                            j["packets"] = serde_json::json!(p);
+                        }
+                        println!("{}", serde_json::to_string(&j).unwrap());
+                    } else {
+                        print_interval(&interval, config.format_char);
+                    }
+                }
+
+                if collecting {
+                    let lost_pct = match (lost, total) {
+                        (Some(l), Some(t)) => Some(lost_percent(l, t)),
+                        _ => None,
+                    };
+                    collected_streams.push(crate::json_report::IntervalStream {
+                        socket: stream.id,
+                        start,
+                        end,
+                        seconds,
+                        bytes,
+                        bits_per_second: bps_val,
+                        retransmits,
+                        snd_cwnd,
+                        rtt,
+                        rttvar,
+                        pmtu,
+                        reorder: reorder_iv,
+                        jitter_ms: jitter.map(|j| j * 1000.0),
+                        lost_packets: lost,
+                        packets: total,
+                        lost_percent: lost_pct,
+                        omitted,
+                        sender: stream.is_sender,
                     });
-                    if let Some(r) = retransmits {
-                        j["retransmits"] = serde_json::json!(r);
-                    }
-                    if let Some(c) = snd_cwnd {
-                        j["snd_cwnd"] = serde_json::json!(c);
-                    }
-                    if let Some(ji) = jitter {
-                        j["jitter_ms"] = serde_json::json!(ji * 1000.0);
-                    }
-                    if let Some(l) = lost {
-                        j["lost_packets"] = serde_json::json!(l);
-                    }
-                    if let Some(p) = total {
-                        j["packets"] = serde_json::json!(p);
-                    }
-                    println!("{}", serde_json::to_string(&j).unwrap());
-                } else {
-                    print_interval(&interval, config.format_char);
                 }
 
                 sum_bytes += bytes;
@@ -468,8 +572,7 @@ pub fn spawn_interval_reporter(
             }
 
             // Print [SUM] line for parallel streams
-            if config.num_streams > 1 {
-                let is_udp = config.protocol == TransportProtocol::Udp;
+            if config.print && config.num_streams > 1 {
                 let sum_interval = StreamInterval {
                     stream_id: -1, // renders as "SUM"
                     start,
@@ -491,10 +594,60 @@ pub fn spawn_interval_reporter(
                 print_interval(&sum_interval, config.format_char);
             }
 
+            if collecting {
+                let sum_bps = if seconds > 0.0 {
+                    sum_bytes as f64 * 8.0 / seconds
+                } else {
+                    0.0
+                };
+                collected.push(crate::json_report::Interval {
+                    streams: collected_streams,
+                    sum: crate::json_report::IntervalSum {
+                        start,
+                        end,
+                        seconds,
+                        bytes: sum_bytes,
+                        bits_per_second: sum_bps,
+                        retransmits: if has_retransmits {
+                            Some(sum_retransmits)
+                        } else {
+                            None
+                        },
+                        jitter_ms: if is_udp {
+                            Some(last_jitter * 1000.0)
+                        } else {
+                            None
+                        },
+                        lost_packets: if is_udp { Some(sum_lost) } else { None },
+                        packets: if is_udp { Some(sum_packets) } else { None },
+                        lost_percent: if is_udp {
+                            Some(lost_percent(sum_lost, sum_packets))
+                        } else {
+                            None
+                        },
+                        omitted,
+                        sender: streams.first().is_none_or(|s| s.is_sender),
+                    },
+                });
+            }
+
             // Flush after each interval if requested
-            if config.forceflush {
+            if config.print && config.forceflush {
                 use std::io::Write;
                 let _ = std::io::stdout().flush();
+            }
+        }
+
+        // Hand the collected samples + extremes to the client (#36 PR2).
+        if let Some(c) = collector {
+            if let Ok(mut g) = c.lock() {
+                for e in acc_extremes.iter_mut() {
+                    if e.min_rtt == u32::MAX {
+                        e.min_rtt = 0;
+                    }
+                }
+                g.intervals = collected;
+                g.extremes = acc_extremes;
             }
         }
     }))

--- a/riperf3/src/reporter.rs
+++ b/riperf3/src/reporter.rs
@@ -290,6 +290,9 @@ pub struct IntervalReporterConfig {
     /// Print interval lines live (text or json-stream). When false the reporter
     /// runs purely to collect intervals for the final `-J` blob (issue #36 PR2).
     pub print: bool,
+    /// Datagram size, used to derive the UDP *sender's* per-interval packet count
+    /// (the sender doesn't measure loss/jitter, so iperf3 reports only `packets`).
+    pub blksize: usize,
 }
 
 /// Per-stream sender-side TCP_INFO extremes accumulated across the run (#36 PR2),
@@ -365,6 +368,9 @@ pub fn spawn_interval_reporter(
         let mut prev_retransmits: Vec<u32> = vec![0; streams.len()];
         let mut prev_cnt_error: Vec<i64> = vec![0; streams.len()];
         let mut prev_packet_count: Vec<i64> = vec![0; streams.len()];
+
+        // Datagram size for the UDP sender's per-interval packet count.
+        let blk = config.blksize.max(1) as u64;
 
         // Accumulated state for the final `-J` report (#36 PR2). Written to the
         // collector once the loop ends; the client reads it after joining us.
@@ -533,9 +539,23 @@ pub fn spawn_interval_reporter(
                 }
 
                 if collecting {
-                    let lost_pct = match (lost, total) {
-                        (Some(l), Some(t)) => Some(lost_percent(l, t)),
-                        _ => None,
+                    // UDP datagram detail: a receiver stream reports measured
+                    // loss/jitter; a sender stream reports only the sent packet
+                    // count (bytes / datagram size), like iperf3.
+                    let (j_ms, lost_p, pkts, lost_pct) = if stream.udp_recv_stats.is_some() {
+                        (
+                            jitter.map(|j| j * 1000.0),
+                            lost,
+                            total,
+                            match (lost, total) {
+                                (Some(l), Some(t)) => Some(lost_percent(l, t)),
+                                _ => None,
+                            },
+                        )
+                    } else if is_udp {
+                        (None, None, Some((bytes / blk) as i64), None)
+                    } else {
+                        (None, None, None, None)
                     };
                     collected_streams.push(crate::json_report::IntervalStream {
                         socket: stream.id,
@@ -546,13 +566,16 @@ pub fn spawn_interval_reporter(
                         bits_per_second: bps_val,
                         retransmits,
                         snd_cwnd,
+                        // snd_wnd is unavailable via libc (see TcpStreamSide); emit
+                        // 0 alongside the other TCP detail, like iperf3.
+                        snd_wnd: snd_cwnd.map(|_| 0u64),
                         rtt,
                         rttvar,
                         pmtu,
                         reorder: reorder_iv,
-                        jitter_ms: jitter.map(|j| j * 1000.0),
-                        lost_packets: lost,
-                        packets: total,
+                        jitter_ms: j_ms,
+                        lost_packets: lost_p,
+                        packets: pkts,
                         lost_percent: lost_pct,
                         omitted,
                         sender: stream.is_sender,
@@ -600,6 +623,21 @@ pub fn spawn_interval_reporter(
                 } else {
                     0.0
                 };
+                // UDP sum: a receiving side reports measured loss/jitter; a pure
+                // sending side reports only the sent packet count, like iperf3.
+                let any_udp_recv = streams.iter().any(|s| s.udp_recv_stats.is_some());
+                let (sum_j, sum_lostp, sum_pkts, sum_lostpct) = if is_udp && any_udp_recv {
+                    (
+                        Some(last_jitter * 1000.0),
+                        Some(sum_lost),
+                        Some(sum_packets),
+                        Some(lost_percent(sum_lost, sum_packets)),
+                    )
+                } else if is_udp {
+                    (None, None, Some((sum_bytes / blk) as i64), None)
+                } else {
+                    (None, None, None, None)
+                };
                 collected.push(crate::json_report::Interval {
                     streams: collected_streams,
                     sum: crate::json_report::IntervalSum {
@@ -613,18 +651,10 @@ pub fn spawn_interval_reporter(
                         } else {
                             None
                         },
-                        jitter_ms: if is_udp {
-                            Some(last_jitter * 1000.0)
-                        } else {
-                            None
-                        },
-                        lost_packets: if is_udp { Some(sum_lost) } else { None },
-                        packets: if is_udp { Some(sum_packets) } else { None },
-                        lost_percent: if is_udp {
-                            Some(lost_percent(sum_lost, sum_packets))
-                        } else {
-                            None
-                        },
+                        jitter_ms: sum_j,
+                        lost_packets: sum_lostp,
+                        packets: sum_pkts,
+                        lost_percent: sum_lostpct,
                         omitted,
                         sender: streams.first().is_none_or(|s| s.is_sender),
                     },

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -436,6 +436,7 @@ impl Server {
                     timestamp_format: self.timestamps.clone(),
                     json_stream: false, // server doesn't stream JSON
                     print: true,        // server prints its interval lines live
+                    blksize: cfg.blksize,
                 },
                 stream_refs,
                 done.clone(),

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -435,9 +435,11 @@ impl Server {
                     forceflush: self.forceflush,
                     timestamp_format: self.timestamps.clone(),
                     json_stream: false, // server doesn't stream JSON
+                    print: true,        // server prints its interval lines live
                 },
                 stream_refs,
                 done.clone(),
+                None, // server has no -J blob to collect for yet (#50)
             )
         };
 

--- a/riperf3/src/tcp_info.rs
+++ b/riperf3/src/tcp_info.rs
@@ -15,6 +15,8 @@ pub struct TcpInfoSnapshot {
     pub snd_mss: u32,
     /// Path MTU.
     pub pmtu: u32,
+    /// Reordering metric (segments).
+    pub reorder: u32,
 }
 
 /// Query TCP_INFO for a connected TCP socket.
@@ -46,11 +48,12 @@ pub fn get_tcp_info(fd: i32) -> Option<TcpInfoSnapshot> {
     Some(TcpInfoSnapshot {
         total_retransmits: info.tcpi_total_retrans,
         snd_cwnd: info.tcpi_snd_cwnd as u64 * info.tcpi_snd_mss as u64,
-        snd_wnd: 0, // tcpi_snd_wnd not available in all libc versions
+        snd_wnd: 0, // tcpi_snd_wnd is not exposed by libc's tcp_info on Linux
         rtt: info.tcpi_rtt,
         rttvar: info.tcpi_rttvar,
         snd_mss: info.tcpi_snd_mss,
         pmtu: info.tcpi_pmtu,
+        reorder: info.tcpi_reordering,
     })
 }
 
@@ -84,7 +87,8 @@ pub fn get_tcp_info(fd: i32) -> Option<TcpInfoSnapshot> {
         rtt: info.tcpi_srtt,
         rttvar: info.tcpi_rttvar,
         snd_mss: info.tcpi_maxseg,
-        pmtu: 0, // not available in tcp_connection_info
+        pmtu: 0,    // not available in tcp_connection_info
+        reorder: 0, // not exposed by tcp_connection_info
     })
 }
 
@@ -119,6 +123,7 @@ pub fn get_tcp_info(fd: i32) -> Option<TcpInfoSnapshot> {
         rttvar: info.tcpi_rttvar,
         snd_mss: info.tcpi_snd_mss,
         pmtu: info.__tcpi_pmtu,
+        reorder: 0, // tcpi_reordering not in FreeBSD's tcp_info
     })
 }
 

--- a/riperf3/src/tcp_info.rs
+++ b/riperf3/src/tcp_info.rs
@@ -53,7 +53,11 @@ pub fn get_tcp_info(fd: i32) -> Option<TcpInfoSnapshot> {
         rttvar: info.tcpi_rttvar,
         snd_mss: info.tcpi_snd_mss,
         pmtu: info.tcpi_pmtu,
-        reorder: info.tcpi_reordering,
+        // iperf3's `reorder` is `tcpi_reord_seen` (count of reordering events),
+        // NOT `tcpi_reordering` (the kernel's reordering-degree estimate). libc's
+        // `tcp_info` truncates before `tcpi_reord_seen`, so it's unreachable here;
+        // report 0, as iperf3 does when the field is unavailable.
+        reorder: 0,
     })
 }
 

--- a/riperf3/tests/integration.rs
+++ b/riperf3/tests/integration.rs
@@ -1278,6 +1278,7 @@ mod interval_reporter_tests {
             timestamp_format: None,
             json_stream: false,
             print: true,
+            blksize: 128 * 1024,
         };
         assert!(spawn_interval_reporter(config, vec![], done, None).is_none());
     }
@@ -1295,6 +1296,7 @@ mod interval_reporter_tests {
             timestamp_format: None,
             json_stream: false,
             print: true,
+            blksize: 128 * 1024,
         };
         assert!(spawn_interval_reporter(config, vec![], done, None).is_none());
     }
@@ -1312,6 +1314,7 @@ mod interval_reporter_tests {
             timestamp_format: None,
             json_stream: false,
             print: true,
+            blksize: 128 * 1024,
         };
         let handle = spawn_interval_reporter(config, vec![], done.clone(), None);
         assert!(handle.is_some());

--- a/riperf3/tests/integration.rs
+++ b/riperf3/tests/integration.rs
@@ -1277,8 +1277,9 @@ mod interval_reporter_tests {
             forceflush: false,
             timestamp_format: None,
             json_stream: false,
+            print: true,
         };
-        assert!(spawn_interval_reporter(config, vec![], done).is_none());
+        assert!(spawn_interval_reporter(config, vec![], done, None).is_none());
     }
 
     #[tokio::test]
@@ -1293,8 +1294,9 @@ mod interval_reporter_tests {
             forceflush: false,
             timestamp_format: None,
             json_stream: false,
+            print: true,
         };
-        assert!(spawn_interval_reporter(config, vec![], done).is_none());
+        assert!(spawn_interval_reporter(config, vec![], done, None).is_none());
     }
 
     #[tokio::test]
@@ -1309,8 +1311,9 @@ mod interval_reporter_tests {
             forceflush: false,
             timestamp_format: None,
             json_stream: false,
+            print: true,
         };
-        let handle = spawn_interval_reporter(config, vec![], done.clone());
+        let handle = spawn_interval_reporter(config, vec![], done.clone(), None);
         assert!(handle.is_some());
         // Let it tick once then stop
         tokio::time::sleep(std::time::Duration::from_millis(600)).await;


### PR DESCRIPTION
**PR 2 of 3 toward #36** (faithful client `-J`). Does not close #36.

## What
Populates the `-J` **`intervals`** array and the per-stream **end TCP_INFO extremes** — previously `intervals` was always `[]` and `end.streams[].sender` had no cwnd/rtt detail.

The interval reporter now collects each tick into a shared structure the client folds into the final blob, and runs even for plain `-J` (collect-only, no live print — gated by a new `print` flag; text and `--json-stream` paths print as before).

## Faithful now
- **`intervals[]`** per-stream: `{bytes, bits_per_second, omitted, sender}` + TCP detail (`retransmits, snd_cwnd, rtt, rttvar, pmtu, reorder`) or UDP detail (`jitter_ms, lost_packets, packets, lost_percent`), plus a populated `sum`.
- **`end.streams[].sender`**: `max_snd_cwnd`, `min`/`max`/`mean_rtt`, `reorder`, and a **real** retransmit total from TCP_INFO (replacing the `-1` sentinel for forward TCP).
- `tcp_info`: added `reorder` (Linux `tcpi_reordering`; 0 elsewhere).

## Intentionally omitted (not faked)
`snd_wnd` (interval) and `max_snd_wnd` (end): libc's `tcp_info` doesn't expose `tcpi_snd_wnd` on Linux, so riperf3 can't produce them — omitted rather than emitted as a fake 0.

## Deferred (tracked)
Full `start{}` metadata (`cookie`, `timestamp`, `system_info`, `tcp_mss_default`, sock buffers) → **PR3**. `sender`/`receiver_tcp_congestion` → **#37**. Reverse-direction sender extremes aren't available (peer TCP_INFO isn't exchanged) → omitted for reverse.

## Validation
- Structural diff vs real iperf3 3.21: `intervals` (stream + sum) and `end.sender` now match **field-for-field except `snd_wnd`**.
- `cargo test --workspace` 346 pass (new model regression test); clippy `-D warnings` + fmt clean; interop gate green (3.12 + 3.21, 64/64).

Part of #36.
