### PR TITLE
fix: library won't compile on other-Unix (NetBSD/OpenBSD/illumos) (#78)

### DIFF
--- a/riperf3/src/client.rs
+++ b/riperf3/src/client.rs
@@ -420,11 +420,26 @@ impl Client {
                         let zc = self.zerocopy;
                         tokio::spawn(async move {
                             if zc {
-                                #[cfg(unix)]
+                                // Zerocopy senders exist only for these targets
+                                // (stream.rs). The gate must match the impls, not
+                                // `unix`: other-Unix (NetBSD/OpenBSD/illumos) is
+                                // `unix` with no zerocopy impl, so `#[cfg(unix)]`
+                                // referenced a nonexistent fn and failed to
+                                // compile there (#78). Elsewhere `-Z` cleanly
+                                // falls back to the normal sender.
+                                #[cfg(any(
+                                    target_os = "linux",
+                                    target_os = "macos",
+                                    target_os = "freebsd"
+                                ))]
                                 {
                                     stream::run_tcp_sender_zerocopy(data_stream, c, buf, d).await
                                 }
-                                #[cfg(not(unix))]
+                                #[cfg(not(any(
+                                    target_os = "linux",
+                                    target_os = "macos",
+                                    target_os = "freebsd"
+                                )))]
                                 {
                                     stream::run_tcp_sender(data_stream, c, buf, d, fp).await
                                 }

--- a/riperf3/src/net.rs
+++ b/riperf3/src/net.rs
@@ -552,7 +552,17 @@ pub fn set_dont_fragment(fd: &impl std::os::windows::io::AsSocket) -> Result<()>
     Ok(())
 }
 
-#[cfg(not(any(unix, windows)))]
+// No-op fallback for every target without a real impl above. This must exclude
+// the handled targets explicitly rather than say `not(any(unix, windows))`:
+// other-Unix (NetBSD/OpenBSD/illumos) is `unix` but has no `set_dont_fragment`
+// arm, so the old gate left the call site referencing a nonexistent fn there
+// (#78). `--dont-fragment` is a silent no-op on those platforms.
+#[cfg(not(any(
+    target_os = "linux",
+    target_os = "macos",
+    target_os = "freebsd",
+    windows
+)))]
 pub fn set_dont_fragment<F>(_fd: &F) -> Result<()> {
     Ok(())
 }

--- a/riperf3/src/stream.rs
+++ b/riperf3/src/stream.rs
@@ -511,8 +511,10 @@ pub async fn run_tcp_sender_zerocopy(
     Ok(())
 }
 
-/// Create a temporary file for zerocopy sends.
-#[cfg(unix)]
+/// Create a temporary file for zerocopy sends. Gated to the targets whose
+/// `run_tcp_sender_zerocopy` impls call it; a broader `#[cfg(unix)]` would be
+/// dead code (and warn) on other-Unix, which has no zerocopy sender (#78).
+#[cfg(any(target_os = "linux", target_os = "macos", target_os = "freebsd"))]
 fn tempfile() -> std::io::Result<std::fs::File> {
     use std::io::Seek;
     let mut f = tempfile_in(std::env::temp_dir())?;
@@ -520,7 +522,7 @@ fn tempfile() -> std::io::Result<std::fs::File> {
     Ok(f)
 }
 
-#[cfg(unix)]
+#[cfg(any(target_os = "linux", target_os = "macos", target_os = "freebsd"))]
 fn tempfile_in(dir: std::path::PathBuf) -> std::io::Result<std::fs::File> {
     let path = dir.join(format!(".riperf3-zc-{}", std::process::id()));
     let f = std::fs::OpenOptions::new()


### PR DESCRIPTION
Fixes #78.

## Problem

Two `cfg` gates claimed broader support than their implementations, so the library failed to compile on any Unix target that isn't Linux/macOS/FreeBSD. Reproduced with `cargo check --target x86_64-unknown-netbsd`:

```
error[E0425]: cannot find function `run_tcp_sender_zerocopy` in module `stream`   client.rs:425
error[E0425]: cannot find function `set_dont_fragment` in module `net`            client.rs:373
```

The second (`set_dont_fragment`) is **not** in the original issue text — the NetBSD build surfaced it. Both share one root cause: a gate that says `unix` / `not(unix)` while the impls only cover linux/macos/freebsd/windows.

## Fix

- **Zerocopy dispatch** (`client.rs`): `#[cfg(unix)]` → `#[cfg(any(linux, macos, freebsd))]`, with the complement as the fallback. `-Z` cleanly degrades to the normal sender on other-Unix (matches the issue's "cleanest" option).
- **`set_dont_fragment` no-op fallback** (`net.rs`): `#[cfg(not(any(unix, windows)))]` → `#[cfg(not(any(linux, macos, freebsd, windows)))]`, so other-Unix gets the no-op arm. `--dont-fragment` is a silent no-op there.

## Verification

- `cargo check --target x86_64-unknown-netbsd` (lib **and** workspace) — clean after the fix, errors before it.
- OpenBSD/illumos have no prebuilt std via rustup to check locally, but they're the same cfg class (`unix` minus the handled set), so the fix covers them by construction.
- Linux `cargo test --workspace` / clippy / fmt — clean. `cargo check --target x86_64-pc-windows-msvc` — clean.

Compile-correctness only; these are tier-3 targets with no CI.