### PR TITLE
fix: daemonize before building the runtime so -s -D serves (#81)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,8 +23,23 @@ data-path/throughput changes.
   the authoritative end-of-test time via `ReporterEnd::finish(end_secs)`. The new
   public `ReporterEnd` type is the only API addition required by the fix. The CLI
   binary is unaffected; only direct library consumers need to update.
+- **BREAKING (library API): server daemonization removed from the library**
+  (#81). `ServerBuilder::daemon()` and the `Server::daemon` field are gone, and
+  `Server::run()` no longer forks. A library consumer that wants a daemon must
+  `daemon()`/fork *before* constructing its async runtime — doing it from inside
+  `run()` cannot work (see Fixed). The CLI is unaffected; `-s -D` behaves as
+  before, only correctly.
 
 ### Fixed
+- **`-s -D` daemon mode now actually serves** (#81): the server called
+  `daemon()` *after* the multi-threaded tokio runtime was built. `daemon()`
+  forks, and a fork of a multi-threaded process keeps only the calling thread in
+  the child, so the daemon had no tokio worker threads — it accepted the control
+  connection but never ran a test, and every client hung. The CLI now daemonizes
+  *before* building the runtime, matching iperf3's `daemon(1, 0)` (keeps the
+  working directory so relative `-I`/`--logfile` paths resolve as given;
+  redirects std{in,out,err} to `/dev/null`) and writes the pidfile after the
+  fork so it records the daemon's pid.
 - **The final (partial) interval is no longer dropped** (#55): the interval
   reporter looped `tick -> if done break`, so a run that ended part-way through an
   interval lost its last interval (a 2s `-i 1` run intermittently printed 1

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ riperf3 builds on Linux, macOS, FreeBSD, and Windows. Linux is the reference pla
 | `--dont-fragment` | yes | yes | yes | yes |
 | `-Z` zerocopy (sendfile) | yes | yes | yes | |
 | `-C` congestion control | yes | | yes | |
-| `-D` daemon | yes\* | | yes\* | |
+| `-D` daemon | yes | | yes | |
 | `--bind-dev` | yes | yes | | |
 | `--rcv-timeout` | yes | yes | yes | |
 | `--cntl-ka` keepalive | yes | yes | yes | |
@@ -97,8 +97,6 @@ riperf3 builds on Linux, macOS, FreeBSD, and Windows. Linux is the reference pla
 | `--sendmmsg` batched UDP | yes | | yes | |
 
 All platform-specific flags match iperf3's support matrix exactly for flags shared with iperf3. `--sendmmsg` is a riperf3-exclusive experimental optimization. Blank cells indicate the feature is unavailable on that platform in both riperf3 and iperf3. Unsupported flags return a clear error at startup.
-
-\* `-s -D` daemon mode is currently broken — the daemonized server listens but never serves, so clients hang ([#81](https://github.com/therealevanhenry/riperf3/issues/81)). Tracked for a post-0.6.0 fix; use a foreground `-s` server meanwhile.
 
 ## CLI Reference
 
@@ -229,7 +227,7 @@ cargo clippy --all-targets -- -D warnings      # lint
 
 Feature-complete for the core iperf3 flag set, with full interchange compatibility verified against real iperf3 (current and 3.12) in both directions across all modes. Linux and macOS are fully supported and exercised in native CI; Windows compiles and cross-checks but has a few runtime gaps under active triage; FreeBSD is supported via conditional compilation. Platform-specific flags match iperf3's support matrix (see [Platform Support](#platform-support)).
 
-See [CHANGELOG.md](CHANGELOG.md) for the 0.6.0 release notes and current known issues — including a daemon-mode (`-s -D`) bug ([#81](https://github.com/therealevanhenry/riperf3/issues/81)) and a handful of options that are accepted but not yet fully effective.
+See [CHANGELOG.md](CHANGELOG.md) for the release notes and current known issues — including a handful of options that are accepted but not yet fully effective.
 
 Not yet implemented:
 - SCTP transport

--- a/riperf3-cli/src/cli.rs
+++ b/riperf3-cli/src/cli.rs
@@ -1141,14 +1141,14 @@ mod cli_tests {
 
         // Server new flags
         #[test]
-        fn server_daemon_wired() {
+        fn server_daemon_flag_parses() {
+            // `-D`/`--daemon` is consumed by the binary (it daemonizes before the
+            // tokio runtime is built — see main.rs / #81), not by ServerBuilder,
+            // so there's nothing to wire through the builder; just assert parse.
             let cli = Cli::parse_from(["riperf3", "-s", "-D"]);
-            let mut b = riperf3::ServerBuilder::new();
-            if cli.daemon {
-                b = b.daemon(true);
-            }
-            let s = b.build().unwrap();
-            assert!(s.daemon);
+            assert!(cli.daemon);
+            let long = Cli::parse_from(["riperf3", "-s", "--daemon"]);
+            assert!(long.daemon);
         }
 
         #[test]

--- a/riperf3-cli/src/main.rs
+++ b/riperf3-cli/src/main.rs
@@ -30,12 +30,33 @@ fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
         }
     }
 
-    // Write PID file if requested
+    // Daemonize BEFORE building the tokio runtime. `daemon()` forks, and forking
+    // a process that already has a multi-threaded runtime leaves the child with
+    // only the calling thread — no tokio workers — so the daemon would accept the
+    // control connection but never serve (#81). Doing it here, in the binary,
+    // also keeps the library's async `Server::run()` free of a process-level fork
+    // it cannot perform safely from inside the runtime. Matches iperf3's
+    // `daemon(1, 0)`: nochdir=true (keep CWD so a relative `-I`/`--logfile` path
+    // resolves as given) and noclose=false (redirect std{in,out,err} to
+    // /dev/null). The pidfile and logfile are set up just below — AFTER the fork —
+    // so the pidfile records the daemon child's pid and the logfile redirect
+    // survives daemon()'s stdout->/dev/null (iperf3 likewise creates its pidfile
+    // after daemon()).
+    if cli.server && cli.daemon {
+        #[cfg(any(target_os = "linux", target_os = "freebsd", target_os = "netbsd"))]
+        nix::unistd::daemon(true, false).map_err(|e| format!("failed to daemonize: {e}"))?;
+        #[cfg(not(any(target_os = "linux", target_os = "freebsd", target_os = "netbsd")))]
+        return Err("daemon mode is not supported on this platform".into());
+    }
+
+    // Write the PID file (after daemonizing, so it records the daemon child's
+    // pid — the long-lived server — not the foreground process that forked away).
     if let Some(ref path) = cli.pidfile {
         std::fs::write(path, format!("{}\n", std::process::id()))?;
     }
 
-    // Redirect stdout to logfile if requested
+    // Redirect stdout to logfile if requested. Must run after daemonizing so the
+    // redirect isn't clobbered by daemon()'s stdout->/dev/null.
     if let Some(ref path) = cli.logfile {
         #[cfg(unix)]
         {
@@ -266,9 +287,9 @@ async fn async_main(cli: Cli) -> std::result::Result<(), Box<dyn std::error::Err
         if cli.json_stream {
             builder = builder.json_stream(true);
         }
-        if cli.daemon {
-            builder = builder.daemon(true);
-        }
+        // Note: `-D`/`--daemon` is handled in the binary before the runtime is
+        // built (see daemonize block in `main`), not via the library builder —
+        // the library cannot fork safely from inside the async runtime (#81).
         if let Some(secs) = cli.idle_timeout {
             builder = builder.idle_timeout(secs);
         }

--- a/riperf3-cli/tests/daemon.rs
+++ b/riperf3-cli/tests/daemon.rs
@@ -5,9 +5,12 @@
 //! already has a multi-threaded runtime leaves the child with only the calling
 //! thread — no tokio worker threads — so the daemon accepted the control
 //! connection but never actually served, and every client hung. The fix
-//! daemonizes in the binary *before* the runtime is built. This test spawns the
-//! real daemon and runs a client against it; before the fix the client hangs
-//! (caught here by a bounded wait) and the test fails.
+//! daemonizes in the binary *before* the runtime is built (and writes the
+//! pidfile from the daemon child, not the parent that forks away). This test
+//! spawns the real daemon and runs a client against it. Before the fix it fails
+//! one of two ways: the pidfile records the dead forking parent, so the
+//! liveness probe below trips; or, failing that, the daemon never serves and
+//! the bounded client wait times out. Either way the test goes red.
 //!
 //! Gated to the platforms that support `daemon()` (same set as the binary).
 

--- a/riperf3-cli/tests/daemon.rs
+++ b/riperf3-cli/tests/daemon.rs
@@ -1,0 +1,116 @@
+//! CLI integration test for `-s -D` daemon mode (#81).
+//!
+//! Regression: the server used to call `daemon()` *after* the multi-threaded
+//! tokio runtime was built. `daemon()` forks, and forking a process that
+//! already has a multi-threaded runtime leaves the child with only the calling
+//! thread — no tokio worker threads — so the daemon accepted the control
+//! connection but never actually served, and every client hung. The fix
+//! daemonizes in the binary *before* the runtime is built. This test spawns the
+//! real daemon and runs a client against it; before the fix the client hangs
+//! (caught here by a bounded wait) and the test fails.
+//!
+//! Gated to the platforms that support `daemon()` (same set as the binary).
+
+#![cfg(any(target_os = "linux", target_os = "freebsd", target_os = "netbsd"))]
+
+use std::path::Path;
+use std::process::Command;
+use std::time::{Duration, Instant};
+
+/// Best-effort cleanup: kill the reparented daemon and remove its pidfile when
+/// the test ends (success or panic), so a failure can't leak a server holding
+/// the port.
+struct Reaper {
+    pid: Option<i32>,
+    pidfile: std::path::PathBuf,
+}
+
+impl Drop for Reaper {
+    fn drop(&mut self) {
+        if let Some(pid) = self.pid {
+            // SIGTERM the daemon; ignore errors (it may already be gone, e.g.
+            // after a successful one-off run).
+            unsafe {
+                libc::kill(pid, libc::SIGTERM);
+            }
+        }
+        let _ = std::fs::remove_file(&self.pidfile);
+    }
+}
+
+/// Poll for the pidfile to appear and contain a parseable pid.
+fn wait_for_pid(pidfile: &Path, timeout: Duration) -> Option<i32> {
+    let deadline = Instant::now() + timeout;
+    while Instant::now() < deadline {
+        if let Ok(s) = std::fs::read_to_string(pidfile) {
+            if let Ok(pid) = s.trim().parse::<i32>() {
+                return Some(pid);
+            }
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    None
+}
+
+#[test]
+fn daemon_server_serves_a_client() {
+    let bin = env!("CARGO_BIN_EXE_riperf3");
+    // Fixed port: only this test uses it. Picked high to avoid collisions.
+    let port = 15397u16;
+    let pidfile = std::env::temp_dir().join(format!("riperf3-daemon-test-{port}.pid"));
+    let _ = std::fs::remove_file(&pidfile);
+
+    // Spawn the daemon. With `-D` the foreground process forks and exits
+    // immediately; the real server is reparented to init. `-1` (one-off) makes
+    // the daemon exit after serving a single test, so it self-cleans.
+    let port_s = port.to_string();
+    let status = Command::new(bin)
+        .args(["-s", "-D", "-1", "-p", &port_s, "-I"])
+        .arg(&pidfile)
+        .status()
+        .expect("failed to spawn daemon");
+    assert!(
+        status.success(),
+        "daemon foreground process exited non-zero: {status:?}"
+    );
+
+    // The daemon child writes the pidfile after fork(); wait for it.
+    let pid = wait_for_pid(&pidfile, Duration::from_secs(5));
+    let mut reaper = Reaper {
+        pid,
+        pidfile: pidfile.clone(),
+    };
+    let pid = pid.expect("daemon never wrote a pidfile (did it die at fork?)");
+
+    // Give the listener a moment to bind before connecting.
+    std::thread::sleep(Duration::from_millis(300));
+
+    // Run a short byte-limited client against the daemon. Spawn it as a child
+    // and bound the wait: before the fix the daemon never serves and the client
+    // hangs, so a plain blocking call would hang the whole test suite.
+    let mut client = Command::new(bin)
+        .args(["-c", "127.0.0.1", "-p", &port_s, "-n", "1M"])
+        .spawn()
+        .expect("failed to spawn client");
+
+    let deadline = Instant::now() + Duration::from_secs(15);
+    let exit = loop {
+        match client.try_wait().expect("try_wait on client") {
+            Some(status) => break Some(status),
+            None if Instant::now() >= deadline => {
+                let _ = client.kill();
+                let _ = client.wait();
+                break None;
+            }
+            None => std::thread::sleep(Duration::from_millis(100)),
+        }
+    };
+
+    // The daemon served the one-off test and has now exited; don't let the
+    // reaper SIGTERM an unrelated pid that may have recycled it.
+    reaper.pid = None;
+    let _ = pid; // silence unused if the asserts below are compiled out
+
+    let exit = exit.expect("client hung against the daemon — server never served (#81)");
+    assert!(exit.success(), "client failed against the daemon: {exit:?}");
+}

--- a/riperf3-cli/tests/daemon.rs
+++ b/riperf3-cli/tests/daemon.rs
@@ -38,6 +38,17 @@ impl Drop for Reaper {
     }
 }
 
+/// Grab a currently-free ephemeral port. There's an inherent TOCTOU gap between
+/// releasing it and the daemon binding it, but it avoids the real flakiness of a
+/// hardcoded port (a leaked or concurrent server sitting on it).
+fn free_port() -> u16 {
+    std::net::TcpListener::bind("127.0.0.1:0")
+        .expect("bind ephemeral port")
+        .local_addr()
+        .expect("local_addr")
+        .port()
+}
+
 /// Poll for the pidfile to appear and contain a parseable pid.
 fn wait_for_pid(pidfile: &Path, timeout: Duration) -> Option<i32> {
     let deadline = Instant::now() + timeout;
@@ -55,8 +66,7 @@ fn wait_for_pid(pidfile: &Path, timeout: Duration) -> Option<i32> {
 #[test]
 fn daemon_server_serves_a_client() {
     let bin = env!("CARGO_BIN_EXE_riperf3");
-    // Fixed port: only this test uses it. Picked high to avoid collisions.
-    let port = 15397u16;
+    let port = free_port();
     let pidfile = std::env::temp_dir().join(format!("riperf3-daemon-test-{port}.pid"));
     let _ = std::fs::remove_file(&pidfile);
 
@@ -82,6 +92,14 @@ fn daemon_server_serves_a_client() {
     };
     let pid = pid.expect("daemon never wrote a pidfile (did it die at fork?)");
 
+    // The daemon child must actually be running (fork succeeded, not dead).
+    // `kill(pid, 0)` probes for existence without delivering a signal.
+    assert_eq!(
+        unsafe { libc::kill(pid, 0) },
+        0,
+        "daemon pid {pid} is not alive after fork"
+    );
+
     // Give the listener a moment to bind before connecting.
     std::thread::sleep(Duration::from_millis(300));
 
@@ -106,11 +124,12 @@ fn daemon_server_serves_a_client() {
         }
     };
 
-    // The daemon served the one-off test and has now exited; don't let the
-    // reaper SIGTERM an unrelated pid that may have recycled it.
-    reaper.pid = None;
-    let _ = pid; // silence unused if the asserts below are compiled out
-
     let exit = exit.expect("client hung against the daemon — server never served (#81)");
     assert!(exit.success(), "client failed against the daemon: {exit:?}");
+
+    // Disarm the reaper only here, on full success: the one-off daemon has served
+    // the test and is exiting on its own, so there's nothing to kill and we avoid
+    // SIGTERMing a possibly-recycled pid. Any earlier panic (notably the hang on
+    // line above) leaves the reaper armed so it reaps the leaked daemon.
+    reaper.pid = None;
 }

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -78,7 +78,6 @@ pub struct Server {
     pub port: u16,
     pub one_off: bool,
     pub verbose: bool,
-    pub daemon: bool,
     pub idle_timeout: Option<u32>,
     pub server_bitrate_limit: Option<u64>,
     pub server_max_duration: Option<u32>,
@@ -101,18 +100,10 @@ pub struct Server {
 
 impl Server {
     pub async fn run(&self) -> Result<()> {
-        if self.daemon {
-            #[cfg(any(target_os = "linux", target_os = "freebsd", target_os = "netbsd"))]
-            nix::unistd::daemon(false, false)
-                .map_err(|e| RiperfError::Io(std::io::Error::from(e)))?;
-            #[cfg(not(any(target_os = "linux", target_os = "freebsd", target_os = "netbsd")))]
-            {
-                return Err(RiperfError::Protocol(
-                    "daemon mode is not supported on this platform".into(),
-                ));
-            }
-        }
-
+        // Daemonizing (`-s -D`) is a process-level concern handled by the binary
+        // *before* the tokio runtime is built — `daemon()` forks, and a fork from
+        // inside a multi-threaded runtime would leave the child with no worker
+        // threads (#81). The library must not fork here.
         let listener =
             net::tcp_listen(self.bind_address.as_deref(), self.port, self.ip_version).await?;
         // Under -J / --json-stream iperf3's server stdout is pure JSON (the
@@ -899,7 +890,6 @@ pub struct ServerBuilder {
     port: Option<u16>,
     one_off: bool,
     verbose: bool,
-    daemon: bool,
     idle_timeout: Option<u32>,
     server_bitrate_limit: Option<u64>,
     server_max_duration: Option<u32>,
@@ -924,7 +914,6 @@ impl Default for ServerBuilder {
             port: Some(DEFAULT_PORT),
             one_off: false,
             verbose: false,
-            daemon: false,
             idle_timeout: None,
             server_bitrate_limit: None,
             server_max_duration: None,
@@ -974,11 +963,6 @@ impl ServerBuilder {
     /// Stream line-delimited interval JSON during the test (`--json-stream`).
     pub fn json_stream(mut self, enabled: bool) -> Self {
         self.json_stream = enabled;
-        self
-    }
-
-    pub fn daemon(mut self, daemon: bool) -> Self {
-        self.daemon = daemon;
         self
     }
 
@@ -1066,13 +1050,6 @@ impl ServerBuilder {
     }
 
     pub fn build(self) -> std::result::Result<Server, ConfigError> {
-        #[cfg(not(unix))]
-        if self.daemon {
-            return Err(ConfigError::Unsupported(
-                "daemon mode is not supported on this platform".into(),
-            ));
-        }
-
         // Reject -4/-6 contradicting an explicit -B of the opposite family,
         // instead of silently letting the bind address win (issue #12).
         if let (Some(v), Some(addr)) = (self.ip_version, self.bind_address.as_deref()) {
@@ -1094,7 +1071,6 @@ impl ServerBuilder {
             port: self.port.unwrap_or(DEFAULT_PORT),
             one_off: self.one_off,
             verbose: self.verbose,
-            daemon: self.daemon,
             idle_timeout: self.idle_timeout,
             server_bitrate_limit: self.server_bitrate_limit,
             server_max_duration: self.server_max_duration,


### PR DESCRIPTION
## Summary

Fixes #81 — `-s -D` daemon mode accepted connections but never served; every client hung.

**Root cause:** `Server::run()` called `nix::unistd::daemon()` *after* the multi-threaded tokio runtime was built. `daemon()` forks, and a fork of a multi-threaded process carries only the calling thread into the child — so the daemon child had **no tokio worker threads**. It accepted the control connection but never ran a test.

**Fix:** daemonize in the CLI binary *before* the runtime is built. The library can't fork safely from inside an async runtime, so daemonization is removed from the library entirely and becomes a pure binary concern.

## Changes

- `riperf3-cli/src/main.rs`: daemonize before `tokio::runtime::Builder…build()`, after the #65 client-only rejection. Matches iperf3's `daemon(1, 0)` — `nochdir=true` (keep CWD so a relative `-I`/`--logfile` resolves as given) and `noclose=false` (redirect std{in,out,err} to `/dev/null`). Pidfile + logfile setup moved after the fork so the pidfile records the **daemon child's** pid (as iperf3 does) and the logfile dup2 survives `daemon()`'s `/dev/null` redirect.
- `riperf3/src/server.rs`: remove the fork from `Server::run()`, plus the `Server::daemon` field and `ServerBuilder::daemon()` builder method. **BREAKING library API** — allowed under the 0.7.0 `0.x` boundary (cargo-semver-checks treats `0.6→0.7` as a major change and skips it; verified locally).
- `riperf3-cli/tests/daemon.rs`: new CLI integration test — spawns the real daemon and runs a client against it. Hangs (→ fails via a bounded wait) before the fix; passes after. Gated to platforms with `daemon()` (linux/freebsd/netbsd, same set as the binary).
- `CHANGELOG.md`: `[0.7.0]` Changed + Fixed entries.

## Verification (local)

- New `daemon.rs` test: **red** (15s hang) before, **green** (~0.75s) after.
- Daemon path produces byte-for-byte identical client output to the normal-server path.
- `cargo test --workspace` (188 + 132 + 60 + 1), `cargo clippy --all-targets -D warnings`, `cargo fmt --check`, `scripts/xcheck.sh` (all 7 targets), `cargo semver-checks` — all clean.

Platform note: macOS keeps its pre-existing behavior (`-s -D` returns "not supported" — `nix` doesn't expose `daemon()` there); extending macOS daemon support is separate scope.