### PR TITLE
fix: normalize iperf3 num=0/blocks=0 to unlimited at server ingest (#119)

### DIFF
--- a/riperf3/src/protocol.rs
+++ b/riperf3/src/protocol.rs
@@ -278,6 +278,24 @@ pub struct TestParams {
     pub authtoken: Option<String>,
 }
 
+impl TestParams {
+    /// Normalize a `0` byte/block limit to `None` (= no limit). iperf3
+    /// *unconditionally* serializes `num`/`blockcount`, sending `0` for a plain
+    /// `-t` run, whereas riperf3 omits them — and serde `default` only fills a
+    /// *missing* field, so a real iperf3 client arrives as `Some(0)`. Without
+    /// this, the server's `is_none()`/`is_some()` limit checks misread a duration
+    /// run as byte-limited: it disables the UDP-sender `-t` deadline (#5 hang
+    /// risk) and skews the summary window (#103). Call once at param ingest. #119
+    pub(crate) fn normalize_unlimited(&mut self) {
+        if self.num == Some(0) {
+            self.num = None;
+        }
+        if self.blockcount == Some(0) {
+            self.blockcount = None;
+        }
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Test results — exchanged as JSON during ExchangeResults
 // ---------------------------------------------------------------------------
@@ -493,6 +511,29 @@ pub async fn udp_connect_server(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn normalize_unlimited_maps_zero_to_none() {
+        // iperf3's plain `-t` run arrives as Some(0) → must become None.
+        let mut p = TestParams {
+            num: Some(0),
+            blockcount: Some(0),
+            ..Default::default()
+        };
+        p.normalize_unlimited();
+        assert_eq!(p.num, None);
+        assert_eq!(p.blockcount, None);
+
+        // Real limits and an already-absent limit are untouched.
+        let mut p = TestParams {
+            num: Some(5_000_000),
+            blockcount: None,
+            ..Default::default()
+        };
+        p.normalize_unlimited();
+        assert_eq!(p.num, Some(5_000_000));
+        assert_eq!(p.blockcount, None);
+    }
 
     #[test]
     fn cookie_is_correct_size_and_null_terminated() {

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -203,7 +203,11 @@ impl Server {
 
         // ---- ParamExchange ----
         protocol::send_state(&mut ctrl, TestState::ParamExchange).await?;
-        let params = protocol::recv_params(&mut ctrl).await?;
+        let mut params = protocol::recv_params(&mut ctrl).await?;
+        // iperf3 sends num/blockcount = 0 for a plain `-t` run; treat 0 as
+        // unlimited so the byte-limit checks below don't misread a duration test
+        // as byte-limited (#119).
+        params.normalize_unlimited();
         let cfg = TestConfig::from_params(&params);
 
         // ---- Auth validation (after params, before streams) ----


### PR DESCRIPTION
## Summary

Fixes #119. iperf3 **unconditionally** serializes `num`/`blockcount`, sending `0` for a plain `-t` run; riperf3 omits them, and serde `default` only fills a *missing* field — so a real iperf3 client arrives as `Some(0)`. The server's `is_none()`/`is_some()` limit checks then misread a duration test as byte-limited:

- **MAJOR:** the UDP-sender `-t` self-deadline (`params.num.is_none() && ...`; issue #5) was disabled → an iperf3 **UDP reverse/bidir at high `-b`** could reintroduce the #5 CPU-starvation hang. (Latent — the interop matrix doesn't run high-`-b` UDP.)
- **MINOR:** the #103 summary window used measured elapsed instead of `-t` (cosmetic).

Found during the #118 cold review.

## Fix

`TestParams::normalize_unlimited()` maps a `0` byte/block limit to `None`, called once right after `recv_params`, so every downstream limit check is correct. The #118 `make_byte_budget` 0-filter is now belt-and-suspenders.

## Verification

- `iperf3 -u -b0 -R -t 2` → riperf3 server terminates cleanly (was the latent hang path).
- Interop matrix: **64/64**. Full suite + clippy + fmt green. Unit test pins the `0 → None` mapping.

Closes #119.