### PR TITLE
feat(api)!: mark -J output model + Server #[non_exhaustive] (0.6.0 semver-proofing)

### DIFF
--- a/riperf3/src/json_report.rs
+++ b/riperf3/src/json_report.rs
@@ -32,6 +32,7 @@ use crate::protocol::TransportProtocol;
 // ---------------------------------------------------------------------------
 
 #[derive(Debug, Clone, Serialize)]
+#[non_exhaustive]
 pub struct Report {
     pub start: Start,
     pub intervals: Vec<Interval>,
@@ -48,6 +49,7 @@ pub struct Report {
 // ---------------------------------------------------------------------------
 
 #[derive(Debug, Clone, Serialize)]
+#[non_exhaustive]
 pub struct Start {
     pub connected: Vec<Connection>,
     pub version: String,
@@ -79,6 +81,7 @@ pub struct Start {
 }
 
 #[derive(Debug, Clone, Serialize)]
+#[non_exhaustive]
 pub struct Timestamp {
     /// RFC 1123 / HTTP-date GMT string, e.g. "Sat, 30 May 2026 02:20:49 GMT".
     pub time: String,
@@ -87,6 +90,7 @@ pub struct Timestamp {
 }
 
 #[derive(Debug, Clone, Serialize)]
+#[non_exhaustive]
 pub struct Connection {
     pub socket: i32,
     pub local_host: String,
@@ -96,12 +100,14 @@ pub struct Connection {
 }
 
 #[derive(Debug, Clone, Serialize)]
+#[non_exhaustive]
 pub struct ConnectingTo {
     pub host: String,
     pub port: u16,
 }
 
 #[derive(Debug, Clone, Serialize)]
+#[non_exhaustive]
 pub struct TestStart {
     pub protocol: String,
     pub num_streams: i32,
@@ -125,12 +131,14 @@ pub struct TestStart {
 // ---------------------------------------------------------------------------
 
 #[derive(Debug, Clone, Serialize)]
+#[non_exhaustive]
 pub struct Interval {
     pub streams: Vec<IntervalStream>,
     pub sum: IntervalSum,
 }
 
 #[derive(Debug, Clone, Serialize)]
+#[non_exhaustive]
 pub struct IntervalStream {
     pub socket: i32,
     pub start: f64,
@@ -168,6 +176,7 @@ pub struct IntervalStream {
 }
 
 #[derive(Debug, Clone, Serialize)]
+#[non_exhaustive]
 pub struct IntervalSum {
     pub start: f64,
     pub end: f64,
@@ -193,6 +202,7 @@ pub struct IntervalSum {
 // ---------------------------------------------------------------------------
 
 #[derive(Debug, Clone, Serialize)]
+#[non_exhaustive]
 pub struct End {
     pub streams: Vec<EndStream>,
     pub sum_sent: SumSide,
@@ -215,6 +225,7 @@ pub struct End {
 /// One `end.streams[]` entry. iperf3 nests the per-direction stats: TCP carries
 /// `{sender, receiver}`, UDP carries `{udp}`. Exactly one shape is populated.
 #[derive(Debug, Clone, Serialize)]
+#[non_exhaustive]
 pub struct EndStream {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub sender: Option<TcpStreamSide>,
@@ -225,6 +236,7 @@ pub struct EndStream {
 }
 
 #[derive(Debug, Clone, Serialize)]
+#[non_exhaustive]
 pub struct TcpStreamSide {
     pub socket: i32,
     pub start: f64,
@@ -257,6 +269,7 @@ pub struct TcpStreamSide {
 }
 
 #[derive(Debug, Clone, Serialize)]
+#[non_exhaustive]
 pub struct UdpStreamEnd {
     pub socket: i32,
     pub start: f64,
@@ -273,6 +286,7 @@ pub struct UdpStreamEnd {
 }
 
 #[derive(Debug, Clone, Serialize)]
+#[non_exhaustive]
 pub struct SumSide {
     pub start: f64,
     pub end: f64,
@@ -293,6 +307,7 @@ pub struct SumSide {
 }
 
 #[derive(Debug, Clone, Serialize)]
+#[non_exhaustive]
 pub struct CpuUtilization {
     pub host_total: f64,
     pub host_user: f64,
@@ -310,6 +325,7 @@ pub struct CpuUtilization {
 /// Per-stream end data, already resolved to the local (this host) and remote
 /// (peer, from the exchanged results) byte counts and roles.
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub struct StreamReport {
     pub id: i32,
     pub local_host: String,
@@ -332,6 +348,7 @@ pub struct StreamReport {
 }
 
 #[derive(Debug, Clone, Copy, Default)]
+#[non_exhaustive]
 pub struct TcpEndExtras {
     pub max_snd_cwnd: u64,
     pub max_rtt: u32,
@@ -341,6 +358,7 @@ pub struct TcpEndExtras {
 }
 
 #[derive(Debug, Clone, Copy)]
+#[non_exhaustive]
 pub struct UdpStreamStats {
     pub jitter_secs: f64,
     pub lost_packets: i64,
@@ -348,6 +366,7 @@ pub struct UdpStreamStats {
     pub out_of_order: i64,
 }
 
+#[non_exhaustive]
 pub struct ReportInput {
     pub protocol: TransportProtocol,
     pub reverse: bool,

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -70,6 +70,10 @@ impl TestConfig {
 // Server
 // ---------------------------------------------------------------------------
 
+// Constructed only via ServerBuilder; #[non_exhaustive] keeps future field
+// additions (like json_output/json_stream in #50) from being breaking changes
+// for downstream crates (#43 semver-proofing, the cheap half).
+#[non_exhaustive]
 pub struct Server {
     pub port: u16,
     pub one_off: bool,


### PR DESCRIPTION
## What

Mark the 19 `json_report` structs and `Server` `#[non_exhaustive]` so future field additions are non-breaking for downstream crates.

## Why

riperf3 keeps adding `-J` fields to match iperf3 (#36/#50 added many; #54/#57 will add more). With all-`pub` fields and no `#[non_exhaustive]`, each addition is a breaking change — that's how #50's `Server.json_output`/`json_stream` forced the 0.6.0 major (now caught by the `SemVer` gate). Marking these `#[non_exhaustive]` makes future field-adds non-breaking, so we stop paying a major per iperf3-fidelity field.

Two verified facts (correcting an earlier mischaracterization in the first draft of this PR):
- The entire `json_report` module is **net-new since 0.5.4** (the published crate has no `json_report`), so marking its structs now is free — no break vs the baseline.
- `Server` **existed at 0.5.4** with all-pub fields → it is the one genuine breaking change here, legal under the 0.6.0 major (semver-checks confirms `struct_marked_non_exhaustive` on `Server` is the only break, allowed by the major).

## Scope

- **Locked (this PR):** the 18 read-only `json_report` result structs + `ReportInput`. `ReportInput` is the internal report-*assembly input* — populated by `client.rs`/`server.rs` with full test state (CPU snapshots, per-stream reports, TCP_INFO extremes). Downstream obtains a `Report` via `Client`/`Server` and never hand-assembles `ReportInput`, and it gains a field on nearly every `-J` change — so locking it (making those frequent adds non-breaking) is intentional, not incidental.
- **Deferred to #67 (not bundled):** other all-pub, reachable, library-produced structs carry the same latent liability — `IntervalReporterConfig`, `TcpInfoSnapshot`, `TestConfig`, `reporter::{StreamInterval, StreamSummary, IntervalStreamRef}`, `cpu::CpuUtilization`, etc. These are fully constructible today (the earlier "field types can't be synthesized" rationale was wrong); they're just better handled by the surface-reduction work in #67 (retract to `pub(crate)`, which removes the liability entirely) than by sprinkling `#[non_exhaustive]` on internals.

## Validation

- `cargo test --workspace`: 177 + 129 + 59 pass.
- `cargo clippy --all-targets -- -D warnings`: clean.
- `cargo semver-checks`: `v0.5.4 -> v0.6.0 (major change)` → no update required.
- Within the crate, construction / FRU / exhaustive matches are unaffected (`#[non_exhaustive]` only restricts *other* crates), so `client.rs`/`server.rs`/tests are untouched.