### PR TITLE
refactor: encapsulate Client/Server fields behind the builder (#43)

### DIFF
--- a/riperf3-cli/src/cli.rs
+++ b/riperf3-cli/src/cli.rs
@@ -743,70 +743,134 @@ mod cli_tests {
         fn json_flag_wired() {
             let cli = Cli::parse_from(["riperf3", "-c", "host", "-J"]);
             let c = build_client_from_cli(&cli);
-            assert!(c.json_output);
+            assert_eq!(
+                c,
+                riperf3::ClientBuilder::new("host")
+                    .json_output(true)
+                    .build()
+                    .unwrap()
+            );
         }
 
         #[test]
         fn udp_flag_wired() {
             let cli = Cli::parse_from(["riperf3", "-c", "host", "-u"]);
             let c = build_client_from_cli(&cli);
-            assert_eq!(c.protocol, TransportProtocol::Udp);
+            assert_eq!(
+                c,
+                riperf3::ClientBuilder::new("host")
+                    .protocol(TransportProtocol::Udp)
+                    .build()
+                    .unwrap()
+            );
         }
 
         #[test]
         fn duration_flag_wired() {
             let cli = Cli::parse_from(["riperf3", "-c", "host", "-t", "30"]);
             let c = build_client_from_cli(&cli);
-            assert_eq!(c.duration, 30);
+            assert_eq!(
+                c,
+                riperf3::ClientBuilder::new("host")
+                    .duration(30)
+                    .build()
+                    .unwrap()
+            );
         }
 
         #[test]
         fn bytes_flag_wired() {
             let cli = Cli::parse_from(["riperf3", "-c", "host", "-n", "1M"]);
             let c = build_client_from_cli(&cli);
-            assert_eq!(c.bytes_to_send, Some(1024 * 1024));
+            assert_eq!(
+                c,
+                riperf3::ClientBuilder::new("host")
+                    .bytes_str("1M")
+                    .unwrap()
+                    .build()
+                    .unwrap()
+            );
         }
 
         #[test]
         fn blockcount_flag_wired() {
             let cli = Cli::parse_from(["riperf3", "-c", "host", "-k", "100"]);
             let c = build_client_from_cli(&cli);
-            assert_eq!(c.blocks_to_send, Some(100));
+            assert_eq!(
+                c,
+                riperf3::ClientBuilder::new("host")
+                    .blocks_str("100")
+                    .unwrap()
+                    .build()
+                    .unwrap()
+            );
         }
 
         #[test]
         fn length_flag_wired() {
             let cli = Cli::parse_from(["riperf3", "-c", "host", "-l", "64K"]);
             let c = build_client_from_cli(&cli);
-            assert_eq!(c.blksize, 64 * 1024);
+            assert_eq!(
+                c,
+                riperf3::ClientBuilder::new("host")
+                    .blksize_str("64K")
+                    .unwrap()
+                    .build()
+                    .unwrap()
+            );
         }
 
         #[test]
         fn parallel_flag_wired() {
             let cli = Cli::parse_from(["riperf3", "-c", "host", "-P", "8"]);
             let c = build_client_from_cli(&cli);
-            assert_eq!(c.num_streams, 8);
+            assert_eq!(
+                c,
+                riperf3::ClientBuilder::new("host")
+                    .num_streams(8)
+                    .build()
+                    .unwrap()
+            );
         }
 
         #[test]
         fn reverse_flag_wired() {
             let cli = Cli::parse_from(["riperf3", "-c", "host", "-R"]);
             let c = build_client_from_cli(&cli);
-            assert!(c.reverse);
+            assert_eq!(
+                c,
+                riperf3::ClientBuilder::new("host")
+                    .reverse(true)
+                    .build()
+                    .unwrap()
+            );
         }
 
         #[test]
         fn bidir_flag_wired() {
             let cli = Cli::parse_from(["riperf3", "-c", "host", "--bidir"]);
             let c = build_client_from_cli(&cli);
-            assert!(c.bidir);
+            assert_eq!(
+                c,
+                riperf3::ClientBuilder::new("host")
+                    .bidir(true)
+                    .build()
+                    .unwrap()
+            );
         }
 
         #[test]
         fn window_flag_wired() {
             let cli = Cli::parse_from(["riperf3", "-c", "host", "-w", "512K"]);
             let c = build_client_from_cli(&cli);
-            assert_eq!(c.window, Some(512 * 1024));
+            assert_eq!(
+                c,
+                riperf3::ClientBuilder::new("host")
+                    .window_str("512K")
+                    .unwrap()
+                    .build()
+                    .unwrap()
+            );
         }
 
         // build() rejects -C/--congestion (TCP congestion control) on non-Unix
@@ -816,56 +880,99 @@ mod cli_tests {
         fn congestion_flag_wired() {
             let cli = Cli::parse_from(["riperf3", "-c", "host", "-C", "bbr"]);
             let c = build_client_from_cli(&cli);
-            assert_eq!(c.congestion, Some("bbr".to_string()));
+            assert_eq!(
+                c,
+                riperf3::ClientBuilder::new("host")
+                    .congestion("bbr")
+                    .build()
+                    .unwrap()
+            );
         }
 
         #[test]
         fn mss_flag_wired() {
             let cli = Cli::parse_from(["riperf3", "-c", "host", "-M", "1400"]);
             let c = build_client_from_cli(&cli);
-            assert_eq!(c.mss, Some(1400));
+            assert_eq!(
+                c,
+                riperf3::ClientBuilder::new("host")
+                    .mss(1400)
+                    .build()
+                    .unwrap()
+            );
         }
 
         #[test]
         fn no_delay_flag_wired() {
             let cli = Cli::parse_from(["riperf3", "-c", "host", "-N"]);
             let c = build_client_from_cli(&cli);
-            assert!(c.no_delay);
+            assert_eq!(
+                c,
+                riperf3::ClientBuilder::new("host")
+                    .no_delay(true)
+                    .build()
+                    .unwrap()
+            );
         }
 
         #[test]
         fn bitrate_flag_wired() {
             let cli = Cli::parse_from(["riperf3", "-c", "host", "-b", "100M"]);
             let c = build_client_from_cli(&cli);
-            assert_eq!(c.bandwidth, 100 * 1_000_000); // -b is decimal, like iperf3 (#56)
+            assert_eq!(
+                c,
+                riperf3::ClientBuilder::new("host")
+                    .bandwidth_str("100M")
+                    .unwrap()
+                    .build()
+                    .unwrap()
+            );
         }
 
         #[test]
         fn tos_flag_wired() {
             let cli = Cli::parse_from(["riperf3", "-c", "host", "-S", "16"]);
             let c = build_client_from_cli(&cli);
-            assert_eq!(c.tos, 16);
+            assert_eq!(
+                c,
+                riperf3::ClientBuilder::new("host").tos(16).build().unwrap()
+            );
         }
 
         #[test]
         fn omit_flag_wired() {
             let cli = Cli::parse_from(["riperf3", "-c", "host", "-O", "3"]);
             let c = build_client_from_cli(&cli);
-            assert_eq!(c.omit, 3);
+            assert_eq!(
+                c,
+                riperf3::ClientBuilder::new("host").omit(3).build().unwrap()
+            );
         }
 
         #[test]
         fn title_flag_wired() {
             let cli = Cli::parse_from(["riperf3", "-c", "host", "-T", "my test"]);
             let c = build_client_from_cli(&cli);
-            assert_eq!(c.title, Some("my test".to_string()));
+            assert_eq!(
+                c,
+                riperf3::ClientBuilder::new("host")
+                    .title("my test")
+                    .build()
+                    .unwrap()
+            );
         }
 
         #[test]
         fn extra_data_flag_wired() {
             let cli = Cli::parse_from(["riperf3", "-c", "host", "--extra-data", "abc"]);
             let c = build_client_from_cli(&cli);
-            assert_eq!(c.extra_data, Some("abc".to_string()));
+            assert_eq!(
+                c,
+                riperf3::ClientBuilder::new("host")
+                    .extra_data("abc")
+                    .build()
+                    .unwrap()
+            );
         }
 
         #[test]
@@ -873,8 +980,11 @@ mod cli_tests {
             let cli = Cli::parse_from(["riperf3", "-c", "host", "--connect-timeout", "500"]);
             let c = build_client_from_cli(&cli);
             assert_eq!(
-                c.connect_timeout,
-                Some(std::time::Duration::from_millis(500))
+                c,
+                riperf3::ClientBuilder::new("host")
+                    .connect_timeout(std::time::Duration::from_millis(500))
+                    .build()
+                    .unwrap()
             );
         }
 
@@ -882,7 +992,13 @@ mod cli_tests {
         fn verbose_flag_wired() {
             let cli = Cli::parse_from(["riperf3", "-c", "host", "-V"]);
             let c = build_client_from_cli(&cli);
-            assert!(c.verbose);
+            assert_eq!(
+                c,
+                riperf3::ClientBuilder::new("host")
+                    .verbose(true)
+                    .build()
+                    .unwrap()
+            );
         }
 
         // Combines the Unix-only flags above (congestion/bind-dev/affinity),
@@ -926,23 +1042,33 @@ mod cli_tests {
                 "500",
             ]);
             let c = build_client_from_cli(&cli);
-            assert_eq!(c.protocol, TransportProtocol::Udp);
-            assert_eq!(c.duration, 30);
-            assert_eq!(c.num_streams, 4);
-            assert!(c.reverse);
-            assert!(c.bidir);
-            assert!(c.no_delay);
-            assert_eq!(c.blksize, 1460);
-            assert_eq!(c.bandwidth, 100 * 1_000_000); // -b is decimal, like iperf3 (#56)
-            assert!(c.json_output);
-            assert_eq!(c.window, Some(512 * 1024));
-            assert_eq!(c.mss, Some(1400));
-            assert_eq!(c.congestion, Some("bbr".to_string()));
-            assert_eq!(c.tos, 16);
-            assert_eq!(c.omit, 2);
-            assert_eq!(c.title, Some("test".to_string()));
-            assert_eq!(c.extra_data, Some("x".to_string()));
-            assert!(c.verbose);
+            assert_eq!(
+                c,
+                riperf3::ClientBuilder::new("host")
+                    .protocol(TransportProtocol::Udp)
+                    .duration(30)
+                    .num_streams(4)
+                    .reverse(true)
+                    .bidir(true)
+                    .no_delay(true)
+                    .blksize_str("1460")
+                    .unwrap()
+                    .bandwidth_str("100M")
+                    .unwrap()
+                    .json_output(true)
+                    .verbose(true)
+                    .window_str("512K")
+                    .unwrap()
+                    .mss(1400)
+                    .congestion("bbr")
+                    .tos(16)
+                    .omit(2)
+                    .title("test")
+                    .extra_data("x")
+                    .connect_timeout(std::time::Duration::from_millis(500))
+                    .build()
+                    .unwrap()
+            );
         }
 
         #[test]
@@ -953,7 +1079,10 @@ mod cli_tests {
                 b = b.one_off(true);
             }
             let s = b.build().unwrap();
-            assert!(s.one_off);
+            assert_eq!(
+                s,
+                riperf3::ServerBuilder::new().one_off(true).build().unwrap()
+            );
         }
 
         // -- New flag wiring tests --
@@ -962,63 +1091,117 @@ mod cli_tests {
         fn udp_counters_64bit_wired() {
             let cli = Cli::parse_from(["riperf3", "-c", "h", "--udp-counters-64bit"]);
             let c = build_client_from_cli(&cli);
-            assert!(c.udp_counters_64bit);
+            assert_eq!(
+                c,
+                riperf3::ClientBuilder::new("h")
+                    .udp_counters_64bit(true)
+                    .build()
+                    .unwrap()
+            );
         }
 
         #[test]
         fn repeating_payload_wired() {
             let cli = Cli::parse_from(["riperf3", "-c", "h", "--repeating-payload"]);
             let c = build_client_from_cli(&cli);
-            assert!(c.repeating_payload);
+            assert_eq!(
+                c,
+                riperf3::ClientBuilder::new("h")
+                    .repeating_payload(true)
+                    .build()
+                    .unwrap()
+            );
         }
 
         #[test]
         fn dont_fragment_wired() {
             let cli = Cli::parse_from(["riperf3", "-c", "h", "--dont-fragment"]);
             let c = build_client_from_cli(&cli);
-            assert!(c.dont_fragment);
+            assert_eq!(
+                c,
+                riperf3::ClientBuilder::new("h")
+                    .dont_fragment(true)
+                    .build()
+                    .unwrap()
+            );
         }
 
         #[test]
         fn cport_wired() {
             let cli = Cli::parse_from(["riperf3", "-c", "h", "--cport", "12345"]);
             let c = build_client_from_cli(&cli);
-            assert_eq!(c.cport, Some(12345));
+            assert_eq!(
+                c,
+                riperf3::ClientBuilder::new("h")
+                    .cport(12345)
+                    .build()
+                    .unwrap()
+            );
         }
 
         #[test]
         fn get_server_output_wired() {
             let cli = Cli::parse_from(["riperf3", "-c", "h", "--get-server-output"]);
             let c = build_client_from_cli(&cli);
-            assert!(c.get_server_output);
+            assert_eq!(
+                c,
+                riperf3::ClientBuilder::new("h")
+                    .get_server_output(true)
+                    .build()
+                    .unwrap()
+            );
         }
 
         #[test]
         fn forceflush_wired() {
             let cli = Cli::parse_from(["riperf3", "-c", "h", "--forceflush"]);
             let c = build_client_from_cli(&cli);
-            assert!(c.forceflush);
+            assert_eq!(
+                c,
+                riperf3::ClientBuilder::new("h")
+                    .forceflush(true)
+                    .build()
+                    .unwrap()
+            );
         }
 
         #[test]
         fn timestamps_wired() {
             let cli = Cli::parse_from(["riperf3", "-c", "h", "--timestamps", "%H:%M"]);
             let c = build_client_from_cli(&cli);
-            assert_eq!(c.timestamps, Some("%H:%M".to_string()));
+            assert_eq!(
+                c,
+                riperf3::ClientBuilder::new("h")
+                    .timestamps("%H:%M")
+                    .build()
+                    .unwrap()
+            );
         }
 
         #[test]
         fn version4_wired() {
             let cli = Cli::parse_from(["riperf3", "-c", "h", "-4"]);
             let c = build_client_from_cli(&cli);
-            assert_eq!(c.ip_version, Some(4));
+            assert_eq!(
+                c,
+                riperf3::ClientBuilder::new("h")
+                    .ip_version(4)
+                    .build()
+                    .unwrap()
+            );
         }
 
         #[test]
         fn version6_wired() {
             let cli = Cli::parse_from(["riperf3", "-c", "h", "-6"]);
             let c = build_client_from_cli(&cli);
-            assert_eq!(c.ip_version, Some(6));
+            assert_eq!(
+                c,
+                riperf3::ClientBuilder::new("h")
+                    .ip_version(6)
+                    .build()
+                    .unwrap()
+            );
         }
 
         #[test]
@@ -1032,7 +1215,13 @@ mod cli_tests {
         fn bind_address_wired() {
             let cli = Cli::parse_from(["riperf3", "-c", "h", "-B", "10.0.0.1"]);
             let c = build_client_from_cli(&cli);
-            assert_eq!(c.bind_address, Some("10.0.0.1".to_string()));
+            assert_eq!(
+                c,
+                riperf3::ClientBuilder::new("h")
+                    .bind_address("10.0.0.1")
+                    .build()
+                    .unwrap()
+            );
         }
 
         // build() rejects --bind-dev (SO_BINDTODEVICE/IP_BOUND_IF) on non-Unix,
@@ -1042,63 +1231,115 @@ mod cli_tests {
         fn bind_dev_wired() {
             let cli = Cli::parse_from(["riperf3", "-c", "h", "--bind-dev", "eth0"]);
             let c = build_client_from_cli(&cli);
-            assert_eq!(c.bind_dev, Some("eth0".to_string()));
+            assert_eq!(
+                c,
+                riperf3::ClientBuilder::new("h")
+                    .bind_dev("eth0")
+                    .build()
+                    .unwrap()
+            );
         }
 
         #[test]
         fn fq_rate_wired() {
             let cli = Cli::parse_from(["riperf3", "-c", "h", "--fq-rate", "1G"]);
             let c = build_client_from_cli(&cli);
-            assert_eq!(c.fq_rate, Some(1_000_000_000)); // --fq-rate is decimal (#56)
+            assert_eq!(
+                c,
+                riperf3::ClientBuilder::new("h")
+                    .fq_rate_str("1G")
+                    .unwrap()
+                    .build()
+                    .unwrap()
+            );
         }
 
         #[test]
         fn flowlabel_wired() {
             let cli = Cli::parse_from(["riperf3", "-c", "h", "-L", "42"]);
             let c = build_client_from_cli(&cli);
-            assert_eq!(c.flowlabel, Some(42));
+            assert_eq!(
+                c,
+                riperf3::ClientBuilder::new("h")
+                    .flowlabel(42)
+                    .build()
+                    .unwrap()
+            );
         }
 
         #[test]
         fn dscp_wired() {
             let cli = Cli::parse_from(["riperf3", "-c", "h", "--dscp", "46"]);
             let c = build_client_from_cli(&cli);
-            assert_eq!(c.dscp, Some("46".to_string()));
+            assert_eq!(
+                c,
+                riperf3::ClientBuilder::new("h").dscp("46").build().unwrap()
+            );
         }
 
         #[test]
         fn mptcp_wired() {
             let cli = Cli::parse_from(["riperf3", "-c", "h", "-m"]);
             let c = build_client_from_cli(&cli);
-            assert!(c.mptcp);
+            assert_eq!(
+                c,
+                riperf3::ClientBuilder::new("h")
+                    .mptcp(true)
+                    .build()
+                    .unwrap()
+            );
         }
 
         #[test]
         fn skip_rx_copy_wired() {
             let cli = Cli::parse_from(["riperf3", "-c", "h", "--skip-rx-copy"]);
             let c = build_client_from_cli(&cli);
-            assert!(c.skip_rx_copy);
+            assert_eq!(
+                c,
+                riperf3::ClientBuilder::new("h")
+                    .skip_rx_copy(true)
+                    .build()
+                    .unwrap()
+            );
         }
 
         #[test]
         fn rcv_timeout_wired() {
             let cli = Cli::parse_from(["riperf3", "-c", "h", "--rcv-timeout", "5000"]);
             let c = build_client_from_cli(&cli);
-            assert_eq!(c.rcv_timeout, Some(5000));
+            assert_eq!(
+                c,
+                riperf3::ClientBuilder::new("h")
+                    .rcv_timeout(5000)
+                    .build()
+                    .unwrap()
+            );
         }
 
         #[test]
         fn snd_timeout_wired() {
             let cli = Cli::parse_from(["riperf3", "-c", "h", "--snd-timeout", "3000"]);
             let c = build_client_from_cli(&cli);
-            assert_eq!(c.snd_timeout, Some(3000));
+            assert_eq!(
+                c,
+                riperf3::ClientBuilder::new("h")
+                    .snd_timeout(3000)
+                    .build()
+                    .unwrap()
+            );
         }
 
         #[test]
         fn file_wired() {
             let cli = Cli::parse_from(["riperf3", "-c", "h", "-F", "/tmp/data"]);
             let c = build_client_from_cli(&cli);
-            assert_eq!(c.file, Some("/tmp/data".to_string()));
+            assert_eq!(
+                c,
+                riperf3::ClientBuilder::new("h")
+                    .file("/tmp/data")
+                    .build()
+                    .unwrap()
+            );
         }
 
         // build() rejects -A/--affinity (CPU affinity) on non-Unix, so gate the
@@ -1108,28 +1349,52 @@ mod cli_tests {
         fn affinity_wired() {
             let cli = Cli::parse_from(["riperf3", "-c", "h", "-A", "2,3"]);
             let c = build_client_from_cli(&cli);
-            assert_eq!(c.affinity, Some("2,3".to_string()));
+            assert_eq!(
+                c,
+                riperf3::ClientBuilder::new("h")
+                    .affinity("2,3")
+                    .build()
+                    .unwrap()
+            );
         }
 
         #[test]
         fn json_stream_wired() {
             let cli = Cli::parse_from(["riperf3", "-c", "h", "--json-stream"]);
             let c = build_client_from_cli(&cli);
-            assert!(c.json_stream);
+            assert_eq!(
+                c,
+                riperf3::ClientBuilder::new("h")
+                    .json_stream(true)
+                    .build()
+                    .unwrap()
+            );
         }
 
         #[test]
         fn pidfile_wired() {
             let cli = Cli::parse_from(["riperf3", "-c", "h", "-I", "/tmp/pid"]);
             let c = build_client_from_cli(&cli);
-            assert_eq!(c.pidfile, Some("/tmp/pid".to_string()));
+            assert_eq!(
+                c,
+                riperf3::ClientBuilder::new("h")
+                    .pidfile("/tmp/pid")
+                    .build()
+                    .unwrap()
+            );
         }
 
         #[test]
         fn logfile_wired() {
             let cli = Cli::parse_from(["riperf3", "-c", "h", "--logfile", "/tmp/log"]);
             let c = build_client_from_cli(&cli);
-            assert_eq!(c.logfile, Some("/tmp/log".to_string()));
+            assert_eq!(
+                c,
+                riperf3::ClientBuilder::new("h")
+                    .logfile("/tmp/log")
+                    .build()
+                    .unwrap()
+            );
         }
 
         // sendmmsg(2) is Linux/FreeBSD/NetBSD-only (stream.rs); build() rejects
@@ -1140,7 +1405,14 @@ mod cli_tests {
             let cli = Cli::parse_from(["riperf3", "-c", "h", "-u", "--sendmmsg"]);
             assert!(cli.sendmmsg);
             let c = build_client_from_cli(&cli);
-            assert!(c.sendmmsg);
+            assert_eq!(
+                c,
+                riperf3::ClientBuilder::new("h")
+                    .protocol(TransportProtocol::Udp)
+                    .sendmmsg(true)
+                    .build()
+                    .unwrap()
+            );
         }
 
         #[test]
@@ -1148,7 +1420,13 @@ mod cli_tests {
             let cli = Cli::parse_from(["riperf3", "-c", "h", "-u"]);
             assert!(!cli.sendmmsg);
             let c = build_client_from_cli(&cli);
-            assert!(!c.sendmmsg);
+            assert_eq!(
+                c,
+                riperf3::ClientBuilder::new("h")
+                    .protocol(TransportProtocol::Udp)
+                    .build()
+                    .unwrap()
+            );
         }
 
         // Server new flags
@@ -1171,7 +1449,13 @@ mod cli_tests {
                 b = b.idle_timeout(secs);
             }
             let s = b.build().unwrap();
-            assert_eq!(s.idle_timeout, Some(30));
+            assert_eq!(
+                s,
+                riperf3::ServerBuilder::new()
+                    .idle_timeout(30)
+                    .build()
+                    .unwrap()
+            );
         }
 
         #[test]
@@ -1182,7 +1466,13 @@ mod cli_tests {
                 b = b.server_max_duration(secs);
             }
             let s = b.build().unwrap();
-            assert_eq!(s.server_max_duration, Some(60));
+            assert_eq!(
+                s,
+                riperf3::ServerBuilder::new()
+                    .server_max_duration(60)
+                    .build()
+                    .unwrap()
+            );
         }
 
         /// Verify every short flag alias parses identically to its long form.

--- a/riperf3/src/client.rs
+++ b/riperf3/src/client.rs
@@ -15,67 +15,75 @@ use crate::utils::*;
 // Client
 // ---------------------------------------------------------------------------
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub struct Client {
-    pub host: String,
-    pub port: u16,
-    pub protocol: TransportProtocol,
-    pub duration: u32,
-    pub num_streams: u32,
-    pub blksize: usize,
+    pub(crate) host: String,
+    pub(crate) port: u16,
+    pub(crate) protocol: TransportProtocol,
+    pub(crate) duration: u32,
+    pub(crate) num_streams: u32,
+    pub(crate) blksize: usize,
     /// Whether `blksize` came from an explicit `-l`. When false for UDP, the
     /// datagram size is derived from the control-socket MSS at run time
     /// (iperf3 parity, issue #6) rather than using the `blksize` default.
     /// Internal: set by the builder from whether `.blksize()` was called.
     blksize_explicit: bool,
-    pub reverse: bool,
-    pub bidir: bool,
-    pub omit: u32,
-    pub no_delay: bool,
-    pub mss: Option<i32>,
-    pub window: Option<i32>,
-    pub bandwidth: u64,
-    pub tos: i32,
-    pub congestion: Option<String>,
-    pub udp_counters_64bit: bool,
-    pub connect_timeout: Option<Duration>,
-    pub title: Option<String>,
-    pub extra_data: Option<String>,
-    pub verbose: bool,
-    pub json_output: bool,
-    pub json_stream: bool,
-    pub bytes_to_send: Option<u64>,
-    pub blocks_to_send: Option<u64>,
-    pub repeating_payload: bool,
-    pub zerocopy: bool,
-    pub gsro: bool,
-    pub sendmmsg: bool,
-    pub dont_fragment: bool,
-    pub cport: Option<u16>,
-    pub get_server_output: bool,
-    pub forceflush: bool,
-    pub timestamps: Option<String>,
-    pub bind_address: Option<String>,
-    pub bind_dev: Option<String>,
-    pub fq_rate: Option<u64>,
-    pub flowlabel: Option<i32>,
-    pub ip_version: Option<u8>,
-    pub mptcp: bool,
-    pub skip_rx_copy: bool,
-    pub rcv_timeout: Option<u64>,
-    pub snd_timeout: Option<u64>,
-    pub file: Option<String>,
-    pub affinity: Option<String>,
-    pub dscp: Option<String>,
-    pub format_char: char,
-    pub interval: Option<f64>,
-    pub cntl_ka: Option<String>,
-    pub pidfile: Option<String>,
-    pub logfile: Option<String>,
-    pub username: Option<String>,
-    pub password: Option<String>,
-    pub rsa_public_key_path: Option<String>,
-    pub use_pkcs1_padding: bool,
+    pub(crate) reverse: bool,
+    pub(crate) bidir: bool,
+    pub(crate) omit: u32,
+    pub(crate) no_delay: bool,
+    pub(crate) mss: Option<i32>,
+    pub(crate) window: Option<i32>,
+    pub(crate) bandwidth: u64,
+    pub(crate) tos: i32,
+    pub(crate) congestion: Option<String>,
+    pub(crate) udp_counters_64bit: bool,
+    pub(crate) connect_timeout: Option<Duration>,
+    pub(crate) title: Option<String>,
+    pub(crate) extra_data: Option<String>,
+    pub(crate) verbose: bool,
+    pub(crate) json_output: bool,
+    pub(crate) json_stream: bool,
+    pub(crate) bytes_to_send: Option<u64>,
+    pub(crate) blocks_to_send: Option<u64>,
+    pub(crate) repeating_payload: bool,
+    pub(crate) zerocopy: bool,
+    pub(crate) gsro: bool,
+    pub(crate) sendmmsg: bool,
+    pub(crate) dont_fragment: bool,
+    pub(crate) cport: Option<u16>,
+    // Builder-settable but never read by `run()` — the CLI realizes these
+    // elsewhere (affinity via `set_cpu_affinity`, pidfile/logfile pre-runtime)
+    // or they are currently no-ops. Prune-vs-wire tracked in #122.
+    #[allow(dead_code)]
+    pub(crate) get_server_output: bool,
+    pub(crate) forceflush: bool,
+    pub(crate) timestamps: Option<String>,
+    pub(crate) bind_address: Option<String>,
+    pub(crate) bind_dev: Option<String>,
+    pub(crate) fq_rate: Option<u64>,
+    pub(crate) flowlabel: Option<i32>,
+    pub(crate) ip_version: Option<u8>,
+    pub(crate) mptcp: bool,
+    pub(crate) skip_rx_copy: bool,
+    pub(crate) rcv_timeout: Option<u64>,
+    pub(crate) snd_timeout: Option<u64>,
+    pub(crate) file: Option<String>,
+    #[allow(dead_code)] // realized by the CLI, not `run()`; see #122
+    pub(crate) affinity: Option<String>,
+    #[allow(dead_code)] // never applied by `run()` (only `tos` is); see #122
+    pub(crate) dscp: Option<String>,
+    pub(crate) format_char: char,
+    pub(crate) interval: Option<f64>,
+    pub(crate) cntl_ka: Option<String>,
+    #[allow(dead_code)] // CLI writes the pidfile pre-runtime, not the library; see #122
+    pub(crate) pidfile: Option<String>,
+    #[allow(dead_code)] // CLI redirects stdout pre-runtime, not the library; see #122
+    pub(crate) logfile: Option<String>,
+    pub(crate) username: Option<String>,
+    pub(crate) password: Option<String>,
+    pub(crate) rsa_public_key_path: Option<String>,
+    pub(crate) use_pkcs1_padding: bool,
 }
 
 /// Build receiver-perspective summaries from the server's results. In a forward
@@ -1808,6 +1816,187 @@ impl ClientBuilder {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // Per-setter builder tests migrated in-crate from `tests/integration.rs`
+    // when `Client`'s fields became `pub(crate)` (#43): an external test crate
+    // can no longer read `c.protocol`, `c.duration`, etc.
+    mod builder_setter_tests {
+        use super::*;
+        use std::time::Duration;
+
+        #[test]
+        fn client_builder_protocol() {
+            let c = ClientBuilder::new("h")
+                .protocol(TransportProtocol::Udp)
+                .build()
+                .unwrap();
+            assert_eq!(c.protocol, TransportProtocol::Udp);
+        }
+
+        #[test]
+        fn client_builder_duration() {
+            let c = ClientBuilder::new("h").duration(30).build().unwrap();
+            assert_eq!(c.duration, 30);
+        }
+
+        #[test]
+        fn client_builder_num_streams() {
+            let c = ClientBuilder::new("h").num_streams(8).build().unwrap();
+            assert_eq!(c.num_streams, 8);
+        }
+
+        #[test]
+        fn client_builder_blksize() {
+            let c = ClientBuilder::new("h").blksize(65536).build().unwrap();
+            assert_eq!(c.blksize, 65536);
+        }
+
+        #[test]
+        fn client_builder_blksize_defaults() {
+            let tcp = ClientBuilder::new("h").build().unwrap();
+            assert_eq!(tcp.blksize, 128 * 1024);
+
+            let udp = ClientBuilder::new("h")
+                .protocol(TransportProtocol::Udp)
+                .build()
+                .unwrap();
+            assert_eq!(udp.blksize, 1460);
+        }
+
+        #[test]
+        fn client_builder_reverse() {
+            let c = ClientBuilder::new("h").reverse(true).build().unwrap();
+            assert!(c.reverse);
+        }
+
+        #[test]
+        fn client_builder_bidir() {
+            let c = ClientBuilder::new("h").bidir(true).build().unwrap();
+            assert!(c.bidir);
+        }
+
+        #[test]
+        fn client_builder_omit() {
+            let c = ClientBuilder::new("h").omit(3).build().unwrap();
+            assert_eq!(c.omit, 3);
+        }
+
+        #[test]
+        fn client_builder_no_delay() {
+            let c = ClientBuilder::new("h").no_delay(true).build().unwrap();
+            assert!(c.no_delay);
+        }
+
+        #[test]
+        fn client_builder_mss() {
+            let c = ClientBuilder::new("h").mss(1400).build().unwrap();
+            assert_eq!(c.mss, Some(1400));
+        }
+
+        #[test]
+        fn client_builder_window() {
+            let c = ClientBuilder::new("h").window(524288).build().unwrap();
+            assert_eq!(c.window, Some(524288));
+        }
+
+        #[test]
+        fn client_builder_bandwidth() {
+            let c = ClientBuilder::new("h")
+                .bandwidth(1_000_000)
+                .build()
+                .unwrap();
+            assert_eq!(c.bandwidth, 1_000_000);
+        }
+
+        #[test]
+        fn client_builder_tos() {
+            let c = ClientBuilder::new("h").tos(0x10).build().unwrap();
+            assert_eq!(c.tos, 0x10);
+        }
+
+        // Congestion is a Linux/FreeBSD feature (net.rs); gate to match (#76).
+        #[cfg(any(target_os = "linux", target_os = "freebsd"))]
+        #[test]
+        fn client_builder_congestion() {
+            let c = ClientBuilder::new("h").congestion("bbr").build().unwrap();
+            assert_eq!(c.congestion, Some("bbr".to_string()));
+        }
+
+        #[test]
+        fn client_builder_udp_64bit() {
+            let c = ClientBuilder::new("h")
+                .udp_counters_64bit(true)
+                .build()
+                .unwrap();
+            assert!(c.udp_counters_64bit);
+        }
+
+        #[test]
+        fn client_builder_connect_timeout() {
+            let c = ClientBuilder::new("h")
+                .connect_timeout(Duration::from_millis(500))
+                .build()
+                .unwrap();
+            assert_eq!(c.connect_timeout, Some(Duration::from_millis(500)));
+        }
+
+        #[test]
+        fn client_builder_title() {
+            let c = ClientBuilder::new("h").title("my test").build().unwrap();
+            assert_eq!(c.title, Some("my test".to_string()));
+        }
+
+        #[test]
+        fn client_builder_extra_data() {
+            let c = ClientBuilder::new("h").extra_data("x").build().unwrap();
+            assert_eq!(c.extra_data, Some("x".to_string()));
+        }
+
+        #[test]
+        fn client_builder_verbose() {
+            let c = ClientBuilder::new("h").verbose(true).build().unwrap();
+            assert!(c.verbose);
+        }
+
+        #[test]
+        fn client_builder_json_output() {
+            let c = ClientBuilder::new("h").json_output(true).build().unwrap();
+            assert!(c.json_output);
+        }
+
+        #[test]
+        fn client_builder_bytes() {
+            let c = ClientBuilder::new("h").bytes(1_000_000).build().unwrap();
+            assert_eq!(c.bytes_to_send, Some(1_000_000));
+        }
+
+        #[test]
+        fn client_builder_blocks() {
+            let c = ClientBuilder::new("h").blocks(100).build().unwrap();
+            assert_eq!(c.blocks_to_send, Some(100));
+        }
+
+        #[test]
+        fn client_builder_format_char() {
+            // -f format is wired to Client.format_char and used in the reporter.
+            let c = ClientBuilder::new("h").format_char('k').build().unwrap();
+            assert_eq!(c.format_char, 'k');
+        }
+
+        #[test]
+        fn client_builder_mptcp() {
+            let c = ClientBuilder::new("h").mptcp(true).build().unwrap();
+            assert!(c.mptcp);
+        }
+
+        #[test]
+        fn client_builder_dscp_maps_to_tos() {
+            // --dscp folds into the TOS byte: EF (46) << 2 == 184. The end-to-end
+            // run lives in tests/integration.rs; here we pin the mapping precisely.
+            let c = ClientBuilder::new("h").dscp("ef").build().unwrap();
+            assert_eq!(c.tos, 46 << 2);
+        }
+    }
 
     mod client_builder_tests {
         use super::*;

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -73,29 +73,34 @@ impl TestConfig {
 // Constructed only via ServerBuilder; #[non_exhaustive] keeps future field
 // additions (like json_output/json_stream in #50) from being breaking changes
 // for downstream crates (#43 semver-proofing, the cheap half).
+#[derive(Debug, PartialEq)]
 #[non_exhaustive]
 pub struct Server {
-    pub port: u16,
-    pub one_off: bool,
-    pub verbose: bool,
-    pub idle_timeout: Option<u32>,
-    pub server_bitrate_limit: Option<u64>,
-    pub server_max_duration: Option<u32>,
-    pub pidfile: Option<String>,
-    pub logfile: Option<String>,
-    pub forceflush: bool,
-    pub bind_address: Option<String>,
-    pub ip_version: Option<u8>,
-    pub timestamps: Option<String>,
-    pub file: Option<String>,
-    pub rsa_private_key_path: Option<String>,
-    pub authorized_users_path: Option<String>,
-    pub time_skew_threshold: u32,
-    pub use_pkcs1_padding: bool,
+    pub(crate) port: u16,
+    pub(crate) one_off: bool,
+    pub(crate) verbose: bool,
+    pub(crate) idle_timeout: Option<u32>,
+    pub(crate) server_bitrate_limit: Option<u64>,
+    pub(crate) server_max_duration: Option<u32>,
+    // Builder-settable but never read by `run()` — the CLI writes the pidfile
+    // and redirects stdout pre-runtime, not the library. Prune-vs-wire in #122.
+    #[allow(dead_code)]
+    pub(crate) pidfile: Option<String>,
+    #[allow(dead_code)] // see above / #122
+    pub(crate) logfile: Option<String>,
+    pub(crate) forceflush: bool,
+    pub(crate) bind_address: Option<String>,
+    pub(crate) ip_version: Option<u8>,
+    pub(crate) timestamps: Option<String>,
+    pub(crate) file: Option<String>,
+    pub(crate) rsa_private_key_path: Option<String>,
+    pub(crate) authorized_users_path: Option<String>,
+    pub(crate) time_skew_threshold: u32,
+    pub(crate) use_pkcs1_padding: bool,
     /// Emit the test results as iperf3-schema JSON on stdout instead of text (#50).
-    pub json_output: bool,
+    pub(crate) json_output: bool,
     /// Stream line-delimited interval JSON during the test (`--json-stream`).
-    pub json_stream: bool,
+    pub(crate) json_stream: bool,
 }
 
 /// Best-effort source IP the kernel would use to reach `client_addr`, paired
@@ -1555,6 +1560,52 @@ impl ServerBuilder {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // Per-setter builder tests migrated in-crate from `tests/integration.rs`
+    // when `Server`'s fields became `pub(crate)` (#43): an external test crate
+    // can no longer read `s.one_off`, `s.verbose`, etc.
+    mod builder_setter_tests {
+        use super::*;
+
+        #[test]
+        fn server_builder_one_off() {
+            let s = ServerBuilder::new().one_off(true).build().unwrap();
+            assert!(s.one_off);
+        }
+
+        #[test]
+        fn server_builder_verbose() {
+            let s = ServerBuilder::new().verbose(true).build().unwrap();
+            assert!(s.verbose);
+        }
+
+        #[test]
+        fn server_builder_rejects_version_bind_conflict() {
+            // -4/-6 contradicting an explicit -B of the opposite family is an
+            // error, not silently honored (issue #12).
+            assert!(ServerBuilder::new()
+                .ip_version(6)
+                .bind_address("127.0.0.1")
+                .build()
+                .is_err());
+            assert!(ServerBuilder::new()
+                .ip_version(4)
+                .bind_address("::")
+                .build()
+                .is_err());
+            // Matching family, or a non-literal bind, is fine.
+            assert!(ServerBuilder::new()
+                .ip_version(6)
+                .bind_address("::")
+                .build()
+                .is_ok());
+            assert!(ServerBuilder::new()
+                .ip_version(4)
+                .bind_address("0.0.0.0")
+                .build()
+                .is_ok());
+        }
+    }
 
     mod server_builder_tests {
         use super::*;

--- a/riperf3/tests/integration.rs
+++ b/riperf3/tests/integration.rs
@@ -832,206 +832,6 @@ async fn cpu_affinity_applied() {
 }
 
 // ---------------------------------------------------------------------------
-// Builder coverage tests
-// ---------------------------------------------------------------------------
-
-mod builder_tests {
-    use super::*;
-    use std::time::Duration;
-
-    #[test]
-    fn client_builder_protocol() {
-        let c = ClientBuilder::new("h")
-            .protocol(TransportProtocol::Udp)
-            .build()
-            .unwrap();
-        assert_eq!(c.protocol, TransportProtocol::Udp);
-    }
-
-    #[test]
-    fn client_builder_duration() {
-        let c = ClientBuilder::new("h").duration(30).build().unwrap();
-        assert_eq!(c.duration, 30);
-    }
-
-    #[test]
-    fn client_builder_num_streams() {
-        let c = ClientBuilder::new("h").num_streams(8).build().unwrap();
-        assert_eq!(c.num_streams, 8);
-    }
-
-    #[test]
-    fn client_builder_blksize() {
-        let c = ClientBuilder::new("h").blksize(65536).build().unwrap();
-        assert_eq!(c.blksize, 65536);
-    }
-
-    #[test]
-    fn client_builder_blksize_defaults() {
-        let tcp = ClientBuilder::new("h").build().unwrap();
-        assert_eq!(tcp.blksize, 128 * 1024);
-
-        let udp = ClientBuilder::new("h")
-            .protocol(TransportProtocol::Udp)
-            .build()
-            .unwrap();
-        assert_eq!(udp.blksize, 1460);
-    }
-
-    #[test]
-    fn client_builder_reverse() {
-        let c = ClientBuilder::new("h").reverse(true).build().unwrap();
-        assert!(c.reverse);
-    }
-
-    #[test]
-    fn client_builder_bidir() {
-        let c = ClientBuilder::new("h").bidir(true).build().unwrap();
-        assert!(c.bidir);
-    }
-
-    #[test]
-    fn client_builder_omit() {
-        let c = ClientBuilder::new("h").omit(3).build().unwrap();
-        assert_eq!(c.omit, 3);
-    }
-
-    #[test]
-    fn client_builder_no_delay() {
-        let c = ClientBuilder::new("h").no_delay(true).build().unwrap();
-        assert!(c.no_delay);
-    }
-
-    #[test]
-    fn client_builder_mss() {
-        let c = ClientBuilder::new("h").mss(1400).build().unwrap();
-        assert_eq!(c.mss, Some(1400));
-    }
-
-    #[test]
-    fn client_builder_window() {
-        let c = ClientBuilder::new("h").window(524288).build().unwrap();
-        assert_eq!(c.window, Some(524288));
-    }
-
-    #[test]
-    fn client_builder_bandwidth() {
-        let c = ClientBuilder::new("h")
-            .bandwidth(1_000_000)
-            .build()
-            .unwrap();
-        assert_eq!(c.bandwidth, 1_000_000);
-    }
-
-    #[test]
-    fn client_builder_tos() {
-        let c = ClientBuilder::new("h").tos(0x10).build().unwrap();
-        assert_eq!(c.tos, 0x10);
-    }
-
-    // Congestion is a Linux/FreeBSD feature (net.rs); gate to match (#76).
-    #[cfg(any(target_os = "linux", target_os = "freebsd"))]
-    #[test]
-    fn client_builder_congestion() {
-        let c = ClientBuilder::new("h").congestion("bbr").build().unwrap();
-        assert_eq!(c.congestion, Some("bbr".to_string()));
-    }
-
-    #[test]
-    fn client_builder_udp_64bit() {
-        let c = ClientBuilder::new("h")
-            .udp_counters_64bit(true)
-            .build()
-            .unwrap();
-        assert!(c.udp_counters_64bit);
-    }
-
-    #[test]
-    fn client_builder_connect_timeout() {
-        let c = ClientBuilder::new("h")
-            .connect_timeout(Duration::from_millis(500))
-            .build()
-            .unwrap();
-        assert_eq!(c.connect_timeout, Some(Duration::from_millis(500)));
-    }
-
-    #[test]
-    fn client_builder_title() {
-        let c = ClientBuilder::new("h").title("my test").build().unwrap();
-        assert_eq!(c.title, Some("my test".to_string()));
-    }
-
-    #[test]
-    fn client_builder_extra_data() {
-        let c = ClientBuilder::new("h").extra_data("x").build().unwrap();
-        assert_eq!(c.extra_data, Some("x".to_string()));
-    }
-
-    #[test]
-    fn client_builder_verbose() {
-        let c = ClientBuilder::new("h").verbose(true).build().unwrap();
-        assert!(c.verbose);
-    }
-
-    #[test]
-    fn client_builder_json_output() {
-        let c = ClientBuilder::new("h").json_output(true).build().unwrap();
-        assert!(c.json_output);
-    }
-
-    #[test]
-    fn client_builder_bytes() {
-        let c = ClientBuilder::new("h").bytes(1_000_000).build().unwrap();
-        assert_eq!(c.bytes_to_send, Some(1_000_000));
-    }
-
-    #[test]
-    fn client_builder_blocks() {
-        let c = ClientBuilder::new("h").blocks(100).build().unwrap();
-        assert_eq!(c.blocks_to_send, Some(100));
-    }
-
-    #[test]
-    fn server_builder_one_off() {
-        let s = ServerBuilder::new().one_off(true).build().unwrap();
-        assert!(s.one_off);
-    }
-
-    #[test]
-    fn server_builder_verbose() {
-        let s = ServerBuilder::new().verbose(true).build().unwrap();
-        assert!(s.verbose);
-    }
-
-    #[test]
-    fn server_builder_rejects_version_bind_conflict() {
-        // -4/-6 contradicting an explicit -B of the opposite family is an
-        // error, not silently honored (issue #12).
-        assert!(ServerBuilder::new()
-            .ip_version(6)
-            .bind_address("127.0.0.1")
-            .build()
-            .is_err());
-        assert!(ServerBuilder::new()
-            .ip_version(4)
-            .bind_address("::")
-            .build()
-            .is_err());
-        // Matching family, or a non-literal bind, is fine.
-        assert!(ServerBuilder::new()
-            .ip_version(6)
-            .bind_address("::")
-            .build()
-            .is_ok());
-        assert!(ServerBuilder::new()
-            .ip_version(4)
-            .bind_address("0.0.0.0")
-            .build()
-            .is_ok());
-    }
-}
-
-// ---------------------------------------------------------------------------
 // TestConfig from params
 // ---------------------------------------------------------------------------
 
@@ -2006,12 +1806,8 @@ mod stream_id_tests {
 mod implemented_flag_tests {
     use super::*;
 
-    #[tokio::test]
-    async fn format_flag_kbits() {
-        // -f format is wired to Client.format_char and used in reporter
-        let c = ClientBuilder::new("h").format_char('k').build().unwrap();
-        assert_eq!(c.format_char, 'k');
-    }
+    // format_char / mptcp builder-field assertions moved in-crate to
+    // `client::tests` (#43, fields are now pub(crate)).
 
     #[tokio::test]
     async fn udp_counters_64bit_flag() {
@@ -2252,14 +2048,6 @@ mod implemented_flag_tests {
         let _ = server_task.await;
     }
 
-    #[tokio::test]
-    async fn mptcp_flag_accepted() {
-        // MPTCP may not be available on all kernels. Just verify the flag
-        // is wired and the client attempts to use it (may fail with EPROTONOSUPPORT).
-        let c = ClientBuilder::new("h").mptcp(true).build().unwrap();
-        assert!(c.mptcp);
-    }
-
     #[test]
     fn dscp_symbolic_and_numeric() {
         use riperf3::utils::parse_dscp;
@@ -2292,7 +2080,8 @@ mod implemented_flag_tests {
             .dscp("ef")
             .build()
             .unwrap();
-        assert_eq!(client.tos, 46 << 2); // EF mapped to TOS
+        // The dscp->tos mapping is asserted in-crate (client::tests); this test
+        // verifies the flag works end-to-end against a live server.
         let result = client.run().await;
         assert!(result.is_ok(), "--dscp ef failed: {result:?}");
         let _ = server_task.await;


### PR DESCRIPTION
## What

`Client` and `Server` exposed all ~55 / ~19 config fields as `pub`. That let callers construct or mutate a config directly and **bypass builder validation**, and because `pub` suppresses dead-code analysis it hid fields the library never reads. This makes every field `pub(crate)` — the builder is now the only construction path — and is **breaking** (lands while 0.7.0 is unpublished).

## How

- **`pub` → `pub(crate)`** on every `Client`/`Server` field. CLI (production) uses only the builders, so it's unaffected.
- **Derive `PartialEq`** on `Client`/`Server`. The CLI crate's 49 flag-wiring tests can no longer read the now-private fields, so they verify the `Cli → builder` mapping by comparing the CLI-built config against one built directly through the public builder:
  ```rust
  let actual   = build_client_from_cli(&parse(["-c","h","-u"]));
  let expected = ClientBuilder::new("h").protocol(TransportProtocol::Udp).build().unwrap();
  assert_eq!(actual, expected);
  ```
  This keeps the wiring coverage (the class that caught the `-J`-not-wired bug) entirely through the lib's public API — no test backdoor, no clap in the lib.
- **Migrate the per-setter builder tests** from `tests/integration.rs` in-crate to `client::tests` / `server::tests` (an external test crate can't read `pub(crate)` fields). Behavioral/run tests stay in `integration.rs`.
- **Annotate 7 inert fields** (`#[allow(dead_code)]`): 5 on `Client` (`get_server_output`, `affinity`, `dscp`, `pidfile`, `logfile`) + 2 on `Server` (`pidfile`, `logfile`). The library never reads them — the CLI realizes them at the process level or they're no-ops. Prune-vs-wire decision tracked in **#122**.

## Scope

Addresses the **encapsulation half** of #43. The builder-boilerplate collapse (the 4×-per-field duplication) is now **non-breaking** (fields are private) and can follow separately without gating the release.

## Validation

- `cargo clippy --all-targets -- -D warnings` clean
- `cargo test --workspace` green (219 lib / 112 integration / 60 CLI / + targeted suites)
- `xcheck` (7-target cross-compile, lib+bins+tests) all green