### PR TITLE
refactor: future-proof public API with #[non_exhaustive] (0.7.0 hardening)

### DIFF
--- a/riperf3/src/error.rs
+++ b/riperf3/src/error.rs
@@ -5,6 +5,7 @@ use thiserror::Error;
 /// Configuration errors — validation failures when building Client/Server.
 /// Kept separate so existing tests that match on these variants continue to work.
 #[derive(Error, Debug, PartialEq)]
+#[non_exhaustive] // future validation variants must be additive, not breaking (#100, #45)
 pub enum ConfigError {
     #[error("missing field: {0}")]
     MissingField(&'static str),
@@ -18,6 +19,7 @@ pub enum ConfigError {
 
 /// Runtime errors covering I/O, protocol, and JSON failures.
 #[derive(Error, Debug)]
+#[non_exhaustive] // future error variants must be additive, not breaking
 pub enum RiperfError {
     #[error("{0}")]
     Config(#[from] ConfigError),

--- a/riperf3/src/lib.rs
+++ b/riperf3/src/lib.rs
@@ -35,7 +35,9 @@ mod client;
 pub use client::{Client, ClientBuilder};
 
 mod server;
-pub use server::{Server, ServerBuilder, TestConfig};
+// TestConfig is server-internal (built from received wire params, not used in
+// any public signature); it stays crate-private rather than a public type (#67).
+pub use server::{Server, ServerBuilder};
 
 // The wire protocol enum and the result model returned by `Client::run()`.
 pub use protocol::{StreamResultJson, TestResultsJson, TransportProtocol};

--- a/riperf3/src/protocol.rs
+++ b/riperf3/src/protocol.rs
@@ -93,6 +93,7 @@ impl TestState {
 
 /// Which data-plane transport to use.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[non_exhaustive] // a future transport (e.g. SCTP) must be additive, not breaking
 pub enum TransportProtocol {
     #[default]
     Tcp,
@@ -329,6 +330,7 @@ where
 
 /// Per-stream result data included in the results JSON.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive] // result model: consumers read it; future fields must be additive
 pub struct StreamResultJson {
     pub id: i32,
     pub bytes: u64,
@@ -348,6 +350,7 @@ pub struct StreamResultJson {
 
 /// Top-level results JSON exchanged between client and server.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive] // result model: consumers read it; future fields must be additive
 pub struct TestResultsJson {
     pub cpu_util_total: f64,
     pub cpu_util_user: f64,
@@ -1167,6 +1170,39 @@ mod protocol_tests {
         assert_eq!(v["TOS"], 16);
         assert_eq!(v["congestion"], "bbr");
         assert_eq!(v["client_version"], "riperf3 0.1.0");
+    }
+
+    // Migrated in-crate when TestResultsJson/StreamResultJson became
+    // #[non_exhaustive] (an external test crate can no longer construct them).
+    #[test]
+    fn test_results_json_structure() {
+        let r = TestResultsJson {
+            cpu_util_total: 50.0,
+            cpu_util_user: 40.0,
+            cpu_util_system: 10.0,
+            sender_has_retransmits: 5,
+            congestion_used: Some("cubic".to_string()),
+            streams: vec![StreamResultJson {
+                id: 1,
+                bytes: 10_000_000_000,
+                retransmits: 5,
+                jitter: 0.001,
+                errors: 2,
+                omitted_errors: 0,
+                packets: 10000,
+                omitted_packets: 0,
+                start_time: 0.0,
+                end_time: 10.0,
+            }],
+        };
+        let json = serde_json::to_string(&r).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(v["cpu_util_total"], 50.0);
+        assert_eq!(v["sender_has_retransmits"], 5);
+        assert_eq!(v["congestion_used"], "cubic");
+        assert_eq!(v["streams"][0]["id"], 1);
+        assert_eq!(v["streams"][0]["bytes"], 10_000_000_000u64);
+        assert_eq!(v["streams"][0]["retransmits"], 5);
     }
 }
 

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -1667,8 +1667,8 @@ mod tests {
 
 #[cfg(test)]
 mod test_config_tests {
+    use super::TestConfig;
     use crate::protocol::{TestParams, TransportProtocol};
-    use crate::TestConfig;
 
     #[test]
     fn tcp_defaults() {

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -9,7 +9,9 @@ use crate::stream::{self, DataStream, StreamCounters, UdpRecvStats};
 use crate::utils::*;
 
 /// Shared test configuration derived from the client's parameter JSON.
-pub struct TestConfig {
+/// Crate-internal (#67): retracted from the public API, so `pub(crate)` keeps a
+/// future stray `pub use` from silently re-leaking it.
+pub(crate) struct TestConfig {
     pub protocol: TransportProtocol,
     pub duration: u32,
     pub num_streams: u32,

--- a/riperf3/tests/integration.rs
+++ b/riperf3/tests/integration.rs
@@ -868,39 +868,9 @@ mod json_output_tests {
         let _ = server_task.await;
     }
 
-    // test_params_serializes_all_fields migrated in-crate to src/protocol.rs (#67).
-
-    #[test]
-    fn test_results_json_structure() {
-        use riperf3::{StreamResultJson, TestResultsJson};
-        let r = TestResultsJson {
-            cpu_util_total: 50.0,
-            cpu_util_user: 40.0,
-            cpu_util_system: 10.0,
-            sender_has_retransmits: 5,
-            congestion_used: Some("cubic".to_string()),
-            streams: vec![StreamResultJson {
-                id: 1,
-                bytes: 10_000_000_000,
-                retransmits: 5,
-                jitter: 0.001,
-                errors: 2,
-                omitted_errors: 0,
-                packets: 10000,
-                omitted_packets: 0,
-                start_time: 0.0,
-                end_time: 10.0,
-            }],
-        };
-        let json = serde_json::to_string(&r).unwrap();
-        let v: serde_json::Value = serde_json::from_str(&json).unwrap();
-        assert_eq!(v["cpu_util_total"], 50.0);
-        assert_eq!(v["sender_has_retransmits"], 5);
-        assert_eq!(v["congestion_used"], "cubic");
-        assert_eq!(v["streams"][0]["id"], 1);
-        assert_eq!(v["streams"][0]["bytes"], 10_000_000_000u64);
-        assert_eq!(v["streams"][0]["retransmits"], 5);
-    }
+    // test_params_serializes_all_fields migrated in-crate to src/protocol.rs (#67);
+    // test_results_json_structure likewise migrated when TestResultsJson became
+    // #[non_exhaustive] (it can no longer be constructed from an external crate).
 }
 
 // interval_reporter_tests migrated in-crate to src/reporter.rs (#67).


### PR DESCRIPTION
## Why

Goal: make **0.7.0 the last breaking release** for the current known-issue set. Several remaining issues will grow the public API when fixed — new error/validation variants (#45, #100), possibly a new transport, more `-J` result fields (#37/#54/#96). Adding `#[non_exhaustive]` to those types is itself a breaking change, so it has to happen in 0.7.0 (the only no-cost window while unpublished). After this, those fixes are all non-breaking 0.7.x work.

## What

- **`#[non_exhaustive]`** on:
  - `RiperfError`, `ConfigError` (error.rs) — future error/validation variants become additive.
  - `TransportProtocol` (protocol.rs) — a future transport (e.g. SCTP) becomes additive. (CLI only references `TransportProtocol::Udp`; no exhaustive external match, so no fallout.)
  - `TestResultsJson`, `StreamResultJson` (protocol.rs) — the `Client::run()` result model; consumers **read** these, so future JSON fields become additive. (The `-J` `json_report` model was already fully `#[non_exhaustive]`.)
- **Retract `TestConfig`** from the public re-export (lib.rs) — it's server-internal (built from received wire params), not used in any public signature.
- **Migrate `test_results_json_structure` in-crate** (protocol.rs) — an external test crate can no longer construct the now-`#[non_exhaustive]` result structs. (lib 255→256, integration 76→75.)

## Validation

- `cargo clippy --all-targets -- -D warnings` clean; `cargo test --workspace` green (256 lib / 75 integration / 60 cli); `xcheck` 7/7.
- The one external `match` on `RiperfError` (integration.rs) already has an `other =>` arm, so non_exhaustive is a no-op there. CLI builds clean.

This is the third of the 0.7.0 breaking set (#43 ✅, #67 ✅, this, then the #122 prune).