### PR TITLE
fix: byte/block-limited summary uses measured elapsed, not -t window (#103)

### DIFF
--- a/riperf3-cli/tests/byte_limit_summary.rs
+++ b/riperf3-cli/tests/byte_limit_summary.rs
@@ -1,0 +1,186 @@
+//! CLI integration test: byte/block-limited (`-n`/`-k`) runs must report the
+//! ACTUAL measured elapsed in the summary window, not the default `-t` duration
+//! (#103). A `-n 1G` transfer finishes far inside the default 10 s window, so
+//! `end.sum_*.seconds` must be the measured time (and the derived bitrate with
+//! it), while `start.test_start.duration` stays the requested `-t` parameter.
+
+use std::io::Read;
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+use serde_json::Value;
+
+fn free_port() -> u16 {
+    std::net::TcpListener::bind("127.0.0.1:0")
+        .expect("bind ephemeral port")
+        .local_addr()
+        .expect("local_addr")
+        .port()
+}
+
+/// Kills the wrapped child on drop so a spawned server is reaped on panic.
+struct ChildGuard(std::process::Child);
+impl Drop for ChildGuard {
+    fn drop(&mut self) {
+        let _ = self.0.kill();
+        let _ = self.0.wait();
+    }
+}
+
+/// See json_stream.rs: a generous fixed margin for the server to bind before the
+/// client connects, robust on loaded CI runners.
+const SERVER_BIND_WAIT: Duration = Duration::from_secs(2);
+
+/// Spawn `riperf3` with `args`, bound its run, and return captured stdout.
+fn run_capturing(args: &[&str], timeout: Duration, who: &str) -> String {
+    let bin = env!("CARGO_BIN_EXE_riperf3");
+    let mut child = Command::new(bin)
+        .args(args)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .unwrap_or_else(|e| panic!("{who}: spawn failed: {e}"));
+
+    let deadline = Instant::now() + timeout;
+    loop {
+        match child.try_wait().expect("try_wait") {
+            Some(_) => break,
+            None if Instant::now() >= deadline => {
+                let _ = child.kill();
+                let _ = child.wait();
+                panic!("{who}: timed out");
+            }
+            None => std::thread::sleep(Duration::from_millis(50)),
+        }
+    }
+    let mut out = String::new();
+    child
+        .stdout
+        .take()
+        .unwrap()
+        .read_to_string(&mut out)
+        .unwrap();
+    out
+}
+
+fn spawn_server(port_str: &str) -> ChildGuard {
+    let bin = env!("CARGO_BIN_EXE_riperf3");
+    let g = ChildGuard(
+        Command::new(bin)
+            .args(["-s", "-1", "-p", port_str])
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("spawn server"),
+    );
+    std::thread::sleep(SERVER_BIND_WAIT);
+    g
+}
+
+/// `-n` (byte-limited) `-J` summary must use the measured elapsed, not the
+/// default 10 s duration window (#103).
+#[test]
+fn json_byte_limited_summary_uses_measured_elapsed() {
+    let port = free_port();
+    let ps = port.to_string();
+    let mut server = spawn_server(&ps);
+
+    // 1 GB forward transfer: completes in well under a second on loopback, far
+    // inside the default 10 s window.
+    let out = run_capturing(
+        &["-c", "127.0.0.1", "-p", &ps, "-n", "1G", "-J"],
+        Duration::from_secs(20),
+        "client",
+    );
+    let _ = server.0.wait();
+
+    let v: Value = serde_json::from_str(&out)
+        .unwrap_or_else(|e| panic!("client -J is not valid JSON ({e}): {out}"));
+
+    let secs = v["end"]["sum_sent"]["seconds"]
+        .as_f64()
+        .unwrap_or_else(|| panic!("missing end.sum_sent.seconds: {out}"));
+    // Pre-#103 this is the default 10.0; the real transfer takes well under 5 s.
+    assert!(
+        secs > 0.0 && secs < 5.0,
+        "summary seconds {secs} should be the measured elapsed, not the default 10 s window"
+    );
+
+    // The derived bitrate must be consistent with bytes / measured seconds, not
+    // bytes / 10 s.
+    let bytes = v["end"]["sum_sent"]["bytes"]
+        .as_f64()
+        .expect("sum_sent.bytes");
+    let bps = v["end"]["sum_sent"]["bits_per_second"]
+        .as_f64()
+        .expect("sum_sent.bits_per_second");
+    let expected_bps = bytes * 8.0 / secs;
+    assert!(
+        (bps - expected_bps).abs() <= expected_bps * 0.02,
+        "bits_per_second {bps} should match bytes*8/seconds {expected_bps}"
+    );
+
+    // The `-t` parameter under start.test_start is unchanged (still the nominal
+    // default), distinct from the measured summary window.
+    let param = v["start"]["test_start"]["duration"]
+        .as_f64()
+        .unwrap_or_else(|| panic!("missing start.test_start.duration: {out}"));
+    assert!(
+        param >= 5.0,
+        "test_start.duration {param} should stay the nominal -t param, not the measured elapsed"
+    );
+}
+
+/// The server's own `-s -J` summary must likewise use the measured elapsed for a
+/// byte-limited test, not the default duration window (#103).
+#[test]
+fn server_json_byte_limited_summary_uses_measured_elapsed() {
+    let port = free_port();
+    let ps = port.to_string();
+    let bin = env!("CARGO_BIN_EXE_riperf3");
+
+    // One-off server in JSON mode; capture its end-of-test report.
+    let mut server = ChildGuard(
+        Command::new(bin)
+            .args(["-s", "-1", "-J", "-p", &ps])
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("spawn server"),
+    );
+    std::thread::sleep(SERVER_BIND_WAIT);
+
+    // Forward byte-limited transfer: the server is the receiver.
+    let _client = run_capturing(
+        &["-c", "127.0.0.1", "-p", &ps, "-n", "1G"],
+        Duration::from_secs(20),
+        "client",
+    );
+
+    let mut out = String::new();
+    server
+        .0
+        .stdout
+        .take()
+        .unwrap()
+        .read_to_string(&mut out)
+        .unwrap();
+    let _ = server.0.wait();
+
+    let v: Value = serde_json::from_str(&out)
+        .unwrap_or_else(|e| panic!("server -J is not valid JSON ({e}): {out}"));
+    let secs = v["end"]["sum_received"]["seconds"]
+        .as_f64()
+        .unwrap_or_else(|| panic!("missing end.sum_received.seconds: {out}"));
+    assert!(
+        secs > 0.0 && secs < 5.0,
+        "server summary seconds {secs} should be the measured elapsed, not the default 10 s window"
+    );
+    let param = v["start"]["test_start"]["duration"]
+        .as_f64()
+        .unwrap_or_else(|| panic!("missing start.test_start.duration: {out}"));
+    assert!(
+        param >= 5.0,
+        "server test_start.duration {param} should stay the nominal -t param"
+    );
+}

--- a/riperf3-cli/tests/byte_limit_summary.rs
+++ b/riperf3-cli/tests/byte_limit_summary.rs
@@ -184,3 +184,56 @@ fn server_json_byte_limited_summary_uses_measured_elapsed() {
         "server test_start.duration {param} should stay the nominal -t param"
     );
 }
+
+/// Block-limited (`-k`) shares the same summary path; lock it in too (#103).
+#[test]
+fn json_block_limited_summary_uses_measured_elapsed() {
+    let port = free_port();
+    let ps = port.to_string();
+    let mut server = spawn_server(&ps);
+
+    // 8000 blocks × 128 KB default ≈ 1 GB: finishes well inside 10 s.
+    let out = run_capturing(
+        &["-c", "127.0.0.1", "-p", &ps, "-k", "8000", "-J"],
+        Duration::from_secs(20),
+        "client",
+    );
+    let _ = server.0.wait();
+
+    let v: Value = serde_json::from_str(&out)
+        .unwrap_or_else(|e| panic!("client -J is not valid JSON ({e}): {out}"));
+    let secs = v["end"]["sum_sent"]["seconds"]
+        .as_f64()
+        .unwrap_or_else(|| panic!("missing end.sum_sent.seconds: {out}"));
+    assert!(
+        secs > 0.0 && secs < 5.0,
+        "block-limited summary seconds {secs} should be the measured elapsed"
+    );
+}
+
+/// Reverse byte-limited (`-n -R`): the client is the receiver, so its summary
+/// comes from `sum_received`; it too must use the measured elapsed (#103). The
+/// reverse `-n` hang was fixed in #60, so this terminates.
+#[test]
+fn json_reverse_byte_limited_summary_uses_measured_elapsed() {
+    let port = free_port();
+    let ps = port.to_string();
+    let mut server = spawn_server(&ps);
+
+    let out = run_capturing(
+        &["-c", "127.0.0.1", "-p", &ps, "-n", "500M", "-R", "-J"],
+        Duration::from_secs(20),
+        "client",
+    );
+    let _ = server.0.wait();
+
+    let v: Value = serde_json::from_str(&out)
+        .unwrap_or_else(|e| panic!("client -R -J is not valid JSON ({e}): {out}"));
+    let secs = v["end"]["sum_received"]["seconds"]
+        .as_f64()
+        .unwrap_or_else(|| panic!("missing end.sum_received.seconds: {out}"));
+    assert!(
+        secs > 0.0 && secs < 5.0,
+        "reverse byte-limited summary seconds {secs} should be the measured elapsed"
+    );
+}

--- a/riperf3/src/client.rs
+++ b/riperf3/src/client.rs
@@ -192,6 +192,9 @@ impl Client {
         let mut streams: Vec<DataStream> = Vec::new();
         let mut cpu_start: Option<CpuSnapshot> = None;
         let mut server_results: Option<TestResultsJson> = None;
+        // Authoritative test duration captured from run_test: `-t` for a duration
+        // run, the measured elapsed for `-n`/`-k`. Drives the summary window (#103).
+        let mut measured_secs = self.duration as f64;
         // Wall-clock at TestStart, for the `-J` start.timestamp (#36 PR3).
         let mut test_start_millis = 0u64;
 
@@ -239,14 +242,15 @@ impl Client {
                 }
 
                 TestState::TestRunning => {
-                    self.run_test(&mut ctrl, &streams, &done, blksize, interval_data.clone())
+                    measured_secs = self
+                        .run_test(&mut ctrl, &streams, &done, blksize, interval_data.clone())
                         .await?;
                     // Test finished — send TestEnd
                     protocol::send_state(&mut ctrl, TestState::TestEnd).await?;
                 }
 
                 TestState::ExchangeResults => {
-                    let results = self.build_results(&streams, cpu_start.as_ref());
+                    let results = self.build_results(&streams, cpu_start.as_ref(), measured_secs);
                     protocol::send_results(&mut ctrl, &results).await?;
                     server_results = Some(protocol::recv_results(&mut ctrl).await?);
                 }
@@ -264,6 +268,7 @@ impl Client {
                             tcp_mss_default: control_mss,
                             start_time_millis: test_start_millis,
                         },
+                        measured_secs,
                     );
                     protocol::send_state(&mut ctrl, TestState::IperfDone).await?;
                     break; // test complete — server will close the connection
@@ -641,7 +646,7 @@ impl Client {
         done: &Arc<AtomicBool>,
         blksize: usize,
         collector: Arc<Mutex<crate::reporter::CollectedIntervals>>,
-    ) -> Result<()> {
+    ) -> Result<f64> {
         // Run the interval reporter whenever intervals are enabled. It prints
         // live for text / json-stream; for plain -J it runs silently to collect
         // intervals for the final blob (#36 PR2).
@@ -759,20 +764,22 @@ impl Client {
             let _ = handle.await;
         }
 
-        Ok(())
+        // The authoritative test duration: exactly `-t` for a duration run, the
+        // measured elapsed for a byte/block-limited run. The summary window and
+        // its derived bitrate use this, not the default `-t` (#103).
+        Ok(end_secs)
     }
 
     fn build_results(
         &self,
         streams: &[DataStream],
         cpu_start: Option<&CpuSnapshot>,
+        test_duration: f64,
     ) -> TestResultsJson {
         let cpu_end = CpuSnapshot::now();
         let cpu_util = cpu_start
             .map(|start| cpu_end.utilization_since(start))
             .unwrap_or_default();
-
-        let test_duration = self.duration as f64;
 
         let stream_results: Vec<_> = streams
             .iter()
@@ -821,6 +828,7 @@ impl Client {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn print_results(
         &self,
         streams: &[DataStream],
@@ -829,6 +837,7 @@ impl Client {
         blksize: usize,
         interval_data: &Arc<Mutex<crate::reporter::CollectedIntervals>>,
         start_meta: &StartMeta,
+        test_duration: f64,
     ) {
         if self.json_output {
             self.print_results_json(
@@ -838,6 +847,7 @@ impl Client {
                 blksize,
                 interval_data,
                 start_meta,
+                test_duration,
             );
         } else if self.json_stream {
             // --json-stream: emit the `end` event. (Previously this fell through
@@ -849,14 +859,19 @@ impl Client {
                 blksize,
                 interval_data,
                 start_meta,
+                test_duration,
             );
         } else {
-            self.print_results_text(streams, remote_cpu);
+            self.print_results_text(streams, remote_cpu, test_duration);
         }
     }
 
-    fn print_results_text(&self, streams: &[DataStream], server_results: Option<&TestResultsJson>) {
-        let test_duration = self.duration as f64;
+    fn print_results_text(
+        &self,
+        streams: &[DataStream],
+        server_results: Option<&TestResultsJson>,
+        test_duration: f64,
+    ) {
         crate::reporter::print_separator();
 
         let mut summaries: Vec<crate::reporter::StreamSummary> = streams
@@ -912,6 +927,7 @@ impl Client {
     /// Shared by `-J` (build + pretty-print) and `--json-stream` (build + emit the
     /// `end` event; and at TestStart, the `start` event from a partial input where
     /// only the start fields are meaningful — see `emit_json_stream_start`).
+    #[allow(clippy::too_many_arguments)]
     fn build_report_input(
         &self,
         streams: &[DataStream],
@@ -920,6 +936,7 @@ impl Client {
         blksize: usize,
         interval_data: &Arc<Mutex<crate::reporter::CollectedIntervals>>,
         start_meta: &StartMeta,
+        test_duration: f64,
     ) -> crate::json_report::ReportInput {
         use crate::json_report::{
             CpuUtilization, ReportInput, StreamReport, TcpEndExtras, UdpStreamStats,
@@ -935,7 +952,6 @@ impl Client {
             Err(_) => (Vec::new(), Vec::new()),
         };
 
-        let test_duration = self.duration as f64;
         let cpu_end = CpuSnapshot::now();
         let cpu_util = cpu_start
             .map(|start| cpu_end.utilization_since(start))
@@ -1041,7 +1057,8 @@ impl Client {
             protocol: self.protocol,
             reverse: self.reverse,
             bidir: self.bidir,
-            duration: test_duration,
+            duration: self.duration as f64,
+            elapsed: test_duration,
             num_streams: self.num_streams as i32,
             blksize: blksize as i64,
             omit: self.omit as i32,
@@ -1095,6 +1112,7 @@ impl Client {
     }
 
     /// `-J`: build and pretty-print the single batched report blob.
+    #[allow(clippy::too_many_arguments)]
     fn print_results_json(
         &self,
         streams: &[DataStream],
@@ -1103,6 +1121,7 @@ impl Client {
         blksize: usize,
         interval_data: &Arc<Mutex<crate::reporter::CollectedIntervals>>,
         start_meta: &StartMeta,
+        test_duration: f64,
     ) {
         let input = self.build_report_input(
             streams,
@@ -1111,6 +1130,7 @@ impl Client {
             blksize,
             interval_data,
             start_meta,
+            test_duration,
         );
         println!("{}", serde_json::to_string_pretty(&input.build()).unwrap());
     }
@@ -1127,8 +1147,17 @@ impl Client {
         interval_data: &Arc<Mutex<crate::reporter::CollectedIntervals>>,
         start_meta: &StartMeta,
     ) {
-        let input =
-            self.build_report_input(streams, cpu_start, None, blksize, interval_data, start_meta);
+        // The `start` event carries no summary window, so the elapsed value is
+        // unused here; pass the nominal duration.
+        let input = self.build_report_input(
+            streams,
+            cpu_start,
+            None,
+            blksize,
+            interval_data,
+            start_meta,
+            self.duration as f64,
+        );
         crate::reporter::emit_json_stream_line(&crate::json_report::json_stream_event(
             "start",
             &input.build().start,
@@ -1137,6 +1166,7 @@ impl Client {
 
     /// `--json-stream`: emit the `end` event (#62) at DisplayResults. The interval
     /// events were already streamed live by the reporter.
+    #[allow(clippy::too_many_arguments)]
     fn emit_json_stream_end(
         &self,
         streams: &[DataStream],
@@ -1145,6 +1175,7 @@ impl Client {
         blksize: usize,
         interval_data: &Arc<Mutex<crate::reporter::CollectedIntervals>>,
         start_meta: &StartMeta,
+        test_duration: f64,
     ) {
         let input = self.build_report_input(
             streams,
@@ -1153,6 +1184,7 @@ impl Client {
             blksize,
             interval_data,
             start_meta,
+            test_duration,
         );
         crate::reporter::emit_json_stream_line(&crate::json_report::json_stream_event(
             "end",

--- a/riperf3/src/json_report.rs
+++ b/riperf3/src/json_report.rs
@@ -529,7 +529,13 @@ pub struct ReportInput {
     pub protocol: TransportProtocol,
     pub reverse: bool,
     pub bidir: bool,
+    /// The requested `-t` duration parameter, reported under `test_start`. Stays
+    /// the nominal value even for a byte/block-limited (`-n`/`-k`) run.
     pub duration: f64,
+    /// The measured elapsed test time, used for the summary window and the
+    /// derived per-stream/aggregate bitrate. Equals `duration` for a duration
+    /// run; for `-n`/`-k` it is the actual time the transfer took (#103).
+    pub elapsed: f64,
     pub num_streams: i32,
     pub blksize: i64,
     pub omit: i32,
@@ -919,7 +925,7 @@ impl ReportInput {
     }
 
     fn end_stream(&self, s: &StreamReport) -> EndStream {
-        let dur = self.duration;
+        let dur = self.elapsed;
         // Shape is driven by the test protocol, not by whether stats happen to be
         // present: a UDP stream with missing stats still emits a valid `udp`
         // object (zeroed datagram fields), never a TCP `{sender,receiver}` body.
@@ -1053,7 +1059,7 @@ impl ReportInput {
     }
 
     fn tcp_sum(&self, bytes: u64, sender: bool, retransmits: Option<i64>) -> SumSide {
-        let dur = self.duration;
+        let dur = self.elapsed;
         SumSide {
             start: 0.0,
             end: dur,
@@ -1077,7 +1083,7 @@ impl ReportInput {
         lost: i64,
         jitter_secs: f64,
     ) -> SumSide {
-        let dur = self.duration;
+        let dur = self.elapsed;
         SumSide {
             start: 0.0,
             end: dur,
@@ -1180,6 +1186,7 @@ mod tests {
             reverse: false,
             bidir: false,
             duration: 10.0,
+            elapsed: 10.0,
             num_streams: 1,
             blksize: 131072,
             omit: 0,

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -536,7 +536,8 @@ impl Server {
         // (`done`) so no received bytes leak past the deadline into the final
         // interval (#55). The reporter prioritises `finish` over `done`, so the
         // final interval still flushes; wait for it before tearing streams down.
-        reporter_end.finish(report_start.elapsed().as_secs_f64());
+        let measured_elapsed = report_start.elapsed().as_secs_f64();
+        reporter_end.finish(measured_elapsed);
         done.store(true, Ordering::Relaxed);
         if let Some(handle) = interval_handle {
             let _ = handle.await;
@@ -547,7 +548,14 @@ impl Server {
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
 
         let mut result_streams = Vec::new();
-        let test_duration = cfg.duration as f64;
+        // Summary window + bitrate: the measured elapsed for a byte/block-limited
+        // run, exactly `-t` otherwise (#103, mirrors the client). The requested
+        // `-t` is reported separately as the test_start `duration` parameter.
+        let test_duration = if params.num.is_some() || params.blockcount.is_some() {
+            measured_elapsed
+        } else {
+            cfg.duration as f64
+        };
 
         for s in &streams {
             let bytes = if s.is_sender {
@@ -1154,7 +1162,8 @@ impl Server {
             protocol: cfg.protocol,
             reverse: cfg.reverse,
             bidir: cfg.bidir,
-            duration: test_duration,
+            duration: cfg.duration as f64,
+            elapsed: test_duration,
             num_streams: cfg.num_streams as i32,
             blksize: cfg.blksize as i64,
             omit: cfg.omit as i32,


### PR DESCRIPTION
## Summary

Fixes #103 — a byte/block-limited run (`-n`/`-k`) that finishes well inside the
default `-t` window reported its **summary** against `self.duration` (default
10 s) instead of the actual elapsed. E.g. `riperf3 -c host -n 25G` finishing at
~2.4 s printed `0.00-10.00 sec ... 25958 Mbits/sec`. The per-interval final
partial was already correct (#55); only the summary line and its derived bitrate
were wrong.

## iperf3 adjudication

Against the real iperf3: `iperf3 -c 127.0.0.1 -n 50M` reports the summary over
the actual elapsed (`0.00-1.00 sec  50.0 MBytes  419 Mbits/sec`), while
`start.test_start.duration` stays the requested `-t` (default 10). riperf3 now
matches both.

## Approach

The report conflated two distinct times. Split them:

- `ReportInput.duration` — the requested `-t`, reported under `test_start`.
- `ReportInput.elapsed` (new) — the **measured** test time, used for the summary
  window and the per-stream/aggregate `seconds` / `bits_per_second`.

For a duration run the two coincide (the run ends at exactly `-t`); for `-n`/`-k`,
`elapsed` is the measured time. `run_test` now returns this authoritative value,
threaded through the client's `build_results` / `print_results` /
`build_report_input`. The symmetric server-side path (`-s` text and `-s -J`) is
fixed the same way.

## Tests

`riperf3-cli/tests/byte_limit_summary.rs`: client and server `-J` byte-limited
summaries report the measured elapsed (< 5 s for a `-n 1G` loopback transfer)
with a bitrate consistent with bytes/seconds, while `test_start.duration` stays
nominal. Both go red on the pre-fix code (`seconds: 10`). Full workspace suite +
clippy + fmt green.

Closes #103.
