### PR TITLE
0.6.3: output & correctness fidelity fixes (#34 #40 #42 #44 #57 #59)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,9 +26,7 @@ log4rs = { version = "1.3", features = ["toml_format"] }
 rand = "0.9"
 rsa = "0.9"
 serde = { version = "1", features = ["derive"] }
-# raw_value: emit cJSON-formatted number tokens in the -J blob (#57) as raw JSON
-# numbers, so integral floats drop the trailing `.0` to match iperf3 byte-for-byte.
-serde_json = { version = "1", features = ["raw_value"] }
+serde_json = "1"
 sha1 = "0.10"
 sha2 = "0.10"
 socket2 = "0.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,9 @@ log4rs = { version = "1.3", features = ["toml_format"] }
 rand = "0.9"
 rsa = "0.9"
 serde = { version = "1", features = ["derive"] }
-serde_json = "1"
+# raw_value: emit cJSON-formatted number tokens in the -J blob (#57) as raw JSON
+# numbers, so integral floats drop the trailing `.0` to match iperf3 byte-for-byte.
+serde_json = { version = "1", features = ["raw_value"] }
 sha1 = "0.10"
 sha2 = "0.10"
 socket2 = "0.5"

--- a/riperf3/Cargo.toml
+++ b/riperf3/Cargo.toml
@@ -21,7 +21,12 @@ rsa.workspace = true
 serde.workspace = true
 sha1.workspace = true
 sha2.workspace = true
-serde_json.workspace = true
+# raw_value enabled at the crate level (not just the workspace) so it flattens
+# into the PUBLISHED manifest: #57 emits cJSON-formatted number tokens via
+# serde_json::value::RawValue. A workspace-only feature does NOT flatten on
+# publish, which would leave the published crate free-riding on a consumer to
+# enable raw_value — the same socket2 #92 trap as `all` below.
+serde_json = { workspace = true, features = ["raw_value"] }
 socket2 = { workspace = true, features = ["all"] }
 thiserror.workspace = true
 tokio.workspace = true

--- a/riperf3/src/client.rs
+++ b/riperf3/src/client.rs
@@ -108,6 +108,14 @@ fn server_receiver_summaries(
 
 impl Client {
     pub async fn run(&self) -> Result<TestResultsJson> {
+        // -T/--title: prefix every client text line with "<title>:  " (#34),
+        // matching iperf3. Run-scoped (cleared on drop) and only in plain-text
+        // mode — `-J` and `--json-stream` emit machine JSON, which iperf3 never
+        // titles. Held for the whole run so the reporter task and the preamble
+        // both see it.
+        let _title_guard = (!self.json_output && !self.json_stream)
+            .then(|| crate::macros::OutputTitleGuard::set(self.title.clone()));
+
         // ---- Generate cookie and connect ----
         let cookie = protocol::make_cookie();
         let mut ctrl = net::tcp_connect(

--- a/riperf3/src/client.rs
+++ b/riperf3/src/client.rs
@@ -1255,6 +1255,13 @@ impl ClientBuilder {
         self
     }
 
+    /// Prefix every client text-output line with `<title>:  ` (`-T/--title`),
+    /// matching iperf3. Applies only to plain-text output, not `-J`/`--json-stream`.
+    ///
+    /// Note: the prefix is tracked in a process-global for the duration of the
+    /// run, so two `Client::run` calls executing concurrently in the same process
+    /// are not isolated for `-T` (their titled lines can interleave). This does
+    /// not affect the CLI (one run per process) or sequential library use.
     pub fn title(mut self, title: &str) -> Self {
         self.title = Some(title.to_string());
         self

--- a/riperf3/src/client.rs
+++ b/riperf3/src/client.rs
@@ -512,6 +512,10 @@ impl Client {
                     let local_addr = udp_sock.local_addr().ok();
                     let peer_addr = udp_sock.peer_addr().ok();
                     let sock = socket2::SockRef::from(&udp_sock);
+                    // Honor -w/--window on the UDP socket too (#59); iperf3 applies
+                    // it to UDP via iperf_udp_buffercheck. Set before the read-back
+                    // so sndbuf_actual/rcvbuf_actual report the realized size.
+                    net::apply_socket_window(&sock, self.window);
                     let sndbuf_actual = sock.send_buffer_size().ok().map(|v| v as u64);
                     let rcvbuf_actual = sock.recv_buffer_size().ok().map(|v| v as u64);
 

--- a/riperf3/src/json_report.rs
+++ b/riperf3/src/json_report.rs
@@ -23,9 +23,103 @@
 //! (`skip_serializing_if`) rather than emitted with placeholder values, so the
 //! shape only ever contains real data.
 
+use serde::ser::Serializer;
 use serde::Serialize;
 
 use crate::protocol::TransportProtocol;
+
+// ---------------------------------------------------------------------------
+// cJSON-compatible float rendering (#57)
+// ---------------------------------------------------------------------------
+//
+// serde_json prints every f64 with a fractional part (`0.0`, `1.0`,
+// `10485760.0`). iperf3 uses cJSON, which prints an *integral* double as an
+// integer token (`0`, `1`, `10485760`) and a fractional one via C's
+// `%.15g`/`%.17g`. These helpers reproduce cJSON's `print_number` so the `-J`
+// blob is byte-compatible with iperf3 for consumers that diff raw text, not just
+// parsed values. Applied to the report's f64 fields via `serialize_with`.
+
+/// Render an `f64` exactly the way cJSON's `print_number` does.
+fn cjson_number(d: f64) -> String {
+    if !d.is_finite() {
+        return "null".to_string(); // cJSON emits the bareword null for NaN/Inf
+    }
+    // Integral and representable as i64 → integer token (drops the `.0`).
+    if d.abs() < 9_223_372_036_854_775_000.0 && d == (d as i64) as f64 {
+        return (d as i64).to_string();
+    }
+    // Fractional: 15 significant digits, falling back to 17 if 15 doesn't
+    // round-trip — exactly cJSON's strategy.
+    let s = format_g(d, 15);
+    let round_trips = s
+        .parse::<f64>()
+        .map(|t| compare_double(t, d))
+        .unwrap_or(false);
+    if round_trips {
+        s
+    } else {
+        format_g(d, 17)
+    }
+}
+
+/// cJSON's `compare_double`: equal within a one-ULP-ish epsilon.
+fn compare_double(a: f64, b: f64) -> bool {
+    let maxval = a.abs().max(b.abs());
+    (a - b).abs() <= maxval * f64::EPSILON
+}
+
+/// C `printf("%.*g", precision, d)` for a finite `d`. `precision` is the number
+/// of significant digits (15 or 17 here).
+fn format_g(d: f64, precision: usize) -> String {
+    let p = precision.max(1);
+    if d == 0.0 {
+        return "0".to_string();
+    }
+    // `{:.*e}` rounds correctly and carries the exponent (9.99e9 → 1.00e10), so
+    // read the decimal exponent from it rather than from log10 (which mis-rounds
+    // at powers of ten).
+    let sci = format!("{:.*e}", p - 1, d);
+    let (mantissa, exp_str) = sci.split_once('e').unwrap();
+    let exp: i32 = exp_str.parse().unwrap();
+
+    if exp < -4 || exp >= p as i32 {
+        // Scientific: trim trailing zeros in the mantissa; C-style signed,
+        // ≥2-digit exponent.
+        let mant = trim_trailing_zeros(mantissa);
+        let sign = if exp < 0 { '-' } else { '+' };
+        format!("{mant}e{sign}{:02}", exp.unsigned_abs())
+    } else {
+        // Fixed: `p-1-exp` fraction digits, trailing zeros trimmed.
+        let frac = (p as i32 - 1 - exp).max(0) as usize;
+        trim_trailing_zeros(&format!("{:.*}", frac, d))
+    }
+}
+
+/// Trim trailing fractional zeros (and a now-bare decimal point).
+fn trim_trailing_zeros(s: &str) -> String {
+    if s.contains('.') {
+        s.trim_end_matches('0').trim_end_matches('.').to_string()
+    } else {
+        s.to_string()
+    }
+}
+
+/// `serialize_with` for an `f64` field: emit the cJSON-formatted token as a raw
+/// JSON number (serde_json), so integral values lose the `.0`.
+fn ser_f64<S: Serializer>(v: &f64, ser: S) -> Result<S::Ok, S::Error> {
+    use serde::ser::Error;
+    let raw = serde_json::value::RawValue::from_string(cjson_number(*v)).map_err(Error::custom)?;
+    raw.serialize(ser)
+}
+
+/// `serialize_with` for an `Option<f64>` field. Paired with
+/// `skip_serializing_if = "Option::is_none"`, so `None` is normally skipped.
+fn ser_opt_f64<S: Serializer>(v: &Option<f64>, ser: S) -> Result<S::Ok, S::Error> {
+    match v {
+        Some(x) => ser_f64(x, ser),
+        None => ser.serialize_none(),
+    }
+}
 
 // ---------------------------------------------------------------------------
 // Top-level report
@@ -121,6 +215,7 @@ pub struct TestStart {
     pub target_bitrate: u64,
     pub bidir: i32,
     pub fqrate: u64,
+    #[serde(serialize_with = "ser_f64")]
     pub interval: f64,
     pub gso: i32,
     pub gro: i32,
@@ -141,10 +236,14 @@ pub struct Interval {
 #[non_exhaustive]
 pub struct IntervalStream {
     pub socket: i32,
+    #[serde(serialize_with = "ser_f64")]
     pub start: f64,
+    #[serde(serialize_with = "ser_f64")]
     pub end: f64,
+    #[serde(serialize_with = "ser_f64")]
     pub seconds: f64,
     pub bytes: u64,
+    #[serde(serialize_with = "ser_f64")]
     pub bits_per_second: f64,
     // TCP per-interval detail (sender side); omitted where TCP_INFO is
     // unavailable. `snd_wnd` is absent — see TcpStreamSide.
@@ -163,13 +262,13 @@ pub struct IntervalStream {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub reorder: Option<u32>,
     // UDP per-interval detail (receiver side).
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", serialize_with = "ser_opt_f64")]
     pub jitter_ms: Option<f64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub lost_packets: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub packets: Option<i64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", serialize_with = "ser_opt_f64")]
     pub lost_percent: Option<f64>,
     pub omitted: bool,
     pub sender: bool,
@@ -178,20 +277,24 @@ pub struct IntervalStream {
 #[derive(Debug, Clone, Serialize)]
 #[non_exhaustive]
 pub struct IntervalSum {
+    #[serde(serialize_with = "ser_f64")]
     pub start: f64,
+    #[serde(serialize_with = "ser_f64")]
     pub end: f64,
+    #[serde(serialize_with = "ser_f64")]
     pub seconds: f64,
     pub bytes: u64,
+    #[serde(serialize_with = "ser_f64")]
     pub bits_per_second: f64,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub retransmits: Option<i64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", serialize_with = "ser_opt_f64")]
     pub jitter_ms: Option<f64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub lost_packets: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub packets: Option<i64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", serialize_with = "ser_opt_f64")]
     pub lost_percent: Option<f64>,
     pub omitted: bool,
     pub sender: bool,
@@ -239,10 +342,14 @@ pub struct EndStream {
 #[non_exhaustive]
 pub struct TcpStreamSide {
     pub socket: i32,
+    #[serde(serialize_with = "ser_f64")]
     pub start: f64,
+    #[serde(serialize_with = "ser_f64")]
     pub end: f64,
+    #[serde(serialize_with = "ser_f64")]
     pub seconds: f64,
     pub bytes: u64,
+    #[serde(serialize_with = "ser_f64")]
     pub bits_per_second: f64,
     /// Sender side only; iperf3 reports -1 when the OS doesn't expose retransmits.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -272,14 +379,20 @@ pub struct TcpStreamSide {
 #[non_exhaustive]
 pub struct UdpStreamEnd {
     pub socket: i32,
+    #[serde(serialize_with = "ser_f64")]
     pub start: f64,
+    #[serde(serialize_with = "ser_f64")]
     pub end: f64,
+    #[serde(serialize_with = "ser_f64")]
     pub seconds: f64,
     pub bytes: u64,
+    #[serde(serialize_with = "ser_f64")]
     pub bits_per_second: f64,
+    #[serde(serialize_with = "ser_f64")]
     pub jitter_ms: f64,
     pub lost_packets: i64,
     pub packets: i64,
+    #[serde(serialize_with = "ser_f64")]
     pub lost_percent: f64,
     pub out_of_order: i64,
     pub sender: bool,
@@ -288,20 +401,24 @@ pub struct UdpStreamEnd {
 #[derive(Debug, Clone, Serialize)]
 #[non_exhaustive]
 pub struct SumSide {
+    #[serde(serialize_with = "ser_f64")]
     pub start: f64,
+    #[serde(serialize_with = "ser_f64")]
     pub end: f64,
+    #[serde(serialize_with = "ser_f64")]
     pub seconds: f64,
     pub bytes: u64,
+    #[serde(serialize_with = "ser_f64")]
     pub bits_per_second: f64,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub retransmits: Option<i64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", serialize_with = "ser_opt_f64")]
     pub jitter_ms: Option<f64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub lost_packets: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub packets: Option<i64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", serialize_with = "ser_opt_f64")]
     pub lost_percent: Option<f64>,
     pub sender: bool,
 }
@@ -309,11 +426,17 @@ pub struct SumSide {
 #[derive(Debug, Clone, Serialize)]
 #[non_exhaustive]
 pub struct CpuUtilization {
+    #[serde(serialize_with = "ser_f64")]
     pub host_total: f64,
+    #[serde(serialize_with = "ser_f64")]
     pub host_user: f64,
+    #[serde(serialize_with = "ser_f64")]
     pub host_system: f64,
+    #[serde(serialize_with = "ser_f64")]
     pub remote_total: f64,
+    #[serde(serialize_with = "ser_f64")]
     pub remote_user: f64,
+    #[serde(serialize_with = "ser_f64")]
     pub remote_system: f64,
 }
 
@@ -943,6 +1066,58 @@ impl ReportInput {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // #57: cjson_number must match C cJSON's print_number byte-for-byte. Expected
+    // values were cross-checked against Python's %.15g/%.17g (same libc path as
+    // cJSON), including the two high-precision bits_per_second cases where 15g
+    // fails the round-trip and 17g kicks in.
+    #[test]
+    fn cjson_number_matches_cjson() {
+        let cases = [
+            (0.0, "0"),
+            (-0.0, "0"),
+            (1.0, "1"),
+            (-5.0, "-5"),
+            (10485760.0, "10485760"),
+            (4194304.0, "4194304"),
+            (0.5, "0.5"),
+            (1.002098, "1.002098"),
+            (99.99, "99.99"),
+            (0.045, "0.045"),
+            (1.0000349, "1.0000349"),
+            // 15g round-trips → kept:
+            (943161195.674271, "943161195.674271"),
+            // 15g fails round-trip → 17g fallback (more digits than ryu's shortest):
+            (943718412.3076923, "943718412.30769229"),
+            (349525333.3333333, "349525333.33333331"),
+        ];
+        for (v, want) in cases {
+            assert_eq!(cjson_number(v), want, "cjson_number({v})");
+        }
+        // Non-finite degrades to JSON null, like cJSON.
+        assert_eq!(cjson_number(f64::NAN), "null");
+        assert_eq!(cjson_number(f64::INFINITY), "null");
+    }
+
+    // The whole point of #57: a serialized report carries no integral `N.0`
+    // token. Build a report whose floats are all integral and assert the raw
+    // text has no `<digit>.0` anywhere.
+    #[test]
+    fn report_json_has_no_integral_dot_zero() {
+        let json = serde_json::to_string_pretty(&base_input().build()).unwrap();
+        let bytes = json.as_bytes();
+        for (i, w) in bytes.windows(3).enumerate() {
+            if w[0].is_ascii_digit() && w[1] == b'.' && w[2] == b'0' {
+                // allow `.0` only if followed by another digit (e.g. 1.02)
+                let next = bytes.get(i + 3).copied().unwrap_or(b' ');
+                assert!(
+                    next.is_ascii_digit(),
+                    "integral N.0 token at byte {i}: ...{}...",
+                    &json[i.saturating_sub(8)..(i + 6).min(json.len())]
+                );
+            }
+        }
+    }
 
     fn base_input() -> ReportInput {
         ReportInput {

--- a/riperf3/src/json_report.rs
+++ b/riperf3/src/json_report.rs
@@ -262,13 +262,19 @@ pub struct IntervalStream {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub reorder: Option<u32>,
     // UDP per-interval detail (receiver side).
-    #[serde(skip_serializing_if = "Option::is_none", serialize_with = "ser_opt_f64")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        serialize_with = "ser_opt_f64"
+    )]
     pub jitter_ms: Option<f64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub lost_packets: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub packets: Option<i64>,
-    #[serde(skip_serializing_if = "Option::is_none", serialize_with = "ser_opt_f64")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        serialize_with = "ser_opt_f64"
+    )]
     pub lost_percent: Option<f64>,
     pub omitted: bool,
     pub sender: bool,
@@ -288,13 +294,19 @@ pub struct IntervalSum {
     pub bits_per_second: f64,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub retransmits: Option<i64>,
-    #[serde(skip_serializing_if = "Option::is_none", serialize_with = "ser_opt_f64")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        serialize_with = "ser_opt_f64"
+    )]
     pub jitter_ms: Option<f64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub lost_packets: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub packets: Option<i64>,
-    #[serde(skip_serializing_if = "Option::is_none", serialize_with = "ser_opt_f64")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        serialize_with = "ser_opt_f64"
+    )]
     pub lost_percent: Option<f64>,
     pub omitted: bool,
     pub sender: bool,
@@ -412,13 +424,19 @@ pub struct SumSide {
     pub bits_per_second: f64,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub retransmits: Option<i64>,
-    #[serde(skip_serializing_if = "Option::is_none", serialize_with = "ser_opt_f64")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        serialize_with = "ser_opt_f64"
+    )]
     pub jitter_ms: Option<f64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub lost_packets: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub packets: Option<i64>,
-    #[serde(skip_serializing_if = "Option::is_none", serialize_with = "ser_opt_f64")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        serialize_with = "ser_opt_f64"
+    )]
     pub lost_percent: Option<f64>,
     pub sender: bool,
 }

--- a/riperf3/src/lib.rs
+++ b/riperf3/src/lib.rs
@@ -17,6 +17,7 @@
 //! | `--bind-dev` | `setsockopt(IP_BOUND_IF)` | macOS | net.rs |
 //! | `-A` (affinity) | `SetThreadAffinityMask` | Windows | net.rs |
 //! | *(internal)* | `getsockopt(IP_MTU_DISCOVER)` | Linux | net.rs |
+//! | *(internal)* | `getsockopt(TCP_MAXSEG)` | Unix | net.rs |
 //! | *(internal)* | `getsockopt(TCP_INFO)` | Linux | tcp_info.rs |
 //! | *(internal)* | `getsockopt(TCP_CONNECTION_INFO)` | macOS | tcp_info.rs |
 //! | *(internal)* | `getsockopt(TCP_INFO)` | FreeBSD | tcp_info.rs |

--- a/riperf3/src/macros.rs
+++ b/riperf3/src/macros.rs
@@ -1,12 +1,79 @@
 // riperf3/riperf3/src/macros.rs
 
+use std::sync::RwLock;
+
+/// The active `-T/--title` prefix, set for the duration of a client run (#34).
+///
+/// iperf3 prepends `<title>:  ` (colon + two spaces) to every client output line
+/// via `iperf_printf` (iperf_api.c). riperf3 has two output paths — the
+/// `vprintln!` macro and the reporter's line printers — so rather than thread the
+/// title through every call site (which would change the public reporter
+/// signatures and break SemVer on a patch), both paths read this run-scoped
+/// global. Process-global is acceptable: human text output already shares stdout,
+/// so concurrent client runs in one process can't interleave coherently anyway.
+static OUTPUT_TITLE: RwLock<Option<String>> = RwLock::new(None);
+
+pub(crate) fn set_output_title(title: Option<String>) {
+    if let Ok(mut g) = OUTPUT_TITLE.write() {
+        *g = title;
+    }
+}
+
+/// The `"<title>:  "` prefix for client output lines, or `""` when no title is
+/// set. Colon followed by two spaces, matching iperf3.
+pub(crate) fn output_title_prefix() -> String {
+    match OUTPUT_TITLE.read() {
+        Ok(g) => g.as_deref().map(|t| format!("{t}:  ")).unwrap_or_default(),
+        Err(_) => String::new(),
+    }
+}
+
+/// RAII guard that clears the run-scoped title on drop, so a title can't leak
+/// into a later run (e.g. a server run) in the same process — even on an early
+/// `?` return or panic.
+pub(crate) struct OutputTitleGuard;
+
+impl OutputTitleGuard {
+    pub(crate) fn set(title: Option<String>) -> Self {
+        set_output_title(title);
+        OutputTitleGuard
+    }
+}
+
+impl Drop for OutputTitleGuard {
+    fn drop(&mut self) {
+        set_output_title(None);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // #34: iperf3 prefixes client lines with "<title>:  " (colon + two spaces),
+    // and the prefix must be cleared when the run ends so it can't leak.
+    #[test]
+    fn title_prefix_matches_iperf3_and_clears() {
+        {
+            let _g = OutputTitleGuard::set(Some("my test".to_string()));
+            assert_eq!(output_title_prefix(), "my test:  ");
+        }
+        // Guard dropped → prefix cleared.
+        assert_eq!(output_title_prefix(), "");
+    }
+}
+
 #[doc(hidden)]
 #[macro_export]
 macro_rules! vprintln {
     ($($arg:tt)*) => {
         {
             log::info!($($arg)*);
-            println!($($arg)*);
+            println!(
+                "{}{}",
+                $crate::macros::output_title_prefix(),
+                format_args!($($arg)*)
+            );
         }
     };
 }

--- a/riperf3/src/macros.rs
+++ b/riperf3/src/macros.rs
@@ -46,6 +46,21 @@ impl Drop for OutputTitleGuard {
     }
 }
 
+#[doc(hidden)]
+#[macro_export]
+macro_rules! vprintln {
+    ($($arg:tt)*) => {
+        {
+            log::info!($($arg)*);
+            println!(
+                "{}{}",
+                $crate::macros::output_title_prefix(),
+                format_args!($($arg)*)
+            );
+        }
+    };
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -61,19 +76,4 @@ mod tests {
         // Guard dropped → prefix cleared.
         assert_eq!(output_title_prefix(), "");
     }
-}
-
-#[doc(hidden)]
-#[macro_export]
-macro_rules! vprintln {
-    ($($arg:tt)*) => {
-        {
-            log::info!($($arg)*);
-            println!(
-                "{}{}",
-                $crate::macros::output_title_prefix(),
-                format_args!($($arg)*)
-            );
-        }
-    };
 }

--- a/riperf3/src/net.rs
+++ b/riperf3/src/net.rs
@@ -348,6 +348,21 @@ pub fn configure_tcp_stream(stream: &TcpStream, no_delay: bool) -> Result<()> {
     Ok(())
 }
 
+/// Apply the requested socket buffer size (`-w/--window`) to a socket's send and
+/// receive buffers (`SO_SNDBUF` / `SO_RCVBUF`).
+///
+/// Best-effort: a kernel that clamps or rejects the size is not fatal — iperf3
+/// likewise proceeds, and the realized size is read back separately for the
+/// `sndbuf_actual` / `rcvbuf_actual` report. Used for both TCP and UDP data
+/// sockets so `-w` is honored on UDP too (#59), matching iperf3's
+/// `iperf_udp_buffercheck`. `None` is a no-op (kernel default).
+pub(crate) fn apply_socket_window(sock: &socket2::SockRef<'_>, window: Option<i32>) {
+    if let Some(size) = window {
+        let _ = sock.set_recv_buffer_size(size as usize);
+        let _ = sock.set_send_buffer_size(size as usize);
+    }
+}
+
 /// Configure a connected TCP stream with all negotiated socket options.
 pub fn configure_tcp_stream_full(
     stream: &TcpStream,
@@ -384,10 +399,7 @@ pub fn configure_tcp_stream_full(
         #[cfg(not(any(unix, windows)))]
         let _ = mss;
 
-        if let Some(size) = window {
-            let _ = sock.set_recv_buffer_size(size as usize);
-            let _ = sock.set_send_buffer_size(size as usize);
-        }
+        apply_socket_window(&sock, window);
     }
 
     // Congestion control: Linux + FreeBSD (iperf3 uses HAVE_TCP_CONGESTION)
@@ -811,6 +823,38 @@ pub async fn udp_bind_reusable(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // #59: -w/--window must be applied to UDP sockets, not just TCP. Requesting a
+    // size *below* the default and asserting the read-back drops is robust across
+    // platforms — the kernel honors reductions down to its floor, whereas a
+    // larger request can be silently clamped by wmem_max/SO_*BUF maximums.
+    #[test]
+    fn apply_socket_window_sets_udp_buffers() {
+        let sock = std::net::UdpSocket::bind("127.0.0.1:0").unwrap();
+        let s = socket2::SockRef::from(&sock);
+        let default_snd = s.send_buffer_size().unwrap();
+        let default_rcv = s.recv_buffer_size().unwrap();
+
+        let window = default_snd.min(default_rcv) as i32 / 4;
+        apply_socket_window(&s, Some(window));
+        assert!(
+            s.send_buffer_size().unwrap() < default_snd,
+            "SO_SNDBUF not applied: {} !< {default_snd}",
+            s.send_buffer_size().unwrap()
+        );
+        assert!(
+            s.recv_buffer_size().unwrap() < default_rcv,
+            "SO_RCVBUF not applied: {} !< {default_rcv}",
+            s.recv_buffer_size().unwrap()
+        );
+
+        // None must be a no-op (kernel default left untouched).
+        let sock2 = std::net::UdpSocket::bind("127.0.0.1:0").unwrap();
+        let s2 = socket2::SockRef::from(&sock2);
+        let before = s2.send_buffer_size().unwrap();
+        apply_socket_window(&s2, None);
+        assert_eq!(s2.send_buffer_size().unwrap(), before);
+    }
 
     #[tokio::test]
     async fn tcp_listen_and_connect() {

--- a/riperf3/src/reporter.rs
+++ b/riperf3/src/reporter.rs
@@ -55,20 +55,29 @@ fn fmt_id(id: i32) -> String {
     }
 }
 
+/// Emit one human-readable report line, prefixed with the `-T/--title` string
+/// when a title is active (#34). Every report line routes through this so the
+/// prefix matches iperf3 without changing the public printer signatures.
+fn titled(line: std::fmt::Arguments) {
+    println!("{}{}", crate::macros::output_title_prefix(), line);
+}
+
 /// Print the header line for interval reports.
 pub fn print_header(protocol: TransportProtocol, has_retransmits: bool) {
     match protocol {
         TransportProtocol::Tcp => {
             if has_retransmits {
-                println!("[ ID] Interval           Transfer     Bitrate         Retr  Cwnd");
+                titled(format_args!(
+                    "[ ID] Interval           Transfer     Bitrate         Retr  Cwnd"
+                ));
             } else {
-                println!("[ ID] Interval           Transfer     Bitrate");
+                titled(format_args!("[ ID] Interval           Transfer     Bitrate"));
             }
         }
         TransportProtocol::Udp => {
-            println!(
+            titled(format_args!(
                 "[ ID] Interval           Transfer     Bitrate         Jitter    Lost/Total Datagrams"
-            );
+            ));
         }
     }
 }
@@ -91,7 +100,7 @@ pub fn print_interval(interval: &StreamInterval, format_char: char) {
         (interval.jitter, interval.lost, interval.total_packets)
     {
         let pct = lost_percent(lost, total);
-        println!(
+        titled(format_args!(
             "[{id}] {:5.2}-{:<5.2} sec  {:>10}  {:>12}  {:7.3} ms  {}/{} ({:.2}%)  {}",
             interval.start,
             interval.end,
@@ -102,24 +111,26 @@ pub fn print_interval(interval: &StreamInterval, format_char: char) {
             total,
             pct,
             omit_tag,
-        );
+        ));
     } else if let (Some(retr), Some(cwnd)) = (interval.retransmits, interval.snd_cwnd) {
         let cwnd_str = units::format_bytes(cwnd as f64, 'A');
-        println!(
+        titled(format_args!(
             "[{id}] {:5.2}-{:<5.2} sec  {:>10}  {:>12}  {:4}   {:>10}  {}",
             interval.start, interval.end, transfer, rate, retr, cwnd_str, omit_tag,
-        );
+        ));
     } else {
-        println!(
+        titled(format_args!(
             "[{id}] {:5.2}-{:<5.2} sec  {:>10}  {:>12}  {}",
             interval.start, interval.end, transfer, rate, omit_tag,
-        );
+        ));
     }
 }
 
 /// Print the separator line.
 pub fn print_separator() {
-    println!("- - - - - - - - - - - - - - - - - - - - - - - - -");
+    titled(format_args!(
+        "- - - - - - - - - - - - - - - - - - - - - - - - -"
+    ));
 }
 
 /// UDP loss as a percentage of total datagrams, guarding the zero-total case
@@ -182,7 +193,7 @@ pub fn format_summary_line(summary: &StreamSummary, format_char: char) -> String
 
 /// Print a single final summary line.
 pub fn print_summary(summary: &StreamSummary, format_char: char) {
-    println!("{}", format_summary_line(summary, format_char));
+    titled(format_args!("{}", format_summary_line(summary, format_char)));
 }
 
 /// Build the full set of final-report lines for a set of per-stream summaries:
@@ -205,7 +216,7 @@ pub fn final_report_lines(per_stream: &[StreamSummary], format_char: char) -> Ve
 /// Print the final report (per-stream summaries + aggregate `[SUM]` rows).
 pub fn print_final_summaries(per_stream: &[StreamSummary], format_char: char) {
     for line in final_report_lines(per_stream, format_char) {
-        println!("{line}");
+        titled(format_args!("{line}"));
     }
 }
 

--- a/riperf3/src/reporter.rs
+++ b/riperf3/src/reporter.rs
@@ -71,7 +71,9 @@ pub fn print_header(protocol: TransportProtocol, has_retransmits: bool) {
                     "[ ID] Interval           Transfer     Bitrate         Retr  Cwnd"
                 ));
             } else {
-                titled(format_args!("[ ID] Interval           Transfer     Bitrate"));
+                titled(format_args!(
+                    "[ ID] Interval           Transfer     Bitrate"
+                ));
             }
         }
         TransportProtocol::Udp => {
@@ -193,7 +195,10 @@ pub fn format_summary_line(summary: &StreamSummary, format_char: char) -> String
 
 /// Print a single final summary line.
 pub fn print_summary(summary: &StreamSummary, format_char: char) {
-    titled(format_args!("{}", format_summary_line(summary, format_char)));
+    titled(format_args!(
+        "{}",
+        format_summary_line(summary, format_char)
+    ));
 }
 
 /// Build the full set of final-report lines for a set of per-stream summaries:

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -390,6 +390,10 @@ impl Server {
                     let peer_addr_s = data_sock.peer_addr().ok();
                     let (sndbuf_actual, rcvbuf_actual) = {
                         let sock = socket2::SockRef::from(&data_sock);
+                        // Honor -w/--window on the server's UDP data socket too
+                        // (#59) so reverse/bidir UDP matches iperf3; set before the
+                        // read-back below.
+                        net::apply_socket_window(&sock, cfg.window);
                         (
                             sock.send_buffer_size().ok().map(|v| v as u64),
                             sock.recv_buffer_size().ok().map(|v| v as u64),

--- a/riperf3/src/stream.rs
+++ b/riperf3/src/stream.rs
@@ -522,9 +522,22 @@ fn tempfile() -> std::io::Result<std::fs::File> {
     Ok(f)
 }
 
+/// A unique temp-file name for one zerocopy sender. The `<pid>-<seq>` form keeps
+/// every sender's backing file distinct: with `-Z -P >1` each sender opened its
+/// own temp file under the same fixed `.riperf3-zc-<pid>` name and raced
+/// create+truncate on that shared path (#42). A monotonic per-process sequence
+/// removes the shared name entirely, so the senders can never collide.
+#[cfg(any(target_os = "linux", target_os = "macos", target_os = "freebsd"))]
+fn zc_tempfile_name() -> String {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static SEQ: AtomicU64 = AtomicU64::new(0);
+    let seq = SEQ.fetch_add(1, Ordering::Relaxed);
+    format!(".riperf3-zc-{}-{}", std::process::id(), seq)
+}
+
 #[cfg(any(target_os = "linux", target_os = "macos", target_os = "freebsd"))]
 fn tempfile_in(dir: std::path::PathBuf) -> std::io::Result<std::fs::File> {
-    let path = dir.join(format!(".riperf3-zc-{}", std::process::id()));
+    let path = dir.join(zc_tempfile_name());
     let f = std::fs::OpenOptions::new()
         .read(true)
         .write(true)
@@ -1188,6 +1201,20 @@ pub fn run_udp_receiver_blocking(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // #42: zerocopy senders must get distinct temp-file names so `-Z -P >1`
+    // can't race create+truncate on a shared path. The race needs concurrency a
+    // sequential test can't reproduce, so we assert the mechanism directly: the
+    // name generator never repeats and carries the pid.
+    #[cfg(any(target_os = "linux", target_os = "macos", target_os = "freebsd"))]
+    #[test]
+    fn zc_tempfile_names_are_unique() {
+        let names: Vec<String> = (0..16).map(|_| zc_tempfile_name()).collect();
+        let unique: std::collections::HashSet<&String> = names.iter().collect();
+        assert_eq!(unique.len(), names.len(), "names collided: {names:?}");
+        let pid = std::process::id().to_string();
+        assert!(names.iter().all(|n| n.contains(&pid)));
+    }
 
     // -- StreamCounters --
 

--- a/riperf3/src/tcp_info.rs
+++ b/riperf3/src/tcp_info.rs
@@ -139,13 +139,18 @@ pub fn get_tcp_info(_fd: i32) -> Option<TcpInfoSnapshot> {
 /// Whether this platform provides a usable TCP **retransmit packet count** for
 /// the sender (the `Retr` column / JSON `sender_has_retransmits`).
 ///
-/// macOS is deliberately excluded (#40): its `tcp_connection_info` exposes only
-/// `tcpi_txretransmitbytes` (retransmitted *bytes*), not a sender packet count,
-/// so `get_tcp_info` can only hard-code `total_retransmits: 0`. Advertising
-/// retransmit info there printed a perpetual `Retr 0`, implying a loss-free
-/// transfer regardless of reality. We now report no retransmit info on macOS
-/// rather than a misleading zero; the coupled `Cwnd` column is suppressed with
-/// it (iperf3 shows both together, gated on the same flag).
+/// macOS is deliberately excluded (#40). iperf3 *does* report retransmits on
+/// macOS — it reads `tcp_connection_info.tcpi_txretransmitpackets` (a sender
+/// retransmit packet count) and shows the Retr+Cwnd columns. But the Rust `libc`
+/// binding's `tcp_connection_info` does not expose that field — its sender-side
+/// retransmit member is `tcpi_txretransmitbytes` (retransmitted *bytes*) — so
+/// riperf3's `get_tcp_info` can only hard-code `total_retransmits: 0`. Rather
+/// than print a perpetual, misleading `Retr 0` (implying a loss-free transfer),
+/// we report no retransmit info on macOS. The Retr and Cwnd columns are gated
+/// together (iperf3 couples them on the same flag), so Cwnd is suppressed with
+/// it. This is a deliberate divergence from iperf3 for now; the faithful fix —
+/// reading `tcpi_txretransmitpackets` via a custom struct binding to show the
+/// real macOS Retr/Cwnd — is a deferred follow-up, not patch scope.
 pub fn has_retransmit_info() -> bool {
     cfg!(any(target_os = "linux", target_os = "freebsd"))
 }

--- a/riperf3/src/tcp_info.rs
+++ b/riperf3/src/tcp_info.rs
@@ -136,13 +136,18 @@ pub fn get_tcp_info(_fd: i32) -> Option<TcpInfoSnapshot> {
     None
 }
 
-/// Whether this platform provides TCP retransmit information.
+/// Whether this platform provides a usable TCP **retransmit packet count** for
+/// the sender (the `Retr` column / JSON `sender_has_retransmits`).
+///
+/// macOS is deliberately excluded (#40): its `tcp_connection_info` exposes only
+/// `tcpi_txretransmitbytes` (retransmitted *bytes*), not a sender packet count,
+/// so `get_tcp_info` can only hard-code `total_retransmits: 0`. Advertising
+/// retransmit info there printed a perpetual `Retr 0`, implying a loss-free
+/// transfer regardless of reality. We now report no retransmit info on macOS
+/// rather than a misleading zero; the coupled `Cwnd` column is suppressed with
+/// it (iperf3 shows both together, gated on the same flag).
 pub fn has_retransmit_info() -> bool {
-    cfg!(any(
-        target_os = "linux",
-        target_os = "macos",
-        target_os = "freebsd"
-    ))
+    cfg!(any(target_os = "linux", target_os = "freebsd"))
 }
 
 #[cfg(test)]
@@ -176,5 +181,17 @@ mod tests {
             let info = get_tcp_info(client_stream.as_raw_fd()).unwrap();
             assert!(info.snd_mss > 0);
         }
+    }
+
+    // #40: only platforms with a real sender retransmit *packet* count advertise
+    // retransmit info. macOS (bytes only) and other targets must report false so
+    // the Retr column isn't a misleading 0. Runs on every platform; the macOS
+    // assertion is validated by the macOS native CI job.
+    #[test]
+    fn retransmit_info_only_where_packet_count_exists() {
+        #[cfg(any(target_os = "linux", target_os = "freebsd"))]
+        assert!(has_retransmit_info());
+        #[cfg(not(any(target_os = "linux", target_os = "freebsd")))]
+        assert!(!has_retransmit_info());
     }
 }


### PR DESCRIPTION
Batch of small, low-risk fidelity/correctness fixes for the 0.6.3 patch. Each is its own commit with a test; no Rust public-API changes (SemVer-clean), no data-path rewrites.

## Fixes

- **#44** — add the missing `getsockopt(TCP_MAXSEG)` row to the lib.rs unsafe-audit table. Re-verified the table against every unsafe block: 13 production blocks (10 net.rs, 3 tcp_info.rs) map 1:1; the only other `unsafe` (`fcntl(F_GETFL)`) is test-only. Doc-only.
- **#40** — stop advertising retransmit info on macOS. `has_retransmit_info()` returned true on macOS, but `get_tcp_info` hard-codes `total_retransmits: 0` there (macOS exposes only `tcpi_txretransmitbytes`, not a sender packet count), so interval reports showed a perpetual misleading `Retr 0`. **Trade-off:** Retr and Cwnd are gated together (iperf3 couples them), so this also suppresses the macOS Cwnd column. Populating a real macOS retransmit count is a deferred follow-up.
- **#42** — give each `-Z` zerocopy temp file a unique `<pid>-<seq>` name. The fixed `.riperf3-zc-<pid>` path raced create+truncate across senders under `-Z -P>1` (latent until per-stream payloads differ).
- **#59** — apply `-w/--window` to UDP sockets (`SO_SNDBUF`/`SO_RCVBUF`) on both client and server paths, via a shared `net::apply_socket_window` helper, matching iperf3's `iperf_udp_buffercheck`. Previously UDP ignored `-w` while still reporting the requested value.
- **#57** — render `-J` floats like cJSON: integral doubles as integer tokens (drop the `.0`), fractionals via `%.15g`/`%.17g`. Reproduces cJSON's `print_number` and emits raw JSON number tokens via `serialize_with` on every f64 report field (enables serde_json's `raw_value` feature). `format_g` validated against C/Python `%g`, including the `%.17g` round-trip-fallback cases. Byte-compatible with iperf3; still parses identically.
- **#34** — prefix client text lines with `<title>:  ` for `-T/--title`, matching iperf3's `iperf_printf` (colon + two spaces). Implemented as a run-scoped global the two output paths (vprintln!/reporter) read, **not** threaded through the reporter config — adding a param/field to the public `print_*` fns / `IntervalReporterConfig` would trip the SemVer gate on a patch. Text-mode only; `-J`/`--json-stream` are never titled. Cleared on run exit (RAII guard).

## Verification

- `cargo test --workspace`: 188 lib + 129 integration + 59 = green; new unit tests per fix.
- `cargo fmt --check`, `cargo clippy --all-targets -D warnings`: clean.
- `scripts/xcheck.sh`: all 7 targets compile (linux gnu/musl, windows-msvc, macOS x86/arm, freebsd, netbsd).
- End-to-end on loopback: `-T` prefixes every text line and leaves `-J` untouched/valid; real `-J` output has zero `N.0` tokens (matches iperf3).

The output-changing fixes (#34/#57/#59) want a `riperf3-matrix` compat re-run against real iperf3 before the 0.6.3 release.