### PR TITLE
fix: reverse -n/-k terminates instead of hanging (#60)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,13 @@ data-path/throughput changes.
   it mirrors iperf3 and gives one socket and thread per stream (kernel-parallel
   receive that scales better at high `-P`). At modest parallelism the two paths
   measure comparably on throughput and loss.
+- **Reverse byte/block-limited tests (`-R -n` / `-R -k`) now terminate** (#60):
+  the client's end-of-test check summed only the sender streams' bytes, so in
+  reverse — where the client only receives — the total never reached the limit
+  and the transfer ran indefinitely at line rate. The check now trips when
+  either the bytes sent or the bytes received reach the target, matching
+  iperf3's `bytes_sent >= N || bytes_received >= N`; a bidir byte/block limit
+  likewise ends at whichever direction reaches the target first.
 
 ### Added
 - **`StreamCounters::peek_sent_interval` / `peek_received_interval`** (#55):
@@ -253,8 +260,6 @@ complete list; the notable user-facing ones:
   `-w`/`--window` ([#59](https://github.com/therealevanhenry/riperf3/issues/59)).
   The server also accepts client-only flags rather than rejecting them as iperf3
   does ([#65](https://github.com/therealevanhenry/riperf3/issues/65)).
-- **Reverse + byte/block limit** (`-R -n` / `-R -k`) never terminates
-  ([#60](https://github.com/therealevanhenry/riperf3/issues/60)).
 - **`-J` fidelity gaps:** `--json-stream` is not valid line-delimited JSON
   ([#62](https://github.com/therealevanhenry/riperf3/issues/62)); integral
   floats render as `N.0` where cJSON omits the decimal

--- a/riperf3/src/client.rs
+++ b/riperf3/src/client.rs
@@ -106,6 +106,25 @@ fn server_receiver_summaries(
         .collect()
 }
 
+/// Bytes transferred so far against an `-n`/`-k` limit. Faithful to iperf3's
+/// `bytes_sent >= N || bytes_received >= N` end check (`iperf_client_api.c`):
+/// the client's senders accumulate in forward, its receivers in reverse, and in
+/// bidir whichever direction reaches the limit first ends the test. Counting
+/// only sent bytes leaves a reverse `-n`/`-k` test spinning forever (#60).
+fn transferred_bytes(streams: &[DataStream]) -> u64 {
+    let sent: u64 = streams
+        .iter()
+        .filter(|s| s.is_sender)
+        .map(|s| s.counters.bytes_sent())
+        .sum();
+    let received: u64 = streams
+        .iter()
+        .filter(|s| !s.is_sender)
+        .map(|s| s.counters.bytes_received())
+        .sum();
+    sent.max(received)
+}
+
 impl Client {
     pub async fn run(&self) -> Result<TestResultsJson> {
         // -T/--title: prefix every client text line with "<title>:  " (#34),
@@ -711,28 +730,17 @@ impl Client {
             EndCondition::Bytes(target) => {
                 loop {
                     tokio::time::sleep(Duration::from_millis(100)).await;
-                    let total: u64 = streams
-                        .iter()
-                        .filter(|s| s.is_sender)
-                        .map(|s| s.counters.bytes_sent())
-                        .sum();
-                    if total >= target {
+                    if transferred_bytes(streams) >= target {
                         break;
                     }
                 }
                 report_start.elapsed().as_secs_f64()
             }
             EndCondition::Blocks(target) => {
-                // For block-based, approximate by dividing bytes by blksize
+                // Block-based: approximate by dividing transferred bytes by blksize.
                 loop {
                     tokio::time::sleep(Duration::from_millis(100)).await;
-                    let total_bytes: u64 = streams
-                        .iter()
-                        .filter(|s| s.is_sender)
-                        .map(|s| s.counters.bytes_sent())
-                        .sum();
-                    let blocks = total_bytes / blksize as u64;
-                    if blocks >= target {
+                    if transferred_bytes(streams) / blksize as u64 >= target {
                         break;
                     }
                 }

--- a/riperf3/tests/integration.rs
+++ b/riperf3/tests/integration.rs
@@ -362,6 +362,81 @@ async fn tcp_bytes_limit() {
     let _ = server_task.await;
 }
 
+#[tokio::test]
+async fn tcp_reverse_bytes_limit_terminates() {
+    // Reverse + byte limit must stop after N bytes, not hang (issue #60). In
+    // reverse the client is the receiver, so the end condition has to count
+    // received bytes; counting only sent bytes (which stay 0 here) spins forever.
+    let port = next_port();
+
+    let server = ServerBuilder::new()
+        .port(Some(port))
+        .one_off(true)
+        .build()
+        .unwrap();
+
+    let server_task = tokio::spawn(async move { server.run().await });
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    let target: u64 = 8 * 1024 * 1024; // 8 MB
+    let client = ClientBuilder::new("127.0.0.1")
+        .port(Some(port))
+        .reverse(true)
+        .bytes(target)
+        .build()
+        .unwrap();
+
+    // On the #60 bug this never returns; cap it so the test fails, not hangs.
+    let result = tokio::time::timeout(Duration::from_secs(15), client.run()).await;
+    assert!(result.is_ok(), "-R -n hung — issue #60 regression");
+    let res = result.unwrap().expect("-R -n errored");
+    // In reverse the server is the sender; it must have pushed at least the
+    // requested volume before the test terminated.
+    let transferred: u64 = res.streams.iter().map(|s| s.bytes).sum();
+    assert!(
+        transferred >= target,
+        "transferred {transferred} < requested {target}"
+    );
+
+    let _ = server_task.await;
+}
+
+#[tokio::test]
+async fn tcp_reverse_blocks_limit_terminates() {
+    // Same guard for the block limit (-R -k), issue #60.
+    let port = next_port();
+
+    let server = ServerBuilder::new()
+        .port(Some(port))
+        .one_off(true)
+        .build()
+        .unwrap();
+
+    let server_task = tokio::spawn(async move { server.run().await });
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    let blksize: usize = 128 * 1024;
+    let blocks: u64 = 64;
+    let client = ClientBuilder::new("127.0.0.1")
+        .port(Some(port))
+        .reverse(true)
+        .blksize(blksize)
+        .blocks(blocks)
+        .build()
+        .unwrap();
+
+    let result = tokio::time::timeout(Duration::from_secs(15), client.run()).await;
+    assert!(result.is_ok(), "-R -k hung — issue #60 regression");
+    let res = result.unwrap().expect("-R -k errored");
+    let transferred: u64 = res.streams.iter().map(|s| s.bytes).sum();
+    assert!(
+        transferred >= blocks * blksize as u64,
+        "transferred {transferred} < requested {blocks} blocks"
+    );
+
+    let _ = server_task.await;
+}
+
 // ---------------------------------------------------------------------------
 // UDP loopback tests (expected to fail until UDP fix lands)
 // ---------------------------------------------------------------------------

--- a/riperf3/tests/integration.rs
+++ b/riperf3/tests/integration.rs
@@ -391,7 +391,10 @@ async fn tcp_reverse_bytes_limit_terminates() {
     assert!(result.is_ok(), "-R -n hung — issue #60 regression");
     let res = result.unwrap().expect("-R -n errored");
     // In reverse the server is the sender; it must have pushed at least the
-    // requested volume before the test terminated.
+    // requested volume before terminating. Lower bound only: at loopback line
+    // rate the 100ms end-condition poll overshoots the target (a pre-existing
+    // characteristic shared with forward `-n`), so this guards termination +
+    // floor, not an exact byte count.
     let transferred: u64 = res.streams.iter().map(|s| s.bytes).sum();
     assert!(
         transferred >= target,


### PR DESCRIPTION
## Summary

Fixes #60 — a reverse test with a byte/block limit (`-R -n` / `-R -k`) never
terminated; it transferred indefinitely instead of stopping after `N`
bytes/blocks. Duration-limited reverse (`-R -t`) was unaffected.

## Root cause

`Client::run_test`'s byte/block end condition summed only **sender-stream**
`bytes_sent()`. In reverse the client's streams are all **receivers**, so the
sum stayed `0` and the `total >= target` poll never tripped — the test spun
forever at line rate.

## Fix

Count `max(sent_over_senders, received_over_receivers)` against the limit,
faithful to iperf3's client end check in `iperf_client_api.c`:

```c
(test->bytes_sent >= test->settings->bytes ||
 test->bytes_received >= test->settings->bytes)
```

This single formula covers all three directions: forward (senders accumulate),
reverse (receivers accumulate), and bidir (whichever direction reaches the
limit first ends the test).

## iperf3 adjudication

Against the real iperf3 (`esnet/iperf` 3.20+): `iperf3 -c … -n 50M -R` transfers
exactly 50 MB and both sender/receiver summary lines report 50 MB. riperf3 now
terminates promptly on `-R -n`/`-R -k` instead of hanging.

## Tests

Added `tcp_reverse_bytes_limit_terminates` and
`tcp_reverse_blocks_limit_terminates` (wrapped in `tokio::time::timeout` so a
regression fails instead of hanging). Both go red on the pre-fix code (15s
timeout, blasting ~90 Gbps) and green after (≈1.4s).

Closes #60.
