### PR TITLE
fix: TCP sender self-enforces -n/-k via shared byte budget (#117)

### DIFF
--- a/riperf3/src/client.rs
+++ b/riperf3/src/client.rs
@@ -1,4 +1,4 @@
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicI64, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
@@ -398,6 +398,17 @@ impl Client {
         let max_duration = (self.bytes_to_send.is_none() && self.blocks_to_send.is_none())
             .then(|| Duration::from_secs(self.duration as u64));
 
+        // `-n`/`-k` shared byte budget for the sending streams: they collectively
+        // stop at ~N bytes (iperf3's `-n` is the test-wide total), bounding the
+        // overshoot to ~one block per stream instead of ~100ms of line rate.
+        let byte_budget: Option<Arc<AtomicI64>> = self
+            .bytes_to_send
+            .or_else(|| {
+                self.blocks_to_send
+                    .map(|k| k.saturating_mul(blksize as u64))
+            })
+            .map(|n| Arc::new(AtomicI64::new(n as i64)));
+
         match self.protocol {
             TransportProtocol::Tcp => {
                 for i in 0..total {
@@ -470,12 +481,14 @@ impl Client {
                         let d = done.clone();
                         let zc = self.zerocopy;
                         let rate = self.bandwidth;
+                        let bb = byte_budget.clone();
                         tokio::spawn(async move {
-                            // Zerocopy (sendfile) is used only for an unlimited
-                            // transfer; with `-b` the paced copy sender runs
-                            // instead — sendfile's benefit is moot under a rate
-                            // cap and its retry loop doesn't pace cleanly (#102).
-                            if zc && rate == 0 {
+                            // Zerocopy (sendfile) is used only for an unlimited,
+                            // duration-based transfer; with `-b` (pacing) or
+                            // `-n`/`-k` (byte budget) the copy sender runs instead,
+                            // since the sendfile retry loop self-limits/paces
+                            // neither cleanly (#102 + byte-limit overshoot fix).
+                            if zc && rate == 0 && bb.is_none() {
                                 // Zerocopy senders exist only for these targets
                                 // (stream.rs). The gate must match the impls, not
                                 // `unix`: other-Unix (NetBSD/OpenBSD/illumos) is
@@ -497,10 +510,11 @@ impl Client {
                                     target_os = "freebsd"
                                 )))]
                                 {
-                                    stream::run_tcp_sender(data_stream, c, buf, d, fp, rate).await
+                                    stream::run_tcp_sender(data_stream, c, buf, d, fp, rate, bb)
+                                        .await
                                 }
                             } else {
-                                stream::run_tcp_sender(data_stream, c, buf, d, fp, rate).await
+                                stream::run_tcp_sender(data_stream, c, buf, d, fp, rate, bb).await
                             }
                         })
                     } else {

--- a/riperf3/src/client.rs
+++ b/riperf3/src/client.rs
@@ -400,14 +400,21 @@ impl Client {
 
         // `-n`/`-k` shared byte budget for the sending streams: they collectively
         // stop at ~N bytes (iperf3's `-n` is the test-wide total), bounding the
-        // overshoot to ~one block per stream instead of ~100ms of line rate.
-        let byte_budget: Option<Arc<AtomicI64>> = self
-            .bytes_to_send
-            .or_else(|| {
-                self.blocks_to_send
-                    .map(|k| k.saturating_mul(blksize as u64))
+        // overshoot to ~one block per stream instead of ~100ms of line rate. Only
+        // the TCP senders consume it (UDP `-n` is left approximate), so it is
+        // built only for a TCP run that has senders; an absurd N is clamped to
+        // i64::MAX so the budget can't start negative and stall every sender.
+        let byte_budget: Option<Arc<AtomicI64>> = (matches!(self.protocol, TransportProtocol::Tcp)
+            && send_count > 0)
+            .then(|| {
+                self.bytes_to_send
+                    .or_else(|| {
+                        self.blocks_to_send
+                            .map(|k| k.saturating_mul(blksize as u64))
+                    })
+                    .map(|n| Arc::new(AtomicI64::new(i64::try_from(n).unwrap_or(i64::MAX))))
             })
-            .map(|n| Arc::new(AtomicI64::new(n as i64)));
+            .flatten();
 
         match self.protocol {
             TransportProtocol::Tcp => {

--- a/riperf3/src/client.rs
+++ b/riperf3/src/client.rs
@@ -400,20 +400,12 @@ impl Client {
 
         // `-n`/`-k` shared byte budget for the sending streams: they collectively
         // stop at ~N bytes (iperf3's `-n` is the test-wide total), bounding the
-        // overshoot to ~one block per stream instead of ~100ms of line rate. Only
-        // the TCP senders consume it (UDP `-n` is left approximate), so it is
-        // built only for a TCP run that has senders; an absurd N is clamped to
-        // i64::MAX so the budget can't start negative and stall every sender.
+        // overshoot to ~one block per stream. Only the TCP senders consume it
+        // (UDP `-n` is left approximate), so build it only for a TCP run that has
+        // senders. See `make_byte_budget` for the 0-is-unlimited / clamp rules.
         let byte_budget: Option<Arc<AtomicI64>> = (matches!(self.protocol, TransportProtocol::Tcp)
             && send_count > 0)
-            .then(|| {
-                self.bytes_to_send
-                    .or_else(|| {
-                        self.blocks_to_send
-                            .map(|k| k.saturating_mul(blksize as u64))
-                    })
-                    .map(|n| Arc::new(AtomicI64::new(i64::try_from(n).unwrap_or(i64::MAX))))
-            })
+            .then(|| stream::make_byte_budget(self.bytes_to_send, self.blocks_to_send, blksize))
             .flatten();
 
         match self.protocol {

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -1,4 +1,4 @@
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicI64, Ordering};
 use std::sync::{Arc, Mutex};
 
 use crate::cpu::CpuSnapshot;
@@ -273,6 +273,19 @@ impl Server {
         };
         let total = recv_count + send_count;
 
+        // `-n`/`-k` shared byte budget for the server's sending streams (reverse /
+        // bidir): they collectively stop at ~N bytes so the server self-limits at
+        // the negotiated total instead of free-running to the client's TestEnd —
+        // the byte-limit overshoot fix, mirroring the client.
+        let byte_budget: Option<Arc<AtomicI64>> = params
+            .num
+            .or_else(|| {
+                params
+                    .blockcount
+                    .map(|k| k.saturating_mul(cfg.blksize as u64))
+            })
+            .map(|n| Arc::new(AtomicI64::new(n as i64)));
+
         // Single-socket UDP server demux (#80): one demux receiver thread serves
         // every receiving stream, so its handle lives outside the per-stream
         // `DataStream`s and is joined alongside them at teardown. `None` on the
@@ -329,8 +342,9 @@ impl Server {
                         // `-b` paces the sender in reverse/bidir too (negotiated
                         // rate; 0 = unlimited). #102
                         let rate = cfg.bandwidth;
+                        let bb = byte_budget.clone();
                         tokio::spawn(async move {
-                            stream::run_tcp_sender(data_stream, c, buf, d, fp, rate).await
+                            stream::run_tcp_sender(data_stream, c, buf, d, fp, rate, bb).await
                         })
                     } else {
                         let c = counters.clone();

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -277,14 +277,22 @@ impl Server {
         // bidir): they collectively stop at ~N bytes so the server self-limits at
         // the negotiated total instead of free-running to the client's TestEnd —
         // the byte-limit overshoot fix, mirroring the client.
-        let byte_budget: Option<Arc<AtomicI64>> = params
-            .num
-            .or_else(|| {
+        // Only the server's TCP senders (reverse/bidir) consume the budget, so it
+        // is built only for a TCP run that has senders; an absurd N is clamped to
+        // i64::MAX so it can't start negative and stall every sender.
+        let byte_budget: Option<Arc<AtomicI64>> = (matches!(cfg.protocol, TransportProtocol::Tcp)
+            && send_count > 0)
+            .then(|| {
                 params
-                    .blockcount
-                    .map(|k| k.saturating_mul(cfg.blksize as u64))
+                    .num
+                    .or_else(|| {
+                        params
+                            .blockcount
+                            .map(|k| k.saturating_mul(cfg.blksize as u64))
+                    })
+                    .map(|n| Arc::new(AtomicI64::new(i64::try_from(n).unwrap_or(i64::MAX))))
             })
-            .map(|n| Arc::new(AtomicI64::new(n as i64)));
+            .flatten();
 
         // Single-socket UDP server demux (#80): one demux receiver thread serves
         // every receiving stream, so its handle lives outside the per-stream

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -277,21 +277,13 @@ impl Server {
         // bidir): they collectively stop at ~N bytes so the server self-limits at
         // the negotiated total instead of free-running to the client's TestEnd —
         // the byte-limit overshoot fix, mirroring the client.
-        // Only the server's TCP senders (reverse/bidir) consume the budget, so it
-        // is built only for a TCP run that has senders; an absurd N is clamped to
-        // i64::MAX so it can't start negative and stall every sender.
+        // Only the server's TCP senders (reverse/bidir) consume the budget, so
+        // build it only for a TCP run that has senders. See `make_byte_budget`
+        // for the 0-is-unlimited (iperf3 sends `num`/`blocks` = 0 for a plain
+        // `-t` run) and overflow-clamp rules.
         let byte_budget: Option<Arc<AtomicI64>> = (matches!(cfg.protocol, TransportProtocol::Tcp)
             && send_count > 0)
-            .then(|| {
-                params
-                    .num
-                    .or_else(|| {
-                        params
-                            .blockcount
-                            .map(|k| k.saturating_mul(cfg.blksize as u64))
-                    })
-                    .map(|n| Arc::new(AtomicI64::new(i64::try_from(n).unwrap_or(i64::MAX))))
-            })
+            .then(|| stream::make_byte_budget(params.num, params.blockcount, cfg.blksize))
             .flatten();
 
         // Single-socket UDP server demux (#80): one demux receiver thread serves

--- a/riperf3/src/stream.rs
+++ b/riperf3/src/stream.rs
@@ -1,4 +1,4 @@
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicI64, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
@@ -329,6 +329,7 @@ pub async fn run_tcp_sender(
     done: Arc<AtomicBool>,
     file_path: Option<std::path::PathBuf>,
     rate: u64,
+    byte_budget: Option<Arc<AtomicI64>>,
 ) -> Result<()> {
     use std::io::Read;
     let mut file = file_path.as_ref().map(std::fs::File::open).transpose()?;
@@ -338,6 +339,18 @@ pub async fn run_tcp_sender(
     let mut limiter = (rate > 0).then(|| RateLimiter::new(rate, 0, buf.len().max(1)));
 
     while !done.load(Ordering::Relaxed) {
+        // `-n`/`-k` byte/block limit: claim this block from the shared budget and
+        // stop when it is exhausted, so the sender stops at ~N instead of
+        // free-running until the controller's next 100ms poll. The budget is
+        // shared across the sending streams — iperf3's `-n` is the test-wide
+        // total, consumed across streams as each sends — so the overshoot is
+        // bounded to ~one block per stream rather than ~100ms of line rate.
+        if let Some(b) = &byte_budget {
+            if b.fetch_sub(buf.len() as i64, Ordering::Relaxed) <= 0 {
+                break;
+            }
+        }
+
         // Refill buffer from file if specified
         if let Some(ref mut f) = file {
             let n = f.read(&mut buf).unwrap_or(0);
@@ -1760,7 +1773,7 @@ mod tests {
                 .await
                 .unwrap();
             let buf = vec![0u8; 1024];
-            run_tcp_sender(stream, sc, buf, d, None, 0).await
+            run_tcp_sender(stream, sc, buf, d, None, 0, None).await
         });
 
         let rc = recv_counters.clone();

--- a/riperf3/src/stream.rs
+++ b/riperf3/src/stream.rs
@@ -316,6 +316,27 @@ pub struct DataStream {
     pub rcvbuf_actual: Option<u64>,
 }
 
+/// Build the shared `-n`/`-k` byte budget the sending streams decrement, or
+/// `None` when there is no limit. A `0` limit means **unlimited** — iperf3 sends
+/// `num`/`blocks` = 0 for a plain `-t` run, so it must be filtered out or a
+/// reverse iperf3 client would make the server build a 0-budget and send
+/// nothing. An absurd N is clamped to `i64::MAX` so the budget can never start
+/// non-positive and stall every sender.
+pub(crate) fn make_byte_budget(
+    bytes: Option<u64>,
+    blocks: Option<u64>,
+    blksize: usize,
+) -> Option<Arc<AtomicI64>> {
+    bytes
+        .filter(|&n| n > 0)
+        .or_else(|| {
+            blocks
+                .filter(|&k| k > 0)
+                .map(|k| k.saturating_mul(blksize as u64))
+        })
+        .map(|n| Arc::new(AtomicI64::new(i64::try_from(n).unwrap_or(i64::MAX))))
+}
+
 // ---------------------------------------------------------------------------
 // TCP send / recv loops
 // ---------------------------------------------------------------------------
@@ -1407,6 +1428,24 @@ pub fn run_udp_receiver_blocking(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn byte_budget_zero_is_unlimited() {
+        let bs = 128 * 1024;
+        // iperf3 sends num=0 / blocks=0 for a plain `-t` run → no budget, or the
+        // server would build a 0-budget and send nothing (regression guard).
+        assert!(make_byte_budget(Some(0), Some(0), bs).is_none());
+        assert!(make_byte_budget(None, None, bs).is_none());
+        // `-n N` → an N-byte budget.
+        let b = make_byte_budget(Some(5_000_000), Some(0), bs).unwrap();
+        assert_eq!(b.load(Ordering::Relaxed), 5_000_000);
+        // `-k K` (num=0 filtered, blocks path) → K*blksize.
+        let b = make_byte_budget(Some(0), Some(10), bs).unwrap();
+        assert_eq!(b.load(Ordering::Relaxed), (10 * bs) as i64);
+        // An absurd N clamps to a positive budget, never negative.
+        let b = make_byte_budget(Some(u64::MAX), None, bs).unwrap();
+        assert!(b.load(Ordering::Relaxed) > 0);
+    }
 
     // #42: zerocopy senders must get distinct temp-file names so `-Z -P >1`
     // can't race create+truncate on a shared path. The race needs concurrency a

--- a/riperf3/tests/integration.rs
+++ b/riperf3/tests/integration.rs
@@ -441,6 +441,81 @@ async fn tcp_reverse_blocks_limit_terminates() {
 }
 
 // ---------------------------------------------------------------------------
+// Byte/block-limit overshoot — sender self-enforces -n/-k (bounded transfer)
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn tcp_byte_limit_overshoot_bounded_forward() {
+    // The TCP sender self-enforces -n via a shared byte budget, stopping at ~N
+    // instead of free-running until the controller's 100ms poll (~1 GB before
+    // the fix). Forward: the client sends; the server (receiver) reports ≈ N.
+    let port = next_port();
+    let server = ServerBuilder::new()
+        .port(Some(port))
+        .one_off(true)
+        .build()
+        .unwrap();
+    let server_task = tokio::spawn(async move { server.run().await });
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    let target: u64 = 8 * 1024 * 1024; // 8 MB
+    let client = ClientBuilder::new("127.0.0.1")
+        .port(Some(port))
+        .bytes(target)
+        .build()
+        .unwrap();
+    let result = tokio::time::timeout(Duration::from_secs(20), client.run())
+        .await
+        .expect("client hung")
+        .expect("client errored");
+    let bytes: u64 = result.streams.iter().map(|s| s.bytes).sum();
+    assert!(
+        bytes > target / 2,
+        "transferred {bytes} far below target {target}"
+    );
+    assert!(
+        bytes < target + 2 * 1024 * 1024,
+        "byte-limit overshoot unbounded: {bytes} vs target {target}"
+    );
+    let _ = server_task.await;
+}
+
+#[tokio::test]
+async fn tcp_byte_limit_overshoot_bounded_reverse() {
+    // Reverse: the server is the sender and must self-enforce the budget too.
+    let port = next_port();
+    let server = ServerBuilder::new()
+        .port(Some(port))
+        .one_off(true)
+        .build()
+        .unwrap();
+    let server_task = tokio::spawn(async move { server.run().await });
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    let target: u64 = 8 * 1024 * 1024;
+    let client = ClientBuilder::new("127.0.0.1")
+        .port(Some(port))
+        .reverse(true)
+        .bytes(target)
+        .build()
+        .unwrap();
+    let result = tokio::time::timeout(Duration::from_secs(20), client.run())
+        .await
+        .expect("client hung")
+        .expect("client errored");
+    let bytes: u64 = result.streams.iter().map(|s| s.bytes).sum();
+    assert!(
+        bytes > target / 2,
+        "transferred {bytes} far below target {target}"
+    );
+    assert!(
+        bytes < target + 2 * 1024 * 1024,
+        "reverse byte-limit overshoot unbounded: {bytes} vs target {target}"
+    );
+    let _ = server_task.await;
+}
+
+// ---------------------------------------------------------------------------
 // TCP bitrate pacing (-b), issue #102
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Fixes #117 — byte/block-limited (`-n`/`-k`) TCP transfers overshot the requested
amount by ~100 ms of line rate (`-n 512K` sent **~925 MB**; `-R` **~1 GB**)
because the sender free-ran at line rate until the client's 100 ms controller
poll noticed the limit and tore down. iperf3 stops the sender crisply at ~N.

Found during the #60 (PR #112) cold review; you approved fixing it for 0.7.0.

## Approach

A shared `Arc<AtomicI64>` byte budget is created on whichever side sends — the
client (forward) or the server (reverse/bidir) — initialized to N bytes (`-n`)
or K×blksize (`-k`). Each `run_tcp_sender` claims a block from the budget
(`fetch_sub`) before sending and stops when it's exhausted. Because the budget
is **shared across the sending streams**, the *total* stops at ~N — matching
iperf3, whose `-n` is the test-wide total distributed across parallel streams as
each consumes it (the uneven split falls out naturally). Overshoot is bounded to
~one block per stream instead of ~100 ms of line rate.

Zerocopy (`-Z`) is now also skipped when byte-limited (the sendfile retry loop
can't self-limit cleanly), alongside the existing `-b` skip — so `-Z` is used
only for an unlimited, duration-based transfer.

## iperf3 adjudication (3.20)

| scenario | riperf3 before | riperf3 after | iperf3 |
|---|--|--|--|
| `-n 512K` forward | ~925 MB | **0.52 MB** | 0.52 MB |
| `-n 512K -R` | ~1 GB | **0.524 MB** | 0.52 MB |
| `-n 100M -P 4` | (overshot) | **104.9 MB** total, split `[26, 22.7, 27, 29.2]` | 105 MB, `[20, 29, 29, 26]` |

UDP `-n` is left approximate (iperf3's UDP `-n` is itself loose).

## Tests

`tcp_byte_limit_overshoot_bounded_forward` / `_reverse` assert the transfer is
bounded to ~N (red at ~1 GB on pre-fix code). Existing #60 termination tests
still pass. Full workspace suite + clippy + fmt + 7-target cross-compile green.

Closes #117.
