### PR TITLE
fix: pace the TCP sender to -b/--bitrate (#102)

### DIFF
--- a/riperf3/src/client.rs
+++ b/riperf3/src/client.rs
@@ -469,8 +469,13 @@ impl Client {
                         let c = counters.clone();
                         let d = done.clone();
                         let zc = self.zerocopy;
+                        let rate = self.bandwidth;
                         tokio::spawn(async move {
-                            if zc {
+                            // Zerocopy (sendfile) is used only for an unlimited
+                            // transfer; with `-b` the paced copy sender runs
+                            // instead — sendfile's benefit is moot under a rate
+                            // cap and its retry loop doesn't pace cleanly (#102).
+                            if zc && rate == 0 {
                                 // Zerocopy senders exist only for these targets
                                 // (stream.rs). The gate must match the impls, not
                                 // `unix`: other-Unix (NetBSD/OpenBSD/illumos) is
@@ -492,10 +497,10 @@ impl Client {
                                     target_os = "freebsd"
                                 )))]
                                 {
-                                    stream::run_tcp_sender(data_stream, c, buf, d, fp).await
+                                    stream::run_tcp_sender(data_stream, c, buf, d, fp, rate).await
                                 }
                             } else {
-                                stream::run_tcp_sender(data_stream, c, buf, d, fp).await
+                                stream::run_tcp_sender(data_stream, c, buf, d, fp, rate).await
                             }
                         })
                     } else {

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -326,8 +326,11 @@ impl Server {
                         let buf = make_send_buffer(cfg.blksize, false);
                         let c = counters.clone();
                         let d = done.clone();
+                        // `-b` paces the sender in reverse/bidir too (negotiated
+                        // rate; 0 = unlimited). #102
+                        let rate = cfg.bandwidth;
                         tokio::spawn(async move {
-                            stream::run_tcp_sender(data_stream, c, buf, d, fp).await
+                            stream::run_tcp_sender(data_stream, c, buf, d, fp, rate).await
                         })
                     } else {
                         let c = counters.clone();

--- a/riperf3/src/stream.rs
+++ b/riperf3/src/stream.rs
@@ -328,9 +328,14 @@ pub async fn run_tcp_sender(
     mut buf: Vec<u8>,
     done: Arc<AtomicBool>,
     file_path: Option<std::path::PathBuf>,
+    rate: u64,
 ) -> Result<()> {
     use std::io::Read;
     let mut file = file_path.as_ref().map(std::fs::File::open).transpose()?;
+    // `-b` pacing: a token bucket caps the application send rate, matching
+    // iperf3's TCP throttle. 0 = unlimited → no limiter, so the default TCP
+    // path is unchanged (#102; mirrors UDP's `-b 0` per #17).
+    let mut limiter = (rate > 0).then(|| RateLimiter::new(rate, 0, buf.len().max(1)));
 
     while !done.load(Ordering::Relaxed) {
         // Refill buffer from file if specified
@@ -342,6 +347,10 @@ pub async fn run_tcp_sender(
                 f.seek(std::io::SeekFrom::Start(0))?;
                 let _ = f.read(&mut buf);
             }
+        }
+
+        if let Some(rl) = limiter.as_mut() {
+            rl.acquire(buf.len() as u64).await;
         }
 
         match stream.write_all(&buf).await {
@@ -1751,7 +1760,7 @@ mod tests {
                 .await
                 .unwrap();
             let buf = vec![0u8; 1024];
-            run_tcp_sender(stream, sc, buf, d, None).await
+            run_tcp_sender(stream, sc, buf, d, None, 0).await
         });
 
         let rc = recv_counters.clone();

--- a/riperf3/tests/integration.rs
+++ b/riperf3/tests/integration.rs
@@ -441,6 +441,125 @@ async fn tcp_reverse_blocks_limit_terminates() {
 }
 
 // ---------------------------------------------------------------------------
+// TCP bitrate pacing (-b), issue #102
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn tcp_bitrate_is_paced() {
+    // TCP `-b` must pace the sender to the target like iperf3 (#102). Before the
+    // fix the TCP client ignored -b and ran at line rate.
+    let port = next_port();
+    let server = ServerBuilder::new()
+        .port(Some(port))
+        .one_off(true)
+        .build()
+        .unwrap();
+    let server_task = tokio::spawn(async move { server.run().await });
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    let target: u64 = 200_000_000; // 200 Mbit/s
+    let secs: u64 = 2;
+    let client = ClientBuilder::new("127.0.0.1")
+        .port(Some(port))
+        .duration(2)
+        .bandwidth(target)
+        .build()
+        .unwrap();
+
+    let result = tokio::time::timeout(Duration::from_secs(20), client.run())
+        .await
+        .expect("client hung")
+        .expect("client errored");
+    // run() returns the server's results; forward → server received ≈ what we sent.
+    let bytes: u64 = result.streams.iter().map(|s| s.bytes).sum();
+    let achieved = bytes * 8 / secs;
+    // Unpaced this is line rate (tens of Gbit/s, >100x target). Paced lands near
+    // target; allow a generous band for burst/timing slack.
+    assert!(
+        achieved < target * 2,
+        "TCP -b not paced: {achieved} bps vs target {target}"
+    );
+    assert!(
+        achieved > target / 2,
+        "TCP -b paced far below target: {achieved} bps vs target {target}"
+    );
+    let _ = server_task.await;
+}
+
+#[tokio::test]
+async fn tcp_unlimited_is_not_paced() {
+    // Regression guard: default TCP (no -b ⇒ rate 0) must stay unthrottled.
+    let port = next_port();
+    let server = ServerBuilder::new()
+        .port(Some(port))
+        .one_off(true)
+        .build()
+        .unwrap();
+    let server_task = tokio::spawn(async move { server.run().await });
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    let client = ClientBuilder::new("127.0.0.1")
+        .port(Some(port))
+        .duration(1)
+        .build()
+        .unwrap();
+
+    let result = tokio::time::timeout(Duration::from_secs(20), client.run())
+        .await
+        .expect("client hung")
+        .expect("client errored");
+    let bytes: u64 = result.streams.iter().map(|s| s.bytes).sum();
+    // A 200 Mbit cap would yield ~25 MB in 1 s; unthrottled loopback moves far
+    // more. >200 MB confirms pacing didn't leak into the rate-0 path.
+    assert!(
+        bytes > 200_000_000,
+        "unlimited TCP moved only {bytes} bytes in 1s — pacing leaked into the rate-0 path"
+    );
+    let _ = server_task.await;
+}
+
+#[tokio::test]
+async fn tcp_bitrate_reverse_is_paced() {
+    // In reverse the server is the sender, so `-b` must pace the server path too
+    // (#102). The negotiated rate reaches the server via the params.
+    let port = next_port();
+    let server = ServerBuilder::new()
+        .port(Some(port))
+        .one_off(true)
+        .build()
+        .unwrap();
+    let server_task = tokio::spawn(async move { server.run().await });
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    let target: u64 = 200_000_000;
+    let secs: u64 = 2;
+    let client = ClientBuilder::new("127.0.0.1")
+        .port(Some(port))
+        .duration(2)
+        .reverse(true)
+        .bandwidth(target)
+        .build()
+        .unwrap();
+
+    let result = tokio::time::timeout(Duration::from_secs(20), client.run())
+        .await
+        .expect("client hung")
+        .expect("client errored");
+    // Reverse: the server sends; its reported bytes ≈ what it paced out.
+    let bytes: u64 = result.streams.iter().map(|s| s.bytes).sum();
+    let achieved = bytes * 8 / secs;
+    assert!(
+        achieved < target * 2,
+        "reverse TCP -b not paced (server): {achieved} bps vs target {target}"
+    );
+    assert!(
+        achieved > target / 2,
+        "reverse TCP -b paced far below target: {achieved} bps vs target {target}"
+    );
+    let _ = server_task.await;
+}
+
+// ---------------------------------------------------------------------------
 // UDP loopback tests (expected to fail until UDP fix lands)
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Fixes #102 — the TCP client ignored `-b`/`--bitrate` and ran at line rate
(~96 Gbit/s on loopback); iperf3 caps a TCP sender at the requested rate. UDP
was already paced.

## Approach

Reuse the existing token-bucket `RateLimiter` (the UDP pacer) in
`run_tcp_sender`, gated on `rate > 0` — `0` = unlimited, so the **default TCP
path is unchanged** and the benchmarks are unaffected. Because both the client
(forward) and the server (reverse/bidir) send through `run_tcp_sender` and the
rate is negotiated in the params, pacing applies in **every sending direction**.
`-b` is per-stream, matching iperf3.

Zerocopy (`-Z`) is used only for an unlimited transfer; with `-b` the paced copy
sender runs instead — sendfile's throughput benefit is moot under a rate cap and
its writable/retry loop doesn't pace cleanly. (`-Z` alone is unchanged.)

## iperf3 adjudication (3.20)

| scenario | riperf3 | iperf3 |
|---|--|--|
| `-b 200M` forward | ~210 Mbps | 200 Mbps |
| `-b 200M -R` (server paces) | ~210 Mbps | — |
| `-b 200M -P 4` | ~840 Mbps total (~210/stream) | ~800 (200/stream) |

The small overshoot is the token bucket's initial burst (~5% at `-t 2`, ~1% at
the default `-t 10`), consistent with riperf3's existing UDP pacing model.

## Tests

`tcp_bitrate_is_paced` (forward), `tcp_bitrate_reverse_is_paced` (server path),
and `tcp_unlimited_is_not_paced` (rate-0 regression guard). The paced tests go
red on pre-fix code (96 Gbit/s line rate). Full workspace suite + clippy + fmt +
the 7-target cross-compile matrix all green.

Closes #102.
