### PR TITLE
test: gate Linux/FreeBSD-only feature tests for native CI (#76 part A)

### DIFF
--- a/riperf3-cli/src/cli.rs
+++ b/riperf3-cli/src/cli.rs
@@ -969,6 +969,9 @@ mod cli_tests {
             assert_eq!(c.logfile, Some("/tmp/log".to_string()));
         }
 
+        // sendmmsg(2) is Linux/FreeBSD/NetBSD-only (stream.rs); build() rejects
+        // --sendmmsg on other platforms, so gate the wiring test to match (#76).
+        #[cfg(any(target_os = "linux", target_os = "freebsd", target_os = "netbsd"))]
         #[test]
         fn sendmmsg_flag_wired() {
             let cli = Cli::parse_from(["riperf3", "-c", "h", "-u", "--sendmmsg"]);

--- a/riperf3/tests/integration.rs
+++ b/riperf3/tests/integration.rs
@@ -511,6 +511,9 @@ async fn tcp_combined_socket_opts() {
 
 /// Verify -C congestion algorithm is applied to data stream sockets.
 /// Bug: congestion was sent in TestParams JSON but not applied via setsockopt.
+// -C congestion control is Linux/FreeBSD-only (net.rs gates the setsockopt on
+// those; iperf3's HAVE_TCP_CONGESTION). No-op elsewhere, so don't run it there (#76).
+#[cfg(any(target_os = "linux", target_os = "freebsd"))]
 #[tokio::test]
 async fn tcp_congestion_applied() {
     let port = next_port();
@@ -654,6 +657,8 @@ mod builder_tests {
         assert_eq!(c.tos, 0x10);
     }
 
+    // Congestion is a Linux/FreeBSD feature (net.rs); gate to match (#76).
+    #[cfg(any(target_os = "linux", target_os = "freebsd"))]
     #[test]
     fn client_builder_congestion() {
         let c = ClientBuilder::new("h").congestion("bbr").build().unwrap();
@@ -1604,6 +1609,8 @@ mod implemented_flag_tests {
         let _ = server_task.await;
     }
 
+    // -C is Linux/FreeBSD-only (net.rs); gate to match (#76).
+    #[cfg(any(target_os = "linux", target_os = "freebsd"))]
     #[tokio::test]
     async fn congestion_cubic_runs() {
         let port = next_port();
@@ -2623,6 +2630,9 @@ mod unimplemented_flags {
 
     // -- Deferred --
 
+    // -Z zerocopy uses sendfile, implemented for Linux/macOS/FreeBSD but not
+    // Windows (no sendfile). Gate to Unix (#76).
+    #[cfg(unix)]
     #[tokio::test]
     async fn zerocopy_send() {
         // -Z zerocopy: uses sendfile() to avoid userspace-to-kernel copy.


### PR DESCRIPTION
## What

Gate the tests for **platform-limited features** (congestion `-C`, zerocopy `-Z`, `sendmmsg`) to the platforms where those features exist — matching iperf3, which is also Linux/(FreeBSD) for these.

| test(s) | gate | rationale |
|---|---|---|
| `tcp_congestion_applied`, `congestion_cubic_runs`, `client_builder_congestion` | `#[cfg(any(linux, freebsd))]` | `net.rs` sets `TCP_CONGESTION` only there (iperf3's `HAVE_TCP_CONGESTION`); no-op elsewhere |
| `zerocopy_send` | `#[cfg(unix)]` | `sendfile` impls exist for Linux/macOS/FreeBSD, not Windows |
| `sendmmsg_flag_wired` | `#[cfg(any(linux, freebsd, netbsd))]` | `sendmmsg(2)` is Linux/BSD-only; `build()` rejects `--sendmmsg` elsewhere |

All still run on **Linux** (no coverage loss — verified 181 + 129 + 59 pass).

## Effect on native CI (#39)

- **macOS → green** (`sendmmsg_flag_wired` was its only failure).
- **Windows** → down to the two **real** cross-platform bugs (`--cport` `WSAEWOULDBLOCK`, udp-bidir-parallel), which are **deferred and tracked** as #76 part B. So Windows native stays red **informationally**; per the agreed plan, native isn't promoted to required until those land.

Addresses the gating half of #76.