### PR TITLE
ci(interop): validate the server's -J JSON too (#50, PR2)

### DIFF
--- a/scripts/interop.sh
+++ b/scripts/interop.sh
@@ -221,9 +221,13 @@ run_case() {
         pass=$((pass + 1))
     else
         printf 'FAIL  %-26s %s\n' "$name" "$col"
-        sed 's/^/    client    | /' "$cj" | tail -4
+        # The validators already print the reason (parse error / no transfer) to
+        # stderr above. These show the raw output for context. The -J files are
+        # pretty JSON whose end-of-test aggregates sit near the bottom, so show
+        # enough of the tail to include the `end` block, not just closing braces.
+        sed 's/^/    client    | /' "$cj" | tail -25
         sed 's/^/    client-err| /' "$cerr" | tail -4
-        sed 's/^/    server    | /' "$sj" | tail -4
+        sed 's/^/    server    | /' "$sj" | tail -25
         sed 's/^/    server-err| /' "$serr" | tail -4
         fail=$((fail + 1))
         failed_cases+=("$name $col")

--- a/scripts/interop.sh
+++ b/scripts/interop.sh
@@ -41,9 +41,9 @@ trap 'rm -rf "$workdir"' EXIT
 # Per-attempt I/O sinks (fixed paths, reused per case). -J JSON (stdout) and
 # diagnostics (stderr) stay SEPARATE: a stray stderr line merged into the JSON
 # sink would make the parser choke and score a good transfer as a false FAIL.
-# The server's output (sj/serr) is kept for failure diagnostics only; it is NOT
-# validated as JSON — the riperf3 server emits text, not JSON yet (#50). Once it
-# gains a -J path, validate sj for the interop pairings too (#49 review).
+# Both sides emit JSON now (the riperf3 server gained a -J path in #50), so the
+# server's output (sj) is validated too — catching server-side-only regressions
+# (e.g. the #23/#48 teardown class) that leave the client JSON looking fine.
 cj="$workdir/c.json"; cerr="$workdir/c.err"
 sj="$workdir/s.json"; serr="$workdir/s.err"
 
@@ -118,6 +118,37 @@ sys.exit(2)
 PY
 }
 
+# Succeeds iff the server's -J output is valid JSON, reports no error, and shows
+# the server moved data on the side it measured. Unlike the client check, the
+# server only ever populates ONE direction's aggregate (forward → sum_received,
+# reverse → sum_sent; bidir populates both — see #50), so require sum_sent>0 OR
+# sum_received>0, not both. This catches a server that crashed, emitted broken
+# JSON, or tore the connection down with no data (the #23/#48 class) — failures
+# invisible in the client JSON alone.
+valid_server_result() {
+    python3 - "$1" <<'PY'
+import json, sys
+try:
+    d = json.load(open(sys.argv[1]))
+except Exception as e:
+    print("  server json parse failed:", e, file=sys.stderr)
+    sys.exit(1)
+if isinstance(d, dict) and d.get("error"):
+    print("  server reported error:", d["error"], file=sys.stderr)
+    sys.exit(1)
+end = d.get("end", {}) if isinstance(d, dict) else {}
+def aggregate_bytes(key):
+    v = end.get(key)
+    return v["bytes"] if isinstance(v, dict) and isinstance(v.get("bytes"), (int, float)) else 0
+sent = aggregate_bytes("sum_sent")
+recv = aggregate_bytes("sum_received")
+if sent > 0 or recv > 0:
+    sys.exit(0)
+print(f"  server moved no data: sum_sent={sent} sum_received={recv}", file=sys.stderr)
+sys.exit(2)
+PY
+}
+
 # attempt <client-bin> <server-bin> <client-opts...>
 # One server/client round on a fresh port. Returns 0 iff the test completed with
 # bidirectional transfer. Writes cj/cerr (client) and sj/serr (server).
@@ -137,9 +168,18 @@ attempt() {
     # with the test duration so a hang costs seconds rather than a fixed ceiling.
     timeout -k 5 "$((DUR + 15))" "$client" -c "$HOST" -p "$p" -J "$@" >"$cj" 2>"$cerr"
     local rc=$?
+    # The one-off server prints its JSON and exits on its own once the test ends.
+    # Let it finish so $sj is complete before we validate it (a premature kill
+    # would truncate the JSON and score a false FAIL); only force-kill if it
+    # overruns, i.e. hung.
+    local w
+    for w in $(seq 1 50); do
+        kill -0 "$spid" 2>/dev/null || break
+        sleep 0.1
+    done
     kill "$spid" 2>/dev/null
     wait "$spid" 2>/dev/null
-    [ "$rc" -eq 0 ] && valid_result "$cj"
+    [ "$rc" -eq 0 ] && valid_result "$cj" && valid_server_result "$sj"
 }
 
 # run_case <name> <client-bin> <server-bin> <client-opts...>

--- a/scripts/interop.sh
+++ b/scripts/interop.sh
@@ -120,11 +120,12 @@ PY
 
 # Succeeds iff the server's -J output is valid JSON, reports no error, and shows
 # the server moved data on the side it measured. Unlike the client check, the
-# server only ever populates ONE direction's aggregate (forward → sum_received,
-# reverse → sum_sent; bidir populates both — see #50), so require sum_sent>0 OR
-# sum_received>0, not both. This catches a server that crashed, emitted broken
-# JSON, or tore the connection down with no data (the #23/#48 class) — failures
-# invisible in the client JSON alone.
+# server populates at most one top-level aggregate per direction (forward →
+# sum_received, reverse → sum_sent; bidir → sum_received, with the reverse half in
+# sum_*_bidir_reverse — see #50), so require sum_sent>0 OR sum_received>0, not
+# both. This catches a server that crashed, emitted broken JSON, or tore the
+# connection down with no data (the #23/#48 class) — failures invisible in the
+# client JSON alone.
 valid_server_result() {
     python3 - "$1" <<'PY'
 import json, sys


### PR DESCRIPTION
## What

Completes **#50** by closing the server-side validation gap the #49 review flagged. The interop harness already ran each server with `-J` and captured its stdout to `$sj`, but only kept it for failure diagnostics — the riperf3 server emitted text, not JSON. Now that the server has a JSON path (#50 PR1, merged), the harness **validates `$sj` on every pairing**.

## Why it matters

A server-side-only regression — the #23/#48 teardown class (connection reset at teardown, zero data, or broken JSON) — can leave the **client** JSON looking fine while the server is broken. Validating the server's own JSON catches that. This is exactly what the #49 cold review asked for and was deferred until the server could emit JSON.

## Details

- **OR, not AND**: the server only populates the one direction it measured (forward → `sum_received`, reverse → `sum_sent`; bidir → both), so `valid_server_result` requires `sum_sent>0 OR sum_received>0` — unlike the client's `AND`. Verified it rejects parse-failure / `error` / zero-transfer and accepts both single-direction server shapes.
- **No truncation**: the one-off (`-s -1`) server now finishes printing and exits on its own before validation (force-killed only if it overruns), so a premature `SIGTERM` can't truncate `$sj` into a false FAIL.

## Validation

Full matrix **64/64 vs iperf 3.12 and 3.21**, no false positives, no retries — locally, across all r→i / i→r / r→r / i→i pairings. Script-only change; the workflow already invokes `scripts/interop.sh` (no workflow edit needed).

Closes #50.