### PR TITLE
release prep 0.7.0: fix json-stream test flake + set CHANGELOG date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ This changelog begins at 0.6.0. For earlier releases (0.1.1–0.5.4), see the
 [git history](https://github.com/therealevanhenry/riperf3/commits/main) and
 release tags.
 
-## [0.7.0] - unreleased
+## [0.7.0] - 2026-06-06
 
 A minor bump (the first `0.x` minor since 0.6.0) because the interval-reporter
 fix needs a new parameter on a public function — see **Changed** below. No

--- a/riperf3-cli/tests/json_stream.rs
+++ b/riperf3-cli/tests/json_stream.rs
@@ -61,6 +61,10 @@ fn assert_valid_ndjson(stdout: &str, who: &str) {
         "end",
         "{who}: last event must be `end` ({events:?})"
     );
+    // Callers must run long enough to cross an interval boundary mid-test (e.g.
+    // `-t 2 -i 1`, not `-t 1 -i 1`): with interval == duration the lone tick
+    // coincides with the end and its boundary-aligned final interval is dropped
+    // (#55), leaving only start+end — an intermittent 2-event flake under load.
     assert!(
         events.len() >= 3,
         "{who}: expected at least one interval between start and end ({events:?})"
@@ -156,7 +160,7 @@ fn client_json_stream_tcp_is_valid_ndjson() {
             "-p",
             &ps,
             "-t",
-            "1",
+            "2",
             "-i",
             "1",
             "--json-stream",
@@ -194,7 +198,7 @@ fn client_json_stream_udp_is_valid_ndjson() {
             "-b",
             "10M",
             "-t",
-            "1",
+            "2",
             "-i",
             "1",
             "--json-stream",
@@ -225,7 +229,7 @@ fn server_json_stream_is_valid_ndjson() {
 
     // Drive one test, bounded so a non-serving server can't hang the suite.
     let mut client = Command::new(bin)
-        .args(["-c", "127.0.0.1", "-p", &ps, "-t", "1", "-i", "1"])
+        .args(["-c", "127.0.0.1", "-p", &ps, "-t", "2", "-i", "1"])
         .stdout(Stdio::null())
         .stderr(Stdio::null())
         .spawn()


### PR DESCRIPTION
Two pre-release items on top of the merged #80 batch:

1. **Fix the intermittent Linux-CI json-stream flake (#62 tests).** `client_json_stream_udp_is_valid_ndjson` (and its TCP/server siblings) ran `-t 1 -i 1`; with interval == duration the single tick coincides with test end and its boundary-aligned final interval is dropped (#55), leaving only `start`+`end` and failing the `events.len() >= 3` assertion. It surfaced once on the post-merge main run (`c21f486`) under concurrent-test load. Fixed by running `-t 2 -i 1` so a tick fires mid-test; documented at the assertion. Test-only, product unchanged.
2. **Set the 0.7.0 CHANGELOG date** ahead of the GitHub release + cargo publish.

After this merges, the release is: `gh release create v0.7.0 --target main` then `cargo publish` riperf3 (lib) → riperf3-cli.