### PR TITLE
test: gate Unix/Linux-only tests so native CI passes (#71, #72)

### DIFF
--- a/riperf3/src/tcp_info.rs
+++ b/riperf3/src/tcp_info.rs
@@ -149,6 +149,10 @@ pub fn has_retransmit_info() -> bool {
 mod tests {
     use super::*;
 
+    // Unix-only: queries TCP_INFO via a raw fd (`as_raw_fd`), which doesn't exist
+    // on Windows (`TcpStream` there is `as_raw_socket`). get_tcp_info returns None
+    // on Windows anyway, so there's nothing to exercise (#71).
+    #[cfg(unix)]
     #[tokio::test]
     async fn tcp_info_on_connected_socket() {
         use std::os::unix::io::AsRawFd;

--- a/riperf3/tests/integration.rs
+++ b/riperf3/tests/integration.rs
@@ -2146,6 +2146,11 @@ mod unimplemented_flags {
         let _ = server_task.await;
     }
 
+    // Linux-only: --bind-dev uses SO_BINDTODEVICE and the "lo" interface name,
+    // both Linux-specific (macOS/BSD use IP_BOUND_IF + "lo0"). Matches the gate
+    // already on bind_device_invalid_rejects below (#72). macOS/Windows support
+    // for --bind-dev is tracked separately.
+    #[cfg(target_os = "linux")]
     #[tokio::test]
     async fn bind_device_loopback() {
         // --bind-dev lo: bind all sockets to the loopback interface.


### PR DESCRIPTION
## What

Gate two tests the new native CI jobs (#39) surfaced as non-portable:
- **#71** — `tcp_info::tests::tcp_info_on_connected_socket` uses Unix-only `as_raw_fd()` → **Windows build fails**. Now `#[cfg(unix)]` (it queries TCP_INFO via a raw fd; `get_tcp_info` returns `None` on Windows, so nothing to test there).
- **#72** — `bind_device_loopback` uses `--bind-dev "lo"` (`SO_BINDTODEVICE` + `"lo"` are Linux-only) → **fails on macOS**. Now `#[cfg(target_os = "linux")]`, matching the gate already on its sibling `bind_device_invalid_rejects` (which was correctly gated; this one was missed).

Both still run on **Linux** — no coverage loss there (verified: 181 + 129 + 59 pass locally).

## Effect on native CI

macOS's only failure was `bind_device_loopback` → should go green. Windows failed to **compile** on the `tcp_info` test → now compiles and runs the full suite for the first time (may pass, or surface more — the native jobs are informational, so anything new gets filed + fixed iteratively).

## Issues

Closes **#71** (purely a test-portability bug). **#72** stays open for the *feature* question — whether `--bind-dev` should work on macOS/BSD via `IP_BOUND_IF` — with the test now Linux-gated so CI is unblocked.