### PR TITLE
refactor: prune inert process-level builder setters (#122)

### DIFF
--- a/riperf3-cli/src/cli.rs
+++ b/riperf3-cli/src/cli.rs
@@ -721,20 +721,11 @@ mod cli_tests {
             if let Some(ref path) = cli.file {
                 b = b.file(path);
             }
-            if let Some(ref spec) = cli.affinity {
-                b = b.affinity(spec);
-            }
             if let Some(ref spec) = cli.cntl_ka {
                 b = b.cntl_ka(spec);
             }
             if let Some(ref val) = cli.dscp {
                 b = b.dscp(val);
-            }
-            if let Some(ref path) = cli.pidfile {
-                b = b.pidfile(path);
-            }
-            if let Some(ref path) = cli.logfile {
-                b = b.logfile(path);
             }
             b.build().unwrap()
         }
@@ -1342,21 +1333,8 @@ mod cli_tests {
             );
         }
 
-        // build() rejects -A/--affinity (CPU affinity) on non-Unix, so gate the
-        // wiring test to match.
-        #[cfg(unix)]
-        #[test]
-        fn affinity_wired() {
-            let cli = Cli::parse_from(["riperf3", "-c", "h", "-A", "2,3"]);
-            let c = build_client_from_cli(&cli);
-            assert_eq!(
-                c,
-                riperf3::ClientBuilder::new("h")
-                    .affinity("2,3")
-                    .build()
-                    .unwrap()
-            );
-        }
+        // affinity/pidfile/logfile builder setters were pruned (#122) — the CLI
+        // realizes those at the process level, not via the builder.
 
         #[test]
         fn json_stream_wired() {
@@ -1366,32 +1344,6 @@ mod cli_tests {
                 c,
                 riperf3::ClientBuilder::new("h")
                     .json_stream(true)
-                    .build()
-                    .unwrap()
-            );
-        }
-
-        #[test]
-        fn pidfile_wired() {
-            let cli = Cli::parse_from(["riperf3", "-c", "h", "-I", "/tmp/pid"]);
-            let c = build_client_from_cli(&cli);
-            assert_eq!(
-                c,
-                riperf3::ClientBuilder::new("h")
-                    .pidfile("/tmp/pid")
-                    .build()
-                    .unwrap()
-            );
-        }
-
-        #[test]
-        fn logfile_wired() {
-            let cli = Cli::parse_from(["riperf3", "-c", "h", "--logfile", "/tmp/log"]);
-            let c = build_client_from_cli(&cli);
-            assert_eq!(
-                c,
-                riperf3::ClientBuilder::new("h")
-                    .logfile("/tmp/log")
                     .build()
                     .unwrap()
             );

--- a/riperf3-cli/src/main.rs
+++ b/riperf3-cli/src/main.rs
@@ -239,20 +239,11 @@ async fn async_main(cli: Cli) -> std::result::Result<(), Box<dyn std::error::Err
         if let Some(ref path) = cli.file {
             builder = builder.file(path);
         }
-        if let Some(ref spec) = cli.affinity {
-            builder = builder.affinity(spec);
-        }
         if let Some(ref val) = cli.dscp {
             builder = builder.dscp(val);
         }
         if let Some(ref spec) = cli.cntl_ka {
             builder = builder.cntl_ka(spec);
-        }
-        if let Some(ref path) = cli.pidfile {
-            builder = builder.pidfile(path);
-        }
-        if let Some(ref path) = cli.logfile {
-            builder = builder.logfile(path);
         }
         if let Some(ref name) = cli.username {
             builder = builder.username(name);
@@ -298,12 +289,6 @@ async fn async_main(cli: Cli) -> std::result::Result<(), Box<dyn std::error::Err
         }
         if let Some(secs) = cli.server_max_duration {
             builder = builder.server_max_duration(secs);
-        }
-        if let Some(ref path) = cli.pidfile {
-            builder = builder.pidfile(path);
-        }
-        if let Some(ref path) = cli.logfile {
-            builder = builder.logfile(path);
         }
         if cli.forceflush {
             builder = builder.forceflush(true);

--- a/riperf3/src/client.rs
+++ b/riperf3/src/client.rs
@@ -52,9 +52,8 @@ pub struct Client {
     pub(crate) sendmmsg: bool,
     pub(crate) dont_fragment: bool,
     pub(crate) cport: Option<u16>,
-    // Builder-settable but never read by `run()` — the CLI realizes these
-    // elsewhere (affinity via `set_cpu_affinity`, pidfile/logfile pre-runtime)
-    // or they are currently no-ops. Prune-vs-wire tracked in #122.
+    // Set by the builder but not yet consumed by `run()`; to be wired into the
+    // library as non-breaking 0.7.x work — get_server_output (#33), dscp below.
     #[allow(dead_code)]
     pub(crate) get_server_output: bool,
     pub(crate) forceflush: bool,
@@ -69,17 +68,11 @@ pub struct Client {
     pub(crate) rcv_timeout: Option<u64>,
     pub(crate) snd_timeout: Option<u64>,
     pub(crate) file: Option<String>,
-    #[allow(dead_code)] // realized by the CLI, not `run()`; see #122
-    pub(crate) affinity: Option<String>,
-    #[allow(dead_code)] // never applied by `run()` (only `tos` is); see #122
+    #[allow(dead_code)] // not yet applied by `run()` (only `tos` is); wire in 0.7.x
     pub(crate) dscp: Option<String>,
     pub(crate) format_char: char,
     pub(crate) interval: Option<f64>,
     pub(crate) cntl_ka: Option<String>,
-    #[allow(dead_code)] // CLI writes the pidfile pre-runtime, not the library; see #122
-    pub(crate) pidfile: Option<String>,
-    #[allow(dead_code)] // CLI redirects stdout pre-runtime, not the library; see #122
-    pub(crate) logfile: Option<String>,
     pub(crate) username: Option<String>,
     pub(crate) password: Option<String>,
     pub(crate) rsa_public_key_path: Option<String>,
@@ -1281,13 +1274,10 @@ pub struct ClientBuilder {
     rcv_timeout: Option<u64>,
     snd_timeout: Option<u64>,
     file: Option<String>,
-    affinity: Option<String>,
     dscp: Option<String>,
     format_char: char,
     interval: Option<f64>,
     cntl_ka: Option<String>,
-    pidfile: Option<String>,
-    logfile: Option<String>,
     username: Option<String>,
     password: Option<String>,
     rsa_public_key_path: Option<String>,
@@ -1340,13 +1330,10 @@ impl Default for ClientBuilder {
             rcv_timeout: None,
             snd_timeout: None,
             file: None,
-            affinity: None,
             dscp: None,
             format_char: 'a',
             interval: None,
             cntl_ka: None,
-            pidfile: None,
-            logfile: None,
             username: None,
             password: None,
             rsa_public_key_path: None,
@@ -1588,11 +1575,6 @@ impl ClientBuilder {
         self
     }
 
-    pub fn affinity(mut self, spec: &str) -> Self {
-        self.affinity = Some(spec.to_string());
-        self
-    }
-
     pub fn dscp(mut self, val: &str) -> Self {
         self.dscp = Some(val.to_string());
         self
@@ -1610,16 +1592,6 @@ impl ClientBuilder {
 
     pub fn cntl_ka(mut self, spec: &str) -> Self {
         self.cntl_ka = Some(spec.to_string());
-        self
-    }
-
-    pub fn pidfile(mut self, path: &str) -> Self {
-        self.pidfile = Some(path.to_string());
-        self
-    }
-
-    pub fn logfile(mut self, path: &str) -> Self {
-        self.logfile = Some(path.to_string());
         self
     }
 
@@ -1697,11 +1669,6 @@ impl ClientBuilder {
             if self.zerocopy {
                 return Err(ConfigError::Unsupported(
                     "this OS does not support sendfile".into(),
-                ));
-            }
-            if self.affinity.is_some() {
-                return Err(ConfigError::Unsupported(
-                    "CPU affinity is not supported on this platform".into(),
                 ));
             }
             if self.bind_dev.is_some() {
@@ -1794,13 +1761,10 @@ impl ClientBuilder {
             rcv_timeout: self.rcv_timeout,
             snd_timeout: self.snd_timeout,
             file: self.file,
-            affinity: self.affinity,
             dscp: self.dscp,
             format_char: self.format_char,
             interval: self.interval,
             cntl_ka: self.cntl_ka,
-            pidfile: self.pidfile,
-            logfile: self.logfile,
             username: self.username,
             password: self.password,
             rsa_public_key_path: self.rsa_public_key_path,

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -86,12 +86,6 @@ pub struct Server {
     pub(crate) idle_timeout: Option<u32>,
     pub(crate) server_bitrate_limit: Option<u64>,
     pub(crate) server_max_duration: Option<u32>,
-    // Builder-settable but never read by `run()` — the CLI writes the pidfile
-    // and redirects stdout pre-runtime, not the library. Prune-vs-wire in #122.
-    #[allow(dead_code)]
-    pub(crate) pidfile: Option<String>,
-    #[allow(dead_code)] // see above / #122
-    pub(crate) logfile: Option<String>,
     pub(crate) forceflush: bool,
     pub(crate) bind_address: Option<String>,
     pub(crate) ip_version: Option<u8>,
@@ -1359,8 +1353,6 @@ pub struct ServerBuilder {
     idle_timeout: Option<u32>,
     server_bitrate_limit: Option<u64>,
     server_max_duration: Option<u32>,
-    pidfile: Option<String>,
-    logfile: Option<String>,
     forceflush: bool,
     bind_address: Option<String>,
     ip_version: Option<u8>,
@@ -1383,8 +1375,6 @@ impl Default for ServerBuilder {
             idle_timeout: None,
             server_bitrate_limit: None,
             server_max_duration: None,
-            pidfile: None,
-            logfile: None,
             forceflush: false,
             bind_address: None,
             ip_version: None,
@@ -1444,16 +1434,6 @@ impl ServerBuilder {
 
     pub fn server_max_duration(mut self, secs: u32) -> Self {
         self.server_max_duration = Some(secs);
-        self
-    }
-
-    pub fn pidfile(mut self, path: &str) -> Self {
-        self.pidfile = Some(path.to_string());
-        self
-    }
-
-    pub fn logfile(mut self, path: &str) -> Self {
-        self.logfile = Some(path.to_string());
         self
     }
 
@@ -1540,8 +1520,6 @@ impl ServerBuilder {
             idle_timeout: self.idle_timeout,
             server_bitrate_limit: self.server_bitrate_limit,
             server_max_duration: self.server_max_duration,
-            pidfile: self.pidfile,
-            logfile: self.logfile,
             forceflush: self.forceflush,
             bind_address: self.bind_address,
             ip_version: self.ip_version,


### PR DESCRIPTION
## What

`ClientBuilder::{pidfile, logfile, affinity}` and `ServerBuilder::{pidfile, logfile}` stored values the **library never reads** — the CLI realizes all of them at the process level (writes the pidfile / redirects stdout before the runtime is built; sets affinity via `set_cpu_affinity`). These setters are inert library surface a library shouldn't own. **Breaking** (removes public builder methods); lands while 0.7.0 is unpublished. This is the 4th and final breaking change in the 0.7.0 set.

## How

Removed, for `affinity`/`pidfile`/`logfile` (Client) and `pidfile`/`logfile` (Server):
- the builder setter methods, the `Client`/`Server` fields, `Default` entries, and `build()` mappings;
- the now-moot `#[cfg(not(unix))]` affinity rejection in `ClientBuilder::build()`;
- the inert `builder.{pidfile,logfile,affinity}(…)` calls in `main.rs` and the test helper in `cli.rs`;
- the 3 CLI wiring tests (`affinity_wired`, `pidfile_wired`, `logfile_wired`).

**Kept** `dscp` and `get_server_output` — those get *wired* into the library as non-breaking 0.7.x work (#33), not pruned.

## Behavior

- The CLI flags `-I/--pidfile`, `--logfile`, `-A/--affinity` are **unchanged** — still parsed and handled at the process level (`main.rs:54/60/79`).
- Side-effect fix: `-A` on **Windows** is no longer spuriously rejected at `build()` (the old `#[cfg(not(unix))]` check errored even though `set_cpu_affinity` supports Windows via `SetThreadAffinityMask`).

## Validation

- `cargo clippy --all-targets -- -D warnings` clean; `cargo test --workspace` green (256 lib / 75 integration / **57 cli**, −3 removed wiring tests); `xcheck` 7/7 (incl. windows-msvc).

Addresses the prune half of #122 (the wire half is #33 + dscp, 0.7.x).