### PR TITLE
fix(net): Windows --cport fails with WSAEWOULDBLOCK (#79)

### DIFF
--- a/riperf3/src/net.rs
+++ b/riperf3/src/net.rs
@@ -240,9 +240,17 @@ pub async fn tcp_connect(
             })?;
         }
         socket.set_nonblocking(true)?;
+        // A non-blocking connect signals "in progress" differently per platform:
+        // Unix returns EINPROGRESS; Windows returns WSAEWOULDBLOCK (surfaced as
+        // ErrorKind::WouldBlock). Both mean the connect started and will complete
+        // asynchronously — we await writability below and then surface SO_ERROR
+        // via take_error(). Treating the Windows WSAEWOULDBLOCK as a hard error
+        // is what broke --cport (and any -B/mptcp connect) on Windows (#79).
         match socket.connect(&remote.into()) {
             Ok(()) => {}
-            Err(e) if e.raw_os_error() == Some(libc::EINPROGRESS) => {}
+            Err(e)
+                if e.raw_os_error() == Some(libc::EINPROGRESS)
+                    || e.kind() == std::io::ErrorKind::WouldBlock => {}
             Err(e) => return Err(RiperfError::Io(e)),
         }
         let std_stream: std::net::TcpStream = socket.into();
@@ -944,6 +952,28 @@ mod tests {
             client.local_addr().unwrap().ip(),
             "127.0.0.2".parse::<std::net::IpAddr>().unwrap()
         );
+    }
+
+    #[tokio::test]
+    async fn tcp_connect_local_port_path_succeeds() {
+        // Setting a local source port (`--cport`) routes through the socket2
+        // bind-then-connect path. That path does a non-blocking connect, which
+        // returns EINPROGRESS on Unix but WSAEWOULDBLOCK on Windows; the latter
+        // was treated as fatal, so the connect failed on Windows (#79). Use an
+        // OS-assigned source port (Some(0)) so this is portable and collision-
+        // free while still exercising the explicit-local-port path on every OS.
+        let listener = tcp_listen(Some("127.0.0.1"), 0, None).await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let client_task = tokio::spawn(async move {
+            tcp_connect("127.0.0.1", port, None, Some(0), None, false, None).await
+        });
+        let (_server, _) = listener.accept().await.unwrap();
+        let client = client_task.await.unwrap();
+        assert!(
+            client.is_ok(),
+            "local-port (--cport) connect must succeed on every platform: {client:?}"
+        );
+        assert!(client.unwrap().peer_addr().is_ok());
     }
 
     #[tokio::test]

--- a/riperf3/src/net.rs
+++ b/riperf3/src/net.rs
@@ -240,12 +240,21 @@ pub async fn tcp_connect(
             })?;
         }
         socket.set_nonblocking(true)?;
-        // A non-blocking connect signals "in progress" differently per platform:
-        // Unix returns EINPROGRESS; Windows returns WSAEWOULDBLOCK (surfaced as
-        // ErrorKind::WouldBlock). Both mean the connect started and will complete
-        // asynchronously — we await writability below and then surface SO_ERROR
-        // via take_error(). Treating the Windows WSAEWOULDBLOCK as a hard error
-        // is what broke --cport (and any -B/mptcp connect) on Windows (#79).
+        // A non-blocking connect signals "in progress" differently per platform,
+        // and the two arms below catch disjoint errno sets — neither subsumes the
+        // other:
+        //   - Unix: EINPROGRESS, matched by raw_os_error (it decodes to
+        //     ErrorKind::InProgress, *not* WouldBlock).
+        //   - Windows: WSAEWOULDBLOCK, which decodes to ErrorKind::WouldBlock
+        //     (libc::EINPROGRESS exists on Windows but is a different value that
+        //     a connect never returns, so that arm is dead there).
+        // Both mean "connect started, completes asynchronously": we await
+        // writability below and surface a genuine failure via take_error()
+        // (SO_ERROR). Treating WSAEWOULDBLOCK as fatal is what broke --cport (and
+        // any -B/mptcp connect) on Windows (#79). The WouldBlock arm can in
+        // principle also swallow a rare Unix EAGAIN (e.g. ephemeral-port
+        // exhaustion), but take_error() still reports a real failure, so this
+        // doesn't mask a broken connection.
         match socket.connect(&remote.into()) {
             Ok(()) => {}
             Err(e)
@@ -973,7 +982,15 @@ mod tests {
             client.is_ok(),
             "local-port (--cport) connect must succeed on every platform: {client:?}"
         );
-        assert!(client.unwrap().peer_addr().is_ok());
+        let client = client.unwrap();
+        assert!(client.peer_addr().is_ok());
+        // A source port was actually bound (the socket2 bind+connect path ran),
+        // so this also guards against --cport silently not binding.
+        assert_ne!(
+            client.local_addr().unwrap().port(),
+            0,
+            "an explicit local port should have been bound"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
Fixes #79.

## Root cause

`net.rs::tcp_connect` uses a manual socket2 bind-then-connect whenever `--cport`, `-B`, or `--mptcp` is set. After `set_nonblocking(true)`, it matched only `EINPROGRESS` as "connect started, await completion":

```rust
Err(e) if e.raw_os_error() == Some(libc::EINPROGRESS) => {}
Err(e) => return Err(RiperfError::Io(e)),
```

A non-blocking `connect()` on **Windows** returns `WSAEWOULDBLOCK` (10035), not `EINPROGRESS`, so it hit the fatal arm. That's the `code: 10035, kind: WouldBlock` failure in `implemented_flag_tests::client_port_binding` on `windows-latest`.

## Fix

Also accept `ErrorKind::WouldBlock` as in-progress. The connect then completes through the **existing** `stream.writable().await` + `take_error()` machinery right below — no new async logic, and a genuine connect failure is still surfaced via `SO_ERROR`. Unix behavior is unchanged (`EINPROGRESS` still matches first; a real `connect()` doesn't return `EAGAIN` on Unix).

This path is shared, so it also fixes `-B` and `--mptcp` connects on Windows.

## Tests (TDD)

- The pre-existing red test is `client_port_binding` on `windows-latest` (can't be run on the Linux dev box; verified via this PR's `Native test (windows-latest)` job).
- Added a **portable** `net::tests::tcp_connect_local_port_path_succeeds` that drives the explicit-local-port connect path on every OS — green on Unix before/after, red on Windows before this fix. It's the unit-level guard.

## Local verification (Linux)
- `cargo test --workspace` — all green
- `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check` — clean
- `cargo check --target x86_64-pc-windows-msvc` — compiles

Real Windows verification is the `Native test (windows-latest)` job on this PR. Promoting that check to required is a separate step once both Windows defects (#79, #80) are green.