### PR TITLE
Bump to 0.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,21 @@ This changelog begins at 0.6.0. For earlier releases (0.1.1–0.5.4), see the
 [git history](https://github.com/therealevanhenry/riperf3/commits/main) and
 release tags.
 
+## [0.6.2] - 2026-06-04
+
+A packaging fix release. There are **no data-path, wire-protocol, or public API
+changes** — behavior and throughput are identical to 0.6.1.
+
+### Fixed
+- **`riperf3` failed to compile as a dependency of downstream crates** (#92): the
+  library calls `socket2`'s `set_mss`, which socket2 gates behind its `all`
+  feature, but the crate never enabled that feature itself. It built only because
+  `tokio` transitively enabled `all` on socket2 0.5. Once a downstream resolved a
+  newer `tokio` that moved to socket2 0.6, riperf3's own socket2 0.5 dependency
+  lost `all` and the build failed with `error[E0599]: no method named set_mss`.
+  riperf3 now enables socket2's `all` feature explicitly, so it compiles
+  regardless of sibling feature unification (#93).
+
 ## [0.6.1] - 2026-05-30
 
 A cross-platform compatibility and CI release. There are **no data-path or

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -793,7 +793,7 @@ dependencies = [
 
 [[package]]
 name = "riperf3"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "base64",
  "libc",
@@ -814,7 +814,7 @@ dependencies = [
 
 [[package]]
 name = "riperf3-cli"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "clap",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.6.1"
+version = "0.6.2"
 authors = ["Evan Henry"]
 edition = "2021"
 homepage = "https://github.com/therealevanhenry/riperf3"

--- a/riperf3-cli/Cargo.toml
+++ b/riperf3-cli/Cargo.toml
@@ -13,7 +13,7 @@ readme = "../README.md"
 
 [dependencies]
 # riperf3 workspace dependencies
-riperf3 = { path = "../riperf3", version = "0.6.1" }
+riperf3 = { path = "../riperf3", version = "0.6.2" }
 
 # external dependencies
 clap.workspace = true


### PR DESCRIPTION
Patch release.

Ships the socket2 `all`-feature fix (#92, merged in #93): riperf3 calls `socket2::SockRef::set_mss`, which socket2 gates behind its `all` feature. The crate never enabled `all` itself and only compiled because `tokio` transitively enabled it on socket2 0.5. Once a downstream resolves a newer `tokio` that moved to socket2 0.6, riperf3's direct socket2 0.5 dependency loses `all` and fails to compile (`E0599: no method named set_mss`). Every fresh downstream of 0.6.1 on a current tokio is affected.

No data-path, wire-protocol, or public API changes — behavior and throughput are identical to 0.6.1.

### Changes
- `[workspace.package].version` → 0.6.2 (root `Cargo.toml`)
- riperf3-cli path-dep pin → 0.6.2
- `Cargo.lock` refreshed
- CHANGELOG 0.6.2 entry