### PR TITLE
feat(json): -J start metadata (timestamp, cookie, system_info, mss, buffers) (#36, PR3/3)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ base64 = "0.22"
 clap = { version = "4.5", features = ["derive"] }
 libc = "0.2"
 log = "0.4"
-nix = { version = "0.29", features = ["net", "sched", "process", "resource", "fs", "term", "socket", "zerocopy"] }
+nix = { version = "0.29", features = ["net", "sched", "process", "resource", "fs", "term", "socket", "zerocopy", "feature"] }
 rpassword = "5"
 log4rs = { version = "1.3", features = ["toml_format"] }
 rand = "0.9"

--- a/riperf3/src/client.rs
+++ b/riperf3/src/client.rs
@@ -122,12 +122,17 @@ impl Client {
         .await?;
         net::configure_tcp_stream(&ctrl, true)?;
 
+        // The control connection's MSS sizes UDP datagrams (issue #6) and feeds
+        // the `-J` start.tcp_mss_default field (#36 PR3).
+        let control_mss_opt = net::tcp_maxseg(&ctrl);
+        let control_mss = control_mss_opt.unwrap_or(0);
+
         // Resolve the UDP datagram size now that the control connection exists:
         // when `-l` wasn't given, derive it from the control-socket MSS so a
         // jumbo-frame path uses large datagrams instead of the 1460 floor
         // (iperf3 parity, issue #6). TCP keeps its own block size unchanged.
         let blksize = if self.protocol == TransportProtocol::Udp && !self.blksize_explicit {
-            resolve_udp_blksize(None, net::tcp_maxseg(&ctrl))
+            resolve_udp_blksize(None, control_mss_opt)
         } else {
             self.blksize
         };
@@ -160,6 +165,8 @@ impl Client {
         let mut streams: Vec<DataStream> = Vec::new();
         let mut cpu_start: Option<CpuSnapshot> = None;
         let mut server_results: Option<TestResultsJson> = None;
+        // Wall-clock at TestStart, for the `-J` start.timestamp (#36 PR3).
+        let mut test_start_millis = 0u64;
 
         // ---- State machine: react to server-driven transitions ----
         loop {
@@ -179,6 +186,10 @@ impl Client {
                     // All streams are set up — release the UDP senders.
                     start.store(true, Ordering::Relaxed);
                     cpu_start = Some(CpuSnapshot::now());
+                    test_start_millis = std::time::SystemTime::now()
+                        .duration_since(std::time::UNIX_EPOCH)
+                        .map(|d| d.as_millis() as u64)
+                        .unwrap_or(0);
                 }
 
                 TestState::TestRunning => {
@@ -201,6 +212,12 @@ impl Client {
                         server_results.as_ref(),
                         blksize,
                         &interval_data,
+                        &StartMeta {
+                            cookie: String::from_utf8_lossy(&cookie[..protocol::COOKIE_SIZE - 1])
+                                .into_owned(),
+                            tcp_mss_default: control_mss,
+                            start_time_millis: test_start_millis,
+                        },
                     );
                     protocol::send_state(&mut ctrl, TestState::IperfDone).await?;
                     break; // test complete — server will close the connection
@@ -387,6 +404,9 @@ impl Client {
                     // into its task, for the `-J` start.connected block (#36).
                     let local_addr = data_stream.local_addr().ok();
                     let peer_addr = data_stream.peer_addr().ok();
+                    let sock = socket2::SockRef::from(&data_stream);
+                    let sndbuf_actual = sock.send_buffer_size().ok().map(|v| v as u64);
+                    let rcvbuf_actual = sock.recv_buffer_size().ok().map(|v| v as u64);
 
                     let stream_id = iperf3_stream_id(i);
                     let is_sender = i < send_count;
@@ -431,6 +451,8 @@ impl Client {
                         raw_fd,
                         local_addr,
                         peer_addr,
+                        sndbuf_actual,
+                        rcvbuf_actual,
                     });
                 }
             }
@@ -474,6 +496,9 @@ impl Client {
                     // (#36) before the socket moves into its task.
                     let local_addr = udp_sock.local_addr().ok();
                     let peer_addr = udp_sock.peer_addr().ok();
+                    let sock = socket2::SockRef::from(&udp_sock);
+                    let sndbuf_actual = sock.send_buffer_size().ok().map(|v| v as u64);
+                    let rcvbuf_actual = sock.recv_buffer_size().ok().map(|v| v as u64);
 
                     // Convert tokio UdpSocket to std for blocking I/O
                     let std_sock = udp_sock.into_std().map_err(RiperfError::Io)?;
@@ -519,6 +544,8 @@ impl Client {
                             raw_fd: None,
                             local_addr,
                             peer_addr,
+                            sndbuf_actual,
+                            rcvbuf_actual,
                         });
                         continue;
                     };
@@ -532,6 +559,8 @@ impl Client {
                         raw_fd: None,
                         local_addr,
                         peer_addr,
+                        sndbuf_actual,
+                        rcvbuf_actual,
                     });
                 }
             }
@@ -719,9 +748,17 @@ impl Client {
         remote_cpu: Option<&TestResultsJson>,
         blksize: usize,
         interval_data: &Arc<Mutex<crate::reporter::CollectedIntervals>>,
+        start_meta: &StartMeta,
     ) {
         if self.json_output {
-            self.print_results_json(streams, cpu_start, remote_cpu, blksize, interval_data);
+            self.print_results_json(
+                streams,
+                cpu_start,
+                remote_cpu,
+                blksize,
+                interval_data,
+                start_meta,
+            );
         } else {
             self.print_results_text(streams, remote_cpu);
         }
@@ -787,6 +824,7 @@ impl Client {
         remote_cpu: Option<&TestResultsJson>,
         blksize: usize,
         interval_data: &Arc<Mutex<crate::reporter::CollectedIntervals>>,
+        start_meta: &StartMeta,
     ) {
         use crate::json_report::{
             CpuUtilization, ReportInput, StreamReport, TcpEndExtras, UdpStreamStats,
@@ -916,8 +954,7 @@ impl Client {
             connecting_host: self.host.clone(),
             connecting_port: self.port,
             version: format!("riperf3 {}", env!("CARGO_PKG_VERSION")),
-            // Full system_info (uname) lands with the rest of start{} metadata in PR3.
-            system_info: String::new(),
+            system_info: system_info(),
             cpu: CpuUtilization {
                 host_total: cpu_util.host_total,
                 host_user: cpu_util.host_user,
@@ -930,6 +967,19 @@ impl Client {
             // the field until that read-back lands rather than emit the requested
             // value (which may differ from what the kernel used).
             congestion_used: None,
+            cookie: start_meta.cookie.clone(),
+            tcp_mss_default: start_meta.tcp_mss_default,
+            fq_rate: self.fq_rate.unwrap_or(0),
+            // iperf3's start.sock_bufsize is the requested -w value (0 if unset);
+            // sndbuf/rcvbuf_actual are the kernel's actual sizes on a data socket.
+            sock_bufsize: self.window.map(|w| w as u64).unwrap_or(0),
+            sndbuf_actual: streams.first().and_then(|s| s.sndbuf_actual).unwrap_or(0),
+            rcvbuf_actual: streams.first().and_then(|s| s.rcvbuf_actual).unwrap_or(0),
+            interval: self.interval.unwrap_or(1.0),
+            // riperf3's single --gsro flag drives both GSO and GRO.
+            gso: i32::from(self.gsro),
+            gro: i32::from(self.gsro),
+            start_time_millis: start_meta.start_time_millis,
             intervals: collected_intervals,
             streams: stream_reports,
         };
@@ -942,6 +992,36 @@ enum EndCondition {
     Duration(Duration),
     Bytes(u64),
     Blocks(u64),
+}
+
+/// Start-of-test metadata for the `-J` `start` block (#36 PR3), captured in
+/// `run()` where the cookie / control-MSS / start wall-clock are known.
+struct StartMeta {
+    cookie: String,
+    tcp_mss_default: u32,
+    start_time_millis: u64,
+}
+
+/// iperf3-style `system_info`: the uname fields joined, e.g.
+/// "Linux host 6.x #1 SMP ... x86_64". Empty on platforms without `uname`.
+#[cfg(unix)]
+fn system_info() -> String {
+    match nix::sys::utsname::uname() {
+        Ok(u) => format!(
+            "{} {} {} {} {}",
+            u.sysname().to_string_lossy(),
+            u.nodename().to_string_lossy(),
+            u.release().to_string_lossy(),
+            u.version().to_string_lossy(),
+            u.machine().to_string_lossy(),
+        ),
+        Err(_) => String::new(),
+    }
+}
+
+#[cfg(not(unix))]
+fn system_info() -> String {
+    String::new()
 }
 
 // ---------------------------------------------------------------------------

--- a/riperf3/src/client.rs
+++ b/riperf3/src/client.rs
@@ -969,10 +969,15 @@ impl Client {
             congestion_used: None,
             cookie: start_meta.cookie.clone(),
             tcp_mss_default: start_meta.tcp_mss_default,
+            // -M/--set-mss request: emitted as start.tcp_mss (TCP only), which
+            // suppresses tcp_mss_default. build() does the TCP/UDP gating.
+            mss: self.mss.filter(|&m| m > 0).map(|m| m as u32),
             fq_rate: self.fq_rate.unwrap_or(0),
             // iperf3's start.sock_bufsize is the requested -w value (0 if unset);
             // sndbuf/rcvbuf_actual are the kernel's actual sizes on a data socket.
-            sock_bufsize: self.window.map(|w| w as u64).unwrap_or(0),
+            // .max(0): the public builder accepts an i32 window; clamp so a
+            // negative can't wrap to a huge u64 (the CLI path is already >= 0).
+            sock_bufsize: self.window.map(|w| w.max(0) as u64).unwrap_or(0),
             sndbuf_actual: streams.first().and_then(|s| s.sndbuf_actual).unwrap_or(0),
             rcvbuf_actual: streams.first().and_then(|s| s.rcvbuf_actual).unwrap_or(0),
             interval: self.interval.unwrap_or(1.0),

--- a/riperf3/src/json_report.rs
+++ b/riperf3/src/json_report.rs
@@ -50,7 +50,13 @@ pub struct Start {
     pub timestamp: Timestamp,
     pub connecting_to: ConnectingTo,
     pub cookie: String,
-    pub tcp_mss_default: u32,
+    // iperf3 emits exactly one of these, and only for TCP (iperf_api.c:1021):
+    // `tcp_mss` when `-M`/`--set-mss` was given, else `tcp_mss_default` (the
+    // control-socket MSS). UDP emits neither.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tcp_mss: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tcp_mss_default: Option<u32>,
     pub target_bitrate: u64,
     pub fq_rate: u64,
     pub sock_bufsize: u64,
@@ -349,7 +355,12 @@ pub struct ReportInput {
     pub congestion_used: Option<String>,
     // start{} metadata (PR3).
     pub cookie: String,
+    /// The control-socket MSS, emitted as `start.tcp_mss_default` for a TCP test
+    /// that did not pass `-M`.
     pub tcp_mss_default: u32,
+    /// The requested `-M`/`--set-mss` value, if any. When set on a TCP test it is
+    /// emitted as `start.tcp_mss` and suppresses `tcp_mss_default` (iperf3 parity).
+    pub mss: Option<u32>,
     pub fq_rate: u64,
     pub sock_bufsize: u64,
     pub sndbuf_actual: u64,
@@ -569,6 +580,17 @@ impl ReportInput {
         };
 
         let secs = self.start_time_millis / 1000;
+        // iperf3 (iperf_api.c:1021) emits the MSS key only for TCP, and picks
+        // exactly one: `tcp_mss` when `-M` was given, else `tcp_mss_default`.
+        // UDP emits neither. `self.mss.filter(|&m| m > 0)` mirrors iperf3's
+        // `if (settings->mss)` truthiness check.
+        let (tcp_mss, tcp_mss_default) = if is_udp {
+            (None, None)
+        } else if let Some(m) = self.mss.filter(|&m| m > 0) {
+            (Some(m), None)
+        } else {
+            (None, Some(self.tcp_mss_default))
+        };
         Report {
             start: Start {
                 connected,
@@ -584,7 +606,8 @@ impl ReportInput {
                     port: self.connecting_port,
                 },
                 cookie: self.cookie.clone(),
-                tcp_mss_default: self.tcp_mss_default,
+                tcp_mss,
+                tcp_mss_default,
                 target_bitrate: self.target_bitrate,
                 fq_rate: self.fq_rate,
                 sock_bufsize: self.sock_bufsize,
@@ -800,6 +823,7 @@ mod tests {
             congestion_used: Some("cubic".into()),
             cookie: "testcookie000000000000000000000000000".into(),
             tcp_mss_default: 1448,
+            mss: None,
             fq_rate: 0,
             sock_bufsize: 0,
             sndbuf_actual: 16384,
@@ -982,9 +1006,14 @@ mod tests {
         assert_eq!(ts["timemillisecs"], 1_780_107_649_449u64);
         assert_eq!(ts["timesecs"], 1_780_107_649u64);
         assert_eq!(ts["time"], "Sat, 30 May 2026 02:20:49 GMT");
-        // pass-through metadata.
+        // pass-through metadata. TCP without -M: tcp_mss_default present, tcp_mss
+        // absent (iperf3 emits exactly one).
         assert_eq!(start["cookie"], "testcookie000000000000000000000000000");
         assert_eq!(start["tcp_mss_default"], 1448);
+        assert!(
+            start.get("tcp_mss").is_none(),
+            "tcp_mss must be absent: {start}"
+        );
         assert_eq!(start["sndbuf_actual"], 16384);
         assert_eq!(start["rcvbuf_actual"], 87380);
         // test_start additions.
@@ -993,6 +1022,36 @@ mod tests {
         assert_eq!(test_start["interval"], 1.0);
         assert_eq!(test_start["gso"], 0);
         assert_eq!(test_start["gro"], 0);
+    }
+
+    #[test]
+    fn udp_start_omits_tcp_mss_keys() {
+        // iperf3 (iperf_api.c:1021) gates the MSS key on SOCK_STREAM; a UDP test
+        // emits neither tcp_mss nor tcp_mss_default.
+        let mut input = base_input();
+        input.protocol = TransportProtocol::Udp;
+        input.mss = Some(1400); // even with -M, UDP must not emit either key
+        input.streams = vec![tcp_stream(1, false, 1000, 1000)];
+        let v = serde_json::to_value(input.build()).unwrap();
+        let start = &v["start"];
+        assert!(start.get("tcp_mss").is_none(), "{start}");
+        assert!(start.get("tcp_mss_default").is_none(), "{start}");
+    }
+
+    #[test]
+    fn set_mss_emits_tcp_mss_and_suppresses_default() {
+        // TCP with -M/--set-mss: iperf3 emits tcp_mss = <value> and omits
+        // tcp_mss_default (the two are mutually exclusive).
+        let mut input = base_input();
+        input.mss = Some(1400);
+        input.streams = vec![tcp_stream(1, true, 10, 10)];
+        let v = serde_json::to_value(input.build()).unwrap();
+        let start = &v["start"];
+        assert_eq!(start["tcp_mss"], 1400);
+        assert!(
+            start.get("tcp_mss_default").is_none(),
+            "tcp_mss_default must be suppressed under -M: {start}"
+        );
     }
 
     #[test]

--- a/riperf3/src/json_report.rs
+++ b/riperf3/src/json_report.rs
@@ -6,22 +6,22 @@
 //! blob, which diverged from iperf3's schema (flat `end.streams`, empty
 //! `intervals`, fabricated addresses).
 //!
-//! Built incrementally (see #36):
-//! - **This PR**: the `end` block — per-stream objects nested as
-//!   `{sender, receiver}` (TCP) or `{udp}` (UDP), the `sum_sent`/`sum_received`
-//!   aggregates plus the UDP `sum` and bidir `sum_*_bidir_reverse`, CPU
-//!   utilization, and `sender`/`receiver_tcp_congestion`; plus real connection
-//!   addresses in `start.connected`.
-//! - **PR2**: populate `intervals` (and the per-stream TCP_INFO extremes
-//!   `max_snd_cwnd` / `min`/`max`/`mean_rtt`, which derive from per-interval
-//!   `TCP_INFO` accumulation).
-//! - **PR3**: full `start` metadata (`cookie`, `timestamp`, `system_info`,
-//!   `tcp_mss_default`, socket buffer sizes, …).
+//! The model covers all three top-level blocks (built incrementally across #36
+//! PR1–PR3):
+//! - `start`: connection metadata and addresses (`connected`, `connecting_to`),
+//!   `timestamp`, `cookie`, `system_info` (uname), `tcp_mss_default`, the socket
+//!   buffer sizes (`sock_bufsize`, `sndbuf_actual`, `rcvbuf_actual`), and the
+//!   `test_start` parameters.
+//! - `intervals`: per-interval stream samples and sums, with the per-stream
+//!   `TCP_INFO` extremes (`max_snd_cwnd` / `min`/`max`/`mean_rtt`) accumulated
+//!   from per-interval `TCP_INFO` reads and surfaced on the `end` streams.
+//! - `end`: per-stream objects nested as `{sender, receiver}` (TCP) or `{udp}`
+//!   (UDP), the `sum_sent`/`sum_received` aggregates plus the UDP `sum` and bidir
+//!   `sum_*_bidir_reverse`, CPU utilization, and `sender`/`receiver_tcp_congestion`.
 //!
 //! Fields iperf3 emits but riperf3 cannot yet produce are omitted
 //! (`skip_serializing_if`) rather than emitted with placeholder values, so the
-//! shape only ever contains real data. The one exception is `system_info`, which
-//! iperf3 always emits: it ships as an empty string until PR3 fills in the uname.
+//! shape only ever contains real data.
 
 use serde::Serialize;
 
@@ -47,8 +47,24 @@ pub struct Start {
     pub connected: Vec<Connection>,
     pub version: String,
     pub system_info: String,
+    pub timestamp: Timestamp,
     pub connecting_to: ConnectingTo,
+    pub cookie: String,
+    pub tcp_mss_default: u32,
+    pub target_bitrate: u64,
+    pub fq_rate: u64,
+    pub sock_bufsize: u64,
+    pub sndbuf_actual: u64,
+    pub rcvbuf_actual: u64,
     pub test_start: TestStart,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct Timestamp {
+    /// RFC 1123 / HTTP-date GMT string, e.g. "Sat, 30 May 2026 02:20:49 GMT".
+    pub time: String,
+    pub timesecs: u64,
+    pub timemillisecs: u64,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -79,6 +95,10 @@ pub struct TestStart {
     pub tos: i32,
     pub target_bitrate: u64,
     pub bidir: i32,
+    pub fqrate: u64,
+    pub interval: f64,
+    pub gso: i32,
+    pub gro: i32,
 }
 
 // ---------------------------------------------------------------------------
@@ -327,6 +347,18 @@ pub struct ReportInput {
     pub system_info: String,
     pub cpu: CpuUtilization,
     pub congestion_used: Option<String>,
+    // start{} metadata (PR3).
+    pub cookie: String,
+    pub tcp_mss_default: u32,
+    pub fq_rate: u64,
+    pub sock_bufsize: u64,
+    pub sndbuf_actual: u64,
+    pub rcvbuf_actual: u64,
+    pub interval: f64,
+    pub gso: i32,
+    pub gro: i32,
+    /// Wall-clock at test start, ms since the Unix epoch — for `start.timestamp`.
+    pub start_time_millis: u64,
     /// Per-interval samples collected during the run (PR2). Empty if interval
     /// reporting was disabled (`-i 0`).
     pub intervals: Vec<Interval>,
@@ -349,9 +381,45 @@ fn pct_lost(lost: i64, total: i64) -> f64 {
     crate::reporter::lost_percent(lost, total)
 }
 
+/// Format a Unix timestamp (seconds) as an RFC 1123 GMT string, e.g.
+/// "Sat, 30 May 2026 02:20:49 GMT" — matching iperf3's `start.timestamp.time`.
+/// Pure safe Rust (no chrono): epoch → civil date via Howard Hinnant's algorithm.
+fn http_date(epoch_secs: u64) -> String {
+    const DOW: [&str; 7] = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+    const MON: [&str; 12] = [
+        "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
+    ];
+    let days = (epoch_secs / 86_400) as i64;
+    let tod = epoch_secs % 86_400;
+    let (hh, mm, ss) = (tod / 3600, (tod % 3600) / 60, tod % 60);
+    // 1970-01-01 was a Thursday (index 4 with Sunday = 0).
+    let dow = (((days % 7) + 4) % 7) as usize;
+    // civil_from_days (Hinnant): days since the epoch -> (year, month, day).
+    let z = days + 719_468;
+    let era = (if z >= 0 { z } else { z - 146_096 }) / 146_097;
+    let doe = z - era * 146_097; // [0, 146096]
+    let yoe = (doe - doe / 1460 + doe / 36_524 - doe / 146_096) / 365; // [0, 399]
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100); // [0, 365]
+    let mp = (5 * doy + 2) / 153; // [0, 11]
+    let day = doy - (153 * mp + 2) / 5 + 1; // [1, 31]
+    let month = if mp < 10 { mp + 3 } else { mp - 9 }; // [1, 12]
+    let year = yoe + era * 400 + if month <= 2 { 1 } else { 0 };
+    format!(
+        "{}, {:02} {} {:04} {:02}:{:02}:{:02} GMT",
+        DOW[dow],
+        day,
+        MON[(month - 1) as usize],
+        year,
+        hh,
+        mm,
+        ss
+    )
+}
+
 impl ReportInput {
-    /// Assemble the iperf3-schema report: `start`, the collected `intervals`, and
-    /// the `end` block. `start` metadata stays minimal (PR3).
+    /// Assemble the iperf3-schema report: the `start` block (timestamp, cookie,
+    /// `system_info`, `tcp_mss_default`, socket buffers, and `test_start`
+    /// parameters), the collected `intervals`, and the `end` block.
     pub fn build(&self) -> Report {
         let dur = self.duration;
         let is_udp = matches!(self.protocol, TransportProtocol::Udp);
@@ -500,15 +568,28 @@ impl ReportInput {
             receiver_tcp_congestion: cong_receiver,
         };
 
+        let secs = self.start_time_millis / 1000;
         Report {
             start: Start {
                 connected,
                 version: self.version.clone(),
                 system_info: self.system_info.clone(),
+                timestamp: Timestamp {
+                    time: http_date(secs),
+                    timesecs: secs,
+                    timemillisecs: self.start_time_millis,
+                },
                 connecting_to: ConnectingTo {
                     host: self.connecting_host.clone(),
                     port: self.connecting_port,
                 },
+                cookie: self.cookie.clone(),
+                tcp_mss_default: self.tcp_mss_default,
+                target_bitrate: self.target_bitrate,
+                fq_rate: self.fq_rate,
+                sock_bufsize: self.sock_bufsize,
+                sndbuf_actual: self.sndbuf_actual,
+                rcvbuf_actual: self.rcvbuf_actual,
                 test_start: TestStart {
                     protocol: if is_udp { "UDP" } else { "TCP" }.to_string(),
                     num_streams: self.num_streams,
@@ -521,6 +602,10 @@ impl ReportInput {
                     tos: self.tos,
                     target_bitrate: self.target_bitrate,
                     bidir: self.bidir as i32,
+                    fqrate: self.fq_rate,
+                    interval: self.interval,
+                    gso: self.gso,
+                    gro: self.gro,
                 },
             },
             intervals: self.intervals.clone(),
@@ -713,6 +798,16 @@ mod tests {
                 remote_system: 1.0,
             },
             congestion_used: Some("cubic".into()),
+            cookie: "testcookie000000000000000000000000000".into(),
+            tcp_mss_default: 1448,
+            fq_rate: 0,
+            sock_bufsize: 0,
+            sndbuf_actual: 16384,
+            rcvbuf_actual: 87380,
+            interval: 1.0,
+            gso: 0,
+            gro: 0,
+            start_time_millis: 1_780_107_649_449,
             intervals: vec![],
             streams: vec![],
         }
@@ -830,10 +925,40 @@ mod tests {
             "connected",
             "version",
             "system_info",
+            "timestamp",
             "connecting_to",
+            "cookie",
+            "tcp_mss_default",
+            "target_bitrate",
+            "fq_rate",
+            "sock_bufsize",
+            "sndbuf_actual",
+            "rcvbuf_actual",
             "test_start",
         ] {
             assert!(v["start"].get(k).is_some(), "start.{k} missing");
+        }
+        for k in [
+            "protocol",
+            "num_streams",
+            "blksize",
+            "omit",
+            "duration",
+            "bytes",
+            "blocks",
+            "reverse",
+            "tos",
+            "target_bitrate",
+            "bidir",
+            "fqrate",
+            "interval",
+            "gso",
+            "gro",
+        ] {
+            assert!(
+                v["start"]["test_start"].get(k).is_some(),
+                "start.test_start.{k} missing"
+            );
         }
         for k in [
             "streams",
@@ -843,6 +968,40 @@ mod tests {
         ] {
             assert!(v["end"].get(k).is_some(), "end.{k} missing");
         }
+    }
+
+    #[test]
+    fn start_metadata_values_match_input() {
+        let mut input = base_input();
+        input.streams = vec![tcp_stream(1, true, 10, 10)];
+        let v = serde_json::to_value(input.build()).unwrap();
+        let start = &v["start"];
+        // timestamp: timesecs = millis / 1000, timemillisecs verbatim, and the
+        // RFC 1123 GMT string derived from timesecs.
+        let ts = &start["timestamp"];
+        assert_eq!(ts["timemillisecs"], 1_780_107_649_449u64);
+        assert_eq!(ts["timesecs"], 1_780_107_649u64);
+        assert_eq!(ts["time"], "Sat, 30 May 2026 02:20:49 GMT");
+        // pass-through metadata.
+        assert_eq!(start["cookie"], "testcookie000000000000000000000000000");
+        assert_eq!(start["tcp_mss_default"], 1448);
+        assert_eq!(start["sndbuf_actual"], 16384);
+        assert_eq!(start["rcvbuf_actual"], 87380);
+        // test_start additions.
+        let test_start = &start["test_start"];
+        assert_eq!(test_start["fqrate"], 0);
+        assert_eq!(test_start["interval"], 1.0);
+        assert_eq!(test_start["gso"], 0);
+        assert_eq!(test_start["gro"], 0);
+    }
+
+    #[test]
+    fn http_date_matches_rfc1123_gmt() {
+        // Reference values cross-checked against `date -u -d @<epoch>`.
+        assert_eq!(http_date(0), "Thu, 01 Jan 1970 00:00:00 GMT");
+        assert_eq!(http_date(1_780_107_649), "Sat, 30 May 2026 02:20:49 GMT");
+        // Leap-year boundary: 2000-02-29 (a leap day) must format as Feb 29.
+        assert_eq!(http_date(951_782_400), "Tue, 29 Feb 2000 00:00:00 GMT");
     }
 
     // ---- cold-review round 1 regressions ------------------------------------

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -292,6 +292,8 @@ impl Server {
                         // Populated for the server's own `-J` output in #50.
                         local_addr: None,
                         peer_addr: None,
+                        sndbuf_actual: None,
+                        rcvbuf_actual: None,
                     });
                 }
             }
@@ -373,6 +375,8 @@ impl Server {
                             raw_fd: None,
                             local_addr: None,
                             peer_addr: None,
+                            sndbuf_actual: None,
+                            rcvbuf_actual: None,
                         });
                     } else {
                         let c = counters.clone();
@@ -400,6 +404,8 @@ impl Server {
                             raw_fd: None,
                             local_addr: None,
                             peer_addr: None,
+                            sndbuf_actual: None,
+                            rcvbuf_actual: None,
                         });
                     }
                 }

--- a/riperf3/src/stream.rs
+++ b/riperf3/src/stream.rs
@@ -298,6 +298,10 @@ pub struct DataStream {
     /// for the `-J` `start.connected` block (issue #36). `None` if unavailable.
     pub local_addr: Option<std::net::SocketAddr>,
     pub peer_addr: Option<std::net::SocketAddr>,
+    /// Actual SO_SNDBUF/SO_RCVBUF on this stream's socket, captured at creation
+    /// for the `-J` `start.sndbuf_actual`/`rcvbuf_actual` fields (#36 PR3).
+    pub sndbuf_actual: Option<u64>,
+    pub rcvbuf_actual: Option<u64>,
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Final PR of the #36 series. Populates the `-J` `start` block so riperf3's JSON `start` is a field-for-field drop-in for iperf3's:

- `timestamp` → `{ time (RFC 1123 GMT), timesecs, timemillisecs }`
- `cookie` (the control-connection cookie)
- `system_info` (uname: sysname nodename release version machine)
- `tcp_mss_default` (from the control-socket MSS, issue #6's `tcp_maxseg`)
- `target_bitrate`, `fq_rate`, `sock_bufsize` (requested `-w`)
- `sndbuf_actual` / `rcvbuf_actual` (actual kernel `SO_SNDBUF`/`SO_RCVBUF`, read off a data socket via `socket2`)
- `test_start` gains `fqrate`, `interval`, `gso`, `gro`

`system_info` was previously an empty-string placeholder; it now carries the real uname (nix `feature`). `http_date()` formats RFC 1123 GMT via Hinnant's `civil_from_days` — no `chrono` dependency.

## Validation

Field-for-field against **iperf 3.21** (reference build), `-w 512K --fq-rate 1M`:

- `start` top-level key set: **identical**
- nested `timestamp`, `connecting_to`, `test_start`, `connected[]`: **identical key sets**

Interop gate green vs **iperf 3.12 and 3.21** (64/64 each). New unit tests:
- `start_metadata_values_match_input` (timestamp split, cookie/mss/buffer pass-through, `test_start` additions)
- `http_date_matches_rfc1123_gmt` (epoch 0, a live epoch, and the 2000-02-29 leap day)
- extended `top_level_shape_matches_iperf3` to assert every new `start` / `test_start` key

`cargo test --workspace`: 162 + 128 + 59 pass. `clippy -D warnings` + `fmt` clean.

## Out of scope (filed as follow-ups during validation)

Two **pre-existing** divergences, not introduced here and not part of schema *structure*:

- **#56** — rate-suffix flags (`-b`, `--fq-rate`) parse 1024-based; iperf3 uses 1000-based for rates (`1M` → 1,000,000 not 1,048,576). Real offered-load divergence.
- **#57** — integral floats render with trailing `.0`; cJSON omits it (`1.0` vs `1`). Codebase-wide; semantically equal under JSON parse.

Closes #36.