### PR TITLE
fix: single-socket UDP server demux so -P>1 works on native winsock (#80)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,9 +75,10 @@ data-path/throughput changes.
   demultiplexes streams by client source address in userspace — correct on every
   platform, and wire-compatible with an iperf3 client (verified against the 3.20
   binary over IPv4 and IPv6, forward/reverse/bidir `-P 4`). It is the default on
-  Windows; the connected-socket recycling path stays the default on Unix
-  (kernel-parallel receive, faithful to iperf3) and is measurably faster with
-  lower loss there.
+  Windows; the connected-socket recycling path stays the default on Unix because
+  it mirrors iperf3 and gives one socket and thread per stream (kernel-parallel
+  receive that scales better at high `-P`). At modest parallelism the two paths
+  measure comparably on throughput and loss.
 
 ### Added
 - **`StreamCounters::peek_sent_interval` / `peek_received_interval`** (#55):

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,11 +62,33 @@ data-path/throughput changes.
   unchanged. The final interval reuses the last-sampled `Cwnd`/`RTT` when the
   socket has already closed (reporting `Retr 0` for the sub-interval, as iperf3
   does) instead of leaving those columns blank.
+- **UDP `-P > 1` no longer hangs setup on native Windows** (#80): the server's
+  UDP design mirrors iperf3 — one connected data socket per stream, recycled on
+  the same port via `SO_REUSEADDR`, with the kernel demultiplexing incoming
+  datagrams by 4-tuple. Native winsock breaks this: once a connected and a
+  wildcard UDP socket share a port, a new source's datagram is silently dropped,
+  so streams 2..N never finish their connect handshake and any `-u -P >1` (hence
+  UDP `--bidir -P`) hung until the client's 30 s connect timeout. (iperf3 itself
+  only runs on Windows under Cygwin, whose socket layer emulates Unix demux, so
+  it never hits this; a native-MSVC build does.) The server now has a second UDP
+  path that binds **one** unconnected socket for the whole test and
+  demultiplexes streams by client source address in userspace — correct on every
+  platform, and wire-compatible with an iperf3 client (verified against the 3.20
+  binary over IPv4 and IPv6, forward/reverse/bidir `-P 4`). It is the default on
+  Windows; the connected-socket recycling path stays the default on Unix
+  (kernel-parallel receive, faithful to iperf3) and is measurably faster with
+  lower loss there.
 
 ### Added
 - **`StreamCounters::peek_sent_interval` / `peek_received_interval`** (#55):
   non-draining reads of the interval byte counters, used to skip an empty final
   partial interval on the receiver side.
+- **`RIPERF3_UDP_SERVER_DEMUX` environment variable** (#80): overrides which
+  server UDP path is used — `0`/`false`/`no`/empty force the connected-socket
+  recycling path, any other value forces the single-socket userspace demux;
+  unset falls back to the platform default (demux on Windows, recycling on Unix).
+  Primarily a testing/escape hatch — it lets either path be exercised on one
+  build.
 
 ## [0.6.3] - 2026-06-04
 

--- a/riperf3-cli/src/cli.rs
+++ b/riperf3-cli/src/cli.rs
@@ -809,6 +809,9 @@ mod cli_tests {
             assert_eq!(c.window, Some(512 * 1024));
         }
 
+        // build() rejects -C/--congestion (TCP congestion control) on non-Unix
+        // (cfg(not(unix)) → Unsupported), so gate the wiring test to match.
+        #[cfg(unix)]
         #[test]
         fn congestion_flag_wired() {
             let cli = Cli::parse_from(["riperf3", "-c", "host", "-C", "bbr"]);
@@ -882,6 +885,9 @@ mod cli_tests {
             assert!(c.verbose);
         }
 
+        // Combines the Unix-only flags above (congestion/bind-dev/affinity),
+        // which build() rejects on non-Unix, so gate to match.
+        #[cfg(unix)]
         #[test]
         fn all_flags_combined() {
             let cli = Cli::parse_from([
@@ -1029,6 +1035,9 @@ mod cli_tests {
             assert_eq!(c.bind_address, Some("10.0.0.1".to_string()));
         }
 
+        // build() rejects --bind-dev (SO_BINDTODEVICE/IP_BOUND_IF) on non-Unix,
+        // so gate the wiring test to match.
+        #[cfg(unix)]
         #[test]
         fn bind_dev_wired() {
             let cli = Cli::parse_from(["riperf3", "-c", "h", "--bind-dev", "eth0"]);
@@ -1092,6 +1101,9 @@ mod cli_tests {
             assert_eq!(c.file, Some("/tmp/data".to_string()));
         }
 
+        // build() rejects -A/--affinity (CPU affinity) on non-Unix, so gate the
+        // wiring test to match.
+        #[cfg(unix)]
         #[test]
         fn affinity_wired() {
             let cli = Cli::parse_from(["riperf3", "-c", "h", "-A", "2,3"]);

--- a/riperf3-cli/tests/udp_demux.rs
+++ b/riperf3-cli/tests/udp_demux.rs
@@ -1,0 +1,171 @@
+//! CLI integration test for the single-socket UDP server demux (#80).
+//!
+//! Regression: on native winsock, the server's per-stream connected-socket
+//! design (`-P` streams sharing one port via `SO_REUSEADDR`, recycled after each
+//! connect) hangs `-P > 1` setup — winsock silently drops a new source's
+//! datagram once a connected and a wildcard UDP socket share a port, so streams
+//! 2..N never complete their connect handshake and the client retries to its
+//! 30 s timeout. The fix binds ONE unconnected server socket and demultiplexes
+//! streams by client source address in userspace.
+//!
+//! The demux path is the default on Windows; the in-process
+//! `udp_bidir_parallel_completes` integration test is its red→green there. This
+//! test exercises the *same* platform-independent demux code on Unix by forcing
+//! it via `RIPERF3_UDP_SERVER_DEMUX=1` on the server child — so the fix is
+//! validated on a host the CI Linux runner can actually run. It spawns the real
+//! server + client binaries and, for forward / reverse / bidir at `-P 4`,
+//! asserts (a) the client completes instead of hanging (the #80 symptom) and
+//! (b) every expected stream carries bytes, which a misrouting demux would not
+//! produce.
+//!
+//! Unix-gated: the env override only changes behavior off Windows (on Windows
+//! demux is already the default), and the server child plumbing here is Unix.
+
+#![cfg(unix)]
+
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+use serde_json::Value;
+
+fn free_port() -> u16 {
+    std::net::TcpListener::bind("127.0.0.1:0")
+        .expect("bind ephemeral port")
+        .local_addr()
+        .expect("local_addr")
+        .port()
+}
+
+/// Kills the wrapped child on drop, so a spawned server is reaped even if the
+/// test panics before it is waited on.
+struct ChildGuard(std::process::Child);
+
+impl Drop for ChildGuard {
+    fn drop(&mut self) {
+        let _ = self.0.kill();
+        let _ = self.0.wait();
+    }
+}
+
+/// Wait for a child to exit, bounded by `timeout`. On timeout, kill it and
+/// return `None` — the caller turns that into the "#80 hang" failure with
+/// context, instead of stalling the whole suite.
+fn wait_bounded(
+    child: &mut std::process::Child,
+    timeout: Duration,
+) -> Option<std::process::ExitStatus> {
+    let deadline = Instant::now() + timeout;
+    loop {
+        match child.try_wait().expect("try_wait") {
+            Some(status) => return Some(status),
+            None if Instant::now() >= deadline => {
+                let _ = child.kill();
+                let _ = child.wait();
+                return None;
+            }
+            None => std::thread::sleep(Duration::from_millis(50)),
+        }
+    }
+}
+
+/// Run one UDP mode against a demux-forced one-off server and return the client's
+/// parsed `-J` report. `extra` carries the direction flag (`-R`, `--bidir`, or
+/// nothing for forward).
+fn run_demux_udp(extra: &[&str], who: &str) -> Value {
+    let bin = env!("CARGO_BIN_EXE_riperf3");
+    let port = free_port();
+    let port_s = port.to_string();
+
+    // One-off server with the demux path forced on (the env var only affects
+    // this child). `-1` makes it exit after serving the single test.
+    let server = Command::new(bin)
+        .args(["-s", "-1", "-p", &port_s])
+        .env("RIPERF3_UDP_SERVER_DEMUX", "1")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .unwrap_or_else(|e| panic!("{who}: spawn server failed: {e}"));
+    let mut server = ChildGuard(server);
+
+    // Let the listener bind before connecting.
+    std::thread::sleep(Duration::from_millis(300));
+
+    // Short duration-limited UDP run at -P 4: the #80 hang is in multi-stream
+    // setup, so completing at all is the core assertion. `-J` lets us also check
+    // routing produced bytes on every stream.
+    let mut client = Command::new(bin)
+        .args(["-c", "127.0.0.1", "-p", &port_s, "-u", "-t", "2", "-P", "4"])
+        .args(extra)
+        .arg("-J")
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .unwrap_or_else(|e| panic!("{who}: spawn client failed: {e}"));
+
+    // Capture stdout concurrently, then bound the wait: a #80 regression hangs
+    // the client at multi-stream setup until its 30 s connect timeout.
+    let stdout = client.stdout.take().expect("client stdout");
+    let reader = std::thread::spawn(move || {
+        use std::io::Read;
+        let mut s = String::new();
+        let _ = std::io::BufReader::new(stdout).read_to_string(&mut s);
+        s
+    });
+
+    let exit = wait_bounded(&mut client, Duration::from_secs(20))
+        .unwrap_or_else(|| panic!("{who}: client hung — UDP demux -P 4 setup wedged (#80)"));
+    let out = reader.join().expect("join stdout reader");
+    assert!(
+        exit.success(),
+        "{who}: client exited non-zero: {exit:?}\n{out}"
+    );
+
+    // The one-off server should now have served and exited on its own.
+    let _ = wait_bounded(&mut server.0, Duration::from_secs(5));
+
+    serde_json::from_str(&out)
+        .unwrap_or_else(|e| panic!("{who}: client -J is not JSON ({e}): {out}"))
+}
+
+/// Assert the report has exactly `expected_streams` streams and every one of
+/// them moved a nonzero number of UDP bytes — i.e. the demux routed each client
+/// to its own stream rather than dropping or collapsing them.
+fn assert_all_streams_have_bytes(report: &Value, expected_streams: usize, who: &str) {
+    let streams = report["end"]["streams"]
+        .as_array()
+        .unwrap_or_else(|| panic!("{who}: end.streams is not an array: {report}"));
+    assert_eq!(
+        streams.len(),
+        expected_streams,
+        "{who}: expected {expected_streams} streams, got {}",
+        streams.len()
+    );
+    for (i, s) in streams.iter().enumerate() {
+        let bytes = s["udp"]["bytes"]
+            .as_u64()
+            .unwrap_or_else(|| panic!("{who}: stream {i} has no udp.bytes: {s}"));
+        assert!(
+            bytes > 0,
+            "{who}: stream {i} moved 0 bytes (demux misrouted?)"
+        );
+    }
+}
+
+#[test]
+fn udp_demux_forward_parallel_completes() {
+    let report = run_demux_udp(&[], "forward");
+    assert_all_streams_have_bytes(&report, 4, "forward");
+}
+
+#[test]
+fn udp_demux_reverse_parallel_completes() {
+    let report = run_demux_udp(&["-R"], "reverse");
+    assert_all_streams_have_bytes(&report, 4, "reverse");
+}
+
+#[test]
+fn udp_demux_bidir_parallel_completes() {
+    // The exact #80 case: 4 receiving + 4 sending streams over one server socket.
+    let report = run_demux_udp(&["--bidir"], "bidir");
+    assert_all_streams_have_bytes(&report, 8, "bidir");
+}

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -344,10 +344,18 @@ impl Server {
                 // when a connected and a wildcard socket share a port, so that
                 // design hangs `-P > 1` setup on Windows (#80). The demux path
                 // binds ONE unconnected socket and routes by source address in
-                // userspace — correct on every platform. Default on Windows;
-                // forceable elsewhere via RIPERF3_UDP_SERVER_DEMUX for testing.
-                let udp_use_demux =
-                    cfg!(windows) || std::env::var_os("RIPERF3_UDP_SERVER_DEMUX").is_some();
+                // userspace — correct on every platform.
+                //
+                // Default: demux on Windows (recycling cannot work there),
+                // recycling on Unix (faithful to iperf3, kernel-parallel
+                // receive). RIPERF3_UDP_SERVER_DEMUX overrides either way —
+                // `0`/`false`/`no`/empty force recycling, any other value forces
+                // demux — so both paths are exercisable on one build (the Windows
+                // red→green sets it to `0` to reproduce the old hang).
+                let udp_use_demux = match std::env::var("RIPERF3_UDP_SERVER_DEMUX") {
+                    Ok(v) => !matches!(v.as_str(), "" | "0" | "false" | "no"),
+                    Err(_) => cfg!(windows),
+                };
 
                 if udp_use_demux {
                     self.setup_udp_demux_streams(

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -864,8 +864,13 @@ impl Server {
         // hanging (#11).
         let mut client_addrs: Vec<SocketAddr> = Vec::with_capacity(total as usize);
         let mut seen: HashSet<SocketAddr> = HashSet::new();
-        let deadline = tokio::time::Instant::now() + protocol::UDP_CONNECT_TOTAL_TIMEOUT;
         let mut magic_buf = [0u8; 65536];
+        // Each *new* stream gets a fresh budget — matching the recycling path,
+        // which calls udp_connect_server(UDP_CONNECT_TOTAL_TIMEOUT) once per
+        // stream, and the client, which retries each stream's connect for that
+        // long independently. A single aggregate deadline would abort setup while
+        // the client is still legitimately handshaking a later stream.
+        let mut deadline = tokio::time::Instant::now() + protocol::UDP_CONNECT_TOTAL_TIMEOUT;
         while client_addrs.len() < total as usize {
             let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
             if remaining.is_zero() {
@@ -896,6 +901,8 @@ impl Server {
                 .await?;
             if seen.insert(src) {
                 client_addrs.push(src);
+                // Fresh per-stream budget for the next stream's handshake.
+                deadline = tokio::time::Instant::now() + protocol::UDP_CONNECT_TOTAL_TIMEOUT;
             }
         }
 
@@ -912,6 +919,19 @@ impl Server {
         let (sndbuf_actual, rcvbuf_actual) = {
             let sock = socket2::SockRef::from(&udp_std);
             net::apply_socket_window(&sock, cfg.window);
+            // The recycling path gives each receiving stream its OWN socket (and
+            // its own SO_RCVBUF), drained by its own thread. This path funnels
+            // every receiving stream through ONE socket drained by a single
+            // thread, so size its receive buffer to the aggregate the recycling
+            // path spreads across `recv_count` sockets. Otherwise riperf3's
+            // batched sender (32-packet bursts per stream) overflows the lone
+            // default buffer and inflates measured UDP loss many-fold (#80 review).
+            if recv_count > 1 {
+                if let Ok(per_stream) = sock.recv_buffer_size() {
+                    let _ =
+                        sock.set_recv_buffer_size(per_stream.saturating_mul(recv_count as usize));
+                }
+            }
             (
                 sock.send_buffer_size().ok().map(|v| v as u64),
                 sock.recv_buffer_size().ok().map(|v| v as u64),

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -98,6 +98,30 @@ pub struct Server {
     pub json_stream: bool,
 }
 
+/// Best-effort source IP the kernel would use to reach `client_addr`, paired
+/// with `server_port` — the per-stream `local_host`/`local_port` for the `-J`
+/// connected block on the single-socket UDP demux path (#80). The demux socket
+/// is never `connect()`'d, so its own `local_addr` is the wildcard bind; the
+/// recycling path reports the connected socket's source IP instead. Reproduce
+/// that by connecting a throwaway socket to the client and reading its local IP.
+/// Returns `None` on any error so the caller can fall back to the shared socket.
+fn demux_local_addr_for(
+    client_addr: std::net::SocketAddr,
+    server_port: u16,
+) -> Option<std::net::SocketAddr> {
+    let bind: std::net::SocketAddr = if client_addr.is_ipv6() {
+        (std::net::Ipv6Addr::UNSPECIFIED, 0).into()
+    } else {
+        (std::net::Ipv4Addr::UNSPECIFIED, 0).into()
+    };
+    let probe = std::net::UdpSocket::bind(bind).ok()?;
+    probe.connect(client_addr).ok()?;
+    Some(std::net::SocketAddr::new(
+        probe.local_addr().ok()?.ip(),
+        server_port,
+    ))
+}
+
 impl Server {
     pub async fn run(&self) -> Result<()> {
         // Daemonizing (`-s -D`) is a process-level concern handled by the binary
@@ -876,14 +900,15 @@ impl Server {
         }
 
         // Move to a blocking std socket for the data phase and share it across the
-        // demux receiver thread and every sender thread. Set blocking ONCE here so
-        // there is no nonblocking window for the threads to race on.
+        // demux receiver thread and every sender thread. Set blocking here before
+        // wrapping in `Arc` so no thread observes a nonblocking socket. (The
+        // receiver thread and the senders' `configure_udp_sender` redundantly set
+        // it again, but to the same value, so the result is deterministic.)
         let udp_std = udp_sock.into_std().map_err(RiperfError::Io)?;
         udp_std.set_nonblocking(false).map_err(RiperfError::Io)?;
 
-        // `-J` metadata is the same socket for every stream: one local address and
-        // one pair of buffer sizes. Honor -w/--window once on the shared socket.
-        let local_addr = udp_std.local_addr().ok();
+        // `-J` metadata: the shared socket is the same for every stream, so the
+        // buffer sizes are read once; honor -w/--window on it once too.
         let (sndbuf_actual, rcvbuf_actual) = {
             let sock = socket2::SockRef::from(&udp_std);
             net::apply_socket_window(&sock, cfg.window);
@@ -892,6 +917,15 @@ impl Server {
                 sock.recv_buffer_size().ok().map(|v| v as u64),
             )
         };
+        // The connected recycling path reports each stream's local_host as the
+        // kernel-selected source IP for that client. The demux socket is never
+        // connect()'d, so its own local_addr is the wildcard bind — only on a
+        // wildcard bind (no -B) do we probe the route per client to reproduce the
+        // recycling/iperf3 local_host; with an explicit -B the bound IP is already
+        // right for every stream. The port is always the shared socket's.
+        let shared_local_addr = udp_std.local_addr().ok();
+        let server_port = shared_local_addr.map_or(self.port, |a| a.port());
+        let bound_wildcard = shared_local_addr.is_none_or(|a| a.ip().is_unspecified());
         let shared = Arc::new(udp_std);
 
         // Build the per-stream entries: senders get their own send_to task;
@@ -905,6 +939,11 @@ impl Server {
             let is_sender = i >= recv_count;
             let client_addr = client_addrs[i as usize];
             let counters = Arc::new(StreamCounters::new());
+            let local_addr = if bound_wildcard {
+                demux_local_addr_for(client_addr, server_port).or(shared_local_addr)
+            } else {
+                shared_local_addr
+            };
 
             if is_sender {
                 let s = shared.clone();

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -249,6 +249,12 @@ impl Server {
         };
         let total = recv_count + send_count;
 
+        // Single-socket UDP server demux (#80): one demux receiver thread serves
+        // every receiving stream, so its handle lives outside the per-stream
+        // `DataStream`s and is joined alongside them at teardown. `None` on the
+        // recycling path and on pure-reverse demux tests (no receivers).
+        let mut udp_demux_handle: Option<tokio::task::JoinHandle<Result<()>>> = None;
+
         match cfg.protocol {
             TransportProtocol::Tcp => {
                 protocol::send_state(&mut ctrl, TestState::CreateStreams).await?;
@@ -323,19 +329,6 @@ impl Server {
                 }
             }
             TransportProtocol::Udp => {
-                // Create the initial UDP listener with SO_REUSEADDR.
-                // For each stream: accept the connect handshake on the listener,
-                // which locks that socket to the client. Then create a fresh
-                // listener for the next stream (iperf3's recycling pattern).
-                let mut udp_listener = net::udp_bind_reusable(
-                    self.bind_address.as_deref(),
-                    self.port,
-                    self.ip_version,
-                )
-                .await?;
-
-                protocol::send_state(&mut ctrl, TestState::CreateStreams).await?;
-
                 // Max send duration the server's UDP senders self-enforce
                 // (issue #5): in bidir/reverse the server sends too, and at a
                 // high `-b` those CPU-bound senders can starve this side's
@@ -344,111 +337,43 @@ impl Server {
                 let max_duration = (params.num.is_none() && params.blockcount.is_none())
                     .then(|| std::time::Duration::from_secs(cfg.duration as u64));
 
-                for i in 0..total {
-                    // Accept: recv magic, connect() to client, send reply.
-                    // Bounded so a client that never connects fails the test
-                    // instead of hanging setup forever (#11); uses the same
-                    // budget as the client's handshake so neither side aborts
-                    // while the other is still retrying.
-                    let _client_addr = protocol::udp_connect_server(
-                        &udp_listener,
-                        protocol::UDP_CONNECT_TOTAL_TIMEOUT,
+                // Two server UDP designs, same wire protocol. The default Unix
+                // path mirrors iperf3: one connected data socket per stream, all
+                // sharing the port via SO_REUSEADDR, with the kernel demuxing by
+                // 4-tuple. Native winsock silently drops a new source's datagram
+                // when a connected and a wildcard socket share a port, so that
+                // design hangs `-P > 1` setup on Windows (#80). The demux path
+                // binds ONE unconnected socket and routes by source address in
+                // userspace — correct on every platform. Default on Windows;
+                // forceable elsewhere via RIPERF3_UDP_SERVER_DEMUX for testing.
+                let udp_use_demux =
+                    cfg!(windows) || std::env::var_os("RIPERF3_UDP_SERVER_DEMUX").is_some();
+
+                if udp_use_demux {
+                    self.setup_udp_demux_streams(
+                        &mut ctrl,
+                        &cfg,
+                        recv_count,
+                        total,
+                        max_duration,
+                        &done,
+                        &start,
+                        &mut streams,
+                        &mut udp_demux_handle,
                     )
                     .await?;
-                    // The listener is now locked to this client — use it as the data socket
-                    let data_sock = udp_listener;
-
-                    // Create a fresh listener for the next stream (if any)
-                    if i + 1 < total {
-                        udp_listener = net::udp_bind_reusable(
-                            self.bind_address.as_deref(),
-                            self.port,
-                            self.ip_version,
-                        )
-                        .await?;
-                    } else {
-                        // Last stream — create a dummy that won't be used
-                        udp_listener = net::udp_bind(None, 0, false).await?;
-                    }
-
-                    let stream_id = iperf3_stream_id(i);
-                    let is_sender = i >= recv_count;
-                    let counters = Arc::new(StreamCounters::new());
-
-                    // Socket addresses + buffer sizes for the `-J` blob (#50),
-                    // captured before the socket is converted to std + moved.
-                    let local_addr = data_sock.local_addr().ok();
-                    let peer_addr_s = data_sock.peer_addr().ok();
-                    let (sndbuf_actual, rcvbuf_actual) = {
-                        let sock = socket2::SockRef::from(&data_sock);
-                        // Honor -w/--window on the server's UDP data socket too
-                        // (#59) so reverse/bidir UDP matches iperf3; set before the
-                        // read-back below.
-                        net::apply_socket_window(&sock, cfg.window);
-                        (
-                            sock.send_buffer_size().ok().map(|v| v as u64),
-                            sock.recv_buffer_size().ok().map(|v| v as u64),
-                        )
-                    };
-
-                    let std_sock = data_sock.into_std().map_err(RiperfError::Io)?;
-
-                    if is_sender {
-                        let c = counters.clone();
-                        let d = done.clone();
-                        let bs = cfg.blksize;
-                        // Already resolved in TestConfig (#17); 0 = unlimited.
-                        let rate = cfg.bandwidth;
-                        let u64bit = cfg.udp_counters_64bit;
-                        let st = start.clone();
-                        let md = max_duration;
-                        let task = tokio::task::spawn_blocking(move || {
-                            stream::run_udp_sender_blocking(
-                                std_sock, c, bs, d, rate, u64bit, st, md,
-                            )
-                        });
-                        streams.push(DataStream {
-                            id: stream_id,
-                            is_sender,
-                            counters,
-                            udp_recv_stats: None,
-                            task,
-                            raw_fd: None,
-                            local_addr,
-                            peer_addr: peer_addr_s,
-                            sndbuf_actual,
-                            rcvbuf_actual,
-                        });
-                    } else {
-                        let c = counters.clone();
-                        let d = done.clone();
-                        let bs = cfg.blksize;
-                        let stats = Arc::new(Mutex::new(UdpRecvStats::new()));
-                        let stats_clone = stats.clone();
-                        let u64bit = cfg.udp_counters_64bit;
-                        let task = tokio::task::spawn_blocking(move || {
-                            stream::run_udp_receiver_blocking(
-                                std_sock,
-                                c,
-                                stats_clone,
-                                bs,
-                                d,
-                                u64bit,
-                            )
-                        });
-                        streams.push(DataStream {
-                            id: stream_id,
-                            is_sender,
-                            counters,
-                            udp_recv_stats: Some(stats),
-                            task,
-                            raw_fd: None,
-                            local_addr,
-                            peer_addr: peer_addr_s,
-                            sndbuf_actual,
-                            rcvbuf_actual,
-                        });
-                    }
+                } else {
+                    self.setup_udp_recycling_streams(
+                        &mut ctrl,
+                        &cfg,
+                        recv_count,
+                        total,
+                        max_duration,
+                        &done,
+                        &start,
+                        &mut streams,
+                    )
+                    .await?;
                 }
             }
         }
@@ -727,7 +652,320 @@ impl Server {
         for s in streams {
             let _ = s.task.await;
         }
+        // The single-socket UDP demux receiver (#80) serves all receiving streams
+        // and lives outside `streams`; join it too. `None` on the recycling path.
+        if let Some(h) = udp_demux_handle {
+            let _ = h.await;
+        }
 
+        Ok(())
+    }
+
+    /// iperf3's UDP server design (the default on Unix): one connected data
+    /// socket per stream, recycled on the same port via SO_REUSEADDR, with the
+    /// kernel demultiplexing incoming datagrams by 4-tuple. For each stream:
+    /// accept the connect handshake on the listener (which locks that socket to
+    /// the client), then bind a fresh listener on the same port for the next
+    /// stream. This is faithful to iperf3 and gives kernel-parallel receive, but
+    /// relies on kernel demux that native winsock doesn't provide (see
+    /// [`Self::setup_udp_demux_streams`] / #80).
+    #[allow(clippy::too_many_arguments)]
+    async fn setup_udp_recycling_streams(
+        &self,
+        ctrl: &mut tokio::net::TcpStream,
+        cfg: &TestConfig,
+        recv_count: u32,
+        total: u32,
+        max_duration: Option<std::time::Duration>,
+        done: &Arc<AtomicBool>,
+        start: &Arc<AtomicBool>,
+        streams: &mut Vec<DataStream>,
+    ) -> Result<()> {
+        let mut udp_listener =
+            net::udp_bind_reusable(self.bind_address.as_deref(), self.port, self.ip_version)
+                .await?;
+
+        protocol::send_state(ctrl, TestState::CreateStreams).await?;
+
+        for i in 0..total {
+            // Accept: recv magic, connect() to client, send reply.
+            // Bounded so a client that never connects fails the test
+            // instead of hanging setup forever (#11); uses the same
+            // budget as the client's handshake so neither side aborts
+            // while the other is still retrying.
+            let _client_addr =
+                protocol::udp_connect_server(&udp_listener, protocol::UDP_CONNECT_TOTAL_TIMEOUT)
+                    .await?;
+            // The listener is now locked to this client — use it as the data socket
+            let data_sock = udp_listener;
+
+            // Create a fresh listener for the next stream (if any)
+            if i + 1 < total {
+                udp_listener = net::udp_bind_reusable(
+                    self.bind_address.as_deref(),
+                    self.port,
+                    self.ip_version,
+                )
+                .await?;
+            } else {
+                // Last stream — create a dummy that won't be used
+                udp_listener = net::udp_bind(None, 0, false).await?;
+            }
+
+            let stream_id = iperf3_stream_id(i);
+            let is_sender = i >= recv_count;
+            let counters = Arc::new(StreamCounters::new());
+
+            // Socket addresses + buffer sizes for the `-J` blob (#50),
+            // captured before the socket is converted to std + moved.
+            let local_addr = data_sock.local_addr().ok();
+            let peer_addr_s = data_sock.peer_addr().ok();
+            let (sndbuf_actual, rcvbuf_actual) = {
+                let sock = socket2::SockRef::from(&data_sock);
+                // Honor -w/--window on the server's UDP data socket too
+                // (#59) so reverse/bidir UDP matches iperf3; set before the
+                // read-back below.
+                net::apply_socket_window(&sock, cfg.window);
+                (
+                    sock.send_buffer_size().ok().map(|v| v as u64),
+                    sock.recv_buffer_size().ok().map(|v| v as u64),
+                )
+            };
+
+            let std_sock = data_sock.into_std().map_err(RiperfError::Io)?;
+
+            if is_sender {
+                let c = counters.clone();
+                let d = done.clone();
+                let bs = cfg.blksize;
+                // Already resolved in TestConfig (#17); 0 = unlimited.
+                let rate = cfg.bandwidth;
+                let u64bit = cfg.udp_counters_64bit;
+                let st = start.clone();
+                let md = max_duration;
+                let task = tokio::task::spawn_blocking(move || {
+                    stream::run_udp_sender_blocking(std_sock, c, bs, d, rate, u64bit, st, md)
+                });
+                streams.push(DataStream {
+                    id: stream_id,
+                    is_sender,
+                    counters,
+                    udp_recv_stats: None,
+                    task,
+                    raw_fd: None,
+                    local_addr,
+                    peer_addr: peer_addr_s,
+                    sndbuf_actual,
+                    rcvbuf_actual,
+                });
+            } else {
+                let c = counters.clone();
+                let d = done.clone();
+                let bs = cfg.blksize;
+                let stats = Arc::new(Mutex::new(UdpRecvStats::new()));
+                let stats_clone = stats.clone();
+                let u64bit = cfg.udp_counters_64bit;
+                let task = tokio::task::spawn_blocking(move || {
+                    stream::run_udp_receiver_blocking(std_sock, c, stats_clone, bs, d, u64bit)
+                });
+                streams.push(DataStream {
+                    id: stream_id,
+                    is_sender,
+                    counters,
+                    udp_recv_stats: Some(stats),
+                    task,
+                    raw_fd: None,
+                    local_addr,
+                    peer_addr: peer_addr_s,
+                    sndbuf_actual,
+                    rcvbuf_actual,
+                });
+            }
+        }
+        Ok(())
+    }
+
+    /// Single-socket UDP server demux (#80; default on Windows). Bind ONE
+    /// unconnected socket for the whole test and demultiplex streams by client
+    /// source address in userspace, instead of one connected socket per stream.
+    /// Native winsock silently drops a new source's datagram when a connected and
+    /// a wildcard UDP socket share a port, which hangs `-P > 1` setup under the
+    /// recycling design; one unconnected socket never forms that pair, so this is
+    /// correct everywhere. The wire protocol is identical, so it interoperates
+    /// with an iperf3 client.
+    ///
+    /// Slots are assigned in connect-arrival order, matching the recycling path's
+    /// positional client/server stream pairing (the client creates streams
+    /// sequentially by index). One demux thread serves every receiving stream;
+    /// each sending stream `send_to`s its own client over the shared socket.
+    #[allow(clippy::too_many_arguments)]
+    async fn setup_udp_demux_streams(
+        &self,
+        ctrl: &mut tokio::net::TcpStream,
+        cfg: &TestConfig,
+        recv_count: u32,
+        total: u32,
+        max_duration: Option<std::time::Duration>,
+        done: &Arc<AtomicBool>,
+        start: &Arc<AtomicBool>,
+        streams: &mut Vec<DataStream>,
+        demux_handle: &mut Option<tokio::task::JoinHandle<Result<()>>>,
+    ) -> Result<()> {
+        use std::collections::{HashMap, HashSet};
+        use std::net::SocketAddr;
+
+        // One unconnected dual-stack socket for the whole test. Never connect()'d
+        // and never sharing its port with a second socket, so there is no
+        // connected+wildcard pair for winsock to drop a new source against (#80).
+        let udp_sock =
+            net::udp_bind_reusable(self.bind_address.as_deref(), self.port, self.ip_version)
+                .await?;
+
+        protocol::send_state(ctrl, TestState::CreateStreams).await?;
+
+        // Accept the connect handshake from every client stream on the one
+        // socket. Record the source address of each NEW client in arrival order
+        // (slot i == stream i). Reply to every valid magic — including a
+        // retransmit from an already-seen client whose reply was lost — but only
+        // a new source claims a slot. Bounded by the same budget as the client
+        // handshake so a client that never connects fails setup instead of
+        // hanging (#11).
+        let mut client_addrs: Vec<SocketAddr> = Vec::with_capacity(total as usize);
+        let mut seen: HashSet<SocketAddr> = HashSet::new();
+        let deadline = tokio::time::Instant::now() + protocol::UDP_CONNECT_TOTAL_TIMEOUT;
+        let mut magic_buf = [0u8; 65536];
+        while client_addrs.len() < total as usize {
+            let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+            if remaining.is_zero() {
+                return Err(RiperfError::Aborted(
+                    "timed out waiting for UDP stream connect".into(),
+                ));
+            }
+            let (n, src) =
+                match tokio::time::timeout(remaining, udp_sock.recv_from(&mut magic_buf)).await {
+                    Ok(r) => r?,
+                    Err(_) => {
+                        return Err(RiperfError::Aborted(
+                            "timed out waiting for UDP stream connect".into(),
+                        ))
+                    }
+                };
+            // Drop anything that isn't the connect magic (too short, or a stray
+            // datagram) and keep waiting — matches udp_connect_server's check.
+            if n < 4 {
+                continue;
+            }
+            let msg = u32::from_ne_bytes(magic_buf[..4].try_into().unwrap());
+            if msg != protocol::UDP_CONNECT_MSG {
+                continue;
+            }
+            udp_sock
+                .send_to(&protocol::UDP_CONNECT_REPLY.to_ne_bytes(), src)
+                .await?;
+            if seen.insert(src) {
+                client_addrs.push(src);
+            }
+        }
+
+        // Move to a blocking std socket for the data phase and share it across the
+        // demux receiver thread and every sender thread. Set blocking ONCE here so
+        // there is no nonblocking window for the threads to race on.
+        let udp_std = udp_sock.into_std().map_err(RiperfError::Io)?;
+        udp_std.set_nonblocking(false).map_err(RiperfError::Io)?;
+
+        // `-J` metadata is the same socket for every stream: one local address and
+        // one pair of buffer sizes. Honor -w/--window once on the shared socket.
+        let local_addr = udp_std.local_addr().ok();
+        let (sndbuf_actual, rcvbuf_actual) = {
+            let sock = socket2::SockRef::from(&udp_std);
+            net::apply_socket_window(&sock, cfg.window);
+            (
+                sock.send_buffer_size().ok().map(|v| v as u64),
+                sock.recv_buffer_size().ok().map(|v| v as u64),
+            )
+        };
+        let shared = Arc::new(udp_std);
+
+        // Build the per-stream entries: senders get their own send_to task;
+        // receivers register a route and share the single demux thread.
+        let mut routes: HashMap<SocketAddr, stream::UdpDemuxRoute> = HashMap::new();
+        let bs = cfg.blksize;
+        let rate = cfg.bandwidth;
+        let u64bit = cfg.udp_counters_64bit;
+        for i in 0..total {
+            let stream_id = iperf3_stream_id(i);
+            let is_sender = i >= recv_count;
+            let client_addr = client_addrs[i as usize];
+            let counters = Arc::new(StreamCounters::new());
+
+            if is_sender {
+                let s = shared.clone();
+                let c = counters.clone();
+                let d = done.clone();
+                let st = start.clone();
+                let md = max_duration;
+                let task = tokio::task::spawn_blocking(move || {
+                    stream::run_udp_server_demux_sender(
+                        s,
+                        client_addr,
+                        c,
+                        bs,
+                        d,
+                        rate,
+                        u64bit,
+                        st,
+                        md,
+                    )
+                });
+                streams.push(DataStream {
+                    id: stream_id,
+                    is_sender,
+                    counters,
+                    udp_recv_stats: None,
+                    task,
+                    raw_fd: None,
+                    local_addr,
+                    peer_addr: Some(client_addr),
+                    sndbuf_actual,
+                    rcvbuf_actual,
+                });
+            } else {
+                let stats = Arc::new(Mutex::new(UdpRecvStats::new()));
+                routes.insert(
+                    client_addr,
+                    stream::UdpDemuxRoute {
+                        counters: counters.clone(),
+                        stats: stats.clone(),
+                    },
+                );
+                // Receiving streams are served by the one demux thread spawned
+                // below; give each a resolved placeholder task so the per-stream
+                // join at teardown stays uniform. The real handle is `demux_handle`.
+                let task = tokio::spawn(async { Ok::<(), RiperfError>(()) });
+                streams.push(DataStream {
+                    id: stream_id,
+                    is_sender,
+                    counters,
+                    udp_recv_stats: Some(stats),
+                    task,
+                    raw_fd: None,
+                    local_addr,
+                    peer_addr: Some(client_addr),
+                    sndbuf_actual,
+                    rcvbuf_actual,
+                });
+            }
+        }
+
+        // Spawn the single demux receiver over the shared socket (only if there
+        // is anything to receive — a pure-reverse test has senders only).
+        if !routes.is_empty() {
+            let s = shared.clone();
+            let d = done.clone();
+            *demux_handle = Some(tokio::task::spawn_blocking(move || {
+                stream::run_udp_server_demux_receiver(s, routes, d, u64bit)
+            }));
+        }
         Ok(())
     }
 

--- a/riperf3/src/stream.rs
+++ b/riperf3/src/stream.rs
@@ -1153,7 +1153,7 @@ pub fn run_udp_sender_blocking(
 /// is per-datagram atomic and thread-safe), each fanning out to its own client.
 /// The socket must already be in blocking mode (the demux setup sets it once).
 #[allow(clippy::too_many_arguments)]
-pub fn run_udp_server_demux_sender(
+pub(crate) fn run_udp_server_demux_sender(
     socket: Arc<std::net::UdpSocket>,
     target: std::net::SocketAddr,
     counters: Arc<StreamCounters>,
@@ -1179,9 +1179,9 @@ pub fn run_udp_server_demux_sender(
 
 /// Where one client's datagrams are accounted in the single-socket UDP server
 /// demux: the receiving stream's byte counters and its jitter/loss stats.
-pub struct UdpDemuxRoute {
-    pub counters: Arc<StreamCounters>,
-    pub stats: Arc<Mutex<UdpRecvStats>>,
+pub(crate) struct UdpDemuxRoute {
+    pub(crate) counters: Arc<StreamCounters>,
+    pub(crate) stats: Arc<Mutex<UdpRecvStats>>,
 }
 
 /// Single-socket UDP server receiver demux (#80). On native winsock a connected
@@ -1199,7 +1199,7 @@ pub struct UdpDemuxRoute {
 /// Teardown mirrors the connected receiver: keep the socket open and drain late
 /// datagrams until the peer goes quiet (issue #48), so a still-sending iperf3
 /// <=3.12 peer isn't reset. The socket must already be in blocking mode.
-pub fn run_udp_server_demux_receiver(
+pub(crate) fn run_udp_server_demux_receiver(
     socket: Arc<std::net::UdpSocket>,
     routes: std::collections::HashMap<std::net::SocketAddr, UdpDemuxRoute>,
     done: Arc<AtomicBool>,

--- a/riperf3/src/stream.rs
+++ b/riperf3/src/stream.rs
@@ -1205,6 +1205,8 @@ pub(crate) fn run_udp_server_demux_receiver(
     done: Arc<AtomicBool>,
     use_64bit: bool,
 ) -> Result<()> {
+    // 65536 >= MAX_UDP_BLKSIZE (65507), so a full UDP datagram never truncates;
+    // this is the same floor run_udp_receiver_blocking caps to via blksize.max().
     let mut buf = vec![0u8; 65536];
     // Match run_udp_receiver_blocking: blocking + a read timeout so the thread
     // parks between datagrams instead of busy-spinning, and so `done` is observed

--- a/riperf3/src/stream.rs
+++ b/riperf3/src/stream.rs
@@ -1005,9 +1005,17 @@ pub fn run_udp_sender_sendmmsg(
 /// Batch pacing: sends N packets in a tight loop, then does a single clock
 /// check and sleep/spin for the aggregate interval. This amortizes the cost
 /// of `Instant::now()` (~50ns) and atomic operations across multiple packets.
+///
+/// `target` selects the destination model. `None` sends on a *connected* socket
+/// (the per-stream client/Unix-server path: one socket per stream, kernel 4-tuple
+/// demux). `Some(addr)` uses `send_to(addr)` on a *shared, unconnected* socket —
+/// the single-socket UDP server demux (#80), where one server socket fans out to
+/// each client by address. The loop body is otherwise identical, so both paths
+/// share the same pacing/batching/error handling.
 #[allow(clippy::too_many_arguments)] // hot-path sender: socket + tuning + lifecycle
-pub fn run_udp_sender_blocking(
-    socket: std::net::UdpSocket,
+fn udp_send_loop(
+    socket: &std::net::UdpSocket,
+    target: Option<std::net::SocketAddr>,
     counters: Arc<StreamCounters>,
     blksize: usize,
     done: Arc<AtomicBool>,
@@ -1034,7 +1042,7 @@ pub fn run_udp_sender_blocking(
 
     // Blocking I/O so send() backpressures in-kernel instead of returning
     // WouldBlock and truncating the batch once SO_SNDBUF fills (issue #6).
-    crate::net::configure_udp_sender(&socket, batch_size as usize * blksize)?;
+    crate::net::configure_udp_sender(socket, batch_size as usize * blksize)?;
 
     let pacing = if rate_bits_per_sec > 0 {
         let rate_bytes = rate_bits_per_sec as f64 / 8.0;
@@ -1068,7 +1076,11 @@ pub fn run_udp_sender_blocking(
             };
             header.write_to(&mut buf, use_64bit);
 
-            match socket.send(&buf) {
+            let sent = match target {
+                Some(addr) => socket.send_to(&buf, addr),
+                None => socket.send(&buf),
+            };
+            match sent {
                 Ok(n) => batch_bytes += n as u64,
                 Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
                     seq -= 1;
@@ -1106,6 +1118,161 @@ pub fn run_udp_sender_blocking(
         }
     }
     Ok(())
+}
+
+/// UDP sender on a *connected* socket — the per-stream client/Unix-server path.
+/// Thin wrapper over [`udp_send_loop`] with no `send_to` target; the public API
+/// (owned socket, `send`) is unchanged.
+#[allow(clippy::too_many_arguments)]
+pub fn run_udp_sender_blocking(
+    socket: std::net::UdpSocket,
+    counters: Arc<StreamCounters>,
+    blksize: usize,
+    done: Arc<AtomicBool>,
+    rate_bits_per_sec: u64,
+    use_64bit: bool,
+    start: Arc<AtomicBool>,
+    max_duration: Option<Duration>,
+) -> Result<()> {
+    udp_send_loop(
+        &socket,
+        None,
+        counters,
+        blksize,
+        done,
+        rate_bits_per_sec,
+        use_64bit,
+        start,
+        max_duration,
+    )
+}
+
+/// UDP sender on a *shared, unconnected* server socket, addressing one client by
+/// `target` via `send_to` — the reverse/bidir half of the single-socket UDP
+/// server demux (#80). Multiple senders share one `Arc<UdpSocket>` (UDP `send_to`
+/// is per-datagram atomic and thread-safe), each fanning out to its own client.
+/// The socket must already be in blocking mode (the demux setup sets it once).
+#[allow(clippy::too_many_arguments)]
+pub fn run_udp_server_demux_sender(
+    socket: Arc<std::net::UdpSocket>,
+    target: std::net::SocketAddr,
+    counters: Arc<StreamCounters>,
+    blksize: usize,
+    done: Arc<AtomicBool>,
+    rate_bits_per_sec: u64,
+    use_64bit: bool,
+    start: Arc<AtomicBool>,
+    max_duration: Option<Duration>,
+) -> Result<()> {
+    udp_send_loop(
+        &socket,
+        Some(target),
+        counters,
+        blksize,
+        done,
+        rate_bits_per_sec,
+        use_64bit,
+        start,
+        max_duration,
+    )
+}
+
+/// Where one client's datagrams are accounted in the single-socket UDP server
+/// demux: the receiving stream's byte counters and its jitter/loss stats.
+pub struct UdpDemuxRoute {
+    pub counters: Arc<StreamCounters>,
+    pub stats: Arc<Mutex<UdpRecvStats>>,
+}
+
+/// Single-socket UDP server receiver demux (#80). On native winsock a connected
+/// UDP socket sharing a port with a wildcard socket silently drops a new source's
+/// datagrams, so the per-stream connected-socket design hangs `-P > 1` setup on
+/// Windows. This path instead binds **one** unconnected server socket for the
+/// whole test and demultiplexes incoming datagrams to the right receiving stream
+/// by source address in userspace — exactly what the kernel does on Linux/BSD,
+/// done explicitly so it is correct on every platform.
+///
+/// One dedicated blocking thread owns `recv_from` (a datagram can be consumed
+/// only once, so a single consumer must route every packet — N threads each
+/// filtering by source would lose each other's data). Datagrams from an unknown
+/// source — a late retransmit of the connect magic, or a stray — are dropped.
+/// Teardown mirrors the connected receiver: keep the socket open and drain late
+/// datagrams until the peer goes quiet (issue #48), so a still-sending iperf3
+/// <=3.12 peer isn't reset. The socket must already be in blocking mode.
+pub fn run_udp_server_demux_receiver(
+    socket: Arc<std::net::UdpSocket>,
+    routes: std::collections::HashMap<std::net::SocketAddr, UdpDemuxRoute>,
+    done: Arc<AtomicBool>,
+    use_64bit: bool,
+) -> Result<()> {
+    let mut buf = vec![0u8; 65536];
+    // Match run_udp_receiver_blocking: blocking + a read timeout so the thread
+    // parks between datagrams instead of busy-spinning, and so `done` is observed
+    // promptly during idle gaps.
+    socket
+        .set_nonblocking(false)
+        .map_err(crate::error::RiperfError::Io)?;
+    socket
+        .set_read_timeout(Some(Duration::from_millis(500)))
+        .map_err(crate::error::RiperfError::Io)?;
+
+    let mut drain = false;
+    loop {
+        if done.load(Ordering::Relaxed) {
+            drain = true;
+            break;
+        }
+        match socket.recv_from(&mut buf) {
+            Ok((n, src)) => {
+                // Route by source address. An unknown source is a late connect
+                // retransmit or stray — drop it (do not count it against any
+                // stream). A 0-byte datagram routes too but carries no header.
+                if let Some(route) = routes.get(&src) {
+                    route.counters.record_received(n as u64);
+                    if let Some(header) = UdpHeader::read_from(&buf[..n], use_64bit) {
+                        let arrival = SystemTime::now()
+                            .duration_since(UNIX_EPOCH)
+                            .unwrap_or_default()
+                            .as_secs_f64();
+                        if let Ok(mut stats) = route.stats.lock() {
+                            stats.update(&header, arrival);
+                        }
+                    }
+                }
+            }
+            Err(e)
+                if e.kind() == std::io::ErrorKind::WouldBlock
+                    || e.kind() == std::io::ErrorKind::TimedOut =>
+            {
+                continue
+            }
+            Err(_) => break,
+        }
+    }
+    if drain {
+        drain_udp_demux_after_done(&socket, &mut buf);
+    }
+    Ok(())
+}
+
+/// `recv_from` analogue of [`drain_udp_after_done`] for the single-socket demux:
+/// after the test ends, keep the shared socket open and discard late datagrams
+/// (from any source) until one read-timeout of silence, bounded by
+/// [`UDP_RECEIVER_DRAIN_TIMEOUT`]. See [`drain_udp_after_done`] for the why.
+fn drain_udp_demux_after_done(socket: &std::net::UdpSocket, buf: &mut [u8]) {
+    let deadline = Instant::now() + UDP_RECEIVER_DRAIN_TIMEOUT;
+    while Instant::now() < deadline {
+        match socket.recv_from(buf) {
+            Ok(_) => continue,
+            Err(e)
+                if e.kind() == std::io::ErrorKind::WouldBlock
+                    || e.kind() == std::io::ErrorKind::TimedOut =>
+            {
+                break
+            }
+            Err(_) => break,
+        }
+    }
 }
 
 /// Hard cap on the post-test UDP drain (issue #48). The normal exit is a single

--- a/riperf3/src/stream.rs
+++ b/riperf3/src/stream.rs
@@ -1228,7 +1228,10 @@ pub(crate) fn run_udp_server_demux_receiver(
             Ok((n, src)) => {
                 // Route by source address. An unknown source is a late connect
                 // retransmit or stray — drop it (do not count it against any
-                // stream). A 0-byte datagram routes too but carries no header.
+                // stream). Unlike the connected receiver, a 0-byte datagram is
+                // NOT a loop-exit here: it must not tear down an N-stream demux
+                // (iperf3 never sends empty data datagrams anyway); it just routes
+                // and records 0 bytes with no header.
                 if let Some(route) = routes.get(&src) {
                     route.counters.record_received(n as u64);
                     if let Some(header) = UdpHeader::read_from(&buf[..n], use_64bit) {


### PR DESCRIPTION
Closes #80.

## The bug
The server's UDP design mirrors iperf3: one connected data socket per stream, all sharing the port via `SO_REUSEADDR`, recycled after each connect handshake, with the kernel demultiplexing incoming datagrams by 4-tuple. **Native winsock breaks this** — once a connected and a wildcard UDP socket share a port, a new source's datagram is *silently dropped* (reaches neither socket), so streams 2..N never finish their connect handshake. Any `-u -P >1` (hence UDP `--bidir -P`) hung setup until the client's 30 s connect timeout. iperf3 itself only runs on Windows under Cygwin, whose socket layer emulates Unix demux, so it sidesteps this; a native-MSVC build hits it directly.

The integration test `udp_bidir_parallel_completes` has been red on the (non-required) `Native test (windows-latest)` CI job for exactly this reason.

## The fix
A second server UDP path that binds **one** unconnected socket for the whole test and demultiplexes streams by client source address in userspace:
- setup accepts each stream's connect magic on the one socket, recording the source addr of each new client in arrival order (slot `i` == stream `i`, preserving the recycling path's positional pairing) and replying to every magic;
- one demux thread owns `recv_from` and routes each datagram to the right receiving stream's counters/stats by source;
- each sending stream (reverse/bidir) `send_to`s its own client over the shared socket.

This is what the kernel does on Linux/BSD, done explicitly so it is correct on every platform. The wire protocol is unchanged.

**Gating:** demux is the default on Windows (recycling cannot work there); the connected-socket recycling path stays the default on Unix (kernel-parallel receive, faithful to iperf3, and measurably faster — see perf below). `RIPERF3_UDP_SERVER_DEMUX` overrides either way (`0`/`false`/`no`/empty → recycling, anything else → demux), so both paths are exercisable on one build.

## Validation
- **Native winsock (Win11 MSVC, same build, before/after):** `udp_bidir_parallel_completes` **FAILS hung @21.12s** with `RIPERF3_UDP_SERVER_DEMUX=0` (recycling) → **PASSES @3.24s** with demux (default). All 22 Windows UDP integration tests pass with demux (incl. IPv6, DSCP, DF, high-rate, reverse, bidir-parallel).
- **iperf3 parity (real network, sandbox fleet):** demux server interoperates with the iperf3 3.20 binary as client over **IPv4 and native IPv6**, forward/reverse/bidir `-P 4` — all streams balanced.
- **Correctness (real network):** riperf3 client ↔ demux server, IPv4+IPv6, fwd/rev/bidir `-P 4`, all balanced, 0 loss.
- **Cross-platform compile:** `cargo check` green on linux-gnu/musl, windows-msvc, x86_64/aarch64 apple-darwin, freebsd, netbsd.
- **No Unix regression:** full test suite green on Linux with the (default) recycling path unchanged.
- **Perf (forward UDP `-b0 -t5 -P4`, real network):** recycling ~32.7–34.0 Gbit/s @ ~0.02% loss vs demux ~31.8–32.7 Gbit/s @ ~1% loss — recycling is ~3–5% faster with ~50× lower loss at max flood, which is why it stays the Unix default.

## Tests
- New `riperf3-cli/tests/udp_demux.rs` (Unix): forces the demux path on the server and runs forward/reverse/bidir `-P 4`, asserting completion + per-stream bytes — exercises the *same* platform-independent demux code on a host CI can run.
- The pre-existing in-process `udp_bidir_parallel_completes` is the red→green on Windows native.

## Refactor
- Extracted `udp_send_loop` (connected `send` vs `send_to(addr)`), shared by `run_udp_sender_blocking` and the new demux sender.
- Moved the recycling UDP setup into `Server::setup_udp_recycling_streams` alongside the new `setup_udp_demux_streams` (pure move, no logic change).

Once green here, the intent is to promote `Native test (windows-latest)` to a required check (this PR makes #80 — its sole remaining failure — pass).