### PR TITLE
fix(cli): accept fractional rate/size suffixes (1.5M, 0.5K), like iperf3 (#73)

### DIFF
--- a/riperf3/src/utils.rs
+++ b/riperf3/src/utils.rs
@@ -173,12 +173,24 @@ fn parse_suffixed(s: &str, base: u64) -> std::result::Result<u64, ConfigError> {
         _ => (s, 1),
     };
 
-    let n: u64 = num_str
+    // Parse the numeric part as f64 so fractional values work (e.g. "1.5M" ->
+    // 1.5 * multiplier), matching iperf3's `sscanf("%lf", ...)`. Scale then
+    // truncate to u64, like iperf3's implicit double->int. Reject non-finite,
+    // negative, and overflow (a plain `as u64` cast would silently saturate).
+    let n: f64 = num_str
         .parse()
         .map_err(|_| ConfigError::InvalidValue("number", s.to_string()))?;
-
-    n.checked_mul(multiplier)
-        .ok_or_else(|| ConfigError::InvalidValue("number", format!("{s} overflows u64")))
+    if !n.is_finite() || n < 0.0 {
+        return Err(ConfigError::InvalidValue("number", s.to_string()));
+    }
+    let scaled = n * multiplier as f64;
+    if scaled >= u64::MAX as f64 {
+        return Err(ConfigError::InvalidValue(
+            "number",
+            format!("{s} overflows u64"),
+        ));
+    }
+    Ok(scaled as u64)
 }
 
 /// Parse a SIZE with an optional K/M/G/T suffix — **binary** (1024-based),
@@ -293,6 +305,28 @@ mod tests {
         assert_eq!(parse_rate("1M").unwrap(), 1_000_000);
         assert_eq!(parse_kmg("1M").unwrap(), 1_048_576);
         assert_ne!(parse_rate("1M").unwrap(), parse_kmg("1M").unwrap());
+    }
+
+    #[test]
+    fn fractional_suffixes_accepted() {
+        // #73: iperf3 parses the numeric part with %lf, so fractional values work.
+        assert_eq!(parse_rate("1.5M").unwrap(), 1_500_000); // 1.5 * 1000^2
+        assert_eq!(parse_kmg("1.5K").unwrap(), 1_536); // 1.5 * 1024
+        assert_eq!(parse_kmg("0.5M").unwrap(), 524_288); // 0.5 * 1024^2
+        assert_eq!(parse_bitrate("2.5M").unwrap(), (2_500_000, 0));
+        // Plain integers and the exact-value tests above still hold (f64 is exact
+        // for these magnitudes).
+        assert_eq!(parse_rate("42").unwrap(), 42);
+    }
+
+    #[test]
+    fn rejects_non_finite_negative_and_garbage() {
+        assert!(parse_rate("-5M").is_err()); // negative
+        assert!(parse_rate("inf").is_err()); // non-finite
+        assert!(parse_kmg("nanK").is_err());
+        assert!(parse_kmg("1.5.5M").is_err()); // not a number
+        assert!(parse_kmg("abc").is_err());
+        assert!(parse_kmg("K").is_err()); // suffix only, no number
     }
 
     // -- parse_keepalive --

--- a/riperf3/src/utils.rs
+++ b/riperf3/src/utils.rs
@@ -174,9 +174,13 @@ fn parse_suffixed(s: &str, base: u64) -> std::result::Result<u64, ConfigError> {
     };
 
     // Parse the numeric part as f64 so fractional values work (e.g. "1.5M" ->
-    // 1.5 * multiplier), matching iperf3's `sscanf("%lf", ...)`. Scale then
-    // truncate to u64, like iperf3's implicit double->int. Reject non-finite,
-    // negative, and overflow (a plain `as u64` cast would silently saturate).
+    // 1.5 * multiplier), matching iperf3's `sscanf("%lf", ...)` for normal
+    // decimal input (incl. scientific / leading-sign / leading-dot). Scale then
+    // truncate to u64 like iperf3's double->int. The non-finite/negative/overflow
+    // guards are a deliberate improvement, NOT iperf3 parity: iperf3 doesn't guard
+    // these and silently emits garbage (inf->0, nan->i64::MAX, overflow->junk) —
+    // we error cleanly instead. (One niche input iperf3 accepts that we don't: hex
+    // like "0x10"; immaterial for a bitrate/size.)
     let n: f64 = num_str
         .parse()
         .map_err(|_| ConfigError::InvalidValue("number", s.to_string()))?;

--- a/riperf3/tests/integration.rs
+++ b/riperf3/tests/integration.rs
@@ -1045,8 +1045,12 @@ mod error_tests {
     }
 
     #[test]
-    fn parse_kmg_float() {
-        assert!(parse_kmg("1.5M").is_err());
+    fn parse_kmg_fractional() {
+        // #73: fractional suffixes are now accepted (iperf3 parses with %lf).
+        // 1.5 * 1024^2 = 1_572_864.
+        assert_eq!(parse_kmg("1.5M").unwrap(), 1_572_864);
+        // Still rejects genuinely-malformed numbers.
+        assert!(parse_kmg("1.5.5M").is_err());
     }
 
     #[test]


### PR DESCRIPTION
## What

Parse the numeric part of a suffixed value (`1.5M`, `0.5K`, `2.5G`) as **f64** instead of `u64`, so fractional inputs work — matching iperf3, which parses with `sscanf("%lf", ...)`.

## Why

`-b 1.5M` errored on riperf3 (`u64` parse rejects `1.5`) but works on iperf3 (`1.5M` rate = 1,500,000). A real drop-in input-parity gap (#73), surfaced during #56's review.

## How

`parse_suffixed` parses the numeric part as `f64`, scales by the binary/decimal multiplier (unchanged from #56), then truncates to `u64` like iperf3's implicit double→int. Guards: non-finite (`inf`/`nan`), negative, and overflow (a bare `as u64` cast would silently saturate). Applies to both **rates** (decimal) and **sizes** (binary).

## Validation

- Verified vs **iperf 3.21**: `-b 1.5M --fq-rate 2.5M` emits `target_bitrate=1500000`, `fqrate=2500000` on **both** tools.
- `-b 1.5M` → 1_500_000; `-w 1.5K` → 1536. Integer/exact tests (`1T`, `128K`, `10G`, …) unchanged — f64 is exact at these magnitudes. New `fractional_suffixes_accepted` + `rejects_non_finite_negative_and_garbage` tests; the old `parse_kmg_float` test (asserted floats error) flipped to the new behavior. 181 + 129 + 59 pass; clippy clean.

Closes #73.