### PR TITLE
fix: --json-stream emits valid NDJSON event objects (#62)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,17 @@ data-path/throughput changes.
   working directory so relative `-I`/`--logfile` paths resolve as given;
   redirects std{in,out,err} to `/dev/null`) and writes the pidfile after the
   fork so it records the daemon's pid.
+- **`--json-stream` now emits valid line-delimited JSON** (#62): it printed text
+  banners (the `[ ID] Interval` header, the `- - -` separator, the final summary
+  lines) interleaved with *bare* per-stream interval objects that had no
+  `event`/`data` wrapping and no `start`/`end` events — so the output was neither
+  parseable NDJSON nor iperf3's event schema. Both the client and the server now
+  emit pure NDJSON: a `{"event":"start","data":{…}}` line, one
+  `{"event":"interval","data":{"streams":[…],"sum":{…}}}` per interval (streamed
+  live and flushed as it happens), then `{"event":"end","data":{…}}`, with no
+  banners. The `start`/`interval`/`end` payloads reuse the typed `-J` model, so
+  each is byte-for-byte the corresponding section of the batched `-J` report
+  (including the cJSON float formatting, #57).
 - **The final (partial) interval is no longer dropped** (#55): the interval
   reporter looped `tick -> if done break`, so a run that ended part-way through an
   interval lost its last interval (a 2s `-i 1` run intermittently printed 1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -822,6 +822,7 @@ dependencies = [
  "log4rs",
  "nix",
  "riperf3",
+ "serde_json",
  "thiserror 2.0.3",
  "tokio",
 ]

--- a/riperf3-cli/Cargo.toml
+++ b/riperf3-cli/Cargo.toml
@@ -26,6 +26,9 @@ tokio.workspace = true
 [target.'cfg(unix)'.dependencies]
 nix.workspace = true
 
+[dev-dependencies]
+serde_json.workspace = true
+
 [[bin]]
 name = "riperf3"
 path = "src/main.rs"

--- a/riperf3-cli/tests/json_stream.rs
+++ b/riperf3-cli/tests/json_stream.rs
@@ -139,12 +139,14 @@ fn client_json_stream_tcp_is_valid_ndjson() {
     let port = free_port();
     let ps = port.to_string();
     let bin = env!("CARGO_BIN_EXE_riperf3");
-    let mut server = Command::new(bin)
-        .args(["-s", "-1", "-p", &ps])
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .spawn()
-        .expect("spawn server");
+    let mut server = ChildGuard(
+        Command::new(bin)
+            .args(["-s", "-1", "-p", &ps])
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("spawn server"),
+    );
     std::thread::sleep(Duration::from_millis(300));
 
     let out = run_capturing(
@@ -162,7 +164,7 @@ fn client_json_stream_tcp_is_valid_ndjson() {
         Duration::from_secs(20),
         "client",
     );
-    let _ = server.wait();
+    let _ = server.0.wait();
     assert_valid_ndjson(&out, "client");
 }
 
@@ -172,12 +174,14 @@ fn client_json_stream_udp_is_valid_ndjson() {
     let port = free_port();
     let ps = port.to_string();
     let bin = env!("CARGO_BIN_EXE_riperf3");
-    let mut server = Command::new(bin)
-        .args(["-s", "-1", "-p", &ps])
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .spawn()
-        .expect("spawn server");
+    let mut server = ChildGuard(
+        Command::new(bin)
+            .args(["-s", "-1", "-p", &ps])
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("spawn server"),
+    );
     std::thread::sleep(Duration::from_millis(300));
 
     let out = run_capturing(
@@ -198,7 +202,7 @@ fn client_json_stream_udp_is_valid_ndjson() {
         Duration::from_secs(20),
         "client-udp",
     );
-    let _ = server.wait();
+    let _ = server.0.wait();
     assert_valid_ndjson(&out, "client-udp");
 }
 

--- a/riperf3-cli/tests/json_stream.rs
+++ b/riperf3-cli/tests/json_stream.rs
@@ -80,8 +80,39 @@ fn assert_valid_ndjson(stdout: &str, who: &str) {
     }
 }
 
-/// Spawn `riperf3` and bound the wait so a hang fails the test instead of the
-/// whole suite. Returns captured stdout (panics on timeout/failure).
+/// Kills the wrapped child on drop, so a spawned server is reaped even if the
+/// test panics before it is waited on.
+struct ChildGuard(std::process::Child);
+
+impl Drop for ChildGuard {
+    fn drop(&mut self) {
+        let _ = self.0.kill();
+        let _ = self.0.wait();
+    }
+}
+
+/// Wait for a child to exit, bounded by `timeout` (kill + panic on timeout), so a
+/// hang fails the test cleanly instead of stalling the whole suite.
+fn wait_bounded(
+    child: &mut std::process::Child,
+    timeout: Duration,
+    who: &str,
+) -> std::process::ExitStatus {
+    let deadline = Instant::now() + timeout;
+    loop {
+        match child.try_wait().expect("try_wait") {
+            Some(status) => return status,
+            None if Instant::now() >= deadline => {
+                let _ = child.kill();
+                let _ = child.wait();
+                panic!("{who}: timed out");
+            }
+            None => std::thread::sleep(Duration::from_millis(50)),
+        }
+    }
+}
+
+/// Spawn `riperf3`, bound its run, and return captured stdout.
 fn run_capturing(args: &[&str], timeout: Duration, who: &str) -> String {
     let bin = env!("CARGO_BIN_EXE_riperf3");
     let mut child = Command::new(bin)
@@ -91,18 +122,7 @@ fn run_capturing(args: &[&str], timeout: Duration, who: &str) -> String {
         .spawn()
         .unwrap_or_else(|e| panic!("{who}: spawn failed: {e}"));
 
-    let deadline = Instant::now() + timeout;
-    loop {
-        match child.try_wait().expect("try_wait") {
-            Some(_) => break,
-            None if Instant::now() >= deadline => {
-                let _ = child.kill();
-                let _ = child.wait();
-                panic!("{who}: timed out");
-            }
-            None => std::thread::sleep(Duration::from_millis(50)),
-        }
-    }
+    wait_bounded(&mut child, timeout, who);
     let mut out = String::new();
     child
         .stdout
@@ -188,30 +208,38 @@ fn server_json_stream_is_valid_ndjson() {
     let port = free_port();
     let ps = port.to_string();
     let bin = env!("CARGO_BIN_EXE_riperf3");
-    let mut server = Command::new(bin)
-        .args(["-s", "-1", "-p", &ps, "--json-stream"])
-        .stdout(Stdio::piped())
-        .stderr(Stdio::null())
-        .spawn()
-        .expect("spawn server");
+    // Guard so the server is reaped even if an assertion below panics.
+    let mut server = ChildGuard(
+        Command::new(bin)
+            .args(["-s", "-1", "-p", &ps, "--json-stream"])
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("spawn server"),
+    );
     std::thread::sleep(Duration::from_millis(300));
 
-    // Drive one test; the one-off server then finishes and closes its stdout.
-    let status = Command::new(bin)
+    // Drive one test, bounded so a non-serving server can't hang the suite.
+    let mut client = Command::new(bin)
         .args(["-c", "127.0.0.1", "-p", &ps, "-t", "1", "-i", "1"])
         .stdout(Stdio::null())
         .stderr(Stdio::null())
-        .status()
-        .expect("run client");
+        .spawn()
+        .expect("spawn client");
+    let status = wait_bounded(&mut client, Duration::from_secs(20), "client");
     assert!(status.success(), "client failed: {status:?}");
 
+    // The one-off server now finishes and closes stdout; bound that wait too.
+    // (Output is a handful of small lines, well under the pipe buffer, so
+    // waiting for exit before reading can't deadlock on a full pipe.)
+    wait_bounded(&mut server.0, Duration::from_secs(20), "server");
     let mut out = String::new();
     server
+        .0
         .stdout
         .take()
         .unwrap()
         .read_to_string(&mut out)
         .unwrap();
-    let _ = server.wait();
     assert_valid_ndjson(&out, "server");
 }

--- a/riperf3-cli/tests/json_stream.rs
+++ b/riperf3-cli/tests/json_stream.rs
@@ -1,0 +1,217 @@
+//! CLI integration test for `--json-stream` NDJSON output (#62).
+//!
+//! Regression: `--json-stream` used to print text banners (the `[ ID] Interval`
+//! header, the `- - -` separator, the final summary lines) interleaved with
+//! *bare* per-stream interval objects that had no `event`/`data` wrapping and no
+//! `start`/`end` events — so the stream was neither valid line-delimited JSON nor
+//! the iperf3 event schema. The fix makes both the client and the server emit
+//! pure NDJSON: `{"event":"start",...}`, one `{"event":"interval",...}` per
+//! interval, then `{"event":"end",...}`, with no banners.
+//!
+//! These tests spawn the real binary, capture the `--json-stream` side's stdout,
+//! and assert every line is a valid JSON event in the right order. Before the
+//! fix the banner lines fail to parse and the bare objects lack `event`.
+
+use std::io::Read;
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+use serde_json::Value;
+
+fn free_port() -> u16 {
+    std::net::TcpListener::bind("127.0.0.1:0")
+        .expect("bind ephemeral port")
+        .local_addr()
+        .expect("local_addr")
+        .port()
+}
+
+/// Assert `stdout` is a valid `--json-stream` document: every non-empty line is a
+/// JSON object with `event` + `data`, and the events run `start`, one or more
+/// `interval`, `end` — in that order, with nothing else mixed in.
+fn assert_valid_ndjson(stdout: &str, who: &str) {
+    let mut events = Vec::new();
+    for (i, line) in stdout.lines().enumerate() {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        let v: Value = serde_json::from_str(line)
+            .unwrap_or_else(|e| panic!("{who}: line {} is not valid JSON ({e}): {line:?}", i + 1));
+        let obj = v
+            .as_object()
+            .unwrap_or_else(|| panic!("{who}: line {} is not a JSON object: {line:?}", i + 1));
+        assert!(
+            obj.contains_key("event") && obj.contains_key("data"),
+            "{who}: line {} is not an event object (keys: {:?})",
+            i + 1,
+            obj.keys().collect::<Vec<_>>()
+        );
+        events.push(obj["event"].as_str().unwrap_or("<non-string>").to_string());
+    }
+
+    assert!(!events.is_empty(), "{who}: no events emitted");
+    assert_eq!(
+        events.first().unwrap(),
+        "start",
+        "{who}: first event must be `start` ({events:?})"
+    );
+    assert_eq!(
+        events.last().unwrap(),
+        "end",
+        "{who}: last event must be `end` ({events:?})"
+    );
+    assert!(
+        events.len() >= 3,
+        "{who}: expected at least one interval between start and end ({events:?})"
+    );
+    for (i, e) in events.iter().enumerate() {
+        let expected = if i == 0 {
+            "start"
+        } else if i == events.len() - 1 {
+            "end"
+        } else {
+            "interval"
+        };
+        assert_eq!(
+            e, expected,
+            "{who}: event {i} should be `{expected}` ({events:?})"
+        );
+    }
+}
+
+/// Spawn `riperf3` and bound the wait so a hang fails the test instead of the
+/// whole suite. Returns captured stdout (panics on timeout/failure).
+fn run_capturing(args: &[&str], timeout: Duration, who: &str) -> String {
+    let bin = env!("CARGO_BIN_EXE_riperf3");
+    let mut child = Command::new(bin)
+        .args(args)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .unwrap_or_else(|e| panic!("{who}: spawn failed: {e}"));
+
+    let deadline = Instant::now() + timeout;
+    loop {
+        match child.try_wait().expect("try_wait") {
+            Some(_) => break,
+            None if Instant::now() >= deadline => {
+                let _ = child.kill();
+                let _ = child.wait();
+                panic!("{who}: timed out");
+            }
+            None => std::thread::sleep(Duration::from_millis(50)),
+        }
+    }
+    let mut out = String::new();
+    child
+        .stdout
+        .take()
+        .unwrap()
+        .read_to_string(&mut out)
+        .unwrap();
+    out
+}
+
+/// Client `--json-stream` against a plain one-off server.
+#[test]
+fn client_json_stream_tcp_is_valid_ndjson() {
+    let port = free_port();
+    let ps = port.to_string();
+    let bin = env!("CARGO_BIN_EXE_riperf3");
+    let mut server = Command::new(bin)
+        .args(["-s", "-1", "-p", &ps])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn server");
+    std::thread::sleep(Duration::from_millis(300));
+
+    let out = run_capturing(
+        &[
+            "-c",
+            "127.0.0.1",
+            "-p",
+            &ps,
+            "-t",
+            "1",
+            "-i",
+            "1",
+            "--json-stream",
+        ],
+        Duration::from_secs(20),
+        "client",
+    );
+    let _ = server.wait();
+    assert_valid_ndjson(&out, "client");
+}
+
+/// Client `--json-stream` for UDP (exercises the datagram interval fields).
+#[test]
+fn client_json_stream_udp_is_valid_ndjson() {
+    let port = free_port();
+    let ps = port.to_string();
+    let bin = env!("CARGO_BIN_EXE_riperf3");
+    let mut server = Command::new(bin)
+        .args(["-s", "-1", "-p", &ps])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn server");
+    std::thread::sleep(Duration::from_millis(300));
+
+    let out = run_capturing(
+        &[
+            "-c",
+            "127.0.0.1",
+            "-p",
+            &ps,
+            "-u",
+            "-b",
+            "10M",
+            "-t",
+            "1",
+            "-i",
+            "1",
+            "--json-stream",
+        ],
+        Duration::from_secs(20),
+        "client-udp",
+    );
+    let _ = server.wait();
+    assert_valid_ndjson(&out, "client-udp");
+}
+
+/// Server `--json-stream`: capture the server's stdout while a plain client runs.
+#[test]
+fn server_json_stream_is_valid_ndjson() {
+    let port = free_port();
+    let ps = port.to_string();
+    let bin = env!("CARGO_BIN_EXE_riperf3");
+    let mut server = Command::new(bin)
+        .args(["-s", "-1", "-p", &ps, "--json-stream"])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn server");
+    std::thread::sleep(Duration::from_millis(300));
+
+    // Drive one test; the one-off server then finishes and closes its stdout.
+    let status = Command::new(bin)
+        .args(["-c", "127.0.0.1", "-p", &ps, "-t", "1", "-i", "1"])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .expect("run client");
+    assert!(status.success(), "client failed: {status:?}");
+
+    let mut out = String::new();
+    server
+        .stdout
+        .take()
+        .unwrap()
+        .read_to_string(&mut out)
+        .unwrap();
+    let _ = server.wait();
+    assert_valid_ndjson(&out, "server");
+}

--- a/riperf3/src/client.rs
+++ b/riperf3/src/client.rs
@@ -198,6 +198,25 @@ impl Client {
                         .duration_since(std::time::UNIX_EPOCH)
                         .map(|d| d.as_millis() as u64)
                         .unwrap_or(0);
+
+                    // --json-stream: emit the `start` event now, before the reporter
+                    // streams any `interval` events (faithful event order, #62).
+                    if self.json_stream {
+                        self.emit_json_stream_start(
+                            &streams,
+                            cpu_start.as_ref(),
+                            blksize,
+                            &interval_data,
+                            &StartMeta {
+                                cookie: String::from_utf8_lossy(
+                                    &cookie[..protocol::COOKIE_SIZE - 1],
+                                )
+                                .into_owned(),
+                                tcp_mss_default: control_mss,
+                                start_time_millis: test_start_millis,
+                            },
+                        );
+                    }
                 }
 
                 TestState::TestRunning => {
@@ -610,6 +629,11 @@ impl Client {
         let interval_secs = self.interval.unwrap_or(1.0);
         let print_intervals = !self.json_output || self.json_stream;
         let collect_intervals = self.json_output && !self.json_stream;
+        // The reporter needs the collector whenever we emit JSON: `-J` collects the
+        // typed intervals for the final blob; `--json-stream` streams them live but
+        // still needs the per-stream TCP_INFO extremes (max cwnd/rtt) handed back
+        // for the `end` event (#62).
+        let want_collector = collect_intervals || self.json_stream;
         // Clock origin shared with the reporter: `report_start` is captured right
         // before spawning it, so `report_start.elapsed()` at end-of-test is the
         // authoritative final-interval boundary (#55).
@@ -642,7 +666,7 @@ impl Client {
                 stream_refs,
                 done.clone(),
                 reporter_end.clone(),
-                collect_intervals.then(|| collector.clone()),
+                want_collector.then(|| collector.clone()),
             )
         } else {
             None
@@ -807,6 +831,17 @@ impl Client {
                 interval_data,
                 start_meta,
             );
+        } else if self.json_stream {
+            // --json-stream: emit the `end` event. (Previously this fell through
+            // to print_results_text, printing text banners into the NDJSON — #62.)
+            self.emit_json_stream_end(
+                streams,
+                cpu_start,
+                remote_cpu,
+                blksize,
+                interval_data,
+                start_meta,
+            );
         } else {
             self.print_results_text(streams, remote_cpu);
         }
@@ -865,7 +900,11 @@ impl Client {
         crate::reporter::print_final_summaries(&summaries, self.format_char);
     }
 
-    fn print_results_json(
+    /// Assemble the typed iperf3-schema report input from the finished test.
+    /// Shared by `-J` (build + pretty-print) and `--json-stream` (build + emit the
+    /// `end` event; and at TestStart, the `start` event from a partial input where
+    /// only the start fields are meaningful — see `emit_json_stream_start`).
+    fn build_report_input(
         &self,
         streams: &[DataStream],
         cpu_start: Option<&CpuSnapshot>,
@@ -873,7 +912,7 @@ impl Client {
         blksize: usize,
         interval_data: &Arc<Mutex<crate::reporter::CollectedIntervals>>,
         start_meta: &StartMeta,
-    ) {
+    ) -> crate::json_report::ReportInput {
         use crate::json_report::{
             CpuUtilization, ReportInput, StreamReport, TcpEndExtras, UdpStreamStats,
         };
@@ -1044,7 +1083,73 @@ impl Client {
             streams: stream_reports,
         };
 
+        input
+    }
+
+    /// `-J`: build and pretty-print the single batched report blob.
+    fn print_results_json(
+        &self,
+        streams: &[DataStream],
+        cpu_start: Option<&CpuSnapshot>,
+        remote_cpu: Option<&TestResultsJson>,
+        blksize: usize,
+        interval_data: &Arc<Mutex<crate::reporter::CollectedIntervals>>,
+        start_meta: &StartMeta,
+    ) {
+        let input = self.build_report_input(
+            streams,
+            cpu_start,
+            remote_cpu,
+            blksize,
+            interval_data,
+            start_meta,
+        );
         println!("{}", serde_json::to_string_pretty(&input.build()).unwrap());
+    }
+
+    /// `--json-stream`: emit the `start` event (#62). Called at TestStart, before
+    /// any interval event. Only the `start` block is meaningful at this point; the
+    /// rest of the report input is placeholder (no bytes/cpu/intervals collected
+    /// yet) and is discarded.
+    fn emit_json_stream_start(
+        &self,
+        streams: &[DataStream],
+        cpu_start: Option<&CpuSnapshot>,
+        blksize: usize,
+        interval_data: &Arc<Mutex<crate::reporter::CollectedIntervals>>,
+        start_meta: &StartMeta,
+    ) {
+        let input =
+            self.build_report_input(streams, cpu_start, None, blksize, interval_data, start_meta);
+        crate::reporter::emit_json_stream_line(&crate::json_report::json_stream_event(
+            "start",
+            &input.build().start,
+        ));
+    }
+
+    /// `--json-stream`: emit the `end` event (#62) at DisplayResults. The interval
+    /// events were already streamed live by the reporter.
+    fn emit_json_stream_end(
+        &self,
+        streams: &[DataStream],
+        cpu_start: Option<&CpuSnapshot>,
+        remote_cpu: Option<&TestResultsJson>,
+        blksize: usize,
+        interval_data: &Arc<Mutex<crate::reporter::CollectedIntervals>>,
+        start_meta: &StartMeta,
+    ) {
+        let input = self.build_report_input(
+            streams,
+            cpu_start,
+            remote_cpu,
+            blksize,
+            interval_data,
+            start_meta,
+        );
+        crate::reporter::emit_json_stream_line(&crate::json_report::json_stream_event(
+            "end",
+            &input.build().end,
+        ));
     }
 }
 

--- a/riperf3/src/json_report.rs
+++ b/riperf3/src/json_report.rs
@@ -138,6 +138,23 @@ pub struct Report {
     pub extra_data: Option<String>,
 }
 
+/// Serialize one `--json-stream` NDJSON line: `{"event":<event>,"data":<data>}`,
+/// compact (one object per line, no pretty-printing), matching iperf3's
+/// `--json-stream` (#62). The `data` payload keeps its own serde formatting —
+/// notably the cJSON-style float rendering (`ser_f64`, #57) — so a streamed
+/// `start` / `interval` / `end` object is byte-for-byte the same as the
+/// corresponding section of the batched `-J` report.
+pub(crate) fn json_stream_event<T: Serialize>(event: &'static str, data: &T) -> String {
+    #[derive(Serialize)]
+    struct Event<'a, T: Serialize> {
+        event: &'static str,
+        data: &'a T,
+    }
+    // Infallible for the report structs (plain owned data), like the other
+    // `to_string` sites in this crate.
+    serde_json::to_string(&Event { event, data }).unwrap()
+}
+
 // ---------------------------------------------------------------------------
 // start{}
 // ---------------------------------------------------------------------------
@@ -1115,6 +1132,26 @@ mod tests {
         // Non-finite degrades to JSON null, like cJSON.
         assert_eq!(cjson_number(f64::NAN), "null");
         assert_eq!(cjson_number(f64::INFINITY), "null");
+    }
+
+    // #62: the --json-stream envelope is `{"event":<event>,"data":<data>}`,
+    // compact (one line), `event` first, and the `data` payload is byte-identical
+    // to the standalone encoding of the typed value (so it keeps the cJSON float
+    // formatting and matches the corresponding `-J` section).
+    #[test]
+    fn json_stream_event_wraps_compactly() {
+        let report = base_input().build();
+        let line = json_stream_event("start", &report.start);
+        assert!(!line.contains('\n'), "must be one compact line: {line}");
+        assert!(
+            line.starts_with(r#"{"event":"start","data":"#),
+            "envelope/field order wrong: {line}"
+        );
+        let data = serde_json::to_string(&report.start).unwrap();
+        assert_eq!(line, format!(r#"{{"event":"start","data":{data}}}"#));
+        let v: serde_json::Value = serde_json::from_str(&line).unwrap();
+        assert_eq!(v["event"], "start");
+        assert!(v["data"].is_object());
     }
 
     // The whole point of #57: a serialized report carries no integral `N.0`

--- a/riperf3/src/reporter.rs
+++ b/riperf3/src/reporter.rs
@@ -84,6 +84,15 @@ pub fn print_header(protocol: TransportProtocol, has_retransmits: bool) {
     }
 }
 
+/// Print one `--json-stream` event line and flush immediately, so a piped
+/// consumer sees the `start`/`end` event as soon as it is produced (#62). The
+/// reporter flushes its own `interval` events via the per-tick flush.
+pub(crate) fn emit_json_stream_line(line: &str) {
+    use std::io::Write;
+    println!("{line}");
+    let _ = std::io::stdout().flush();
+}
+
 /// Print one interval line.
 pub fn print_interval(interval: &StreamInterval, format_char: char) {
     let id = fmt_id(interval.stream_id);
@@ -470,8 +479,8 @@ pub fn spawn_interval_reporter(
         let mut emit_interval = |start: f64, end: f64, omitted: bool| {
             let seconds = end - start;
 
-            // Timestamp prefix for this tick
-            if config.print && config.timestamp_format.is_some() {
+            // Timestamp prefix for this tick (text decoration; never on --json-stream)
+            if config.print && !config.json_stream && config.timestamp_format.is_some() {
                 // Use libc strftime for iperf3-compatible timestamp formatting
                 let now = std::time::SystemTime::now()
                     .duration_since(std::time::UNIX_EPOCH)
@@ -484,7 +493,8 @@ pub fn spawn_interval_reporter(
                 print!("{hours:02}:{mins:02}:{s:02} ");
             }
 
-            if config.print && !header_printed {
+            // The text header banner is suppressed under --json-stream (pure NDJSON).
+            if config.print && !config.json_stream && !header_printed {
                 print_header(config.protocol, has_retransmits);
                 header_printed = true;
             }
@@ -583,7 +593,11 @@ pub fn spawn_interval_reporter(
                     0.0
                 };
 
-                if config.print {
+                // Text mode prints a per-stream line here. `--json-stream` emits
+                // one typed `interval` event per tick (assembled after the loop
+                // from the same typed streams the `-J` collector builds), so it
+                // has nothing to print per stream.
+                if config.print && !config.json_stream {
                     let interval = StreamInterval {
                         stream_id: stream.id,
                         start,
@@ -598,37 +612,7 @@ pub fn spawn_interval_reporter(
                         total_packets: total,
                         omitted,
                     };
-
-                    if config.json_stream {
-                        let mut j = serde_json::json!({
-                            "socket": stream.id,
-                            "start": start,
-                            "end": end,
-                            "seconds": seconds,
-                            "bytes": bytes,
-                            "bits_per_second": bps_val,
-                            "omitted": omitted,
-                            "sender": stream.is_sender,
-                        });
-                        if let Some(r) = retransmits {
-                            j["retransmits"] = serde_json::json!(r);
-                        }
-                        if let Some(c) = snd_cwnd {
-                            j["snd_cwnd"] = serde_json::json!(c);
-                        }
-                        if let Some(ji) = jitter {
-                            j["jitter_ms"] = serde_json::json!(ji * 1000.0);
-                        }
-                        if let Some(l) = lost {
-                            j["lost_packets"] = serde_json::json!(l);
-                        }
-                        if let Some(p) = total {
-                            j["packets"] = serde_json::json!(p);
-                        }
-                        println!("{}", serde_json::to_string(&j).unwrap());
-                    } else {
-                        print_interval(&interval, config.format_char);
-                    }
+                    print_interval(&interval, config.format_char);
                 }
 
                 if collecting {
@@ -687,8 +671,9 @@ pub fn spawn_interval_reporter(
                 }
             }
 
-            // Print [SUM] line for parallel streams
-            if config.print && config.num_streams > 1 {
+            // Print [SUM] line for parallel streams (text only; the json-stream
+            // `interval` event below carries the typed `sum` instead).
+            if config.print && !config.json_stream && config.num_streams > 1 {
                 let sum_interval = StreamInterval {
                     stream_id: -1, // renders as "SUM"
                     start,
@@ -737,7 +722,7 @@ pub fn spawn_interval_reporter(
                 // sender=false) it must be omitted, not just gated on "any stream
                 // sends" — otherwise the received-flow sum carries a spurious count.
                 let sum_is_sender = streams.first().is_none_or(|s| s.is_sender);
-                collected.push(crate::json_report::Interval {
+                let interval = crate::json_report::Interval {
                     streams: collected_streams,
                     sum: crate::json_report::IntervalSum {
                         start,
@@ -757,11 +742,23 @@ pub fn spawn_interval_reporter(
                         omitted,
                         sender: sum_is_sender,
                     },
-                });
+                };
+                // `-J` collects intervals for the final batched blob; `--json-stream`
+                // emits each one live as `{"event":"interval","data":{...}}`.
+                if config.json_stream {
+                    println!(
+                        "{}",
+                        crate::json_report::json_stream_event("interval", &interval)
+                    );
+                } else {
+                    collected.push(interval);
+                }
             }
 
-            // Flush after each interval if requested
-            if config.print && config.forceflush {
+            // Flush after each interval if requested. --json-stream always flushes
+            // so a piped consumer sees each event as it happens (the point of the
+            // streaming format), regardless of --forceflush.
+            if config.print && (config.forceflush || config.json_stream) {
                 use std::io::Write;
                 let _ = std::io::stdout().flush();
             }

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -470,7 +470,25 @@ impl Server {
         // the client's gating (#50).
         let print_intervals = !json || self.json_stream;
         let collect_intervals = json && !self.json_stream;
+        // Like the client: `--json-stream` streams intervals live but still needs
+        // the per-stream TCP_INFO extremes handed back for the `end` event (#62).
+        let want_collector = collect_intervals || self.json_stream;
         let interval_data = Arc::new(Mutex::new(crate::reporter::CollectedIntervals::default()));
+
+        // --json-stream: emit the `start` event now — before the reporter is
+        // spawned, so it is guaranteed to precede every `interval` event (#62).
+        if self.json_stream {
+            self.emit_json_stream_start(
+                &streams,
+                &cfg,
+                &params,
+                &cookie,
+                &accepted_host,
+                accepted_port,
+                test_start_millis,
+                &interval_data,
+            );
+        }
 
         // Spawn interval reporter (server uses 1.0s default). `report_start` is
         // captured right before the spawn so its elapsed at TEST_END is the
@@ -504,7 +522,7 @@ impl Server {
                 stream_refs,
                 done.clone(),
                 reporter_end.clone(),
-                collect_intervals.then(|| interval_data.clone()),
+                want_collector.then(|| interval_data.clone()),
             )
         };
 
@@ -640,9 +658,23 @@ impl Server {
             }
         }
 
-        if json {
+        if self.json_output {
             // Emit the iperf3-schema JSON report on stdout (#50).
             self.print_results_json(
+                &streams,
+                &cfg,
+                &params,
+                &cpu_util,
+                test_duration,
+                &cookie,
+                &accepted_host,
+                accepted_port,
+                test_start_millis,
+                &interval_data,
+            );
+        } else if self.json_stream {
+            // --json-stream: emit the `end` event (intervals already streamed; #62).
+            self.emit_json_stream_end(
                 &streams,
                 &cfg,
                 &params,
@@ -704,8 +736,11 @@ impl Server {
     /// via `is_server: true`: `accepted_connection` instead of `connecting_to`,
     /// no peer-byte graft (the un-measured side is 0), and `tcp_mss_default` of 0
     /// (iperf3's server never reads its control-socket MSS).
+    /// Assemble the server's typed iperf3-schema report input. Shared by `-J`
+    /// (build + pretty-print) and `--json-stream` (build + emit the `start`/`end`
+    /// events). The server's perspective is baked in via `is_server: true`.
     #[allow(clippy::too_many_arguments)]
-    fn print_results_json(
+    fn build_report_input(
         &self,
         streams: &[DataStream],
         cfg: &TestConfig,
@@ -717,7 +752,7 @@ impl Server {
         accepted_port: u16,
         start_time_millis: u64,
         interval_data: &Arc<Mutex<crate::reporter::CollectedIntervals>>,
-    ) {
+    ) -> crate::json_report::ReportInput {
         use crate::json_report::{
             CpuUtilization, ReportInput, StreamReport, TcpEndExtras, UdpStreamStats,
         };
@@ -865,20 +900,107 @@ impl Server {
             streams: stream_reports,
         };
 
-        let report = input.build();
-        if self.json_stream {
-            // --json-stream: the interval lines were already streamed; emit the
-            // final document the same way the client does.
-            match serde_json::to_string(&report) {
-                Ok(s) => println!("{s}"),
-                Err(e) => eprintln!("iperf3: error - failed to serialize JSON: {e}"),
-            }
-        } else {
-            match serde_json::to_string_pretty(&report) {
-                Ok(s) => println!("{s}"),
-                Err(e) => eprintln!("iperf3: error - failed to serialize JSON: {e}"),
-            }
+        input
+    }
+
+    /// `-J`: build and pretty-print the server's single batched report blob (#50).
+    #[allow(clippy::too_many_arguments)]
+    fn print_results_json(
+        &self,
+        streams: &[DataStream],
+        cfg: &TestConfig,
+        params: &TestParams,
+        cpu_util: &crate::cpu::CpuUtilization,
+        test_duration: f64,
+        cookie: &[u8; protocol::COOKIE_SIZE],
+        accepted_host: &str,
+        accepted_port: u16,
+        start_time_millis: u64,
+        interval_data: &Arc<Mutex<crate::reporter::CollectedIntervals>>,
+    ) {
+        let input = self.build_report_input(
+            streams,
+            cfg,
+            params,
+            cpu_util,
+            test_duration,
+            cookie,
+            accepted_host,
+            accepted_port,
+            start_time_millis,
+            interval_data,
+        );
+        match serde_json::to_string_pretty(&input.build()) {
+            Ok(s) => println!("{s}"),
+            Err(e) => eprintln!("iperf3: error - failed to serialize JSON: {e}"),
         }
+    }
+
+    /// `--json-stream`: emit the server's `end` event (#62). The interval events
+    /// were already streamed live by the reporter.
+    #[allow(clippy::too_many_arguments)]
+    fn emit_json_stream_end(
+        &self,
+        streams: &[DataStream],
+        cfg: &TestConfig,
+        params: &TestParams,
+        cpu_util: &crate::cpu::CpuUtilization,
+        test_duration: f64,
+        cookie: &[u8; protocol::COOKIE_SIZE],
+        accepted_host: &str,
+        accepted_port: u16,
+        start_time_millis: u64,
+        interval_data: &Arc<Mutex<crate::reporter::CollectedIntervals>>,
+    ) {
+        let input = self.build_report_input(
+            streams,
+            cfg,
+            params,
+            cpu_util,
+            test_duration,
+            cookie,
+            accepted_host,
+            accepted_port,
+            start_time_millis,
+            interval_data,
+        );
+        crate::reporter::emit_json_stream_line(&crate::json_report::json_stream_event(
+            "end",
+            &input.build().end,
+        ));
+    }
+
+    /// `--json-stream`: emit the server's `start` event (#62), before any interval
+    /// event. Only the `start` block is meaningful at this point; cpu/bytes are
+    /// zero and intervals empty (the test hasn't run yet), and are discarded.
+    #[allow(clippy::too_many_arguments)]
+    fn emit_json_stream_start(
+        &self,
+        streams: &[DataStream],
+        cfg: &TestConfig,
+        params: &TestParams,
+        cookie: &[u8; protocol::COOKIE_SIZE],
+        accepted_host: &str,
+        accepted_port: u16,
+        start_time_millis: u64,
+        interval_data: &Arc<Mutex<crate::reporter::CollectedIntervals>>,
+    ) {
+        let input = self.build_report_input(
+            streams,
+            cfg,
+            params,
+            &crate::cpu::CpuUtilization::default(),
+            cfg.duration as f64,
+            cookie,
+            accepted_host,
+            accepted_port,
+            start_time_millis,
+            interval_data,
+        );
+        crate::reporter::emit_json_stream_line(&crate::json_report::json_stream_event(
+            "start",
+            &input.build().start,
+        ));
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes #62 — `--json-stream` was not valid line-delimited JSON.

**Before:** the output printed text banners (the `[ ID] Interval` header, the `- - -` separator, the final summary lines) interleaved with *bare* per-stream interval objects that had no `event`/`data` wrapping and no `start`/`end` events. Neither parseable NDJSON nor iperf3's event schema. (The server was doubly wrong: bare interval objects during the run **and** the entire `{start,intervals,end}` report as one compact line at the end.)

**After:** both the client and the server emit pure NDJSON, matching iperf3:
- `{"event":"start","data":{…}}` before any interval,
- one `{"event":"interval","data":{"streams":[…],"sum":{…}}}` per interval, streamed live and flushed as it happens,
- `{"event":"end","data":{…}}` at the end,

with all text banners suppressed.

**Design call — LIVE (not batched):** intervals are already produced live by the reporter, so streaming them costs nothing extra over collecting; `start` is emitted at TestStart (client) / before the reporter spawns (server), guaranteeing event order; `end` at DisplayResults. A consumer gets `start` immediately, intervals as they happen, then `end` — faithful to iperf3.

## How

- **`json_report.rs`**: `json_stream_event(event, &data)` wraps a typed value as a compact `{"event":…,"data":…}` line (`pub(crate)`). The `start`/`interval`/`end` payloads reuse the existing typed `-J` model, so each is **byte-for-byte the corresponding section of the `-J` report**, including the cJSON float formatting (#57).
- **`reporter.rs`**: json-stream routes through the same typed `Interval` the `-J` collector builds (instead of a hand-rolled `serde_json::json!` object), emitted live; text decorations (header/separator/`[SUM]`/timestamp prefix) are suppressed; json-stream always flushes per tick.
- **`client.rs` / `server.rs`**: one shared `build_report_input` feeds both `-J` (build + pretty-print) and the stream `start`/`end` events. json-stream now passes a collector so the per-stream `TCP_INFO` extremes (max cwnd/rtt) flow back for the `end` event.

## Verification (local)

- New `riperf3-cli/tests/json_stream.rs`: spawns the binary, validates the **client and server** NDJSON event sequence (`start → interval+ → end`, every line a valid `event` object) for **TCP and UDP**. Fails before the fix (banner lines don't parse; bare objects lack `event`).
- `json_report` unit test for the event wrapper (compact, `event` first, payload byte-identical to the standalone encoding).
- **Adjudicated against the real iperf3 binary** (`/home/evan/workspace/esnet/iperf/src/iperf3`): event types and per-event data-field presence match for TCP forward, UDP, and reverse, **both client and server**.
- `cargo test --workspace` (189 + 132 + 60 + 1 + 3), `clippy --all-targets -D warnings`, `fmt --check`, `scripts/xcheck.sh` (7 targets), `cargo semver-checks` — all clean. `-J` output is unchanged (shared builder; integration tests pass).

Pre-existing `-J` behaviors that also appear in the stream and are **out of scope** (tracked elsewhere): `snd_wnd:0` (libc can't read it), omitted `*_tcp_congestion` (#37). Field-order differences between iperf3's own client vs server `start` blobs are semantically irrelevant; riperf3 uses one order for both, as it already does for `-J`.