### PR TITLE
fix: emit an exact final interval instead of dropping it (#55) [0.7.0]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,36 @@ This changelog begins at 0.6.0. For earlier releases (0.1.1–0.5.4), see the
 [git history](https://github.com/therealevanhenry/riperf3/commits/main) and
 release tags.
 
+## [0.7.0] - unreleased
+
+A minor bump (the first `0.x` minor since 0.6.0) because the interval-reporter
+fix needs a new parameter on a public function — see **Changed** below. No
+data-path/throughput changes.
+
+### Changed
+- **BREAKING (library API): `riperf3::reporter::spawn_interval_reporter` gains a
+  `ReporterEnd` argument** (#55). Callers pass an `Arc<ReporterEnd>` and signal
+  the authoritative end-of-test time via `ReporterEnd::finish(end_secs)`. The new
+  public `ReporterEnd` type is the only API addition required by the fix. The CLI
+  binary is unaffected; only direct library consumers need to update.
+
+### Fixed
+- **The final (partial) interval is no longer dropped** (#55): the interval
+  reporter looped `tick -> if done break`, so a run that ended part-way through an
+  interval lost its last interval (a 2s `-i 1` run intermittently printed 1
+  interval instead of 2; `-J`/`--json-stream` lost the tail too). The test driver
+  now hands the reporter the authoritative end time and the reporter flushes a
+  final interval `[last_boundary, end]` before stopping, matching iperf3. A
+  duration run passes its exact `-t`, so a boundary-aligned end produces no
+  spurious trailing interval; the senders stop at the deadline, so the summary is
+  unchanged. The final interval reuses the last-sampled TCP_INFO when the socket
+  has already closed, so it still carries `Cwnd`/`RTT`/`Retr`.
+
+### Added
+- **`StreamCounters::peek_sent_interval` / `peek_received_interval`** (#55):
+  non-draining reads of the interval byte counters, used to skip an empty final
+  partial interval on the receiver side.
+
 ## [0.6.3] - 2026-06-04
 
 An iperf3-fidelity and correctness release. There are **no public Rust API

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,8 +33,9 @@ data-path/throughput changes.
   final interval `[last_boundary, end]` before stopping, matching iperf3. A
   duration run passes its exact `-t`, so a boundary-aligned end produces no
   spurious trailing interval; the senders stop at the deadline, so the summary is
-  unchanged. The final interval reuses the last-sampled TCP_INFO when the socket
-  has already closed, so it still carries `Cwnd`/`RTT`/`Retr`.
+  unchanged. The final interval reuses the last-sampled `Cwnd`/`RTT` when the
+  socket has already closed (reporting `Retr 0` for the sub-interval, as iperf3
+  does) instead of leaving those columns blank.
 
 ### Added
 - **`StreamCounters::peek_sent_interval` / `peek_received_interval`** (#55):

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -793,7 +793,7 @@ dependencies = [
 
 [[package]]
 name = "riperf3"
-version = "0.6.3"
+version = "0.7.0"
 dependencies = [
  "base64",
  "libc",
@@ -814,7 +814,7 @@ dependencies = [
 
 [[package]]
 name = "riperf3-cli"
-version = "0.6.3"
+version = "0.7.0"
 dependencies = [
  "clap",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.6.3"
+version = "0.7.0"
 authors = ["Evan Henry"]
 edition = "2021"
 homepage = "https://github.com/therealevanhenry/riperf3"

--- a/riperf3-cli/Cargo.toml
+++ b/riperf3-cli/Cargo.toml
@@ -13,7 +13,7 @@ readme = "../README.md"
 
 [dependencies]
 # riperf3 workspace dependencies
-riperf3 = { path = "../riperf3", version = "0.6.3" }
+riperf3 = { path = "../riperf3", version = "0.7.0" }
 
 # external dependencies
 clap.workspace = true

--- a/riperf3/src/client.rs
+++ b/riperf3/src/client.rs
@@ -610,6 +610,11 @@ impl Client {
         let interval_secs = self.interval.unwrap_or(1.0);
         let print_intervals = !self.json_output || self.json_stream;
         let collect_intervals = self.json_output && !self.json_stream;
+        // Clock origin shared with the reporter: `report_start` is captured right
+        // before spawning it, so `report_start.elapsed()` at end-of-test is the
+        // authoritative final-interval boundary (#55).
+        let reporter_end = Arc::new(crate::reporter::ReporterEnd::new());
+        let report_start = std::time::Instant::now();
         let interval_handle = if interval_secs > 0.0 {
             let stream_refs: Vec<_> = streams
                 .iter()
@@ -636,6 +641,7 @@ impl Client {
                 },
                 stream_refs,
                 done.clone(),
+                reporter_end.clone(),
                 collect_intervals.then(|| collector.clone()),
             )
         } else {
@@ -651,7 +657,13 @@ impl Client {
             EndCondition::Duration(Duration::from_secs(self.duration as u64))
         };
 
-        match end_condition {
+        // The authoritative end time for the reporter's final interval (#55). A
+        // duration run ends at exactly `-t`, so pass that value (not the measured
+        // elapsed, which trails the deadline by a variable scheduling slack and
+        // would smear a boundary-aligned end into a spurious sliver). A
+        // byte/block run ends at an arbitrary instant, so use the measured
+        // elapsed.
+        let end_secs = match end_condition {
             EndCondition::Duration(dur) => {
                 // Use select to handle both timer and control socket.
                 //
@@ -670,18 +682,22 @@ impl Client {
                         }
                     }
                 }
+                dur.as_secs_f64()
             }
-            EndCondition::Bytes(target) => loop {
-                tokio::time::sleep(Duration::from_millis(100)).await;
-                let total: u64 = streams
-                    .iter()
-                    .filter(|s| s.is_sender)
-                    .map(|s| s.counters.bytes_sent())
-                    .sum();
-                if total >= target {
-                    break;
+            EndCondition::Bytes(target) => {
+                loop {
+                    tokio::time::sleep(Duration::from_millis(100)).await;
+                    let total: u64 = streams
+                        .iter()
+                        .filter(|s| s.is_sender)
+                        .map(|s| s.counters.bytes_sent())
+                        .sum();
+                    if total >= target {
+                        break;
+                    }
                 }
-            },
+                report_start.elapsed().as_secs_f64()
+            }
             EndCondition::Blocks(target) => {
                 // For block-based, approximate by dividing bytes by blksize
                 loop {
@@ -696,12 +712,17 @@ impl Client {
                         break;
                     }
                 }
+                report_start.elapsed().as_secs_f64()
             }
-        }
+        };
 
+        // End of test: hand the reporter the authoritative end time, then stop
+        // the senders immediately (`done`) so no bytes leak past the deadline into
+        // the final interval or the summary (#55). The reporter prioritises this
+        // `finish` over `done` (see its select), so the final interval still
+        // flushes; we then wait for it before tearing the streams down.
+        reporter_end.finish(end_secs);
         done.store(true, Ordering::Relaxed);
-
-        // Wait for interval reporter to finish its last tick
         if let Some(handle) = interval_handle {
             let _ = handle.await;
         }

--- a/riperf3/src/reporter.rs
+++ b/riperf3/src/reporter.rs
@@ -311,6 +311,17 @@ pub struct IntervalReporterConfig {
     pub blksize: usize,
 }
 
+/// A single TCP_INFO sample reused for the final interval (#55) when the socket
+/// has already closed by the time the reporter flushes it.
+#[derive(Clone, Copy)]
+struct TcpSample {
+    snd_cwnd: u64,
+    rtt: u32,
+    rttvar: u32,
+    pmtu: u32,
+    reorder: u32,
+}
+
 /// Per-stream sender-side TCP_INFO extremes accumulated across the run (#36 PR2),
 /// for the `end.streams[].sender` object. Only meaningful for TCP sender streams.
 #[derive(Debug, Default, Clone, Copy)]
@@ -346,14 +357,60 @@ pub struct CollectedIntervals {
     pub extremes: Vec<StreamExtremes>,
 }
 
+/// End-of-test signal from the test driver to the interval reporter (#55).
+///
+/// The reporter's periodic ticks fall on idealized boundaries, but a run can end
+/// part-way through an interval. The driver calls [`ReporterEnd::finish`] with the
+/// authoritative elapsed test time at the exact moment the run ends; the reporter
+/// then flushes one final interval `[last_boundary, end_secs]` and stops. Using the
+/// driver's measured end time (rather than the reporter's own late, polled
+/// detection) keeps the final interval's boundary and bitrate exact, and because
+/// the driver signals *before* it tears the streams down, the final flush still
+/// reads live TCP_INFO.
+#[derive(Debug)]
+pub struct ReporterEnd {
+    notify: tokio::sync::Notify,
+    end_secs_bits: std::sync::atomic::AtomicU64,
+}
+
+impl ReporterEnd {
+    pub fn new() -> Self {
+        Self {
+            notify: tokio::sync::Notify::new(),
+            end_secs_bits: std::sync::atomic::AtomicU64::new(0),
+        }
+    }
+
+    /// Signal that the run ended at `end_secs` elapsed (test-relative seconds).
+    /// Wakes the reporter to emit its final partial interval up to `end_secs`.
+    pub fn finish(&self, end_secs: f64) {
+        self.end_secs_bits
+            .store(end_secs.to_bits(), Ordering::Relaxed);
+        self.notify.notify_one();
+    }
+
+    fn end_secs(&self) -> f64 {
+        f64::from_bits(self.end_secs_bits.load(Ordering::Relaxed))
+    }
+}
+
+impl Default for ReporterEnd {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 /// Spawn an async task that prints interval reports periodically.
 ///
-/// Returns `None` if interval reporting is disabled (interval_secs <= 0).
-/// The handle should be awaited after the test's `done` flag is set.
+/// Returns `None` if interval reporting is disabled (interval_secs <= 0). On a
+/// normal run the driver calls [`ReporterEnd::finish`] to flush the final partial
+/// interval and stop the task; `done` is the fallback stop signal for error/early
+/// teardown paths. The handle should be awaited after `finish`/`done`.
 pub fn spawn_interval_reporter(
     config: IntervalReporterConfig,
     streams: Vec<IntervalStreamRef>,
     done: Arc<AtomicBool>,
+    reporter_end: Arc<ReporterEnd>,
     collector: Option<Arc<Mutex<CollectedIntervals>>>,
 ) -> Option<JoinHandle<()>> {
     if config.interval_secs <= 0.0 {
@@ -372,15 +429,6 @@ pub fn spawn_interval_reporter(
         ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
         ticker.tick().await; // skip the immediate first tick
 
-        // Clock origin for this reporter. Idealized interval boundaries are
-        // `k * interval_secs` from here; the final partial interval (#55) ends
-        // at the real elapsed time measured from this point.
-        let loop_start = tokio::time::Instant::now();
-        // How often to check `done` while waiting for the next tick, so the run
-        // end is noticed promptly (see the wait loop below). Small relative to
-        // the interval; capped so sub-second intervals still stay responsive.
-        let poll_dur = interval_dur.min(std::time::Duration::from_millis(10));
-
         let mut interval_num: u64 = 0;
         let mut header_printed = false;
         let omit_intervals = if config.interval_secs > 0.0 {
@@ -393,6 +441,11 @@ pub fn spawn_interval_reporter(
         let mut prev_retransmits: Vec<u32> = vec![0; streams.len()];
         let mut prev_cnt_error: Vec<i64> = vec![0; streams.len()];
         let mut prev_packet_count: Vec<i64> = vec![0; streams.len()];
+        // Last successfully sampled TCP_INFO per stream. Reused for the final
+        // interval (#55) when the socket has already closed by the time it
+        // flushes, so the final line still carries Cwnd/RTT like the periodic
+        // ones rather than going blank.
+        let mut last_tcp: Vec<Option<TcpSample>> = vec![None; streams.len()];
 
         // Datagram size for the UDP sender's per-interval packet count.
         let blk = config.blksize.max(1) as u64;
@@ -470,6 +523,13 @@ pub fn spawn_interval_reporter(
                                 e.rtt_samples += 1;
                             }
                             e.total_retransmits = Some(info.total_retransmits);
+                            last_tcp[i] = Some(TcpSample {
+                                snd_cwnd: info.snd_cwnd,
+                                rtt: info.rtt,
+                                rttvar: info.rttvar,
+                                pmtu: info.pmtu,
+                                reorder: info.reorder,
+                            });
                             (
                                 Some(delta as i64),
                                 Some(info.snd_cwnd),
@@ -477,6 +537,19 @@ pub fn spawn_interval_reporter(
                                 Some(info.rttvar),
                                 Some(info.pmtu),
                                 Some(info.reorder),
+                            )
+                        } else if let Some(s) = last_tcp[i] {
+                            // Final-interval fallback (#55): the socket closed as
+                            // the run ended, so a fresh read failed. Reuse the
+                            // last sample's cwnd/rtt; no new retransmit count is
+                            // measurable for the sub-interval, so report 0.
+                            (
+                                Some(0),
+                                Some(s.snd_cwnd),
+                                Some(s.rtt),
+                                Some(s.rttvar),
+                                Some(s.pmtu),
+                                Some(s.reorder),
                             )
                         } else {
                             (None, None, None, None, None, None)
@@ -695,57 +768,57 @@ pub fn spawn_interval_reporter(
         };
 
         loop {
-            // Wait for the next interval boundary, but notice `done` promptly
-            // (within `poll_dur`) rather than only at the next tick. Otherwise
-            // the final partial (#55) would be measured up to a whole interval
-            // late, skewing its duration and bitrate. `biased` checks the tick
-            // first, so a `done` that lands exactly on a boundary still emits
-            // that boundary's full interval before the loop exits.
-            let tick = ticker.tick();
-            tokio::pin!(tick);
-            let became_done = loop {
-                tokio::select! {
-                    biased;
-                    _ = &mut tick => break false,
-                    _ = tokio::time::sleep(poll_dur) => {
-                        if done.load(Ordering::Relaxed) {
-                            break true;
-                        }
+            // Wait for either the next interval boundary or the driver's
+            // end-of-test signal. `biased` checks the end signal FIRST: the driver
+            // sets `done` immediately after `finish` (to stop the senders at the
+            // deadline), so the notify must win that race — otherwise the tick
+            // branch would observe `done` and exit without flushing the final
+            // interval. When `finish` and a boundary tick are both ready, that
+            // boundary's data is folded into the recovered final interval below.
+            tokio::select! {
+                biased;
+                _ = reporter_end.notify.notified() => {
+                    // #55: the run ended part-way through an interval. Flush one
+                    // final interval `[last_boundary, end_secs]` using the
+                    // driver's authoritative end time, then stop.
+                    //
+                    // Skip a remainder that is zero-length (the run ended on a
+                    // boundary — the sender driver passes the exact `-t`, so this
+                    // is exact) OR carries no residual bytes (the receiver side:
+                    // the peer has stopped, so its boundary-aligned tail is empty
+                    // even though `end_secs` trails the boundary by the control
+                    // round-trip).
+                    let last_end = interval_num as f64 * config.interval_secs;
+                    let end_secs = reporter_end.end_secs();
+                    let residual_bytes: u64 = streams
+                        .iter()
+                        .map(|s| {
+                            if s.is_sender {
+                                s.counters.peek_sent_interval()
+                            } else {
+                                s.counters.peek_received_interval()
+                            }
+                        })
+                        .sum();
+                    if end_secs > last_end + 1e-3 && residual_bytes > 0 {
+                        let omitted = (interval_num + 1) <= omit_intervals;
+                        emit_interval(last_end, end_secs, omitted);
                     }
+                    break;
                 }
-            };
-            if became_done {
-                break;
+                _ = ticker.tick() => {
+                    // `done` without a `finish` is the error/early-teardown path:
+                    // stop without inventing a final interval.
+                    if done.load(Ordering::Relaxed) {
+                        break;
+                    }
+                    interval_num += 1;
+                    let omitted = interval_num <= omit_intervals;
+                    let start = (interval_num - 1) as f64 * config.interval_secs;
+                    let end = interval_num as f64 * config.interval_secs;
+                    emit_interval(start, end, omitted);
+                }
             }
-
-            interval_num += 1;
-            let omitted = interval_num <= omit_intervals;
-            let start = (interval_num - 1) as f64 * config.interval_secs;
-            let end = interval_num as f64 * config.interval_secs;
-            emit_interval(start, end, omitted);
-        }
-
-        // #55: flush a final partial interval for the sub-interval remainder.
-        // The periodic ticks covered `[0, interval_num * interval_secs]`; if the
-        // run ran past that boundary AND residual bytes accrued since the last
-        // tick, emit one more interval `[last_end, elapsed]`. The residual-bytes
-        // guard drops the empty interval produced when a run ends on a boundary
-        // (prompt detection still leaves ~`poll_dur` of measured slack there).
-        let last_end = interval_num as f64 * config.interval_secs;
-        let elapsed = loop_start.elapsed().as_secs_f64();
-        let residual_bytes: u64 = streams
-            .iter()
-            .map(|s| {
-                if s.is_sender {
-                    s.counters.peek_sent_interval()
-                } else {
-                    s.counters.peek_received_interval()
-                }
-            })
-            .sum();
-        if elapsed > last_end + 1e-6 && residual_bytes > 0 {
-            let omitted = (interval_num + 1) <= omit_intervals;
-            emit_interval(last_end, elapsed, omitted);
         }
 
         // Hand the collected samples + extremes to the client (#36 PR2).

--- a/riperf3/src/reporter.rs
+++ b/riperf3/src/reporter.rs
@@ -372,6 +372,15 @@ pub fn spawn_interval_reporter(
         ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
         ticker.tick().await; // skip the immediate first tick
 
+        // Clock origin for this reporter. Idealized interval boundaries are
+        // `k * interval_secs` from here; the final partial interval (#55) ends
+        // at the real elapsed time measured from this point.
+        let loop_start = tokio::time::Instant::now();
+        // How often to check `done` while waiting for the next tick, so the run
+        // end is noticed promptly (see the wait loop below). Small relative to
+        // the interval; capped so sub-second intervals still stay responsive.
+        let poll_dur = interval_dur.min(std::time::Duration::from_millis(10));
+
         let mut interval_num: u64 = 0;
         let mut header_printed = false;
         let omit_intervals = if config.interval_secs > 0.0 {
@@ -400,17 +409,12 @@ pub fn spawn_interval_reporter(
             })
             .collect();
 
-        loop {
-            ticker.tick().await;
-
-            if done.load(Ordering::Relaxed) {
-                break;
-            }
-
-            interval_num += 1;
-            let omitted = interval_num <= omit_intervals;
-            let start = (interval_num - 1) as f64 * config.interval_secs;
-            let end = interval_num as f64 * config.interval_secs;
+        // Emit one interval [start, end] (`omitted` marks warm-up under -O).
+        // Shared by the periodic ticks and the final partial flush (#55) so both
+        // render and collect identically. Each call drains the per-stream
+        // interval counters, reporting exactly the bytes/stats accrued since the
+        // previous call.
+        let mut emit_interval = |start: f64, end: f64, omitted: bool| {
             let seconds = end - start;
 
             // Timestamp prefix for this tick
@@ -688,6 +692,60 @@ pub fn spawn_interval_reporter(
                 use std::io::Write;
                 let _ = std::io::stdout().flush();
             }
+        };
+
+        loop {
+            // Wait for the next interval boundary, but notice `done` promptly
+            // (within `poll_dur`) rather than only at the next tick. Otherwise
+            // the final partial (#55) would be measured up to a whole interval
+            // late, skewing its duration and bitrate. `biased` checks the tick
+            // first, so a `done` that lands exactly on a boundary still emits
+            // that boundary's full interval before the loop exits.
+            let tick = ticker.tick();
+            tokio::pin!(tick);
+            let became_done = loop {
+                tokio::select! {
+                    biased;
+                    _ = &mut tick => break false,
+                    _ = tokio::time::sleep(poll_dur) => {
+                        if done.load(Ordering::Relaxed) {
+                            break true;
+                        }
+                    }
+                }
+            };
+            if became_done {
+                break;
+            }
+
+            interval_num += 1;
+            let omitted = interval_num <= omit_intervals;
+            let start = (interval_num - 1) as f64 * config.interval_secs;
+            let end = interval_num as f64 * config.interval_secs;
+            emit_interval(start, end, omitted);
+        }
+
+        // #55: flush a final partial interval for the sub-interval remainder.
+        // The periodic ticks covered `[0, interval_num * interval_secs]`; if the
+        // run ran past that boundary AND residual bytes accrued since the last
+        // tick, emit one more interval `[last_end, elapsed]`. The residual-bytes
+        // guard drops the empty interval produced when a run ends on a boundary
+        // (prompt detection still leaves ~`poll_dur` of measured slack there).
+        let last_end = interval_num as f64 * config.interval_secs;
+        let elapsed = loop_start.elapsed().as_secs_f64();
+        let residual_bytes: u64 = streams
+            .iter()
+            .map(|s| {
+                if s.is_sender {
+                    s.counters.peek_sent_interval()
+                } else {
+                    s.counters.peek_received_interval()
+                }
+            })
+            .sum();
+        if elapsed > last_end + 1e-6 && residual_bytes > 0 {
+            let omitted = (interval_num + 1) <= omit_intervals;
+            emit_interval(last_end, elapsed, omitted);
         }
 
         // Hand the collected samples + extremes to the client (#36 PR2).

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -481,7 +481,11 @@ impl Server {
         let collect_intervals = json && !self.json_stream;
         let interval_data = Arc::new(Mutex::new(crate::reporter::CollectedIntervals::default()));
 
-        // Spawn interval reporter (server uses 1.0s default)
+        // Spawn interval reporter (server uses 1.0s default). `report_start` is
+        // captured right before the spawn so its elapsed at TEST_END is the
+        // authoritative final-interval boundary handed to the reporter (#55).
+        let reporter_end = Arc::new(crate::reporter::ReporterEnd::new());
+        let report_start = std::time::Instant::now();
         let interval_handle = {
             let stream_refs: Vec<_> = streams
                 .iter()
@@ -508,13 +512,14 @@ impl Server {
                 },
                 stream_refs,
                 done.clone(),
+                reporter_end.clone(),
                 collect_intervals.then(|| interval_data.clone()),
             )
         };
 
         // ---- Wait for TEST_END (with optional max duration and bitrate limit) ----
         let bitrate_limit = self.server_bitrate_limit;
-        let test_start = std::time::Instant::now();
+        let test_start = report_start;
         let max_dur_secs = self.server_max_duration.unwrap_or(0) as u64;
 
         let mut rate_check = tokio::time::interval(std::time::Duration::from_secs(1));
@@ -561,8 +566,12 @@ impl Server {
         let _ = server_terminated;
 
         // ---- Shut down streams ----
+        // Hand the reporter the authoritative end time, then stop the streams
+        // (`done`) so no received bytes leak past the deadline into the final
+        // interval (#55). The reporter prioritises `finish` over `done`, so the
+        // final interval still flushes; wait for it before tearing streams down.
+        reporter_end.finish(report_start.elapsed().as_secs_f64());
         done.store(true, Ordering::Relaxed);
-
         if let Some(handle) = interval_handle {
             let _ = handle.await;
         }

--- a/riperf3/src/stream.rs
+++ b/riperf3/src/stream.rs
@@ -70,6 +70,19 @@ impl StreamCounters {
         self.bytes_received_interval.swap(0, Ordering::Relaxed)
     }
 
+    /// Read the sent interval counter without clearing it. Used to decide
+    /// whether a final partial interval has any residual bytes to report (#55)
+    /// without disturbing the next `take_sent_interval`.
+    pub fn peek_sent_interval(&self) -> u64 {
+        self.bytes_sent_interval.load(Ordering::Relaxed)
+    }
+
+    /// Read the received interval counter without clearing it (see
+    /// [`Self::peek_sent_interval`]).
+    pub fn peek_received_interval(&self) -> u64 {
+        self.bytes_received_interval.load(Ordering::Relaxed)
+    }
+
     pub fn bytes_sent(&self) -> u64 {
         self.bytes_sent.load(Ordering::Relaxed)
     }

--- a/riperf3/src/stream.rs
+++ b/riperf3/src/stream.rs
@@ -70,9 +70,8 @@ impl StreamCounters {
         self.bytes_received_interval.swap(0, Ordering::Relaxed)
     }
 
-    /// Read the sent interval counter without clearing it. Used to decide
-    /// whether a final partial interval has any residual bytes to report (#55)
-    /// without disturbing the next `take_sent_interval`.
+    /// Read the sent interval counter without clearing it, to test whether a
+    /// final partial interval carries any residual bytes (#55).
     pub fn peek_sent_interval(&self) -> u64 {
         self.bytes_sent_interval.load(Ordering::Relaxed)
     }

--- a/riperf3/tests/integration.rs
+++ b/riperf3/tests/integration.rs
@@ -1374,6 +1374,148 @@ mod interval_reporter_tests {
             let _ = h.await;
         }
     }
+
+    /// #55: a test that ends part-way through an interval must still emit a
+    /// final partial interval carrying the residual bytes, rather than dropping
+    /// it. Drives two full intervals, then a partial third, and asserts the last
+    /// collected interval is the short partial (residual bytes, sub-interval
+    /// duration) — not a full interval and not missing entirely.
+    #[tokio::test]
+    async fn final_partial_interval_is_emitted() {
+        use riperf3::reporter::{CollectedIntervals, IntervalStreamRef};
+        use riperf3::stream::StreamCounters;
+        use std::sync::Mutex;
+        use std::time::Duration;
+
+        let interval = 0.5_f64;
+        let counters = Arc::new(StreamCounters::new());
+        let done = Arc::new(AtomicBool::new(false));
+        let collector = Arc::new(Mutex::new(CollectedIntervals::default()));
+
+        let stream_ref = IntervalStreamRef {
+            id: 1,
+            is_sender: true,
+            counters: counters.clone(),
+            udp_recv_stats: None,
+            raw_fd: None,
+        };
+        let config = IntervalReporterConfig {
+            interval_secs: interval,
+            protocol: TransportProtocol::Tcp,
+            format_char: 'a',
+            omit_secs: 0,
+            num_streams: 1,
+            forceflush: false,
+            timestamp_format: None,
+            json_stream: false,
+            print: false, // collect-only; assert on the collector
+            blksize: 128 * 1024,
+        };
+        let handle = spawn_interval_reporter(
+            config,
+            vec![stream_ref],
+            done.clone(),
+            Some(collector.clone()),
+        )
+        .expect("reporter spawns for a positive interval");
+
+        // Two full intervals, each draining 1000 bytes at its tick. The 650ms
+        // sleeps give ~150ms slack so each tick lands before the next batch.
+        counters.record_sent(1000);
+        tokio::time::sleep(Duration::from_millis(650)).await; // tick @0.5 -> [0,0.5]=1000
+        counters.record_sent(1000);
+        tokio::time::sleep(Duration::from_millis(650)).await; // tick @1.0 -> [0.5,1.0]=1000
+
+        // Partial third interval: residual bytes, then end well before the @1.5
+        // tick so the run terminates mid-interval.
+        counters.record_sent(500);
+        tokio::time::sleep(Duration::from_millis(120)).await; // ~1.42s
+        done.store(true, Ordering::Relaxed);
+        let _ = handle.await;
+
+        let g = collector.lock().unwrap();
+        let n = g.intervals.len();
+        assert!(n >= 1, "expected at least one collected interval");
+        let last = &g.intervals[n - 1];
+        // The defining property of the fix: the last interval is the short
+        // partial holding the 500 residual bytes — pre-fix it was dropped, so
+        // the last interval would be a full [0.5,1.0]=1000 instead.
+        assert_eq!(
+            last.sum.bytes, 500,
+            "final partial must carry the residual 500 bytes; got {} (intervals={n})",
+            last.sum.bytes
+        );
+        let dur = last.sum.end - last.sum.start;
+        assert!(
+            dur > 0.0 && dur < interval,
+            "final interval must be a sub-interval partial; start={} end={} dur={dur}",
+            last.sum.start,
+            last.sum.end
+        );
+    }
+
+    /// #55 guard: a run that ends right after a tick (no residual bytes) must
+    /// NOT emit a trailing empty partial. The prompt `done` detection still
+    /// measures a few ms of slack past the boundary, so without the residual
+    /// guard a spurious 0-byte interval would appear.
+    #[tokio::test]
+    async fn no_spurious_partial_when_ending_on_boundary() {
+        use riperf3::reporter::{CollectedIntervals, IntervalStreamRef};
+        use riperf3::stream::StreamCounters;
+        use std::sync::Mutex;
+        use std::time::Duration;
+
+        let interval = 0.5_f64;
+        let counters = Arc::new(StreamCounters::new());
+        let done = Arc::new(AtomicBool::new(false));
+        let collector = Arc::new(Mutex::new(CollectedIntervals::default()));
+
+        let stream_ref = IntervalStreamRef {
+            id: 1,
+            is_sender: true,
+            counters: counters.clone(),
+            udp_recv_stats: None,
+            raw_fd: None,
+        };
+        let config = IntervalReporterConfig {
+            interval_secs: interval,
+            protocol: TransportProtocol::Tcp,
+            format_char: 'a',
+            omit_secs: 0,
+            num_streams: 1,
+            forceflush: false,
+            timestamp_format: None,
+            json_stream: false,
+            print: false,
+            blksize: 128 * 1024,
+        };
+        let handle = spawn_interval_reporter(
+            config,
+            vec![stream_ref],
+            done.clone(),
+            Some(collector.clone()),
+        )
+        .expect("reporter spawns for a positive interval");
+
+        // Two full intervals, then end without recording any further bytes — the
+        // 1.0s tick already drained everything, so the tail has zero residual.
+        counters.record_sent(1000);
+        tokio::time::sleep(Duration::from_millis(650)).await; // tick @0.5
+        counters.record_sent(1000);
+        tokio::time::sleep(Duration::from_millis(650)).await; // tick @1.0, now ~1.3s
+        done.store(true, Ordering::Relaxed); // ends ~1.3s, no residual bytes
+        let _ = handle.await;
+
+        let g = collector.lock().unwrap();
+        assert_eq!(
+            g.intervals.len(),
+            2,
+            "no trailing empty partial expected; got {} intervals",
+            g.intervals.len()
+        );
+        let last = g.intervals.last().unwrap();
+        assert_eq!(last.sum.bytes, 1000, "last interval is the full [0.5,1.0]");
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/riperf3/tests/integration.rs
+++ b/riperf3/tests/integration.rs
@@ -1310,7 +1310,7 @@ mod json_output_tests {
 
 mod interval_reporter_tests {
     use riperf3::protocol::TransportProtocol;
-    use riperf3::reporter::{spawn_interval_reporter, IntervalReporterConfig};
+    use riperf3::reporter::{spawn_interval_reporter, IntervalReporterConfig, ReporterEnd};
     use std::sync::atomic::{AtomicBool, Ordering};
     use std::sync::Arc;
 
@@ -1329,7 +1329,10 @@ mod interval_reporter_tests {
             print: true,
             blksize: 128 * 1024,
         };
-        assert!(spawn_interval_reporter(config, vec![], done, None).is_none());
+        assert!(
+            spawn_interval_reporter(config, vec![], done, Arc::new(ReporterEnd::new()), None)
+                .is_none()
+        );
     }
 
     #[tokio::test]
@@ -1347,7 +1350,10 @@ mod interval_reporter_tests {
             print: true,
             blksize: 128 * 1024,
         };
-        assert!(spawn_interval_reporter(config, vec![], done, None).is_none());
+        assert!(
+            spawn_interval_reporter(config, vec![], done, Arc::new(ReporterEnd::new()), None)
+                .is_none()
+        );
     }
 
     #[tokio::test]
@@ -1365,9 +1371,15 @@ mod interval_reporter_tests {
             print: true,
             blksize: 128 * 1024,
         };
-        let handle = spawn_interval_reporter(config, vec![], done.clone(), None);
+        let handle = spawn_interval_reporter(
+            config,
+            vec![],
+            done.clone(),
+            Arc::new(ReporterEnd::new()),
+            None,
+        );
         assert!(handle.is_some());
-        // Let it tick once then stop
+        // Let it tick once then stop via the `done` fallback (no `finish`).
         tokio::time::sleep(std::time::Duration::from_millis(600)).await;
         done.store(true, Ordering::Relaxed);
         if let Some(h) = handle {
@@ -1411,10 +1423,13 @@ mod interval_reporter_tests {
             print: false, // collect-only; assert on the collector
             blksize: 128 * 1024,
         };
+        let reporter_end = Arc::new(ReporterEnd::new());
+        let report_start = std::time::Instant::now();
         let handle = spawn_interval_reporter(
             config,
             vec![stream_ref],
             done.clone(),
+            reporter_end.clone(),
             Some(collector.clone()),
         )
         .expect("reporter spawns for a positive interval");
@@ -1426,11 +1441,12 @@ mod interval_reporter_tests {
         counters.record_sent(1000);
         tokio::time::sleep(Duration::from_millis(650)).await; // tick @1.0 -> [0.5,1.0]=1000
 
-        // Partial third interval: residual bytes, then end well before the @1.5
-        // tick so the run terminates mid-interval.
+        // Partial third interval: residual bytes, then end mid-interval (well
+        // before the @1.5 tick) by signalling the authoritative end time, exactly
+        // as the client/server driver does.
         counters.record_sent(500);
         tokio::time::sleep(Duration::from_millis(120)).await; // ~1.42s
-        done.store(true, Ordering::Relaxed);
+        reporter_end.finish(report_start.elapsed().as_secs_f64());
         let _ = handle.await;
 
         let g = collector.lock().unwrap();
@@ -1454,10 +1470,12 @@ mod interval_reporter_tests {
         );
     }
 
-    /// #55 guard: a run that ends right after a tick (no residual bytes) must
-    /// NOT emit a trailing empty partial. The prompt `done` detection still
-    /// measures a few ms of slack past the boundary, so without the residual
-    /// guard a spurious 0-byte interval would appear.
+    /// #55 guard: a run that ends exactly on an interval boundary must NOT emit a
+    /// trailing partial — even when the sender is still writing into the socket
+    /// at that instant (the saturating-TCP case). Records "slack" bytes after the
+    /// last tick to model the live sender, then finishes on the boundary; the
+    /// zero-length remainder must be dropped, so the slack bytes never surface as
+    /// a spurious interval.
     #[tokio::test]
     async fn no_spurious_partial_when_ending_on_boundary() {
         use riperf3::reporter::{CollectedIntervals, IntervalStreamRef};
@@ -1489,32 +1507,105 @@ mod interval_reporter_tests {
             print: false,
             blksize: 128 * 1024,
         };
+        let reporter_end = Arc::new(ReporterEnd::new());
         let handle = spawn_interval_reporter(
             config,
             vec![stream_ref],
             done.clone(),
+            reporter_end.clone(),
             Some(collector.clone()),
         )
         .expect("reporter spawns for a positive interval");
 
-        // Two full intervals, then end without recording any further bytes — the
-        // 1.0s tick already drained everything, so the tail has zero residual.
+        // Two full intervals.
         counters.record_sent(1000);
         tokio::time::sleep(Duration::from_millis(650)).await; // tick @0.5
         counters.record_sent(1000);
         tokio::time::sleep(Duration::from_millis(650)).await; // tick @1.0, now ~1.3s
-        done.store(true, Ordering::Relaxed); // ends ~1.3s, no residual bytes
+
+        // Live sender: bytes are still landing right as the run ends on the 1.0s
+        // boundary. The authoritative end time is exactly 1.0, so the remainder is
+        // zero-length and must be dropped despite these residual bytes.
+        counters.record_sent(777);
+        reporter_end.finish(1.0);
         let _ = handle.await;
 
         let g = collector.lock().unwrap();
         assert_eq!(
             g.intervals.len(),
             2,
-            "no trailing empty partial expected; got {} intervals",
+            "no trailing partial when ending on a boundary; got {} intervals",
             g.intervals.len()
         );
         let last = g.intervals.last().unwrap();
-        assert_eq!(last.sum.bytes, 1000, "last interval is the full [0.5,1.0]");
+        assert_eq!(
+            last.sum.bytes, 1000,
+            "last interval is the full [0.5,1.0]; the 777 slack bytes are not a new interval"
+        );
+    }
+
+    /// #55 receiver-side guard: a receiver whose `end_secs` trails the last
+    /// boundary (the control round-trip that delivers TEST_END) but whose tail
+    /// has no residual bytes (the peer already stopped) must not emit a trailing
+    /// empty interval. Mirrors the server's situation.
+    #[tokio::test]
+    async fn no_partial_for_receiver_with_no_residual() {
+        use riperf3::reporter::{CollectedIntervals, IntervalStreamRef};
+        use riperf3::stream::StreamCounters;
+        use std::sync::Mutex;
+        use std::time::Duration;
+
+        let interval = 0.5_f64;
+        let counters = Arc::new(StreamCounters::new());
+        let done = Arc::new(AtomicBool::new(false));
+        let collector = Arc::new(Mutex::new(CollectedIntervals::default()));
+
+        let stream_ref = IntervalStreamRef {
+            id: 1,
+            is_sender: false, // receiver side
+            counters: counters.clone(),
+            udp_recv_stats: None,
+            raw_fd: None,
+        };
+        let config = IntervalReporterConfig {
+            interval_secs: interval,
+            protocol: TransportProtocol::Tcp,
+            format_char: 'a',
+            omit_secs: 0,
+            num_streams: 1,
+            forceflush: false,
+            timestamp_format: None,
+            json_stream: false,
+            print: false,
+            blksize: 128 * 1024,
+        };
+        let reporter_end = Arc::new(ReporterEnd::new());
+        let handle = spawn_interval_reporter(
+            config,
+            vec![stream_ref],
+            done.clone(),
+            reporter_end.clone(),
+            Some(collector.clone()),
+        )
+        .expect("reporter spawns for a positive interval");
+
+        // One full interval of received bytes, then the peer stops: no further
+        // bytes arrive before the run ends.
+        counters.record_received(1000);
+        tokio::time::sleep(Duration::from_millis(650)).await; // tick @0.5 -> [0,0.5]=1000
+
+        // end_secs trails the 0.5 boundary (as TEST_END would), but the tail is
+        // empty — the residual-bytes guard must drop it.
+        reporter_end.finish(0.62);
+        let _ = handle.await;
+
+        let g = collector.lock().unwrap();
+        assert_eq!(
+            g.intervals.len(),
+            1,
+            "no trailing empty interval for an idle receiver tail; got {} intervals",
+            g.intervals.len()
+        );
     }
 }
 


### PR DESCRIPTION
Closes #55. **Minor bump to 0.7.0** (breaking: `spawn_interval_reporter` gains a `ReporterEnd` parameter).

## Problem
The interval reporter looped `tick -> if done break`, so it learned of test-end only at its next tick and could drop the final in-progress interval. A 2s `-i 1` run intermittently printed 1 interval instead of 2; `-J`/`--json-stream` lost the tail too.

## Design (authoritative end signal)
The naive fix — emit `[last_boundary, detection_time]` — fails: the reporter detects `done` a slack after the deadline, and a saturating sender writes into that slack, so the "partial" becomes a spurious extra interval with real bytes (this was caught reviewing the binary, not the unit test). iperf3 avoids it by stopping senders synchronously before its final stats; riperf3's reporter is a decoupled task, so it can't measure that itself without help.

So the **driver hands the reporter the authoritative end time**:
- New `ReporterEnd` (a `Notify` + end-seconds). The client/server call `finish(end_secs)` at the deadline, then set `done`. The reporter's select is **biased to the finish signal**, so it flushes the final interval `[last_boundary, end_secs]` before it would observe `done`, then stops.
- The sender driver passes the **exact `-t`** (not measured elapsed, which trails the deadline by scheduling slack). A boundary-aligned duration yields a zero-length remainder → skipped → **no spurious trailing interval**.
- `finish` precedes `done`, so senders stop **at** the deadline: the summary isn't inflated and the final interval carries no post-deadline bytes. The receiver side keeps a residual-bytes guard (`peek_*`, additive) for its boundary tail.
- The final interval reuses the **last sampled TCP_INFO** when the socket has already closed, so it still shows Cwnd/RTT/Retr like the periodic lines (was flaky/blank otherwise).
- The ~250-line per-tick body is extracted into a shared `emit_interval` closure so periodic ticks and the final flush render/collect identically.

## iperf3 ground truth (re: the review's "iperf3 emits two intervals")
Built and ran real iperf3 on loopback: its **server also emits an intermittent in-flight tail interval** (`[2.00-2.00] sec ~MBytes`, ~50% of runs) — the reviewer's claim was source-derived but is empirically false on loopback. So riperf3's receiver-side tail (in-flight TCP data) is **faithful** to iperf3; the canonical client side now matches iperf3's 2 intervals exactly.

## Verification (binary, loopback)
- `-i 1 -t 2`: **2 intervals**, every run, across default / `-R` / `-J`.
- `-i 0.3 -t 1`: genuine `0.90-1.00` partial, with Cwnd/RTT columns (8/8).
- Byte-limited `-n`: final partial emitted.
- Summary throughput unchanged (separate code path; senders stop at the deadline).
- `cargo test --workspace` (3 new timing tests), `clippy -D warnings`, `fmt --check` all clean.

## Tests
`final_partial_interval_is_emitted`, `no_spurious_partial_when_ending_on_boundary` (models a live sender writing slack bytes), `no_partial_for_receiver_with_no_residual`.

## Notes
- Under extreme loopback throughput (~120 Gbit/s), CPU-bound senders can starve the reporter task and it may collect fewer ticks (pre-existing #5 territory; not a real-network case).