### PR TITLE
fix(cli)!: parse -b/--fq-rate rate suffixes as decimal, like iperf3 (#56)

### DIFF
--- a/riperf3-cli/src/cli.rs
+++ b/riperf3-cli/src/cli.rs
@@ -683,7 +683,7 @@ mod cli_tests {
         fn bitrate_flag_wired() {
             let cli = Cli::parse_from(["riperf3", "-c", "host", "-b", "100M"]);
             let c = build_client_from_cli(&cli);
-            assert_eq!(c.bandwidth, 100 * 1024 * 1024);
+            assert_eq!(c.bandwidth, 100 * 1_000_000); // -b is decimal, like iperf3 (#56)
         }
 
         #[test]
@@ -776,7 +776,7 @@ mod cli_tests {
             assert!(c.bidir);
             assert!(c.no_delay);
             assert_eq!(c.blksize, 1460);
-            assert_eq!(c.bandwidth, 100 * 1024 * 1024);
+            assert_eq!(c.bandwidth, 100 * 1_000_000); // -b is decimal, like iperf3 (#56)
             assert!(c.json_output);
             assert_eq!(c.window, Some(512 * 1024));
             assert_eq!(c.mss, Some(1400));
@@ -889,7 +889,7 @@ mod cli_tests {
         fn fq_rate_wired() {
             let cli = Cli::parse_from(["riperf3", "-c", "h", "--fq-rate", "1G"]);
             let c = build_client_from_cli(&cli);
-            assert_eq!(c.fq_rate, Some(1024 * 1024 * 1024));
+            assert_eq!(c.fq_rate, Some(1_000_000_000)); // --fq-rate is decimal (#56)
         }
 
         #[test]

--- a/riperf3/src/client.rs
+++ b/riperf3/src/client.rs
@@ -1442,7 +1442,8 @@ impl ClientBuilder {
     }
 
     pub fn fq_rate_str(self, s: &str) -> std::result::Result<Self, ConfigError> {
-        Ok(self.fq_rate(parse_kmg(s)?))
+        // --fq-rate is a rate: decimal (1000-based) suffixes, like iperf3 (#56).
+        Ok(self.fq_rate(crate::utils::parse_rate(s)?))
     }
 
     pub fn build(self) -> std::result::Result<Client, ConfigError> {

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -1047,8 +1047,9 @@ impl ServerBuilder {
     }
 
     pub fn server_bitrate_limit_str(self, s: &str) -> std::result::Result<Self, ConfigError> {
-        use crate::utils::parse_kmg;
-        Ok(self.server_bitrate_limit(parse_kmg(s)?))
+        // A bitrate limit is a rate: decimal (1000-based) suffixes, like iperf3 (#56).
+        use crate::utils::parse_rate;
+        Ok(self.server_bitrate_limit(parse_rate(s)?))
     }
 
     pub fn build(self) -> std::result::Result<Server, ConfigError> {

--- a/riperf3/src/utils.rs
+++ b/riperf3/src/utils.rs
@@ -155,45 +155,64 @@ pub fn resolve_udp_blksize(explicit: Option<usize>, ctrl_mss: Option<u32>) -> us
 // KMG suffix parser
 // ---------------------------------------------------------------------------
 
-/// Parse a numeric string with an optional K/M/G/T suffix (case-insensitive).
-/// K = 1024, M = 1024^2, G = 1024^3, T = 1024^4.
-///
-/// Examples: "128K" -> 131072, "1M" -> 1048576, "10G" -> 10737418240, "42" -> 42
-pub fn parse_kmg(s: &str) -> std::result::Result<u64, ConfigError> {
+/// Parse a numeric string with an optional K/M/G/T suffix (case-insensitive),
+/// where each suffix level multiplies by `base` (K=base, M=base^2, G=base^3,
+/// T=base^4). iperf3 splits this: *sizes* use 1024 (`unit_atof`), *rates* use
+/// 1000 (`unit_atof_rate`).
+fn parse_suffixed(s: &str, base: u64) -> std::result::Result<u64, ConfigError> {
     let s = s.trim();
     if s.is_empty() {
         return Err(ConfigError::InvalidValue("number", s.to_string()));
     }
 
     let (num_str, multiplier) = match s.as_bytes().last() {
-        Some(b'k' | b'K') => (&s[..s.len() - 1], 1024_u64),
-        Some(b'm' | b'M') => (&s[..s.len() - 1], 1024_u64 * 1024),
-        Some(b'g' | b'G') => (&s[..s.len() - 1], 1024_u64 * 1024 * 1024),
-        Some(b't' | b'T') => (&s[..s.len() - 1], 1024_u64 * 1024 * 1024 * 1024),
+        Some(b'k' | b'K') => (&s[..s.len() - 1], base),
+        Some(b'm' | b'M') => (&s[..s.len() - 1], base * base),
+        Some(b'g' | b'G') => (&s[..s.len() - 1], base * base * base),
+        Some(b't' | b'T') => (&s[..s.len() - 1], base * base * base * base),
         _ => (s, 1),
     };
 
-    let base: u64 = num_str
+    let n: u64 = num_str
         .parse()
         .map_err(|_| ConfigError::InvalidValue("number", s.to_string()))?;
 
-    base.checked_mul(multiplier)
+    n.checked_mul(multiplier)
         .ok_or_else(|| ConfigError::InvalidValue("number", format!("{s} overflows u64")))
+}
+
+/// Parse a SIZE with an optional K/M/G/T suffix — **binary** (1024-based),
+/// matching iperf3's `unit_atof` for `-w`/`-l`/`-n`/`-k`.
+///
+/// Examples: "128K" -> 131072, "1M" -> 1048576, "10G" -> 10737418240, "42" -> 42
+pub fn parse_kmg(s: &str) -> std::result::Result<u64, ConfigError> {
+    parse_suffixed(s, 1024)
+}
+
+/// Parse a RATE (bits/sec) with an optional K/M/G/T suffix — **decimal**
+/// (1000-based), matching iperf3's `unit_atof_rate` for `-b`/`--fq-rate`.
+/// iperf3 parses sizes with 1024 but rates with 1000, so "1M" as a rate is
+/// 1_000_000, not 1_048_576 (#56).
+///
+/// Examples: "1M" -> 1_000_000, "10G" -> 10_000_000_000, "42" -> 42
+pub fn parse_rate(s: &str) -> std::result::Result<u64, ConfigError> {
+    parse_suffixed(s, 1000)
 }
 
 /// Parse a bitrate string with optional KMG suffix and optional burst count.
 /// Format: `<rate>[KMG][/<burst>]`
-/// Returns (rate_bits_per_sec, burst_packets).
+/// Returns (rate_bits_per_sec, burst_packets). The rate uses decimal (1000-based)
+/// suffixes like iperf3 (`-b`), e.g. "100M" -> 100_000_000 (#56).
 pub fn parse_bitrate(s: &str) -> std::result::Result<(u64, u32), ConfigError> {
     let s = s.trim();
     if let Some((rate_str, burst_str)) = s.split_once('/') {
-        let rate = parse_kmg(rate_str)?;
+        let rate = parse_rate(rate_str)?;
         let burst: u32 = burst_str
             .parse()
             .map_err(|_| ConfigError::InvalidValue("burst count", burst_str.to_string()))?;
         Ok((rate, burst))
     } else {
-        let rate = parse_kmg(s)?;
+        let rate = parse_rate(s)?;
         Ok((rate, 0))
     }
 }
@@ -249,12 +268,31 @@ mod tests {
 
     #[test]
     fn parse_bitrate_plain() {
-        assert_eq!(parse_bitrate("100M").unwrap(), (100 * 1024 * 1024, 0));
+        // Rates are decimal (1000-based), like iperf3: 100M = 100_000_000.
+        assert_eq!(parse_bitrate("100M").unwrap(), (100 * 1_000_000, 0));
     }
 
     #[test]
     fn parse_bitrate_with_burst() {
-        assert_eq!(parse_bitrate("100M/10").unwrap(), (100 * 1024 * 1024, 10));
+        assert_eq!(parse_bitrate("100M/10").unwrap(), (100 * 1_000_000, 10));
+    }
+
+    #[test]
+    fn parse_rate_is_decimal() {
+        // Rates use 1000-based suffixes (iperf3's unit_atof_rate).
+        assert_eq!(parse_rate("1K").unwrap(), 1_000);
+        assert_eq!(parse_rate("1M").unwrap(), 1_000_000);
+        assert_eq!(parse_rate("10G").unwrap(), 10_000_000_000);
+        assert_eq!(parse_rate("42").unwrap(), 42);
+        assert_eq!(parse_rate("1m").unwrap(), 1_000_000); // case-insensitive
+    }
+
+    #[test]
+    fn rate_and_size_suffix_bases_differ() {
+        // The crux of #56: the same "1M" is 1000^2 as a rate, 1024^2 as a size.
+        assert_eq!(parse_rate("1M").unwrap(), 1_000_000);
+        assert_eq!(parse_kmg("1M").unwrap(), 1_048_576);
+        assert_ne!(parse_rate("1M").unwrap(), parse_kmg("1M").unwrap());
     }
 
     // -- parse_keepalive --


### PR DESCRIPTION
## What

Parse the K/M/G/T suffix on **rate** flags (`-b`/`--bitrate`, `--fq-rate`, `--server-bitrate-limit`) as **decimal (1000-based)**, matching iperf3. Sizes (`-w`/`-l`/`-n`/`-k`) stay **binary (1024-based)** — also matching iperf3.

## Why

riperf3 used `parse_kmg` (1024-based) for everything. iperf3 splits it: `unit_atof` (sizes, 1024) vs `unit_atof_rate` (rates, 1000) — verified in `units.c`. So `-b 1M` offered **1,048,576 bit/s** where iperf3 offers **1,000,000** — a real **~4.9%-per-suffix-level divergence in offered load**, not just a reporting cosmetic.

## How

`parse_kmg` (1024) and new `parse_rate` (1000) now share a `parse_suffixed(s, base)` helper. `parse_bitrate`, `fq_rate_str`, and `server_bitrate_limit_str` route through `parse_rate`. The `DEFAULT_UDP_RATE` constant stays `1024*1024` — iperf3's `UDP_RATE` default is also binary (`iperf.h`); only *suffix parsing* differs.

## Validation

- Verified vs **iperf 3.21**: `-b 1M --fq-rate 1M` now emits `target_bitrate = fqrate = 1000000` (was 1048576) — exact match.
- New unit tests: `parse_rate_is_decimal`, `rate_and_size_suffix_bases_differ`. CLI `bitrate_flag_wired`/`fq_rate_wired` updated to decimal. 179 + 129 + cli pass; clippy clean.

## Breaking (behavioral — fits the 0.6.0 major)

A script passing `-b 100M` now offers 100 Mbit/s (was 104.86). This is a behavior change, appropriate for a major. Library API is unchanged (the `bandwidth(u64)` setter still takes raw bits/sec), so cargo-semver-checks sees no API break.

Closes #56.