### PR TITLE
ci: native macOS/Windows test runners + musl check (#39, informational)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,3 +62,47 @@ jobs:
         with:
           key: ${{ matrix.target }}
       - run: cargo check --target ${{ matrix.target }}
+
+  # Native build + test on macOS and Windows (#39). The cross-check job above
+  # only cargo-checks those targets (cross-compiled from Linux) — it never builds
+  # or runs them natively, so platform-specific runtime behavior (e.g. the macOS
+  # tcp_connection_info path, winsock) is unverified. These jobs run the real test
+  # suite on native runners.
+  #
+  # INFORMATIONAL for now: they are deliberately NOT in branch protection's
+  # required checks, because turning native tests on may surface pre-existing
+  # platform bugs (e.g. #40, macOS retransmits always 0). They report without
+  # blocking merges; issues get filed + fixed, then the checks are promoted to
+  # required. fail-fast: false so a failure on one OS doesn't cancel the other.
+  native-test:
+    name: Native test (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - macos-latest
+          - windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: native-${{ matrix.os }}
+      - run: cargo test --workspace
+
+  # Static/musl build check (#39). riperf3 ships in containers; musl is where
+  # libc differences (the libc/nix syscall surface) tend to bite. cargo check
+  # doesn't link, so musl-gcc isn't needed. Informational, like native-test.
+  musl-check:
+    name: musl check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: x86_64-unknown-linux-musl
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: musl
+      - run: cargo check --workspace --target x86_64-unknown-linux-musl


### PR DESCRIPTION
## What

Adds three CI jobs (all **informational** — not in branch protection's required checks):
- **`Native test (macos-latest)`** + **`Native test (windows-latest)`** — full `cargo test --workspace` on native runners.
- **`musl check`** — `cargo check --workspace --target x86_64-unknown-linux-musl`.

## Why

The existing `Cross-platform (…)` jobs only `cargo check` the Windows/macOS targets, **cross-compiled from Ubuntu** — they catch compile errors but never build or run natively, so platform-specific *runtime* behavior is unverified. riperf3 has genuinely divergent platform code (the macOS `tcp_connection_info` path in `tcp_info.rs`, winsock) — e.g. **#40** (macOS retransmits always 0) is exactly the class of bug a compile-check can't see. musl matters because riperf3 ships in containers, where libc/`nix` syscall differences surface.

Mainstream Linux is already the best-covered platform (Ubuntu runs the full suite + lint + both interop matrices), so this fills the actual gap: native macOS/Windows execution.

## Informational-first (per plan)

These jobs are **not required-to-merge**. Turning native tests on may surface pre-existing platform bugs, so the plan is: **run informationally → file issues for what reds → fix → then promote to required.** The existing `cross-check` stays the fast required compile gate.

I'll triage whatever the native jobs surface on this PR and file issues before merge.