### PR TITLE
ci: cargo-semver-checks gate + bump to 0.6.0 dev version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,20 @@ jobs:
       - run: cargo clippy --all-targets -- -D warnings
       - run: cargo fmt --all -- --check
 
+  semver:
+    name: SemVer
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      # Compares the library crate's public API against the latest version
+      # published to crates.io and fails if the Cargo.toml version bump is
+      # insufficient for the API change (e.g. a breaking change on a patch bump).
+      # Caught #50's Server field additions, which required the 0.5.x -> 0.6.0
+      # major bump. riperf3-cli is a binary (no library API) and is not checked.
+      - uses: obi1kenobi/cargo-semver-checks-action@v2
+        with:
+          package: riperf3
+
   cross-check:
     name: Cross-platform (${{ matrix.target }})
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -793,7 +793,7 @@ dependencies = [
 
 [[package]]
 name = "riperf3"
-version = "0.5.4"
+version = "0.6.0"
 dependencies = [
  "base64",
  "libc",
@@ -814,7 +814,7 @@ dependencies = [
 
 [[package]]
 name = "riperf3-cli"
-version = "0.5.4"
+version = "0.6.0"
 dependencies = [
  "clap",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.5.4"
+version = "0.6.0"
 authors = ["Evan Henry"]
 edition = "2021"
 homepage = "https://github.com/therealevanhenry/riperf3"

--- a/riperf3-cli/Cargo.toml
+++ b/riperf3-cli/Cargo.toml
@@ -13,7 +13,7 @@ readme = "../README.md"
 
 [dependencies]
 # riperf3 workspace dependencies
-riperf3 = { path = "../riperf3", version = "0.5.4" }
+riperf3 = { path = "../riperf3", version = "0.6.0" }
 
 # external dependencies
 clap.workspace = true


### PR DESCRIPTION
## What

1. **Wires `cargo-semver-checks` into CI** (`obi1kenobi/cargo-semver-checks-action@v2`, `package: riperf3` — the CLI is a binary with no library API). It compares the lib's public API against the latest crates.io release and fails if the version bump is insufficient for the API change.
2. **Bumps the workspace dev version 0.5.4 → 0.6.0.** The unreleased work since 0.5.4 contains a breaking library-API change (`Server` gained `pub json_output`/`json_stream`, #50) — `cargo-semver-checks` flags it as requiring a major. Under the 0.x convention that's `0.5.x → 0.6.0`. The bump makes the gate green (`v0.5.4 -> v0.6.0 (major change)` → "no semver update required"). `riperf3-cli`'s path-dep on `riperf3` bumped to match.

## Not a release

In-development version only — **no git tag, GitHub release, or `cargo publish`** here. Cutting 0.6.0 stays gated on approval.

Verified locally: `cargo semver-checks check-release` passes at 0.6.0. Going forward this gate would have caught #50's breaking change on the PR automatically.