### PR TITLE
0.6.0 release prep: rebuilt benchmark harness + refreshed docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,10 @@ target/
 # MSVC Windows builds of rustc generate these, which store debugging information
 *.pdb
 
+# Python bytecode cache (benchmark analysis script)
+__pycache__/
+*.pyc
+
 # Claude Code local config
 .claude/
 CLAUDE.md

--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -129,7 +129,9 @@ characteristic rather than a regression.
 | riperf3 UDP | 27.0 | 21.9 |
 | iperf3 UDP | 29.3 | 26.2 |
 
-TCP bidir is at parity (~80 Gbps aggregate); UDP bidir aggregate is comparable.
+TCP bidir aggregate is close (~78–83 Gbps; iperf3 edges it a few percent in this
+single run); UDP bidir aggregate is likewise comparable. These are single
+non-campaign runs — directional, not statistical.
 
 ### UDP datagram-size sweep (IPv6 forward, P1)
 

--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -6,40 +6,42 @@ bridge. Throughput numbers measure protocol and CPU efficiency of the
 implementations, **not** physical link speed — there is no physical NIC in the
 path, so the ceiling is set by the guests' CPU and the host's virtio bridge.
 
-Reproducible via the `riperf3-matrix` skill (`compat` and `campaign` modes).
+Reproducible from the committed harness in [`scripts/`](scripts): `compat.sh`
+(interop grid), `bench.sh` + `analyze.py` (statistical campaign), and
+`interop.sh` (the loopback CI gate). See [Reproducing](#reproducing).
 
 ## Test environment
 
 | | |
 |---|---|
-| Date | 2026-05-29 |
+| Date | 2026-05-30 |
 | Host | Intel i9-13900K, Linux 7.0.10-arch1-1 (Arch), KVM |
-| Guests | 2× Debian 13 (Trixie), Linux 6.12.74-cloud, 8 vCPU, 8 GB RAM each |
+| Guests | 2× Debian 13 (Trixie), Linux 6.12.90-cloud, 8 vCPU, 8 GB RAM each |
 | NIC | virtio-net (vhost=on), bridged, MTU 9000; IPv4 `172.20.0.0/24` + IPv6 `fd00:20::/64` |
-| riperf3 | 0.5.1 |
+| riperf3 | 0.6.0 |
 | iperf3 | 3.20+ (cJSON 1.7.15), built from source |
 
 ## Compatibility matrix (iperf3 interop)
 
 Every client→server tool pairing across protocol × direction, plus
-param-exchange features. **All 42 cells interoperate** — each completes with a
+param-exchange features. **All 44 cells interoperate** — each completes with a
 valid result and no protocol error. `r` = riperf3, `i` = iperf3; the
 interop-relevant pairings are `r→i` and `i→r`.
 
-### Base: protocol × direction (sender/receiver rate, Gbps)
+### Base: protocol × direction (Gbps; bidir is two-way aggregate)
 
 | config | r→r | r→i | i→r | i→i |
 |---|--:|--:|--:|--:|
-| TCP forward | 71.0 | 75.9 | 61.6 | 76.2 |
-| TCP reverse | 75.1 | 77.1 | 54.9 | 75.5 |
-| TCP bidir | 44.5 | 43.3 | 39.2 | 44.6 |
-| UDP forward `-b 0` | 37.3 | 34.3 | 33.5 | 32.4 |
-| UDP reverse `-b 0` | 31.5 | 28.1 | 31.7 | 27.1 |
-| UDP bidir `-b 0` | 19.9 | 23.7 | 23.2 | 27.2 |
+| TCP forward | 72.1 | 70.9 | 73.2 | 74.2 |
+| TCP reverse | 75.2 | 75.1 | 73.8 | 75.0 |
+| TCP bidir | 81.0 | 84.3 | 82.9 | 82.0 |
+| UDP forward `-b 0` | 34.9 | 35.9 | 31.4 | 32.7 |
+| UDP reverse `-b 0` | 30.4 | 26.8 | 30.7 | 27.4 |
+| UDP bidir `-b 0` | 51.5 | 55.0 | 38.8 | 53.3 |
 
-Feature interop (cross pairs, all PASS): `-P 4`, `-l 128K`, `-O` (omit), `-w`
-(window), `-M` (MSS), `--get-server-output`, `-Z` (zerocopy), UDP `-l 8192`,
-`--udp-counters-64bit`, UDP `-P 4`.
+Feature interop (cross pairs `r→i` and `i→r`, all PASS): `-P 4`, `-l 128K`, `-O`
+(omit), `-w` (window), `-M` (MSS), `--get-server-output`, `-Z` (zerocopy), UDP
+`-l 8192`, `--udp-counters-64bit`, UDP `-P 4`.
 
 > The earlier 1 Mbit/s throttle on `i→r` UDP reverse/bidir at `-b 0` — iperf3
 > omits the `bandwidth` param for unlimited and riperf3's server defaulted it to
@@ -54,55 +56,56 @@ comparison is defensible rather than anecdotal.
 × {riperf3, iperf3}, each tool head-to-head against itself. **N = 30** runs per
 cell (`-t 5` s each), **960 runs total**, run in **randomized order** across all
 (cell, tool, iteration) tuples so host/thermal drift can't systematically favor
-either tool. 2 warm-ups discarded; fresh `-s -1` server per run on a unique
-port; hard `timeout` wrappers; VMs confirmed idle and isolated for the duration.
-0 failed runs. Per-cell coefficient of variation was 1.5–8.5% (TCP reverse P1
-highest, ~5–7%; UDP ~3.5–8.5%), giving the tight 95% CIs below. Significance is
-Welch's t (two-sided, normal approx at n=30); "parity" = not significant at
-p<0.05.
+either tool. 2 warm-ups per cell discarded; fresh `-s -1` server per run on a
+unique port; hard `timeout` wrappers; VMs confirmed idle and isolated for the
+duration. **0 failed runs** (1 transient blip auto-recovered on retry). Per-cell
+coefficient of variation was 1.0–7.0%. Significance is Welch's t (two-sided,
+normal approx at n=30); "parity" = not significant at p<0.05.
 
 ### Throughput: riperf3 vs iperf3 (mean Gbps [95% CI])
 
 | cell | riperf3 | iperf3 | Δ | p | verdict |
 |---|--:|--:|--:|--:|---|
-| TCP fwd P1 v4 | 74.4 [73.6–75.2] | 74.1 [73.6–74.6] | +0.4% | 0.58 | parity |
-| TCP fwd P1 v6 | 75.7 [74.9–76.5] | 75.5 [75.0–76.0] | +0.3% | 0.64 | parity |
-| TCP fwd P8 v4 | 61.5 [61.0–62.0] | 56.8 [56.4–57.3] | +8.2% | <1e-4 | **riperf3** |
-| TCP fwd P8 v6 | 62.4 [62.1–62.8] | 56.8 [56.2–57.3] | +10.0% | <1e-4 | **riperf3** |
-| TCP rev P1 v4 | 73.9 [72.0–75.7] | 75.5 [74.7–76.4] | −2.2% | 0.10 | parity |
-| TCP rev P1 v6 | 75.3 [73.9–76.7] | 75.4 [73.8–77.1] | −0.2% | 0.89 | parity |
-| TCP rev P8 v4 | 62.1 [61.7–62.5] | 58.7 [57.9–59.5] | +5.8% | <1e-4 | **riperf3** |
-| TCP rev P8 v6 | 63.0 [62.7–63.3] | 58.4 [57.8–59.0] | +7.9% | <1e-4 | **riperf3** |
-| UDP fwd P1 v4 | 34.8 [33.7–35.8] | 29.8 [29.0–30.6] | +16.8% | <1e-4 | **riperf3** |
-| UDP fwd P1 v6 | 35.6 [34.6–36.5] | 30.0 [29.1–31.0] | +18.4% | <1e-4 | **riperf3** |
-| UDP fwd P8 v4 | 33.0 [32.6–33.4] | 29.4 [28.9–29.8] | +12.4% | <1e-4 | **riperf3** |
-| UDP fwd P8 v6 | 33.0 [32.4–33.5] | 29.2 [28.9–29.6] | +12.8% | <1e-4 | **riperf3** |
-| UDP rev P1 v4 | 33.6 [32.7–34.4] | 29.2 [28.5–30.0] | +14.9% | <1e-4 | **riperf3** |
-| UDP rev P1 v6 | 33.0 [32.2–33.8] | 29.1 [28.4–29.8] | +13.3% | <1e-4 | **riperf3** |
-| UDP rev P8 v4 | 31.2 [30.8–31.6] | 28.5 [28.1–28.9] | +9.6% | <1e-4 | **riperf3** |
-| UDP rev P8 v6 | 31.6 [31.2–32.1] | 28.4 [28.0–28.9] | +11.2% | <1e-4 | **riperf3** |
+| TCP fwd P1 v4 | 73.7 [72.8–74.5] | 73.8 [73.2–74.4] | −0.2% | 0.81 | parity |
+| TCP fwd P1 v6 | 74.4 [73.6–75.2] | 72.8 [71.2–74.4] | +2.2% | 0.09 | parity |
+| TCP fwd P8 v4 | 61.9 [61.6–62.2] | 57.6 [57.3–57.9] | +7.5% | <1e-4 | **riperf3** |
+| TCP fwd P8 v6 | 62.4 [62.0–62.7] | 57.8 [57.4–58.2] | +7.9% | <1e-4 | **riperf3** |
+| TCP rev P1 v4 | 74.8 [73.5–76.1] | 74.6 [73.8–75.4] | +0.3% | 0.79 | parity |
+| TCP rev P1 v6 | 76.3 [75.7–76.9] | 74.8 [73.4–76.1] | +2.1% | 0.03 | **riperf3** |
+| TCP rev P8 v4 | 62.4 [61.9–62.9] | 59.5 [58.8–60.1] | +5.0% | <1e-4 | **riperf3** |
+| TCP rev P8 v6 | 63.3 [63.0–63.5] | 59.9 [59.5–60.3] | +5.7% | <1e-4 | **riperf3** |
+| UDP fwd P1 v4 | 35.3 [34.4–36.1] | 31.1 [30.3–31.8] | +13.6% | <1e-4 | **riperf3** |
+| UDP fwd P1 v6 | 34.8 [34.1–35.6] | 30.7 [29.9–31.5] | +13.5% | <1e-4 | **riperf3** |
+| UDP fwd P8 v4 | 34.1 [33.4–34.9] | 29.2 [28.9–29.6] | +16.8% | <1e-4 | **riperf3** |
+| UDP fwd P8 v6 | 33.1 [32.6–33.7] | 28.8 [28.4–29.2] | +15.1% | <1e-4 | **riperf3** |
+| UDP rev P1 v4 | 34.3 [33.5–35.2] | 30.2 [29.5–30.8] | +13.7% | <1e-4 | **riperf3** |
+| UDP rev P1 v6 | 34.2 [33.4–35.1] | 30.7 [30.1–31.3] | +11.4% | <1e-4 | **riperf3** |
+| UDP rev P8 v4 | 31.7 [31.3–32.0] | 28.9 [28.5–29.3] | +9.6% | <1e-4 | **riperf3** |
+| UDP rev P8 v6 | 32.3 [31.9–32.7] | 28.5 [28.1–28.9] | +13.1% | <1e-4 | **riperf3** |
 
 **Findings.**
 - **TCP single-stream is a statistical dead heat** (P1, both directions, both
-  families: Δ within ±2.2%, not significant). Both ~75 Gbps.
-- **TCP multi-stream: riperf3 significantly faster** at P8 (+5.8% to +10.0%,
+  families: Δ within ±2.2%). Both ~74–76 Gbps. Three of four cells are not
+  significant; the one marginal exception (TCP rev P1 v6, +2.1%, p=0.03) is a
+  hair above the threshold and inside the noise of the rest.
+- **TCP multi-stream: riperf3 significantly faster** at P8 (+5.0% to +7.9%,
   p<1e-4) — its thread-per-stream model scales better on the 8-vCPU guests.
-- **UDP: riperf3 significantly faster in every cell** (+9.6% to +18.4%,
+- **UDP: riperf3 significantly faster in every cell** (+9.6% to +16.8%,
   p<1e-4), the result of the 0.4.0 UDP rebuild ([#6](https://github.com/therealevanhenry/riperf3/issues/6): MSS-derived datagram size + blocking sockets).
-- No cell where iperf3 is significantly faster.
+- No cell where iperf3 is significantly faster (13 riperf3, 3 parity, 0 iperf3).
 
-### UDP loss (%) at `-b 0`
+### UDP loss (%) at `-b 0`, P8
 
 | direction | riperf3 | iperf3 |
 |---|--:|--:|
-| forward (server receives), P8 | 2.4–2.8 | 0.9–1.0 |
-| reverse (server sends), P8 | 1.2–1.6 | 0.6–0.7 |
+| forward (server receives) | 1.3–5.5 | 0.5–2.2 |
+| reverse (server sends) | 1.0–2.7 | 0.4–1.3 |
 
 UDP loss at `-b 0` is receiver-side socket-buffer overflow on a saturated link —
 kernel `RcvbufErrors` on the receiving host, while sender `SndbufErrors` stay 0
 (the sender never drops). It is roughly symmetric by direction; if anything,
 forward drops a touch more. riperf3 loses somewhat more than iperf3 in both
-directions because it pushes ~10–15% more throughput, so it overruns the
+directions because it pushes ~10–17% more throughput, so it overruns the
 receiver's buffer harder — higher goodput, slightly higher loss, a
 characteristic rather than a regression.
 
@@ -112,7 +115,7 @@ characteristic rather than a regression.
 > server-measured receiver loss, so it *looked* loss-free
 > ([#25](https://github.com/therealevanhenry/riperf3/issues/25), fixed in 0.5.4)
 > — and the campaign never passed `--sendmmsg`, so both directions used the same
-> per-packet sender. Kernel counters confirm forward drops the same ~2–3% as
+> per-packet sender. Kernel counters confirm forward drops the same ~1–5% as
 > reverse; the "asymmetry" was measurement, not packet loss.
 
 ## Single-run supplements
@@ -121,10 +124,10 @@ characteristic rather than a regression.
 
 | tool | TX | RX |
 |---|--:|--:|
-| riperf3 TCP | 40.0 | 39.5 |
-| iperf3 TCP | 40.6 | 40.6 |
-| riperf3 UDP | 31.2 | 24.5 |
-| iperf3 UDP | 27.7 | 27.6 |
+| riperf3 TCP | 39.2 | 39.2 |
+| iperf3 TCP | 41.5 | 41.5 |
+| riperf3 UDP | 27.0 | 21.9 |
+| iperf3 UDP | 29.3 | 26.2 |
 
 TCP bidir is at parity (~80 Gbps aggregate); UDP bidir aggregate is comparable.
 
@@ -137,16 +140,32 @@ datagrams are large.
 
 | `-l` (bytes) | riperf3 | iperf3 |
 |-------------:|--------:|-------:|
-| 1460 | 15.9 | 16.3 |
-| 4096 | 25.1 | 23.3 |
-| 8192 | 37.8 | 32.5 |
-| 8928 (≈MSS) | 39.0 | 33.3 |
+| 1460 | 15.7 | 16.5 |
+| 4096 | 24.3 | 23.2 |
+| 8192 | 37.8 | 32.4 |
+| 8928 (≈MSS) | 37.0 | 33.3 |
 
 ## Reproducing
 
-`/riperf3-matrix compat` for the interop gate; `/riperf3-matrix campaign` for the
-statistical throughput run (`bench.sh` samples N randomized iterations/cell to a
-CSV; `analyze.py` computes the per-cell CIs and Welch's-t verdicts above). UDP
-uses `-b 0`. Direction-aware parse: forward → client `sender` line, reverse →
-client `receiver` line, `-P>1` → `[SUM]`. See the skill for the full procedure
-and the VM-fleet isolation rules.
+The harness lives in [`scripts/`](scripts) and drives the two-VM sandbox over
+SSH (server on `sandbox-server-1`, client on `sandbox-client-1`, data crossing
+the bridge). With both binaries built on the VMs at
+`~/riperf3/target/release/riperf3` and `~/iperf/src/iperf3`:
+
+```bash
+# Compatibility grid + feature spot-checks (cross-tool, over the bridge):
+./scripts/compat.sh "$RIPERF3" "$IPERF3"
+
+# Statistical campaign (~2h: 64 warmup + 960 measured, randomized, seeded):
+N=30 WARMUP=2 DURATION=5 PROTOS="TCP UDP" SEED=20260530 \
+  ./scripts/bench.sh "$RIPERF3" "$IPERF3" campaign.csv
+./scripts/analyze.py campaign.csv      # per-cell CIs, UDP loss, Welch's-t verdicts
+```
+
+`bench.sh` samples N randomized iterations/cell to a CSV; `analyze.py` computes
+the per-cell CIs and Welch's-t verdicts above. UDP uses `-b 0`. Direction-aware
+parse: forward → client `sum_sent`, reverse → client `sum_received`, UDP →
+`sum`; `-P>1` aggregates are already summed in `-J`. For pure wire-interop
+without a sandbox, `./scripts/interop.sh <riperf3-bin> <iperf3-bin>` is the
+loopback CI gate. The `riperf3-matrix` skill wraps these scripts with the
+provisioning steps and VM-fleet isolation rules.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,7 +55,7 @@ sides of the connection.
 - Real-iperf3 wire-interop CI gate against current and 3.12 iperf3 (#38), now
   also validating the server's `-J` output (#50).
 - Linux/Unix-only feature tests are gated by target so the native macOS/Windows
-  CI runners pass cleanly (#71, #72, #76, #77).
+  CI runners pass cleanly (#71, #72, #76).
 
 ### Known issues
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,8 +29,9 @@ sides of the connection.
   socket buffer sizes).
 - **`--extra-data` surfaced in `-J` output** (#35), matching iperf3's top-level
   `extra_data` field.
-- **Native macOS and Windows CI runners plus a musl build check** (#39), so
-  cross-platform behavior is observed rather than assumed.
+- **Native macOS and Windows CI runners plus a musl build check**, so
+  cross-platform behavior is observed rather than assumed. (FreeBSD CI is still
+  outstanding — see Known issues, #39.)
 - **`cargo-semver-checks` gate** in CI (a required check) to catch unintended
   public-API breaks before release.
 
@@ -55,7 +56,8 @@ sides of the connection.
 - Real-iperf3 wire-interop CI gate against current and 3.12 iperf3 (#38), now
   also validating the server's `-J` output (#50).
 - Linux/Unix-only feature tests are gated by target so the native macOS/Windows
-  CI runners pass cleanly (#71, #72, #76).
+  CI runners pass cleanly (#71, #76). (The macOS `--bind-dev` test is gated
+  pending its underlying fix — see Known issues, #72.)
 
 ### Known issues
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,102 @@
+# Changelog
+
+All notable changes to riperf3 are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+While the crate is pre-1.0 (`0.x`), a minor-version bump may carry a breaking
+change, per the SemVer 0.x convention; breaking changes are called out below.
+
+This changelog begins at 0.6.0. For earlier releases (0.1.1–0.5.4), see the
+[git history](https://github.com/therealevanhenry/riperf3/commits/main) and
+release tags.
+
+## [0.6.0] - 2026-05-30
+
+End-to-end iperf3 `-J` JSON faithfulness (client **and** server), a locked-down
+public API surface, and native cross-platform CI. The headline is JSON: a
+riperf3 `-J` document is now field-for-field comparable to iperf3's on both
+sides of the connection.
+
+### Added
+- **Server-side `-J` and `--json-stream` output** (#50). The server now emits the
+  same structured JSON document as the client, with server-perspective byte
+  attribution and address reporting (`accepted_connection`), so `-J` is usable
+  regardless of which side you run.
+- **Faithful client `-J` document** (#36): a typed, iperf3-compatible `end` block
+  with real local/remote addresses; `intervals` with per-stream `TCP_INFO`
+  extremes; and `start` metadata (timestamp, cookie, `system_info`, MSS,
+  socket buffer sizes).
+- **`--extra-data` surfaced in `-J` output** (#35), matching iperf3's top-level
+  `extra_data` field.
+- **Native macOS and Windows CI runners plus a musl build check** (#39), so
+  cross-platform behavior is observed rather than assumed.
+- **`cargo-semver-checks` gate** in CI (a required check) to catch unintended
+  public-API breaks before release.
+
+### Changed
+- **API (breaking).** The `-J` output model types and `Server` are now
+  `#[non_exhaustive]`, so future field additions are non-breaking. This is the
+  breaking change that motivates the 0.6.0 minor bump: downstream code that
+  constructed these structs with literal initializers must adapt.
+- **CLI (breaking).** `-b`/`--bitrate` and `--fq-rate` rate suffixes are now
+  parsed as **decimal** (1000-based: `10M` = 10,000,000 bits/s), matching
+  iperf3's `unit_atof_rate`. Size suffixes (`-l`, `-w`, `-n`, `-k`) remain
+  **binary** (1024-based), matching iperf3's `unit_atof`. Previously rate
+  suffixes were parsed as binary (#56).
+- **CLI.** Fractional suffixes are now accepted (`1.5M`, `0.5K`), matching
+  iperf3's `sscanf`-based parse (#73).
+
+### Fixed
+- UDP receiver is drained at teardown so reverse/bidirectional tests no longer
+  reset an iperf3 server at version ≤ 3.12 (#48).
+
+### Internal
+- Real-iperf3 wire-interop CI gate against current and 3.12 iperf3 (#38), now
+  also validating the server's `-J` output (#50).
+- Linux/Unix-only feature tests are gated by target so the native macOS/Windows
+  CI runners pass cleanly (#71, #72, #76, #77).
+
+### Known issues
+
+Tracked for a follow-up cleanup after 0.6.0. See the
+[issue tracker](https://github.com/therealevanhenry/riperf3/issues) for the
+complete list; the notable user-facing ones:
+
+- **`-s -D` daemon mode is broken** — a daemonized server listens but never
+  serves, so any client (riperf3 or iperf3) hangs after connecting. Use a
+  foreground `-s` server (or a process manager) until this is fixed.
+  ([#81](https://github.com/therealevanhenry/riperf3/issues/81))
+- **Options accepted but not yet effective** (silent no-ops):
+  `--get-server-output` ([#33](https://github.com/therealevanhenry/riperf3/issues/33)),
+  `--pacing-timer` ([#32](https://github.com/therealevanhenry/riperf3/issues/32)),
+  `-O`/`--omit` (warm-up isn't excluded from the summary)
+  ([#31](https://github.com/therealevanhenry/riperf3/issues/31)),
+  `-T`/`--title` (doesn't prefix output lines)
+  ([#34](https://github.com/therealevanhenry/riperf3/issues/34)), and UDP
+  `-w`/`--window` ([#59](https://github.com/therealevanhenry/riperf3/issues/59)).
+  The server also accepts client-only flags rather than rejecting them as iperf3
+  does ([#65](https://github.com/therealevanhenry/riperf3/issues/65)).
+- **Reverse + byte/block limit** (`-R -n` / `-R -k`) never terminates
+  ([#60](https://github.com/therealevanhenry/riperf3/issues/60)).
+- **`-J` fidelity gaps:** `--json-stream` is not valid line-delimited JSON
+  ([#62](https://github.com/therealevanhenry/riperf3/issues/62)); integral
+  floats render as `N.0` where cJSON omits the decimal
+  ([#57](https://github.com/therealevanhenry/riperf3/issues/57)); the final
+  interval is occasionally dropped
+  ([#55](https://github.com/therealevanhenry/riperf3/issues/55)); bidir interval
+  `sum` lumps both directions
+  ([#54](https://github.com/therealevanhenry/riperf3/issues/54));
+  `congestion_used` is never populated
+  ([#37](https://github.com/therealevanhenry/riperf3/issues/37)).
+- **Platform-specific:** on Windows, `--cport` fails with `WSAEWOULDBLOCK`
+  ([#79](https://github.com/therealevanhenry/riperf3/issues/79)) and UDP
+  `--bidir -P 4` hangs ([#80](https://github.com/therealevanhenry/riperf3/issues/80));
+  on macOS, retransmit counts always read 0
+  ([#40](https://github.com/therealevanhenry/riperf3/issues/40)) and `--bind-dev`
+  is Linux-only ([#72](https://github.com/therealevanhenry/riperf3/issues/72)).
+  The library does not yet compile on NetBSD/OpenBSD/illumos
+  ([#78](https://github.com/therealevanhenry/riperf3/issues/78)), and FreeBSD has
+  no CI coverage ([#39](https://github.com/therealevanhenry/riperf3/issues/39)).
+
+[0.6.0]: https://github.com/therealevanhenry/riperf3/releases/tag/v0.6.0

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # riperf3
 
-A ground-up Rust implementation of [iperf3](https://github.com/esnet/iperf), the standard network performance measurement tool. Wire-compatible with ESNet's iperf3 — a riperf3 client talks to an iperf3 server and vice versa.
+A ground-up, idiomatic Rust implementation of [iperf3](https://github.com/esnet/iperf), the standard network performance measurement tool — not a C port or a binding, but a faithful reimplementation in safe, async Rust.
+
+riperf3 speaks iperf3's exact wire protocol: a riperf3 client interoperates with an iperf3 server, and vice versa, across every mode. Fidelity is the guiding principle — riperf3 matches iperf3 flag for flag and quirk for quirk rather than reinventing the interface. Where iperf3 accepts an option, riperf3 implements it to behave the same way; it does not reject, rename, or work around iperf3's semantics. The goal is a drop-in you can swap in without your scripts, dashboards, or muscle memory noticing.
 
 ## Highlights
 
@@ -9,7 +11,7 @@ A ground-up Rust implementation of [iperf3](https://github.com/esnet/iperf), the
 - **Safe Rust** — `unsafe` is used only for platform-specific kernel syscalls (`setsockopt`/`getsockopt`) with no safe wrapper. No unsafe in any application logic or public API. See the [audit table](https://github.com/therealevanhenry/riperf3/blob/main/riperf3/src/lib.rs) for the full inventory.
 - **Single static binary** with no runtime dependencies.
 - **Idiomatic Rust** — not a C port. Uses tokio for async I/O, serde for JSON, clap for CLI parsing, nix for safe Unix syscalls.
-- **269 tests** — unit, integration, and full client-server loopback with interchange verification.
+- **369 tests** — unit, integration, and full client-server loopback with interchange verification.
 
 ## Quick Start
 
@@ -61,7 +63,7 @@ On a two-VM QEMU/KVM sandbox (virtio-net, MTU 9000, 8 vCPU), a 30-run-per-cell
 campaign puts riperf3 **at or above iperf3** throughput across the board:
 
 - **TCP** — statistical parity single-stream (~75 Gbps); a few percent ahead at `-P 8`.
-- **UDP** — significantly faster in every cell (~+10–18%), and holds steady across `-P` instead of collapsing.
+- **UDP** — significantly faster in every cell (~+10–17%), and holds steady across `-P` instead of collapsing.
 - **Wire-compatible** with iperf3 (current and 3.12) in both directions.
 
 [**BENCHMARKS.md**](https://github.com/therealevanhenry/riperf3/blob/main/BENCHMARKS.md)
@@ -70,7 +72,7 @@ tests, the compatibility matrix, and full methodology.
 
 ## Platform Support
 
-riperf3 compiles and runs on Linux, macOS, FreeBSD, and Windows. Platform-specific features use safe Rust wrappers where available, with graceful degradation or clear error messages on unsupported platforms.
+riperf3 builds on Linux, macOS, FreeBSD, and Windows. Linux is the reference platform (full feature set, primary CI); macOS is verified in native CI; Windows compiles and is cross-checked in CI, with a few runtime gaps still under triage in the [issue tracker](https://github.com/therealevanhenry/riperf3/issues); FreeBSD is supported via conditional compilation but is not yet exercised in CI. Platform-specific features use safe Rust wrappers where available, with graceful degradation or a clear error message where a flag is unavailable.
 
 | Feature | Linux | macOS | FreeBSD | Windows |
 |---|:---:|:---:|:---:|:---:|
@@ -223,7 +225,9 @@ cargo clippy --all-targets -- -D warnings      # lint
 
 ## Status
 
-Feature-complete for the core iperf3 flag set. Full interchange compatibility verified across all modes. Full platform parity across Linux, macOS, FreeBSD, and Windows.
+Feature-complete for the core iperf3 flag set, with full interchange compatibility verified against real iperf3 (current and 3.12) in both directions across all modes. Linux and macOS are fully supported and exercised in native CI; Windows compiles and cross-checks but has a few runtime gaps under active triage; FreeBSD is supported via conditional compilation. Platform-specific flags match iperf3's support matrix (see [Platform Support](#platform-support)).
+
+See [CHANGELOG.md](CHANGELOG.md) for the 0.6.0 release notes and current known issues — including a daemon-mode (`-s -D`) bug ([#81](https://github.com/therealevanhenry/riperf3/issues/81)) and a handful of options that are accepted but not yet fully effective.
 
 Not yet implemented:
 - SCTP transport

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Verified across TCP (normal, reverse, bidir, parallel, zerocopy, BBR, file mode)
 On a two-VM QEMU/KVM sandbox (virtio-net, MTU 9000, 8 vCPU), a 30-run-per-cell
 campaign puts riperf3 **at or above iperf3** throughput across the board:
 
-- **TCP** — statistical parity single-stream (~75 Gbps); a few percent ahead at `-P 8`.
+- **TCP** — near-parity single-stream (~75 Gbps; one marginal cell aside); a few percent ahead at `-P 8`.
 - **UDP** — significantly faster in every cell (~+10–17%), and holds steady across `-P` instead of collapsing.
 - **Wire-compatible** with iperf3 (current and 3.12) in both directions.
 
@@ -85,7 +85,7 @@ riperf3 builds on Linux, macOS, FreeBSD, and Windows. Linux is the reference pla
 | `--dont-fragment` | yes | yes | yes | yes |
 | `-Z` zerocopy (sendfile) | yes | yes | yes | |
 | `-C` congestion control | yes | | yes | |
-| `-D` daemon | yes | | yes | |
+| `-D` daemon | yes\* | | yes\* | |
 | `--bind-dev` | yes | yes | | |
 | `--rcv-timeout` | yes | yes | yes | |
 | `--cntl-ka` keepalive | yes | yes | yes | |
@@ -97,6 +97,8 @@ riperf3 builds on Linux, macOS, FreeBSD, and Windows. Linux is the reference pla
 | `--sendmmsg` batched UDP | yes | | yes | |
 
 All platform-specific flags match iperf3's support matrix exactly for flags shared with iperf3. `--sendmmsg` is a riperf3-exclusive experimental optimization. Blank cells indicate the feature is unavailable on that platform in both riperf3 and iperf3. Unsupported flags return a clear error at startup.
+
+\* `-s -D` daemon mode is currently broken — the daemonized server listens but never serves, so clients hang ([#81](https://github.com/therealevanhenry/riperf3/issues/81)). Tracked for a post-0.6.0 fix; use a foreground `-s` server meanwhile.
 
 ## CLI Reference
 
@@ -234,7 +236,7 @@ Not yet implemented:
 - `libiperf`-compatible FFI library
 
 Experimental:
-- `--sendmmsg` — batched UDP sends via `sendmmsg(2)`. Uses safe Rust only (nix wrapper). Available on Linux and FreeBSD. Not part of iperf3 — a riperf3-exclusive optimization exploring safe Rust performance at the kernel boundary.
+- `--sendmmsg` — batched UDP sends via `sendmmsg(2)`. Uses safe Rust only (nix wrapper). Available on Linux and FreeBSD (the send path is also written for NetBSD, but the crate doesn't yet build there — [#78](https://github.com/therealevanhenry/riperf3/issues/78)). Not part of iperf3 — a riperf3-exclusive optimization exploring safe Rust performance at the kernel boundary.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ Not yet implemented:
 - `libiperf`-compatible FFI library
 
 Experimental:
-- `--sendmmsg` — batched UDP sends via `sendmmsg(2)`. Uses safe Rust only (nix wrapper). Available on Linux, FreeBSD, NetBSD. Not part of iperf3 — a riperf3-exclusive optimization exploring safe Rust performance at the kernel boundary.
+- `--sendmmsg` — batched UDP sends via `sendmmsg(2)`. Uses safe Rust only (nix wrapper). Available on Linux and FreeBSD. Not part of iperf3 — a riperf3-exclusive optimization exploring safe Rust performance at the kernel boundary.
 
 ## License
 

--- a/scripts/analyze.py
+++ b/scripts/analyze.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""Reduce a bench.sh campaign CSV to the BENCHMARKS.md throughput tables.
+
+Per config cell ({TCP,UDP} x {fwd,rev} x {P1,P8} x {v4,v6}) it computes, for each
+tool, the mean throughput, 95% CI, and coefficient of variation, then a head-to-
+head riperf3-vs-iperf3 verdict via Welch's t (two-sided). Per the campaign design
+(n=30) the p-value uses a normal approximation, so this depends only on the
+stdlib -- no scipy/numpy. Also emits the UDP-loss summary at -b 0.
+
+Usage: analyze.py <campaign.csv>
+"""
+import sys
+import csv
+import math
+from collections import defaultdict
+
+Z95 = 1.959963984540054  # standard-normal two-sided 95%
+
+
+def normal_sf(x):
+    """Upper-tail standard-normal survival function, P(Z > x), via erf."""
+    return 0.5 * math.erfc(x / math.sqrt(2.0))
+
+
+def stats(xs):
+    n = len(xs)
+    m = sum(xs) / n
+    var = sum((x - m) ** 2 for x in xs) / (n - 1) if n > 1 else 0.0
+    sd = math.sqrt(var)
+    ci = Z95 * sd / math.sqrt(n) if n > 0 else 0.0
+    cv = (sd / m * 100.0) if m else 0.0
+    return {"n": n, "mean": m, "sd": sd, "ci": ci, "cv": cv}
+
+
+def welch_p(a, b):
+    """Two-sided p-value for H0: mean(a)==mean(b), Welch t + normal approx."""
+    na, nb = len(a), len(b)
+    if na < 2 or nb < 2:
+        return float("nan")
+    ma, mb = sum(a) / na, sum(b) / nb
+    va = sum((x - ma) ** 2 for x in a) / (na - 1)
+    vb = sum((x - mb) ** 2 for x in b) / (nb - 1)
+    se = math.sqrt(va / na + vb / nb)
+    if se == 0:
+        return 1.0 if ma == mb else 0.0
+    t = (ma - mb) / se
+    return 2.0 * normal_sf(abs(t))
+
+
+def fmt_p(p):
+    if p != p:  # NaN
+        return "n/a"
+    if p < 1e-4:
+        return "<1e-4"
+    return f"{p:.2f}"
+
+
+# Stable cell ordering matching BENCHMARKS.md: proto, dir, parallel, family.
+PROTO_ORD = {"TCP": 0, "UDP": 1}
+DIR_ORD = {"forward": 0, "reverse": 1}
+PAR_ORD = {"P1": 0, "P8": 1}
+FAM_ORD = {"v4": 0, "v6": 1}
+DIR_LBL = {"forward": "fwd", "reverse": "rev"}
+
+
+def main():
+    if len(sys.argv) != 2:
+        sys.exit("usage: analyze.py <campaign.csv>")
+    # data[(proto,dir,par,fam)][tool] = [gbps,...] ; loss[...] = [lost_percent,...]
+    data = defaultdict(lambda: defaultdict(list))
+    loss = defaultdict(lambda: defaultdict(list))
+    with open(sys.argv[1], newline="") as f:
+        for row in csv.DictReader(f):
+            key = (row["proto"], row["dir"], row["parallel"], row["family"])
+            tool = row["tool"]
+            data[key][tool].append(float(row["gbps"]))
+            if row["proto"] == "UDP":
+                loss[key][tool].append(float(row["lost_percent"]))
+
+    keys = sorted(
+        data,
+        key=lambda k: (PROTO_ORD[k[0]], DIR_ORD[k[1]], PAR_ORD[k[2]], FAM_ORD[k[3]]),
+    )
+
+    print("### Throughput: riperf3 vs iperf3 (mean Gbps [95% CI])\n")
+    print("| cell | riperf3 | iperf3 | Δ | p | verdict |")
+    print("|---|--:|--:|--:|--:|---|")
+    cv_lo, cv_hi = 100.0, 0.0
+    for k in keys:
+        proto, d, par, fam = k
+        r = data[k].get("riperf3", [])
+        i = data[k].get("iperf3", [])
+        if not r or not i:
+            continue
+        rs, is_ = stats(r), stats(i)
+        cv_lo = min(cv_lo, rs["cv"], is_["cv"])
+        cv_hi = max(cv_hi, rs["cv"], is_["cv"])
+        delta = (rs["mean"] - is_["mean"]) / is_["mean"] * 100.0
+        p = welch_p(r, i)
+        if p == p and p < 0.05:
+            verdict = "**riperf3**" if rs["mean"] > is_["mean"] else "**iperf3**"
+        else:
+            verdict = "parity"
+        label = f"{proto} {DIR_LBL[d]} {par} {fam}"
+        rcell = f"{rs['mean']:.1f} [{rs['mean']-rs['ci']:.1f}–{rs['mean']+rs['ci']:.1f}]"
+        icell = f"{is_['mean']:.1f} [{is_['mean']-is_['ci']:.1f}–{is_['mean']+is_['ci']:.1f}]"
+        print(f"| {label} | {rcell} | {icell} | {delta:+.1f}% | {fmt_p(p)} | {verdict} |")
+
+    print(f"\n_Per-cell CV range: {cv_lo:.1f}–{cv_hi:.1f}%._")
+
+    # UDP loss at -b 0, P8, by direction (aggregate over families).
+    udp_p8 = defaultdict(lambda: defaultdict(list))
+    for k in keys:
+        proto, d, par, fam = k
+        if proto == "UDP" and par == "P8":
+            for tool, xs in loss[k].items():
+                udp_p8[d][tool].extend(xs)
+    if udp_p8:
+        print("\n### UDP loss (%) at `-b 0`, P8\n")
+        print("| direction | riperf3 | iperf3 |")
+        print("|---|--:|--:|")
+        for d in ("forward", "reverse"):
+            if d not in udp_p8:
+                continue
+            r = udp_p8[d].get("riperf3", [0])
+            i = udp_p8[d].get("iperf3", [0])
+            who = "server receives" if d == "forward" else "server sends"
+            print(
+                f"| {d} ({who}) | {min(r):.1f}–{max(r):.1f} | {min(i):.1f}–{max(i):.1f} |"
+            )
+
+    # Compact significance summary to sanity-check the verdict column.
+    wins = {"riperf3": 0, "iperf3": 0, "parity": 0}
+    for k in keys:
+        r, i = data[k].get("riperf3", []), data[k].get("iperf3", [])
+        if not r or not i:
+            continue
+        p = welch_p(r, i)
+        if p == p and p < 0.05:
+            wins["riperf3" if stats(r)["mean"] > stats(i)["mean"] else "iperf3"] += 1
+        else:
+            wins["parity"] += 1
+    print(
+        f"\n_Verdicts: riperf3 {wins['riperf3']}, iperf3 {wins['iperf3']}, "
+        f"parity {wins['parity']} (of {sum(wins.values())} cells)._"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/analyze.py
+++ b/scripts/analyze.py
@@ -106,7 +106,8 @@ def main():
         icell = f"{is_['mean']:.1f} [{is_['mean']-is_['ci']:.1f}–{is_['mean']+is_['ci']:.1f}]"
         print(f"| {label} | {rcell} | {icell} | {delta:+.1f}% | {fmt_p(p)} | {verdict} |")
 
-    print(f"\n_Per-cell CV range: {cv_lo:.1f}–{cv_hi:.1f}%._")
+    if cv_lo <= cv_hi:  # at least one cell contributed (else the seed values invert)
+        print(f"\n_Per-cell CV range: {cv_lo:.1f}–{cv_hi:.1f}%._")
 
     # UDP loss at -b 0, P8, by direction (aggregate over families).
     udp_p8 = defaultdict(lambda: defaultdict(list))

--- a/scripts/bench.sh
+++ b/scripts/bench.sh
@@ -1,0 +1,219 @@
+#!/usr/bin/env bash
+# riperf3-vs-iperf3 throughput campaign over the two-VM sandbox bridge.
+#
+# Reconstructs the statistical campaign documented in BENCHMARKS.md: a replicated,
+# randomized head-to-head so the comparison is defensible rather than anecdotal.
+# Throughput here measures protocol + CPU efficiency of the implementations, NOT
+# physical link speed — the path is a virtio-net bridge between two guests, no NIC.
+#
+# Design: 32 cells = {TCP,UDP} x {forward,reverse} x {P1,P8} x {IPv4,IPv6} x
+# {riperf3,iperf3}, each tool head-to-head against itself. N measured runs per
+# cell (default 30), preceded by WARMUP discarded runs per cell. All measured
+# (cell, iter) tuples are executed in RANDOMIZED order so host/thermal drift
+# can't systematically favor either tool. Each run gets a fresh `-s -1` one-shot
+# server on a unique port; a hard `timeout` wraps every client. Rows stream to a
+# CSV consumed by analyze.py.
+#
+# Orchestrated from the host: the server runs on the server VM, the client on the
+# client VM, data crosses the bridge VM<->VM. JSON (-J) is captured from the
+# client over ssh and parsed here, so the guests need no jq/python.
+#
+# Usage:   bench.sh <riperf3-remote-path> <iperf3-remote-path> <out.csv>
+# Env:
+#   N=30                 measured runs per cell
+#   WARMUP=2             discarded warmup runs per cell
+#   DURATION=5           seconds per run (-t)
+#   SERVER_SSH=sandbox-server-1   ssh alias for the server VM
+#   CLIENT_SSH=sandbox-client-1   ssh alias for the client VM
+#   SERVER_V4=172.20.0.20         server address the client dials (IPv4)
+#   SERVER_V6=fd00:20::20         server address the client dials (IPv6)
+#   PORT_BASE=5301       first ephemeral test port (incremented per run)
+#   PROTOS="TCP UDP"     restrict protocols (smoke: PROTOS=TCP)
+#   SEED=                optional integer seed for reproducible shuffle order
+set -uo pipefail
+
+RIPERF3="${1:?usage: bench.sh <riperf3-remote-path> <iperf3-remote-path> <out.csv>}"
+IPERF3="${2:?usage: bench.sh <riperf3-remote-path> <iperf3-remote-path> <out.csv>}"
+OUT="${3:?usage: bench.sh <riperf3-remote-path> <iperf3-remote-path> <out.csv>}"
+
+N="${N:-30}"
+WARMUP="${WARMUP:-2}"
+DURATION="${DURATION:-5}"
+SERVER_SSH="${SERVER_SSH:-sandbox-server-1}"
+CLIENT_SSH="${CLIENT_SSH:-sandbox-client-1}"
+SERVER_V4="${SERVER_V4:-172.20.0.20}"
+SERVER_V6="${SERVER_V6:-fd00:20::20}"
+PORT_BASE="${PORT_BASE:-5301}"
+PROTOS="${PROTOS:-TCP UDP}"
+SEED="${SEED:-}"
+
+# Per-run client wall-clock ceiling: the test itself plus connect/teardown slack.
+RUN_TIMEOUT=$((DURATION + 20))
+
+# Reuse one ssh connection per VM for the whole campaign (960+ invocations) so we
+# pay the TCP/auth handshake once, not per run. Sockets live under a temp dir.
+SSH_CTL="$(mktemp -d)"
+trap 'rm -rf "$SSH_CTL"' EXIT
+SSH_OPTS=(-o ControlMaster=auto -o "ControlPath=$SSH_CTL/%r@%h:%p" -o ControlPersist=300 \
+          -o BatchMode=yes -o ConnectTimeout=10)
+
+ssh_server() { ssh "${SSH_OPTS[@]}" "$SERVER_SSH" "$@"; }
+ssh_client() { ssh "${SSH_OPTS[@]}" "$CLIENT_SSH" "$@"; }
+
+# Pull the direction-correct aggregate throughput (Gbps) plus retransmits, UDP
+# loss, and host/remote CPU out of one iperf3/riperf3 -J document on stdin.
+#   forward (client sends)  -> end.sum_sent      (TCP) / end.sum (UDP)
+#   reverse (-R, client rx) -> end.sum_received  (TCP) / end.sum (UDP)
+# Emits: "<gbps> <retransmits> <lost_percent> <host_cpu> <remote_cpu>" or "ERR".
+# The program is passed via -c (not stdin) so the piped JSON is free to be read
+# by json.load(sys.stdin); proto/direction arrive as argv.
+extract() {
+    python3 -c '
+import sys, json
+proto, direction = sys.argv[1], sys.argv[2]
+try:
+    d = json.load(sys.stdin)
+    end = d["end"]
+    if proto == "UDP":
+        s = end["sum"]
+        bps = s["bits_per_second"]
+        retr = 0
+        loss = s.get("lost_percent", 0.0)
+    else:
+        s = end["sum_sent"] if direction == "forward" else end["sum_received"]
+        bps = s["bits_per_second"]
+        retr = end.get("sum_sent", {}).get("retransmits", 0)
+        loss = 0.0
+    cpu = end.get("cpu_utilization_percent", {})
+    host = cpu.get("host_total", 0.0)
+    rem = cpu.get("remote_total", 0.0)
+    print(f"{bps/1e9:.4f} {retr} {loss:.4f} {host:.2f} {rem:.2f}")
+except Exception:
+    print("ERR")
+' "$1" "$2"
+}
+
+# Wait until <port> is in LISTEN on the server VM (TCP control socket exists for
+# both TCP and UDP tests). Connect-probing would consume the one-shot server's
+# single accept, so we poll `ss` instead. Returns non-zero if it never appears.
+wait_listen() {
+    local port="$1" i
+    for i in $(seq 1 50); do
+        if ssh_server "ss -Hltn 'sport = :$port' | grep -q LISTEN" 2>/dev/null; then
+            return 0
+        fi
+        sleep 0.1
+    done
+    return 1
+}
+
+bin_for() { [ "$1" = riperf3 ] && echo "$RIPERF3" || echo "$IPERF3"; }
+addr_for() { [ "$1" = v4 ] && echo "$SERVER_V4" || echo "$SERVER_V6"; }
+
+# One measured (or warmup) run. Echoes a CSV line on success, nothing on failure
+# (caller counts the gap). Args: tool proto dir parallel family iter port.
+do_run() {
+    local tool="$1" proto="$2" dir="$3" par="$4" fam="$5" iter="$6" port="$7"
+    local bin addr pflag dirflag uflag
+    bin="$(bin_for "$tool")"
+    addr="$(addr_for "$fam")"
+    [ "$par" = P8 ] && pflag="-P 8" || pflag=""
+    [ "$dir" = reverse ] && dirflag="-R" || dirflag=""
+    [ "$proto" = UDP ] && uflag="-u -b 0" || uflag=""
+
+    # Fresh one-shot server on a unique port; -1 makes it exit after this single
+    # client, so no lingering listener collides with the next run. Started via
+    # shell backgrounding (nohup, fds detached) rather than the tool's own -D:
+    # riperf3 0.6.0's -D daemon mode hangs the client (filed separately), and
+    # nohup-backgrounding works identically for both tools.
+    ssh_server "nohup $bin -s -1 -p $port >/dev/null 2>&1 </dev/null &" >/dev/null 2>&1
+    if ! wait_listen "$port"; then
+        ssh_server "pkill -f \"$bin -s -1 -p $port\"" >/dev/null 2>&1
+        return 1
+    fi
+
+    local json metric
+    json="$(ssh_client "timeout $RUN_TIMEOUT $bin -c $addr -p $port -t $DURATION $dirflag $pflag $uflag -J" 2>/dev/null)"
+    metric="$(printf '%s' "$json" | extract "$proto" "$dir")"
+    if [ "$metric" = ERR ] || [ -z "$metric" ]; then
+        ssh_server "pkill -f \"$bin -s -1 -p $port\"" >/dev/null 2>&1
+        return 1
+    fi
+    # cell,tool,proto,dir,parallel,family,iter,gbps,retransmits,lost_percent,host_cpu,remote_cpu
+    local cell="${proto}_${dir}_${par}_${fam}"
+    echo "$cell,$tool,$proto,$dir,$par,$fam,$iter,$metric" | tr ' ' ','
+}
+
+echo "campaign: N=$N warmup=$WARMUP duration=${DURATION}s protos='$PROTOS'" >&2
+echo "  server=$SERVER_SSH ($SERVER_V4 / $SERVER_V6)  client=$CLIENT_SSH" >&2
+echo "  riperf3=$RIPERF3" >&2
+echo "  iperf3 =$IPERF3" >&2
+
+echo "cell,tool,proto,dir,parallel,family,iter,gbps,retransmits,lost_percent,host_cpu,remote_cpu" > "$OUT"
+
+# Enumerate the cell space, then the full measured job list (cell x iter).
+cells=()
+for proto in $PROTOS; do
+    for dir in forward reverse; do
+        for par in P1 P8; do
+            for fam in v4 v6; do
+                for tool in riperf3 iperf3; do
+                    cells+=("$tool $proto $dir $par $fam")
+                done
+            done
+        done
+    done
+done
+
+# Warmups: WARMUP runs of every cell, discarded. Caches/CC state settle before
+# any measured sample is taken.
+echo "warmup: ${#cells[@]} cells x $WARMUP ..." >&2
+for cell in "${cells[@]}"; do
+    for ((w=0; w<WARMUP; w++)); do
+        do_run $cell 0 $((PORT_BASE)) >/dev/null
+    done
+done
+
+# Build measured job list, then shuffle so (cell, iter) execution order is random
+# across the whole campaign — drift can't track a single tool/cell.
+jobs=()
+for cell in "${cells[@]}"; do
+    for ((i=1; i<=N; i++)); do
+        jobs+=("$cell $i")
+    done
+done
+if [ -n "$SEED" ]; then
+    mapfile -t jobs < <(printf '%s\n' "${jobs[@]}" | shuf --random-source=<(yes "$SEED"))
+else
+    mapfile -t jobs < <(printf '%s\n' "${jobs[@]}" | shuf)
+fi
+
+total="${#jobs[@]}"
+echo "measured: $total runs (randomized)" >&2
+done_n=0; ok=0; fail=0; retried=0; port=$PORT_BASE
+for job in "${jobs[@]}"; do
+    # Up to 3 attempts per measured run (fresh port each), so a transient blip
+    # (rare listen race / UDP setup hiccup) doesn't drop a cell's sample. The
+    # campaign target is 0 unrecovered failures.
+    got=0
+    for attempt in 1 2 3; do
+        port=$((port + 1)); [ "$port" -gt 65000 ] && port=$PORT_BASE
+        if line="$(do_run $job "$port")"; then
+            echo "$line" >> "$OUT"
+            ok=$((ok + 1)); got=1
+            [ "$attempt" -gt 1 ] && retried=$((retried + 1))
+            break
+        fi
+    done
+    if [ "$got" -eq 0 ]; then
+        fail=$((fail + 1))
+        echo "  FAIL run (3 attempts): $job" >&2
+    fi
+    done_n=$((done_n + 1))
+    if (( done_n % 32 == 0 )); then
+        echo "  progress: $done_n/$total (ok=$ok fail=$fail retried=$retried)" >&2
+    fi
+done
+
+echo "done: $ok ok, $fail failed, $retried recovered-on-retry -> $OUT" >&2
+[ "$fail" -eq 0 ]

--- a/scripts/compat.sh
+++ b/scripts/compat.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+# riperf3 <-> iperf3 compatibility matrix over the two-VM sandbox bridge.
+#
+# Complements interop.sh (which proves wire-interop over loopback in CI, where
+# throughput is meaningless) by exercising every client->server tool pairing
+# VM-to-VM, so each cell reports a real cross-bridge throughput AND a PASS/FAIL.
+# This is the "compat" half of the benchmark; bench.sh is the statistical
+# "campaign" half. See BENCHMARKS.md.
+#
+# For each pairing {r->r, r->i, i->r, i->i} it runs the base protocol x direction
+# grid (TCP/UDP forward/reverse/bidir), then a set of param-exchange feature
+# spot-checks on the cross pairings (r->i, i->r) that the same-tool controls
+# can't catch. A cell PASSES if the transfer completes and moved data.
+#
+# Usage:   compat.sh <riperf3-remote-path> <iperf3-remote-path>
+# Env:     DURATION (default 4), SERVER_SSH, CLIENT_SSH, SERVER_V4, PORT_BASE
+set -uo pipefail
+
+RIPERF3="${1:?usage: compat.sh <riperf3-remote-path> <iperf3-remote-path>}"
+IPERF3="${2:?usage: compat.sh <riperf3-remote-path> <iperf3-remote-path>}"
+DURATION="${DURATION:-4}"
+SERVER_SSH="${SERVER_SSH:-sandbox-server-1}"
+CLIENT_SSH="${CLIENT_SSH:-sandbox-client-1}"
+SERVER_V4="${SERVER_V4:-172.20.0.20}"
+PORT_BASE="${PORT_BASE:-5601}"
+RUN_TIMEOUT=$((DURATION + 20))
+
+SSH_CTL="$(mktemp -d)"
+trap 'rm -rf "$SSH_CTL"' EXIT
+SSH_OPTS=(-o ControlMaster=auto -o "ControlPath=$SSH_CTL/%r@%h:%p" -o ControlPersist=120 \
+          -o BatchMode=yes -o ConnectTimeout=10)
+ssh_server() { ssh "${SSH_OPTS[@]}" "$SERVER_SSH" "$@"; }
+ssh_client() { ssh "${SSH_OPTS[@]}" "$CLIENT_SSH" "$@"; }
+bin_for() { [ "$1" = r ] && echo "$RIPERF3" || echo "$IPERF3"; }
+
+port=$PORT_BASE
+next_port() { port=$((port + 1)); echo "$port"; }
+
+wait_listen() {
+    local p="$1" i
+    for i in $(seq 1 50); do
+        ssh_server "ss -Hltn 'sport = :$p' | grep -q LISTEN" 2>/dev/null && return 0
+        sleep 0.1
+    done
+    return 1
+}
+
+# Representative throughput (Gbps) from a -J doc on stdin. $1=1 for bidir.
+# A unidirectional flow reports the same bytes under both sum_sent and
+# sum_received (and UDP also under sum), so summing them double/triple-counts;
+# take a single perspective. For --bidir the two are distinct directions, so
+# their sum is the real aggregate. Prints "ERR" if nothing positive parses.
+extract_gbps() {
+    python3 -c '
+import sys, json
+bidir = len(sys.argv) > 1 and sys.argv[1] == "1"
+try:
+    end = json.load(sys.stdin)["end"]
+    def g(k): return end.get(k, {}).get("bits_per_second", 0.0)
+    if bidir:
+        bps = g("sum_sent") + g("sum_received") or g("sum")
+    else:
+        bps = g("sum_received") or g("sum_sent") or g("sum")
+    print(f"{bps/1e9:.1f}" if bps > 0 else "ERR")
+except Exception:
+    print("ERR")
+' "$1"
+}
+
+# Run one cell: <client_tool r|i> <server_tool r|i> <"flags for client"> -> echoes
+# Gbps on success, "FAIL" otherwise. Server is the one-shot, shell-backgrounded
+# pattern bench.sh uses (riperf3 -D is broken; nohup works for both tools).
+run_cell() {
+    local ctool="$1" stool="$2" cflags="$3" p
+    p="$(next_port)"
+    local sbin cbin; sbin="$(bin_for "$stool")"; cbin="$(bin_for "$ctool")"
+    ssh_server "nohup $sbin -s -1 -p $p >/dev/null 2>&1 </dev/null &" >/dev/null 2>&1
+    if ! wait_listen "$p"; then echo FAIL; return 1; fi
+    local g bidir=0
+    [[ "$cflags" == *"--bidir"* ]] && bidir=1
+    g="$(ssh_client "timeout $RUN_TIMEOUT $cbin -c $SERVER_V4 -p $p -t $DURATION $cflags -J" 2>/dev/null | extract_gbps "$bidir")"
+    if [ "$g" = ERR ] || [ -z "$g" ]; then
+        ssh_server "pkill -f \"$sbin -s -1 -p $p\"" >/dev/null 2>&1
+        echo FAIL; return 1
+    fi
+    echo "$g"
+}
+
+echo "compat matrix over the bridge ($SERVER_SSH <- $CLIENT_SSH), -t ${DURATION}s"
+echo "  riperf3=$RIPERF3"
+echo "  iperf3 =$IPERF3"
+echo
+
+# Base grid: rows = protocol x direction, cols = the four pairings.
+declare -a CONFIGS=(
+    "TCP forward|"
+    "TCP reverse|-R"
+    "TCP bidir|--bidir"
+    "UDP forward|-u -b 0"
+    "UDP reverse|-u -b 0 -R"
+    "UDP bidir|-u -b 0 --bidir"
+)
+PAIRS=("r r" "r i" "i r" "i i")
+PAIR_HDR=("r→r" "r→i" "i→r" "i→i")
+
+printf "| %-18s | %6s | %6s | %6s | %6s |\n" "config (Gbps)" "${PAIR_HDR[@]}"
+printf "|%s|%s|%s|%s|%s|\n" "--------------------" "-------:" "-------:" "-------:" "-------:"
+fail=0
+for cfg in "${CONFIGS[@]}"; do
+    label="${cfg%%|*}"; flags="${cfg#*|}"
+    row="| $(printf '%-18s' "$label") |"
+    for pair in "${PAIRS[@]}"; do
+        set -- $pair
+        res="$(run_cell "$1" "$2" "$flags")"
+        [ "$res" = FAIL ] && fail=$((fail + 1))
+        row="$row $(printf '%6s' "$res") |"
+    done
+    echo "$row"
+done
+
+# Feature spot-checks on the cross pairings only (same-tool can't catch a wire
+# constant that's wrong against real iperf3). Each must PASS in both directions.
+echo
+echo "Feature interop (cross pairs r→i / i→r, each must PASS):"
+declare -a FEATURES=(
+    "-P 4"
+    "-l 128K"
+    "-O 2"
+    "-w 256K"
+    "-M 1400"
+    "--get-server-output"
+    "-Z"
+    "-u -b 0 -l 8192"
+    "-u -b 0 --udp-counters-64bit"
+    "-u -b 0 -P 4"
+)
+for feat in "${FEATURES[@]}"; do
+    ri="$(run_cell r i "$feat")"; ir="$(run_cell i r "$feat")"
+    rs=PASS; [ "$ri" = FAIL ] && { rs=FAIL; fail=$((fail + 1)); }
+    is=PASS; [ "$ir" = FAIL ] && { is=FAIL; fail=$((fail + 1)); }
+    printf "  %-32s r→i %-4s  i→r %-4s\n" "$feat" "$rs" "$is"
+done
+
+echo
+if [ "$fail" -eq 0 ]; then
+    echo "RESULT: all cells interoperate (0 failures)"
+else
+    echo "RESULT: $fail FAILED cell(s)"
+fi
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
Release **prep** for 0.6.0 — the cut itself (tag + GitHub release + `cargo publish`) is a separate, gated step.

## Benchmark harness (rebuilt + committed)

The `riperf3-matrix` benchmark was a personal skill lost in a workstation rebuild, so `BENCHMARKS.md`'s "reproducible via the skill" claim was false. Reconstructed as committed scripts under `scripts/`:

- `bench.sh` — 32-cell randomized throughput campaign → CSV
- `analyze.py` — per-cell 95% CIs + Welch's-t verdicts + UDP loss (stdlib only)
- `compat.sh` — cross-tool interop grid (r→r/r→i/i→r/i→i) + feature spot-checks over the bridge

## 0.6.0 benchmark results

Full campaign on 0.6.0 over the two-VM sandbox (**960 runs, 0 failures**):
- TCP single-stream: **parity** (~74–76 Gbps)
- TCP `-P 8`: **riperf3 +5.0–7.9%** (p<1e-4)
- UDP: **riperf3 faster in every cell, +9.6–16.8%** (p<1e-4)
- 0 cells where iperf3 wins; no regression vs 0.5.1
- Compat: all 44 cells interoperate, every feature check passes

## Docs

- **README**: ethos-forward intro ("a ground-up, idiomatic Rust implementation of iperf3…"); right-sized cross-platform claims; test count 269→369.
- **BENCHMARKS.md**: full 0.6.0 refresh; "Reproducing" re-pointed at `scripts/`.
- **CHANGELOG.md**: new; 0.6.0 changes + a Known Issues section.

## Found while benchmarking

`riperf3 -s -D` (daemon mode) is broken — listens but never serves; any client hangs (#81). Pre-existing (0.6.0 didn't touch the daemonize path); deferred to a post-0.6.0 cleanup and documented under CHANGELOG → Known issues.

Closes #41, #46.

🤖 Generated with [Claude Code](https://claude.com/claude-code)