### PR TITLE
feat(json): server -J / --json-stream output (#50, PR1)

### DIFF
--- a/riperf3-cli/src/main.rs
+++ b/riperf3-cli/src/main.rs
@@ -242,6 +242,12 @@ async fn async_main(cli: Cli) -> std::result::Result<(), Box<dyn std::error::Err
         if cli.verbose {
             builder = builder.verbose(true);
         }
+        if cli.json {
+            builder = builder.json_output(true);
+        }
+        if cli.json_stream {
+            builder = builder.json_stream(true);
+        }
         if cli.daemon {
             builder = builder.daemon(true);
         }

--- a/riperf3/src/client.rs
+++ b/riperf3/src/client.rs
@@ -886,13 +886,16 @@ impl Client {
                     None
                 };
 
+                // to_canonical(): unwrap an IPv4-mapped IPv6 address to plain IPv4
+                // (matches iperf3); a no-op for the client's usual canonical
+                // addresses, correct if the client is bound to a dual-stack socket.
                 let (local_host, local_port) = s
                     .local_addr
-                    .map(|a| (a.ip().to_string(), a.port()))
+                    .map(|a| (a.ip().to_canonical().to_string(), a.port()))
                     .unwrap_or_else(|| (self.host.clone(), 0));
                 let (remote_host, remote_port) = s
                     .peer_addr
-                    .map(|a| (a.ip().to_string(), a.port()))
+                    .map(|a| (a.ip().to_canonical().to_string(), a.port()))
                     .unwrap_or_else(|| (self.host.clone(), self.port));
 
                 // Sender-side TCP_INFO extremes + real retransmit total collected

--- a/riperf3/src/client.rs
+++ b/riperf3/src/client.rs
@@ -953,6 +953,9 @@ impl Client {
             blocks: self.blocks_to_send.unwrap_or(0),
             connecting_host: self.host.clone(),
             connecting_port: self.port,
+            is_server: false,
+            accepted_host: String::new(),
+            accepted_port: 0,
             version: format!("riperf3 {}", env!("CARGO_PKG_VERSION")),
             system_info: system_info(),
             cpu: CpuUtilization {
@@ -1005,28 +1008,6 @@ struct StartMeta {
     cookie: String,
     tcp_mss_default: u32,
     start_time_millis: u64,
-}
-
-/// iperf3-style `system_info`: the uname fields joined, e.g.
-/// "Linux host 6.x #1 SMP ... x86_64". Empty on platforms without `uname`.
-#[cfg(unix)]
-fn system_info() -> String {
-    match nix::sys::utsname::uname() {
-        Ok(u) => format!(
-            "{} {} {} {} {}",
-            u.sysname().to_string_lossy(),
-            u.nodename().to_string_lossy(),
-            u.release().to_string_lossy(),
-            u.version().to_string_lossy(),
-            u.machine().to_string_lossy(),
-        ),
-        Err(_) => String::new(),
-    }
-}
-
-#[cfg(not(unix))]
-fn system_info() -> String {
-    String::new()
 }
 
 // ---------------------------------------------------------------------------

--- a/riperf3/src/json_report.rs
+++ b/riperf3/src/json_report.rs
@@ -48,7 +48,15 @@ pub struct Start {
     pub version: String,
     pub system_info: String,
     pub timestamp: Timestamp,
-    pub connecting_to: ConnectingTo,
+    // The client emits `connecting_to` (the server it dialed); the server emits
+    // `accepted_connection` (the client's control-socket address). Exactly one is
+    // present, and they share the `{host, port}` shape. They sit in the same slot
+    // (right after `timestamp`), so a single struct serializes both roles in
+    // iperf3's order.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub connecting_to: Option<ConnectingTo>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub accepted_connection: Option<ConnectingTo>,
     pub cookie: String,
     // iperf3 emits exactly one of these, and only for TCP (iperf_api.c:1021):
     // `tcp_mss` when `-M`/`--set-mss` was given, else `tcp_mss_default` (the
@@ -349,6 +357,15 @@ pub struct ReportInput {
     pub blocks: u64,
     pub connecting_host: String,
     pub connecting_port: u16,
+    /// True when this report is the server's (`-s -J`). It flips the role-specific
+    /// behavior: emit `accepted_connection` instead of `connecting_to`, report
+    /// only this host's measured bytes (no peer graft — the un-measured side is 0),
+    /// and gate the single `*_tcp_congestion` side on the server's direction.
+    pub is_server: bool,
+    /// The client's control-socket address, for the server's `accepted_connection`.
+    /// Unused on the client.
+    pub accepted_host: String,
+    pub accepted_port: u16,
     pub version: String,
     pub system_info: String,
     pub cpu: CpuUtilization,
@@ -509,7 +526,57 @@ impl ReportInput {
         let mut sum_sent_bidir_reverse = None;
         let mut sum_received_bidir_reverse = None;
 
-        let (sum_sent, sum_received) = if self.bidir {
+        let (sum_sent, sum_received) = if self.is_server {
+            // Server: report only this host's OWN measured bytes — iperf3 sums
+            // local per-stream counters filtered by `sp->sender` and never grafts
+            // the peer's reported bytes, so the side the server didn't measure is
+            // genuinely 0 (forward → sent 0, reverse → received 0). The aggregate
+            // `sender` flag is the server's role: it is the sender only in reverse.
+            let server_is_sender = self.reverse;
+            if self.bidir {
+                // Two flows: forward (client→server, server receives → sender=false)
+                // in sum_sent/sum_received; reverse (server→client, server sends →
+                // sender=true) in the *_bidir_reverse pair. Retransmits, measured on
+                // the server's send path, attach to the reverse (sent) side.
+                sum_sent_bidir_reverse = Some(self.tcp_sum(local_sent, true, retransmits));
+                sum_received_bidir_reverse = Some(self.tcp_sum(0, true, None));
+                (
+                    self.tcp_sum(0, false, None),
+                    self.tcp_sum(local_recv, false, None),
+                )
+            } else if is_udp {
+                // sum_sent is always the sender perspective (bytes the server sent,
+                // no loss); sum_received the receiver perspective (bytes received,
+                // with measured loss/jitter). `sum` carries the server's sent bytes
+                // tagged with its role, and the packet/loss/jitter of whichever side
+                // the server actually measured (received in forward, sent in reverse).
+                let sent_packets = (local_sent / blk) as i64;
+                let (sum_packets, sum_lost, sum_jitter) = if server_is_sender {
+                    (sent_packets, 0, 0.0)
+                } else {
+                    (udp_packets, udp_lost, udp_jitter)
+                };
+                sum = Some(self.udp_sum(
+                    local_sent,
+                    server_is_sender,
+                    sum_packets,
+                    sum_lost,
+                    sum_jitter,
+                ));
+                (
+                    self.udp_sum(local_sent, true, sent_packets, 0, 0.0),
+                    self.udp_sum(local_recv, false, udp_packets, udp_lost, udp_jitter),
+                )
+            } else {
+                // Single-direction TCP. sum_sent = bytes the server sent (0 forward),
+                // sum_received = bytes received (0 reverse); both carry the server's
+                // role flag. Retransmits live on the sent side.
+                (
+                    self.tcp_sum(local_sent, server_is_sender, retransmits),
+                    self.tcp_sum(local_recv, server_is_sender, None),
+                )
+            }
+        } else if self.bidir {
             // Forward (this host → peer) goes in sum_sent/sum_received; reverse
             // (peer → this host) in the *_bidir_reverse pair, matching iperf3 —
             // rather than folding the reverse flow into sum_received (which would
@@ -563,6 +630,19 @@ impl ReportInput {
 
         let (cong_sender, cong_receiver) = if is_udp {
             (None, None)
+        } else if self.is_server {
+            // The peer's (client's) congestion algorithm is never exchanged to the
+            // server, so only one side is emitted — the server's local algorithm,
+            // on the side matching its role: receiver in forward, sender in reverse
+            // and bidir (iperf_api.c:4544 swaps by stream_must_be_sender). Until
+            // #37 reads the applied algorithm back, `congestion_used` is None on
+            // both client and server, so both currently omit the field.
+            let local = self.congestion_used.clone();
+            if self.reverse || self.bidir {
+                (local, None)
+            } else {
+                (None, local)
+            }
         } else {
             (self.congestion_used.clone(), self.congestion_used.clone())
         };
@@ -580,6 +660,25 @@ impl ReportInput {
         };
 
         let secs = self.start_time_millis / 1000;
+        // Role-specific connection target: the client dialed a server
+        // (`connecting_to`), the server accepted a client (`accepted_connection`).
+        let (connecting_to, accepted_connection) = if self.is_server {
+            (
+                None,
+                Some(ConnectingTo {
+                    host: self.accepted_host.clone(),
+                    port: self.accepted_port,
+                }),
+            )
+        } else {
+            (
+                Some(ConnectingTo {
+                    host: self.connecting_host.clone(),
+                    port: self.connecting_port,
+                }),
+                None,
+            )
+        };
         // iperf3 (iperf_api.c:1021) emits the MSS key only for TCP, and picks
         // exactly one: `tcp_mss` when `-M` was given, else `tcp_mss_default`.
         // UDP emits neither. `self.mss.filter(|&m| m > 0)` mirrors iperf3's
@@ -601,10 +700,8 @@ impl ReportInput {
                     timesecs: secs,
                     timemillisecs: self.start_time_millis,
                 },
-                connecting_to: ConnectingTo {
-                    host: self.connecting_host.clone(),
-                    port: self.connecting_port,
-                },
+                connecting_to,
+                accepted_connection,
                 cookie: self.cookie.clone(),
                 tcp_mss,
                 tcp_mss_default,
@@ -648,6 +745,22 @@ impl ReportInput {
                 packets: 0,
                 out_of_order: 0,
             });
+            // `bytes` is a sender-side count. The client reports its own local
+            // bytes (it grafts the peer's count elsewhere); the server only knows
+            // the bytes it *sent*, so a stream it received reports 0 bytes (iperf3
+            // parity) while still carrying the packet/loss/jitter it measured. A
+            // stream the server sent has no receiver stats, so its sent packet
+            // count is derived from the bytes it pushed.
+            let (bytes, packets) = if self.is_server {
+                if s.is_sender {
+                    let blk = self.blksize.max(1) as u64;
+                    (s.local_bytes, (s.local_bytes / blk) as i64)
+                } else {
+                    (0, u.packets)
+                }
+            } else {
+                (s.local_bytes, u.packets)
+            };
             return EndStream {
                 sender: None,
                 receiver: None,
@@ -656,11 +769,11 @@ impl ReportInput {
                     start: 0.0,
                     end: dur,
                     seconds: dur,
-                    bytes: s.local_bytes,
-                    bits_per_second: bps(s.local_bytes, dur),
+                    bytes,
+                    bits_per_second: bps(bytes, dur),
                     jitter_ms: u.jitter_secs * 1000.0,
                     lost_packets: u.lost_packets,
-                    packets: u.packets,
+                    packets,
                     lost_percent: pct_lost(u.lost_packets, u.packets),
                     out_of_order: u.out_of_order,
                     sender: s.is_sender,
@@ -677,12 +790,21 @@ impl ReportInput {
         // Sender-side TCP_INFO extremes go on whichever sub-object is the local
         // sender (forward). The peer's extremes aren't exchanged, so the sender
         // sub-object of a reverse stream omits them.
-        let remote_bytes = s.remote_bytes.unwrap_or(s.local_bytes);
-        // iperf3 always emits the sender sub-object's TCP_INFO keys (0 when
-        // unmeasured). The local sender's extremes (forward) are real; the peer's
-        // (reverse) aren't exchanged, so they default to 0 — exactly what iperf3
-        // emits for a reverse stream's sender block. The receiver sub-object omits
-        // them, like iperf3.
+        // The server never learns the peer's per-stream byte count, so its
+        // un-measured side is 0 (iperf3 reports only local counters) — never
+        // grafted from `local_bytes` the way the client fills the peer side.
+        let remote_bytes = if self.is_server {
+            0
+        } else {
+            s.remote_bytes.unwrap_or(s.local_bytes)
+        };
+        // The client always emits the sender sub-object's TCP_INFO keys (real on
+        // the forward side, 0 on the reverse side it didn't measure). iperf3's
+        // *server*, by contrast, omits them entirely on a stream it didn't send
+        // (a forward receiver) and emits them only on a stream it sent
+        // (reverse/bidir). Match that asymmetry: emit the extras unless this is a
+        // server stream the server received.
+        let emit_extras = !self.is_server || s.is_sender;
         let e = s.tcp_end.unwrap_or_default();
         let sender_side = |bytes: u64, retransmits: Option<i64>| TcpStreamSide {
             socket: s.id,
@@ -691,13 +813,13 @@ impl ReportInput {
             seconds: dur,
             bytes,
             bits_per_second: bps(bytes, dur),
-            retransmits,
-            max_snd_cwnd: Some(e.max_snd_cwnd),
-            max_snd_wnd: Some(0), // tcpi_snd_wnd unavailable via libc; 0 like iperf3
-            max_rtt: Some(e.max_rtt),
-            min_rtt: Some(e.min_rtt),
-            mean_rtt: Some(e.mean_rtt),
-            reorder: Some(e.reorder),
+            retransmits: if emit_extras { retransmits } else { None },
+            max_snd_cwnd: emit_extras.then_some(e.max_snd_cwnd),
+            max_snd_wnd: emit_extras.then_some(0), // tcpi_snd_wnd unavailable via libc; 0 like iperf3
+            max_rtt: emit_extras.then_some(e.max_rtt),
+            min_rtt: emit_extras.then_some(e.min_rtt),
+            mean_rtt: emit_extras.then_some(e.mean_rtt),
+            reorder: emit_extras.then_some(e.reorder),
             sender: dir,
         };
         let receiver_side = |bytes: u64| TcpStreamSide {
@@ -810,6 +932,9 @@ mod tests {
             blocks: 0,
             connecting_host: "host".into(),
             connecting_port: 5201,
+            is_server: false,
+            accepted_host: String::new(),
+            accepted_port: 0,
             version: "riperf3 0.5.4".into(),
             system_info: String::new(),
             cpu: CpuUtilization {
@@ -1052,6 +1177,230 @@ mod tests {
             start.get("tcp_mss_default").is_none(),
             "tcp_mss_default must be suppressed under -M: {start}"
         );
+    }
+
+    // ---- server-perspective JSON (#50) --------------------------------------
+
+    #[test]
+    fn server_emits_accepted_connection_not_connecting_to() {
+        let mut input = base_input();
+        input.is_server = true;
+        input.accepted_host = "10.0.0.5".into();
+        input.accepted_port = 41810;
+        input.streams = vec![tcp_stream(1, false, 1000, 0)];
+        let v = serde_json::to_value(input.build()).unwrap();
+        let start = &v["start"];
+        assert!(
+            start.get("connecting_to").is_none(),
+            "server must not emit connecting_to: {start}"
+        );
+        assert_eq!(start["accepted_connection"]["host"], "10.0.0.5");
+        assert_eq!(start["accepted_connection"]["port"], 41810);
+    }
+
+    #[test]
+    fn client_emits_connecting_to_not_accepted_connection() {
+        let mut input = base_input(); // is_server = false
+        input.streams = vec![tcp_stream(1, true, 1000, 1000)];
+        let v = serde_json::to_value(input.build()).unwrap();
+        let start = &v["start"];
+        assert!(start["connecting_to"].is_object());
+        assert!(
+            start.get("accepted_connection").is_none(),
+            "client must not emit accepted_connection: {start}"
+        );
+    }
+
+    #[test]
+    fn server_forward_tcp_zeroes_sent_side() {
+        // Forward: the server is the receiver. It measured the received bytes; it
+        // sent nothing, and never grafts the client's count. Both aggregates carry
+        // sender=false (the server is not the sender in forward).
+        let mut input = base_input();
+        input.is_server = true;
+        input.streams = vec![tcp_stream(1, false, 1_000_000, 7_777)]; // remote ignored
+        let v = serde_json::to_value(input.build()).unwrap();
+        let e = &v["end"];
+        assert_eq!(e["sum_sent"]["bytes"], 0);
+        assert_eq!(e["sum_received"]["bytes"], 1_000_000);
+        assert_eq!(e["sum_sent"]["sender"], false);
+        assert_eq!(e["sum_received"]["sender"], false);
+        assert_eq!(e["streams"][0]["sender"]["bytes"], 0);
+        assert_eq!(e["streams"][0]["receiver"]["bytes"], 1_000_000);
+    }
+
+    #[test]
+    fn server_reverse_tcp_zeroes_received_side() {
+        // Reverse: the server is the sender. sum_received is 0; both aggregates
+        // carry sender=true; retransmits live on the sent side.
+        let mut input = base_input();
+        input.is_server = true;
+        input.reverse = true;
+        let mut s = tcp_stream(1, true, 2_000_000, 9_999);
+        s.retransmits = Some(5);
+        input.streams = vec![s];
+        let v = serde_json::to_value(input.build()).unwrap();
+        let e = &v["end"];
+        assert_eq!(e["sum_sent"]["bytes"], 2_000_000);
+        assert_eq!(e["sum_received"]["bytes"], 0);
+        assert_eq!(e["sum_sent"]["sender"], true);
+        assert_eq!(e["sum_received"]["sender"], true);
+        assert_eq!(e["sum_sent"]["retransmits"], 5);
+        assert_eq!(e["streams"][0]["sender"]["bytes"], 2_000_000);
+        assert_eq!(e["streams"][0]["receiver"]["bytes"], 0);
+    }
+
+    #[test]
+    fn server_forward_congestion_receiver_only() {
+        // base_input has congestion_used = Some("cubic"). Forward server → the
+        // local algorithm appears on the receiver side only; sender side absent.
+        let mut input = base_input();
+        input.is_server = true;
+        input.streams = vec![tcp_stream(1, false, 1000, 0)];
+        let v = serde_json::to_value(input.build()).unwrap();
+        let e = &v["end"];
+        assert_eq!(e["receiver_tcp_congestion"], "cubic");
+        assert!(
+            e.get("sender_tcp_congestion").is_none(),
+            "forward server: sender congestion must be absent: {e}"
+        );
+    }
+
+    #[test]
+    fn server_reverse_congestion_sender_only() {
+        let mut input = base_input();
+        input.is_server = true;
+        input.reverse = true;
+        input.streams = vec![tcp_stream(1, true, 1000, 0)];
+        let v = serde_json::to_value(input.build()).unwrap();
+        let e = &v["end"];
+        assert_eq!(e["sender_tcp_congestion"], "cubic");
+        assert!(e.get("receiver_tcp_congestion").is_none(), "{e}");
+    }
+
+    #[test]
+    fn server_bidir_congestion_sender_only_and_directions_split() {
+        // Bidir server: congestion on the sender side only (verified vs iperf3
+        // 3.21). Forward flow (received) → sum_sent/sum_received with sender=false;
+        // reverse flow (sent) → *_bidir_reverse with sender=true.
+        let mut input = base_input();
+        input.is_server = true;
+        input.bidir = true;
+        input.streams = vec![
+            tcp_stream(1, false, 1_000_000, 0), // forward: server receives
+            tcp_stream(3, true, 2_000_000, 0),  // reverse: server sends
+        ];
+        let v = serde_json::to_value(input.build()).unwrap();
+        let e = &v["end"];
+        assert_eq!(e["sender_tcp_congestion"], "cubic");
+        assert!(e.get("receiver_tcp_congestion").is_none(), "{e}");
+        assert_eq!(e["sum_sent"]["bytes"], 0);
+        assert_eq!(e["sum_received"]["bytes"], 1_000_000);
+        assert_eq!(e["sum_sent"]["sender"], false);
+        assert_eq!(e["sum_sent_bidir_reverse"]["bytes"], 2_000_000);
+        assert_eq!(e["sum_received_bidir_reverse"]["bytes"], 0);
+        assert_eq!(e["sum_sent_bidir_reverse"]["sender"], true);
+    }
+
+    #[test]
+    fn server_forward_sender_omits_tcp_info_keys() {
+        // iperf3's server emits the sender sub-object's TCP_INFO keys only for a
+        // stream it sent. On a forward test (server receives) the sender block is
+        // bytes-only — no retransmits / max_snd_cwnd / *_rtt / reorder.
+        let mut input = base_input();
+        input.is_server = true;
+        input.streams = vec![tcp_stream(1, false, 1_000_000, 0)];
+        let v = serde_json::to_value(input.build()).unwrap();
+        let sender = &v["end"]["streams"][0]["sender"];
+        for k in [
+            "retransmits",
+            "max_snd_cwnd",
+            "max_snd_wnd",
+            "max_rtt",
+            "min_rtt",
+            "mean_rtt",
+            "reorder",
+        ] {
+            assert!(
+                sender.get(k).is_none(),
+                "forward server sender must omit {k}: {sender}"
+            );
+        }
+        // The bytes-only fields remain.
+        assert!(sender["bytes"].is_number());
+        assert!(sender["bits_per_second"].is_number());
+    }
+
+    #[test]
+    fn server_reverse_sender_emits_tcp_info_keys() {
+        // On a reverse test the server sends, so its sender block carries the
+        // TCP_INFO extras (real cwnd/rtt, snd_wnd 0 like iperf3).
+        let mut input = base_input();
+        input.is_server = true;
+        input.reverse = true;
+        input.streams = vec![StreamReport {
+            tcp_end: Some(TcpEndExtras {
+                max_snd_cwnd: 65535,
+                max_rtt: 200,
+                min_rtt: 90,
+                mean_rtt: 120,
+                reorder: 0,
+            }),
+            ..tcp_stream(1, true, 2_000_000, 0)
+        }];
+        let v = serde_json::to_value(input.build()).unwrap();
+        let sender = &v["end"]["streams"][0]["sender"];
+        assert_eq!(sender["max_snd_cwnd"], 65535);
+        assert_eq!(sender["max_rtt"], 200);
+        assert_eq!(sender["max_snd_wnd"], 0); // libc has no tcpi_snd_wnd
+        assert!(sender["retransmits"].is_number());
+    }
+
+    #[test]
+    fn server_udp_forward_stream_reports_zero_bytes_measured_packets() {
+        // Forward UDP: the server received the datagrams. iperf3's per-stream udp
+        // `bytes` is a sender-side count the server doesn't know → 0, while the
+        // measured packet/loss/jitter it observed are reported.
+        let mut input = base_input();
+        input.protocol = TransportProtocol::Udp;
+        input.blksize = 1460;
+        input.is_server = true;
+        input.streams = vec![StreamReport {
+            udp: Some(UdpStreamStats {
+                jitter_secs: 0.00002,
+                lost_packets: 3,
+                packets: 700,
+                out_of_order: 0,
+            }),
+            ..tcp_stream(1, false, 1_022_000, 0)
+        }];
+        let v = serde_json::to_value(input.build()).unwrap();
+        let udp = &v["end"]["streams"][0]["udp"];
+        assert_eq!(
+            udp["bytes"], 0,
+            "server received → sender-side bytes 0: {udp}"
+        );
+        assert_eq!(udp["packets"], 700, "measured received packets reported");
+        assert_eq!(udp["lost_packets"], 3);
+        assert_eq!(udp["sender"], false);
+    }
+
+    #[test]
+    fn server_udp_reverse_stream_derives_sent_packets() {
+        // Reverse UDP: the server sent the datagrams; it has no receiver stats, so
+        // the sent packet count is derived from the bytes pushed (bytes / blksize).
+        let mut input = base_input();
+        input.protocol = TransportProtocol::Udp;
+        input.blksize = 1000;
+        input.reverse = true;
+        input.is_server = true;
+        // 20_000 bytes / 1000 blksize = 20 packets, no udp_recv_stats (sender).
+        input.streams = vec![tcp_stream(1, true, 20_000, 0)];
+        let v = serde_json::to_value(input.build()).unwrap();
+        let udp = &v["end"]["streams"][0]["udp"];
+        assert_eq!(udp["bytes"], 20_000);
+        assert_eq!(udp["packets"], 20, "sent packets = bytes / blksize: {udp}");
+        assert_eq!(udp["sender"], true);
     }
 
     #[test]

--- a/riperf3/src/reporter.rs
+++ b/riperf3/src/reporter.rs
@@ -638,6 +638,12 @@ pub fn spawn_interval_reporter(
                 } else {
                     (None, None, None, None)
                 };
+                // iperf3 emits the sum's retransmits only on a sender-direction
+                // sum (sender_has_retransmits && stream_must_be_sender). On the
+                // server's bidir `sum` (which describes the received flow, so
+                // sender=false) it must be omitted, not just gated on "any stream
+                // sends" — otherwise the received-flow sum carries a spurious count.
+                let sum_is_sender = streams.first().is_none_or(|s| s.is_sender);
                 collected.push(crate::json_report::Interval {
                     streams: collected_streams,
                     sum: crate::json_report::IntervalSum {
@@ -646,7 +652,7 @@ pub fn spawn_interval_reporter(
                         seconds,
                         bytes: sum_bytes,
                         bits_per_second: sum_bps,
-                        retransmits: if has_retransmits {
+                        retransmits: if has_retransmits && sum_is_sender {
                             Some(sum_retransmits)
                         } else {
                             None
@@ -656,7 +662,7 @@ pub fn spawn_interval_reporter(
                         packets: sum_pkts,
                         lost_percent: sum_lostpct,
                         omitted,
-                        sender: streams.first().is_none_or(|s| s.is_sender),
+                        sender: sum_is_sender,
                     },
                 });
             }

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -173,7 +173,11 @@ impl Server {
         // The control-socket peer address feeds the server's `start.accepted_connection`
         // (iperf_api.c uses getpeername(ctrl_sck) — distinct from the data-stream
         // addresses in `connected[]`). Captured for the `-J` blob (#50).
-        let (accepted_host, accepted_port) = (peer_addr.ip().to_string(), peer_addr.port());
+        // `to_canonical()` unwraps an IPv4-mapped IPv6 address (`::ffff:127.0.0.1`)
+        // from the dual-stack listener back to plain `127.0.0.1`, as iperf3 does
+        // (mapped_v4_to_regular_v4).
+        let (accepted_host, accepted_port) =
+            (peer_addr.ip().to_canonical().to_string(), peer_addr.port());
 
         // ---- Cookie ----
         let cookie = protocol::recv_cookie(&mut ctrl).await?;
@@ -741,13 +745,15 @@ impl Server {
                     })
                 });
 
+                // to_canonical(): unwrap IPv4-mapped IPv6 from the dual-stack
+                // listener to plain IPv4 in connected[], matching iperf3.
                 let (local_host, local_port) = s
                     .local_addr
-                    .map(|a| (a.ip().to_string(), a.port()))
+                    .map(|a| (a.ip().to_canonical().to_string(), a.port()))
                     .unwrap_or_default();
                 let (remote_host, remote_port) = s
                     .peer_addr
-                    .map(|a| (a.ip().to_string(), a.port()))
+                    .map(|a| (a.ip().to_canonical().to_string(), a.port()))
                     .unwrap_or_default();
 
                 // Sender-side TCP_INFO extremes + retransmit total, present only

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -89,6 +89,10 @@ pub struct Server {
     pub authorized_users_path: Option<String>,
     pub time_skew_threshold: u32,
     pub use_pkcs1_padding: bool,
+    /// Emit the test results as iperf3-schema JSON on stdout instead of text (#50).
+    pub json_output: bool,
+    /// Stream line-delimited interval JSON during the test (`--json-stream`).
+    pub json_stream: bool,
 }
 
 impl Server {
@@ -107,10 +111,16 @@ impl Server {
 
         let listener =
             net::tcp_listen(self.bind_address.as_deref(), self.port, self.ip_version).await?;
+        // Under -J / --json-stream iperf3's server stdout is pure JSON (the
+        // "Server listening" banners are suppressed) so the document parses
+        // cleanly; match that.
+        let json = self.json_output || self.json_stream;
         let sep = "-----------------------------------------------------------";
-        println!("{sep}");
-        println!("Server listening on {}", self.port);
-        println!("{sep}");
+        if !json {
+            println!("{sep}");
+            println!("Server listening on {}", self.port);
+            println!("{sep}");
+        }
 
         loop {
             match self.handle_one_test(&listener).await {
@@ -128,9 +138,11 @@ impl Server {
             if self.one_off {
                 break;
             }
-            println!("{sep}");
-            println!("Server listening on {}", self.port);
-            println!("{sep}");
+            if !json {
+                println!("{sep}");
+                println!("Server listening on {}", self.port);
+                println!("{sep}");
+            }
         }
         Ok(())
     }
@@ -156,6 +168,12 @@ impl Server {
             vprintln!("Accepted connection from {peer_addr}");
         }
         net::configure_tcp_stream(&ctrl, true)?;
+
+        let json = self.json_output || self.json_stream;
+        // The control-socket peer address feeds the server's `start.accepted_connection`
+        // (iperf_api.c uses getpeername(ctrl_sck) — distinct from the data-stream
+        // addresses in `connected[]`). Captured for the `-J` blob (#50).
+        let (accepted_host, accepted_port) = (peer_addr.ip().to_string(), peer_addr.port());
 
         // ---- Cookie ----
         let cookie = protocol::recv_cookie(&mut ctrl).await?;
@@ -266,6 +284,15 @@ impl Server {
                     let raw_fd: Option<i32> = None;
                     let fp = self.file.as_ref().map(std::path::PathBuf::from);
 
+                    // Real socket addresses + kernel buffer sizes for the server's
+                    // `-J` `connected[]` / `sndbuf_actual` / `rcvbuf_actual` (#50),
+                    // captured before the stream moves into its task.
+                    let local_addr = data_stream.local_addr().ok();
+                    let peer_addr_s = data_stream.peer_addr().ok();
+                    let sock = socket2::SockRef::from(&data_stream);
+                    let sndbuf_actual = sock.send_buffer_size().ok().map(|v| v as u64);
+                    let rcvbuf_actual = sock.recv_buffer_size().ok().map(|v| v as u64);
+
                     let task = if is_sender {
                         let buf = make_send_buffer(cfg.blksize, false);
                         let c = counters.clone();
@@ -289,11 +316,10 @@ impl Server {
                         udp_recv_stats: None,
                         task,
                         raw_fd,
-                        // Populated for the server's own `-J` output in #50.
-                        local_addr: None,
-                        peer_addr: None,
-                        sndbuf_actual: None,
-                        rcvbuf_actual: None,
+                        local_addr,
+                        peer_addr: peer_addr_s,
+                        sndbuf_actual,
+                        rcvbuf_actual,
                     });
                 }
             }
@@ -350,6 +376,18 @@ impl Server {
                     let is_sender = i >= recv_count;
                     let counters = Arc::new(StreamCounters::new());
 
+                    // Socket addresses + buffer sizes for the `-J` blob (#50),
+                    // captured before the socket is converted to std + moved.
+                    let local_addr = data_sock.local_addr().ok();
+                    let peer_addr_s = data_sock.peer_addr().ok();
+                    let (sndbuf_actual, rcvbuf_actual) = {
+                        let sock = socket2::SockRef::from(&data_sock);
+                        (
+                            sock.send_buffer_size().ok().map(|v| v as u64),
+                            sock.recv_buffer_size().ok().map(|v| v as u64),
+                        )
+                    };
+
                     let std_sock = data_sock.into_std().map_err(RiperfError::Io)?;
 
                     if is_sender {
@@ -373,10 +411,10 @@ impl Server {
                             udp_recv_stats: None,
                             task,
                             raw_fd: None,
-                            local_addr: None,
-                            peer_addr: None,
-                            sndbuf_actual: None,
-                            rcvbuf_actual: None,
+                            local_addr,
+                            peer_addr: peer_addr_s,
+                            sndbuf_actual,
+                            rcvbuf_actual,
                         });
                     } else {
                         let c = counters.clone();
@@ -402,10 +440,10 @@ impl Server {
                             udp_recv_stats: Some(stats),
                             task,
                             raw_fd: None,
-                            local_addr: None,
-                            peer_addr: None,
-                            sndbuf_actual: None,
-                            rcvbuf_actual: None,
+                            local_addr,
+                            peer_addr: peer_addr_s,
+                            sndbuf_actual,
+                            rcvbuf_actual,
                         });
                     }
                 }
@@ -417,7 +455,19 @@ impl Server {
         start.store(true, Ordering::Relaxed);
         protocol::send_state(&mut ctrl, TestState::TestStart).await?;
         let cpu_start = CpuSnapshot::now();
+        // Wall-clock at TestStart, for the `-J` start.timestamp (#50).
+        let test_start_millis = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_millis() as u64)
+            .unwrap_or(0);
         protocol::send_state(&mut ctrl, TestState::TestRunning).await?;
+
+        // For plain -J the reporter runs silently to collect intervals for the
+        // final blob; for text or --json-stream it prints/streams live, matching
+        // the client's gating (#50).
+        let print_intervals = !json || self.json_stream;
+        let collect_intervals = json && !self.json_stream;
+        let interval_data = Arc::new(Mutex::new(crate::reporter::CollectedIntervals::default()));
 
         // Spawn interval reporter (server uses 1.0s default)
         let interval_handle = {
@@ -440,13 +490,13 @@ impl Server {
                     num_streams: streams.len(),
                     forceflush: self.forceflush,
                     timestamp_format: self.timestamps.clone(),
-                    json_stream: false, // server doesn't stream JSON
-                    print: true,        // server prints its interval lines live
+                    json_stream: self.json_stream,
+                    print: print_intervals,
                     blksize: cfg.blksize,
                 },
                 stream_refs,
                 done.clone(),
-                None, // server has no -J blob to collect for yet (#50)
+                collect_intervals.then(|| interval_data.clone()),
             )
         };
 
@@ -559,7 +609,9 @@ impl Server {
         };
 
         protocol::send_state(&mut ctrl, TestState::ExchangeResults).await?;
-        // iperf3 protocol: server reads client results first, then sends its own
+        // iperf3 protocol: server reads client results first, then sends its own.
+        // The client's results are not used in the server's own report — iperf3's
+        // server reports only its own measured bytes and a 0 remote CPU (#50).
         let _client_results = protocol::recv_results(&mut ctrl).await?;
         protocol::send_results(&mut ctrl, &server_results).await?;
 
@@ -576,40 +628,56 @@ impl Server {
             }
         }
 
-        // Print summary: per-stream lines plus aggregate [SUM] row(s) for
-        // parallel streams (issue #4), via the shared path the client uses.
-        let summaries: Vec<crate::reporter::StreamSummary> = streams
-            .iter()
-            .map(|s| {
-                let bytes = if s.is_sender {
-                    s.counters.bytes_sent()
-                } else {
-                    s.counters.bytes_received()
-                };
+        if json {
+            // Emit the iperf3-schema JSON report on stdout (#50).
+            self.print_results_json(
+                &streams,
+                &cfg,
+                &params,
+                &cpu_util,
+                test_duration,
+                &cookie,
+                &accepted_host,
+                accepted_port,
+                test_start_millis,
+                &interval_data,
+            );
+        } else {
+            // Print summary: per-stream lines plus aggregate [SUM] row(s) for
+            // parallel streams (issue #4), via the shared path the client uses.
+            let summaries: Vec<crate::reporter::StreamSummary> = streams
+                .iter()
+                .map(|s| {
+                    let bytes = if s.is_sender {
+                        s.counters.bytes_sent()
+                    } else {
+                        s.counters.bytes_received()
+                    };
 
-                let (jitter, lost, total) = if let Some(ref udp_stats) = s.udp_recv_stats {
-                    udp_stats
-                        .lock()
-                        .map(|st| (Some(st.jitter), Some(st.cnt_error), Some(st.packet_count)))
-                        .unwrap_or((None, None, None))
-                } else {
-                    (None, None, None)
-                };
+                    let (jitter, lost, total) = if let Some(ref udp_stats) = s.udp_recv_stats {
+                        udp_stats
+                            .lock()
+                            .map(|st| (Some(st.jitter), Some(st.cnt_error), Some(st.packet_count)))
+                            .unwrap_or((None, None, None))
+                    } else {
+                        (None, None, None)
+                    };
 
-                crate::reporter::StreamSummary {
-                    stream_id: s.id,
-                    start: 0.0,
-                    end: test_duration,
-                    bytes,
-                    is_sender: s.is_sender,
-                    retransmits: None,
-                    jitter,
-                    lost,
-                    total_packets: total,
-                }
-            })
-            .collect();
-        crate::reporter::print_final_summaries(&summaries, 'a');
+                    crate::reporter::StreamSummary {
+                        stream_id: s.id,
+                        start: 0.0,
+                        end: test_duration,
+                        bytes,
+                        is_sender: s.is_sender,
+                        retransmits: None,
+                        jitter,
+                        lost,
+                        total_packets: total,
+                    }
+                })
+                .collect();
+            crate::reporter::print_final_summaries(&summaries, 'a');
+        }
 
         // Join stream tasks (best-effort, they should be done)
         for s in streams {
@@ -617,6 +685,183 @@ impl Server {
         }
 
         Ok(())
+    }
+
+    /// Assemble and print the server's iperf3-schema `-J` report (#50). Mirrors
+    /// the client's `print_results_json`, with the server's perspective baked in
+    /// via `is_server: true`: `accepted_connection` instead of `connecting_to`,
+    /// no peer-byte graft (the un-measured side is 0), and `tcp_mss_default` of 0
+    /// (iperf3's server never reads its control-socket MSS).
+    #[allow(clippy::too_many_arguments)]
+    fn print_results_json(
+        &self,
+        streams: &[DataStream],
+        cfg: &TestConfig,
+        params: &TestParams,
+        cpu_util: &crate::cpu::CpuUtilization,
+        test_duration: f64,
+        cookie: &[u8; protocol::COOKIE_SIZE],
+        accepted_host: &str,
+        accepted_port: u16,
+        start_time_millis: u64,
+        interval_data: &Arc<Mutex<crate::reporter::CollectedIntervals>>,
+    ) {
+        use crate::json_report::{
+            CpuUtilization, ReportInput, StreamReport, TcpEndExtras, UdpStreamStats,
+        };
+
+        // Take the interval samples + per-stream TCP_INFO extremes the reporter
+        // collected (its task is joined by now, so this is final).
+        let (collected_intervals, extremes) = match interval_data.lock() {
+            Ok(mut g) => (
+                std::mem::take(&mut g.intervals),
+                std::mem::take(&mut g.extremes),
+            ),
+            Err(_) => (Vec::new(), Vec::new()),
+        };
+
+        let is_udp = matches!(cfg.protocol, TransportProtocol::Udp);
+
+        let stream_reports: Vec<StreamReport> = streams
+            .iter()
+            .map(|s| {
+                let local_bytes = if s.is_sender {
+                    s.counters.bytes_sent()
+                } else {
+                    s.counters.bytes_received()
+                };
+
+                // The server measures UDP loss/jitter on the streams it receives.
+                let udp = s.udp_recv_stats.as_ref().and_then(|lock| {
+                    lock.lock().ok().map(|st| UdpStreamStats {
+                        jitter_secs: st.jitter,
+                        lost_packets: st.cnt_error,
+                        packets: st.packet_count,
+                        out_of_order: st.outoforder_packets,
+                    })
+                });
+
+                let (local_host, local_port) = s
+                    .local_addr
+                    .map(|a| (a.ip().to_string(), a.port()))
+                    .unwrap_or_default();
+                let (remote_host, remote_port) = s
+                    .peer_addr
+                    .map(|a| (a.ip().to_string(), a.port()))
+                    .unwrap_or_default();
+
+                // Sender-side TCP_INFO extremes + retransmit total, present only
+                // for streams the server sent (reverse / bidir).
+                let ext = extremes
+                    .iter()
+                    .find(|e| e.stream_id == s.id && e.has_samples());
+                let tcp_end = ext.map(|e| TcpEndExtras {
+                    max_snd_cwnd: e.max_snd_cwnd,
+                    max_rtt: e.max_rtt,
+                    min_rtt: e.min_rtt,
+                    mean_rtt: e.mean_rtt(),
+                    reorder: e.reorder,
+                });
+                // Retransmits are a sender-side metric. The server only sends on
+                // reverse/bidir streams; a stream it received has no retransmit
+                // count (None → omitted), so it can't leak a 0 into sum_sent on a
+                // forward test (where iperf3's server emits no retransmits).
+                let retransmits = if is_udp || !s.is_sender {
+                    None
+                } else {
+                    ext.and_then(|e| e.total_retransmits)
+                        .map(|r| r as i64)
+                        .or(Some(if crate::tcp_info::has_retransmit_info() {
+                            0
+                        } else {
+                            -1
+                        }))
+                };
+
+                StreamReport {
+                    id: s.id,
+                    local_host,
+                    local_port,
+                    remote_host,
+                    remote_port,
+                    is_sender: s.is_sender,
+                    local_bytes,
+                    // The server never learns the peer's per-stream bytes; build()
+                    // zeroes the un-measured side for is_server reports.
+                    remote_bytes: None,
+                    retransmits,
+                    tcp_end,
+                    udp,
+                }
+            })
+            .collect();
+
+        let input = ReportInput {
+            protocol: cfg.protocol,
+            reverse: cfg.reverse,
+            bidir: cfg.bidir,
+            duration: test_duration,
+            num_streams: cfg.num_streams as i32,
+            blksize: cfg.blksize as i64,
+            omit: cfg.omit as i32,
+            tos: cfg.tos,
+            target_bitrate: cfg.bandwidth,
+            bytes: params.num.unwrap_or(0),
+            blocks: params.blockcount.unwrap_or(0),
+            connecting_host: String::new(),
+            connecting_port: 0,
+            is_server: true,
+            accepted_host: accepted_host.to_string(),
+            accepted_port,
+            version: format!("riperf3 {}", env!("CARGO_PKG_VERSION")),
+            system_info: crate::utils::system_info(),
+            cpu: CpuUtilization {
+                // Only the server's own CPU. iperf3's server reports the remote
+                // (client) CPU as 0 — it doesn't surface the client's figure even
+                // though the client sends it — so match that rather than graft it.
+                host_total: cpu_util.host_total,
+                host_user: cpu_util.host_user,
+                host_system: cpu_util.host_system,
+                remote_total: 0.0,
+                remote_user: 0.0,
+                remote_system: 0.0,
+            },
+            // Reporting the server's actually-applied congestion is #37; until then
+            // it stays None (omitted), consistent with the client.
+            congestion_used: None,
+            cookie: String::from_utf8_lossy(&cookie[..protocol::COOKIE_SIZE - 1]).to_string(),
+            // iperf3's server emits tcp_mss_default = 0 (it never reads the control
+            // socket MSS); the requested -M (via params) still surfaces as tcp_mss.
+            tcp_mss_default: 0,
+            mss: cfg.mss.filter(|&m| m > 0).map(|m| m as u32),
+            fq_rate: params.fqrate.unwrap_or(0),
+            sock_bufsize: cfg.window.map(|w| w.max(0) as u64).unwrap_or(0),
+            sndbuf_actual: streams.first().and_then(|s| s.sndbuf_actual).unwrap_or(0),
+            rcvbuf_actual: streams.first().and_then(|s| s.rcvbuf_actual).unwrap_or(0),
+            // The server reports at its 1s default; it has no -i.
+            interval: 1.0,
+            // GSO/GRO are client-side knobs, not exchanged; iperf3's server emits 0.
+            gso: 0,
+            gro: 0,
+            start_time_millis,
+            intervals: collected_intervals,
+            streams: stream_reports,
+        };
+
+        let report = input.build();
+        if self.json_stream {
+            // --json-stream: the interval lines were already streamed; emit the
+            // final document the same way the client does.
+            match serde_json::to_string(&report) {
+                Ok(s) => println!("{s}"),
+                Err(e) => eprintln!("iperf3: error - failed to serialize JSON: {e}"),
+            }
+        } else {
+            match serde_json::to_string_pretty(&report) {
+                Ok(s) => println!("{s}"),
+                Err(e) => eprintln!("iperf3: error - failed to serialize JSON: {e}"),
+            }
+        }
     }
 }
 
@@ -643,6 +888,8 @@ pub struct ServerBuilder {
     authorized_users_path: Option<String>,
     time_skew_threshold: u32,
     use_pkcs1_padding: bool,
+    json_output: bool,
+    json_stream: bool,
 }
 
 impl Default for ServerBuilder {
@@ -666,6 +913,8 @@ impl Default for ServerBuilder {
             authorized_users_path: None,
             time_skew_threshold: 10,
             use_pkcs1_padding: false,
+            json_output: false,
+            json_stream: false,
         }
     }
 }
@@ -687,6 +936,18 @@ impl ServerBuilder {
 
     pub fn verbose(mut self, verbose: bool) -> Self {
         self.verbose = verbose;
+        self
+    }
+
+    /// Emit the results as iperf3-schema JSON on stdout instead of text (`-J`).
+    pub fn json_output(mut self, enabled: bool) -> Self {
+        self.json_output = enabled;
+        self
+    }
+
+    /// Stream line-delimited interval JSON during the test (`--json-stream`).
+    pub fn json_stream(mut self, enabled: bool) -> Self {
+        self.json_stream = enabled;
         self
     }
 
@@ -821,6 +1082,8 @@ impl ServerBuilder {
             authorized_users_path: self.authorized_users_path,
             time_skew_threshold: self.time_skew_threshold,
             use_pkcs1_padding: self.use_pkcs1_padding,
+            json_output: self.json_output,
+            json_stream: self.json_stream,
         })
     }
 }

--- a/riperf3/src/utils.rs
+++ b/riperf3/src/utils.rs
@@ -107,6 +107,29 @@ pub fn iperf3_stream_id(index: u32) -> i32 {
     }
 }
 
+/// iperf3-style `system_info`: the uname fields joined, e.g.
+/// "Linux host 6.x #1 SMP ... x86_64". Empty on platforms without `uname`.
+/// Shared by the client and server `-J` `start.system_info` (#36, #50).
+#[cfg(unix)]
+pub fn system_info() -> String {
+    match nix::sys::utsname::uname() {
+        Ok(u) => format!(
+            "{} {} {} {} {}",
+            u.sysname().to_string_lossy(),
+            u.nodename().to_string_lossy(),
+            u.release().to_string_lossy(),
+            u.version().to_string_lossy(),
+            u.machine().to_string_lossy(),
+        ),
+        Err(_) => String::new(),
+    }
+}
+
+#[cfg(not(unix))]
+pub fn system_info() -> String {
+    String::new()
+}
+
 /// Maximum UDP payload: 65535 - 8 (UDP header) - 20 (IP header)
 pub const MAX_UDP_BLKSIZE: usize = 65507;
 

--- a/riperf3/tests/integration.rs
+++ b/riperf3/tests/integration.rs
@@ -71,6 +71,46 @@ async fn regression_udp_default_path() {
     let _ = server_task.await;
 }
 
+/// #50: the server's `-J` JSON output path must complete the test cleanly in
+/// both directions (the JSON assembly runs after the run; a panic or protocol
+/// break there would surface as a client/server error). The JSON document goes
+/// to the server's stdout; field-for-field fidelity is validated separately
+/// against real iperf3.
+#[tokio::test]
+async fn server_json_output_completes_forward_and_reverse() {
+    for reverse in [false, true] {
+        let port = next_port();
+        let server = ServerBuilder::new()
+            .port(Some(port))
+            .one_off(true)
+            .json_output(true)
+            .build()
+            .unwrap();
+        let server_task = tokio::spawn(async move { server.run().await });
+        tokio::time::sleep(Duration::from_millis(200)).await;
+
+        // Duration-limited (not byte-limited): reverse + `-n` has a pre-existing
+        // non-termination bug unrelated to JSON output, so use the duration path
+        // the JSON output was validated against.
+        let client = ClientBuilder::new("127.0.0.1")
+            .port(Some(port))
+            .reverse(reverse)
+            .duration(1)
+            .build()
+            .unwrap();
+        let result = client.run().await;
+        assert!(
+            result.is_ok(),
+            "server -J path failed (reverse={reverse}): {result:?}"
+        );
+        let server_result = server_task.await.unwrap();
+        assert!(
+            server_result.is_ok(),
+            "server -J run errored (reverse={reverse}): {server_result:?}"
+        );
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Issue #1: dual-stack server bind regression
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Gives the riperf3 **server** a `-J` / `--json-stream` JSON output path that faithfully matches `iperf3 -s -J`. Previously the server silently ignored both flags and always printed text — a drop-in gap, and the blocker for server-side interop validation (the deferred #49 ask).

Reuses the typed `json_report` model from #36; server-perspective behavior is driven by a new `ReportInput.is_server` flag.

## Server vs client schema (verified empirically vs iperf 3.21)

| aspect | client | server |
|--------|--------|--------|
| connection target | `connecting_to` | **`accepted_connection`** (client's control-socket addr) |
| byte attribution | grafts peer's reported bytes into the un-measured side | **only own measured bytes** — un-measured side is 0 (fwd: sent=0; rev: received=0) |
| `tcp_mss_default` | control-socket MSS | **0** (iperf3's server never reads it); client `-M` still surfaces as `tcp_mss` |
| sender TCP_INFO keys | always emitted | **only on streams the server sent** (fwd receiver's sender block is bytes-only) |
| UDP per-stream | local bytes + peer packets | **sender-side bytes** (0 when received) + measured/derived packets |
| `*_tcp_congestion` | both sides | server's role only (receiver fwd, sender rev/bidir) |
| remote CPU | from server results | **0** (server doesn't surface the client's CPU) |

Listener banners are suppressed under `-J` so stdout is a clean JSON document (matches iperf3).

## Validation

Built a field-by-field structural comparator (riperf3-server vs iperf3-server) across **all six direction×protocol combos**. After iterating to convergence, **every combo is structurally identical** to iperf 3.21. The only remaining diffs are documented gaps **shared with the client** (verified), tracked elsewhere:
- `*_tcp_congestion` absent → **#37** (`congestion_used` not populated yet)
- `snd_wnd`/`max_snd_wnd` = 0 → libc `tcp_info` has no `tcpi_snd_wnd` (documented)
- bidir UDP `sum`/`sum_*` UDP fields → **#54** (the client `build()` bidir branch precedes the UDP branch; same gap on both sides)

Interop gate green vs iperf **3.12 and 3.21** (64/64 each). 9 new model unit tests pin the server attribution rules; an end-to-end integration test exercises the forward + reverse JSON path.

## Scope / follow-ups

- Extend `scripts/interop.sh` to validate the **server** side of each pairing — deferred to **#50 PR2** (now unblocked).
- **#60** (new) — reverse + byte/block limit (`-R -n`) never terminates; pre-existing, found while writing the integration test (which uses duration mode instead).
- `system_info()` moved from `client.rs` to `utils.rs` so client and server share it.