### PR TITLE
Bump to 0.6.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,9 +115,10 @@ jobs:
   # FreeBSD runner — hence a VM via vmactions/freebsd-vm (QEMU; Rust from the
   # FreeBSD `rust` package). `release` is pinned for reproducibility.
   #
-  # INFORMATIONAL to start, like native-test: a first run may surface
-  # pre-existing FreeBSD bugs. Those get filed + fixed, then this check is
-  # promoted into branch protection's required set.
+  # REQUIRED check (added informational in 0.6.1, promoted the same release once
+  # the first runs were clean): it gates merges like the Linux jobs. The
+  # macOS/Windows native jobs above stay informational for now — Windows has the
+  # open UDP multi-stream issue (#80) and macOS isn't promoted yet.
   freebsd-test:
     name: Native test (FreeBSD)
     runs-on: ubuntu-latest

--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -10,6 +10,11 @@ Reproducible from the committed harness in [`scripts/`](scripts): `compat.sh`
 (interop grid), `bench.sh` + `analyze.py` (statistical campaign), and
 `interop.sh` (the loopback CI gate). See [Reproducing](#reproducing).
 
+> **0.6.1 status.** The compatibility matrix below was re-verified on 0.6.1 (all
+> cells PASS). The throughput campaign is carried forward from 0.6.0 unchanged:
+> 0.6.1 is a cross-platform/CI release with no data-path change, so Linux
+> throughput is identical.
+
 ## Test environment
 
 | | |
@@ -18,7 +23,7 @@ Reproducible from the committed harness in [`scripts/`](scripts): `compat.sh`
 | Host | Intel i9-13900K, Linux 7.0.10-arch1-1 (Arch), KVM |
 | Guests | 2× Debian 13 (Trixie), Linux 6.12.90-cloud, 8 vCPU, 8 GB RAM each |
 | NIC | virtio-net (vhost=on), bridged, MTU 9000; IPv4 `172.20.0.0/24` + IPv6 `fd00:20::/64` |
-| riperf3 | 0.6.0 |
+| riperf3 | 0.6.1 |
 | iperf3 | 3.20+ (cJSON 1.7.15), built from source |
 
 ## Compatibility matrix (iperf3 interop)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,48 @@ This changelog begins at 0.6.0. For earlier releases (0.1.1–0.5.4), see the
 [git history](https://github.com/therealevanhenry/riperf3/commits/main) and
 release tags.
 
+## [0.6.1] - 2026-05-30
+
+A cross-platform compatibility and CI release. There are **no data-path or
+wire-protocol changes** — the Linux fast path is byte-for-byte unchanged, so
+throughput is identical to 0.6.0 (the iperf3 compatibility matrix was re-verified;
+the performance campaign carries forward).
+
+### Added
+- **Native FreeBSD CI** (#39): a `vmactions/freebsd-vm` job builds and runs the
+  full test suite on real FreeBSD, so FreeBSD-specific code (the `sendfile` arity,
+  the FreeBSD `tcp_info` fields, the `sendmmsg` sender, `TCP_CONGESTION`) is
+  observed rather than assumed. Promoted to a required check.
+- **macOS `--bind-dev` verified** (#72): `--bind-dev` was already implemented on
+  macOS via `IP_BOUND_IF`; its tests now select the loopback name per-OS and run
+  on macOS, so the path is exercised in native CI.
+
+### Fixed
+- **Windows: `--cport`/`-B`/`--mptcp` connect failed with `WSAEWOULDBLOCK`** (#79).
+  The non-blocking socket2 connect path treated Windows' in-progress
+  `WSAEWOULDBLOCK` as fatal — it only accepted Unix's `EINPROGRESS`. It now also
+  accepts `WouldBlock`, awaits writability, and surfaces a genuine failure via
+  `take_error()`, matching the Unix path.
+- **Compilation on other-Unix** (#78): the library failed to compile on Unix
+  targets that aren't Linux/macOS/FreeBSD (NetBSD/OpenBSD/illumos). Two `cfg`
+  gates — the zerocopy sender dispatch and `set_dont_fragment`'s no-op fallback —
+  promised more than their implementations covered. `-Z` falls back to the normal
+  sender and `--dont-fragment` becomes a no-op on those targets.
+
+### Known issues
+
+- **Windows UDP `-P`/`--bidir` multi-stream hangs** during stream setup
+  ([#80](https://github.com/therealevanhenry/riperf3/issues/80)). A native-winsock
+  limitation: a connected UDP data socket and the recycled wildcard listener share
+  one port (`SO_REUSEADDR`), and winsock doesn't route a new stream's handshake to
+  the listener the way Linux/BSD do (iperf3 sidesteps this by running under
+  Cygwin). Single-stream UDP is unaffected. The Windows native CI check stays
+  informational until this is fixed.
+- **TCP `--bind-dev` is applied after `connect()`**
+  ([#88](https://github.com/therealevanhenry/riperf3/issues/88)), so it may not
+  constrain routing for TCP (the UDP path binds before connect). macOS
+  `--bind-dev` over IPv6 (`IPV6_BOUND_IF`) is also not yet implemented.
+
 ## [0.6.0] - 2026-05-30
 
 End-to-end iperf3 `-J` JSON faithfulness (client **and** server), a locked-down
@@ -101,4 +143,5 @@ complete list; the notable user-facing ones:
   ([#78](https://github.com/therealevanhenry/riperf3/issues/78)), and FreeBSD has
   no CI coverage ([#39](https://github.com/therealevanhenry/riperf3/issues/39)).
 
+[0.6.1]: https://github.com/therealevanhenry/riperf3/releases/tag/v0.6.1
 [0.6.0]: https://github.com/therealevanhenry/riperf3/releases/tag/v0.6.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@ the performance campaign carries forward).
 
 ### Known issues
 
+Tracked for a follow-up; the notable user-facing ones:
+
 - **Windows UDP `-P`/`--bidir` multi-stream hangs** during stream setup
   ([#80](https://github.com/therealevanhenry/riperf3/issues/80)). A native-winsock
   limitation: a connected UDP data socket and the recycled wildcard listener share

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -793,7 +793,7 @@ dependencies = [
 
 [[package]]
 name = "riperf3"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "base64",
  "libc",
@@ -814,7 +814,7 @@ dependencies = [
 
 [[package]]
 name = "riperf3-cli"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "clap",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.6.0"
+version = "0.6.1"
 authors = ["Evan Henry"]
 edition = "2021"
 homepage = "https://github.com/therealevanhenry/riperf3"

--- a/riperf3-cli/Cargo.toml
+++ b/riperf3-cli/Cargo.toml
@@ -13,7 +13,7 @@ readme = "../README.md"
 
 [dependencies]
 # riperf3 workspace dependencies
-riperf3 = { path = "../riperf3", version = "0.6.0" }
+riperf3 = { path = "../riperf3", version = "0.6.1" }
 
 # external dependencies
 clap.workspace = true


### PR DESCRIPTION
0.6.1 release prep — non-breaking patch (cross-platform compatibility + CI).

## Contents
- Version bump `0.6.0` → `0.6.1` (workspace + CLI path-dep pin + Cargo.lock).
- CHANGELOG `[0.6.1]` section.
- BENCHMARKS.md stamp → 0.6.1, with an honest note: the compat matrix was re-verified on 0.6.1 (all cells PASS on the sandbox fleet), and the throughput campaign is carried forward from 0.6.0 unchanged (no data-path change in 0.6.1).

## What shipped in 0.6.1 (already on main)
- #79 — Windows `--cport`/`-B`/`--mptcp` `WSAEWOULDBLOCK` connect fix (verified on Windows CI).
- #78 — compile on other-Unix (NetBSD/OpenBSD/illumos); verified on `x86_64-unknown-netbsd`.
- #72 — macOS `--bind-dev` verified via `IP_BOUND_IF` (macOS CI green).
- #39 — native FreeBSD CI, now a required check.

## Known issues noted in the changelog
- #80 — Windows UDP `-P`/`--bidir` multi-stream hang (native-winsock demux); Windows native check stays informational.
- #88 — TCP `--bind-dev` applied after connect.

No code changes here beyond the version bump; release docs only.