### PR TITLE
chore: post-0.7.0 internal cleanup — Windows clippy casts + dead-code triage (#129, #125)

### DIFF
--- a/riperf3/src/net.rs
+++ b/riperf3/src/net.rs
@@ -389,9 +389,9 @@ pub fn configure_tcp_stream_full(
             unsafe {
                 windows_sys::Win32::Networking::WinSock::setsockopt(
                     raw as usize,
-                    windows_sys::Win32::Networking::WinSock::IPPROTO_TCP as i32,
-                    windows_sys::Win32::Networking::WinSock::TCP_MAXSEG as i32,
-                    &(mss_val as i32) as *const i32 as *const u8,
+                    windows_sys::Win32::Networking::WinSock::IPPROTO_TCP,
+                    windows_sys::Win32::Networking::WinSock::TCP_MAXSEG,
+                    &mss_val as *const i32 as *const u8,
                     std::mem::size_of::<i32>() as i32,
                 );
             }
@@ -569,8 +569,8 @@ pub fn set_dont_fragment(fd: &impl std::os::windows::io::AsSocket) -> Result<()>
     let ret = unsafe {
         windows_sys::Win32::Networking::WinSock::setsockopt(
             raw as usize,
-            windows_sys::Win32::Networking::WinSock::IPPROTO_IP as i32,
-            windows_sys::Win32::Networking::WinSock::IP_DONTFRAGMENT as i32,
+            windows_sys::Win32::Networking::WinSock::IPPROTO_IP,
+            windows_sys::Win32::Networking::WinSock::IP_DONTFRAGMENT,
             &val as *const i32 as *const u8,
             std::mem::size_of::<i32>() as i32,
         )

--- a/riperf3/src/reporter.rs
+++ b/riperf3/src/reporter.rs
@@ -204,8 +204,9 @@ pub fn format_summary_line(summary: &StreamSummary, format_char: char) -> String
     }
 }
 
-/// Print a single final summary line.
-#[allow(dead_code)]
+/// Print a single final summary line. Test-only: production reporting routes
+/// through `final_report_lines`; this helper exists for unit-testing the format.
+#[cfg(test)]
 pub fn print_summary(summary: &StreamSummary, format_char: char) {
     titled(format_args!(
         "{}",

--- a/riperf3/src/stream.rs
+++ b/riperf3/src/stream.rs
@@ -173,6 +173,9 @@ pub struct UdpRecvStats {
     prev_transit: f64,
 
     // Snapshots taken at the end of the omit period so we can subtract them.
+    // Test-only today: only `snapshot_omit` (now `#[cfg(test)]`) writes non-zero
+    // values here; in production these stay at their 0 init until `-O/--omit` is
+    // wired into the UDP receive path (#31).
     #[allow(dead_code)]
     pub omitted_packet_count: i64,
     #[allow(dead_code)]

--- a/riperf3/src/stream.rs
+++ b/riperf3/src/stream.rs
@@ -230,7 +230,11 @@ impl UdpRecvStats {
 
     /// Snapshot current values as the omit-period baseline.
     /// Call this at the end of the omit period.
-    #[allow(dead_code)]
+    ///
+    /// Test-only today: `-O/--omit` is not yet wired into the UDP receive path
+    /// (#31), so production never calls this; the unit tests exercise it so the
+    /// omit-accounting fields stay correct for when #31 lands.
+    #[cfg(test)]
     pub fn snapshot_omit(&mut self) {
         self.omitted_packet_count = self.packet_count;
         self.omitted_cnt_error = self.cnt_error;

--- a/riperf3/src/utils.rs
+++ b/riperf3/src/utils.rs
@@ -11,8 +11,6 @@ pub const DEFAULT_NUM_STREAMS: u32 = 1;
 pub const DEFAULT_TCP_BLKSIZE: usize = 128 * 1024; // 128 KiB
 pub const DEFAULT_UDP_BLKSIZE: usize = 1460;
 pub const DEFAULT_UDP_RATE: u64 = 1024 * 1024; // 1 Mbit/sec in bits
-#[allow(dead_code)]
-pub const DEFAULT_TIMESTAMP_FORMAT: &str = "%c ";
 
 /// Minimum UDP datagram size: 4 (sec) + 4 (usec) + 8 (64-bit counter)
 pub const MIN_UDP_BLKSIZE: usize = 16;


### PR DESCRIPTION
First 0.7.1 PR: non-functional cleanup of debt left by the 0.7.0 API-narrowing refactor (#67). No behavior change; data path untouched.

## #129 — redundant `as i32` casts on Windows socket constants
`cargo clippy --target x86_64-pc-windows-msvc --all-targets -- -D warnings` failed with 5 `unnecessary_cast` errors in `net.rs` (IPPROTO_TCP/IP, TCP_MAXSEG, IP_DONTFRAGMENT, and the already-`i32` MSS value). Host-target clippy (CI's Lint job) never sees them and xcheck is `cargo check` not clippy, so it was invisible until #128 review. Dropped the no-op casts; kept the real pointer/`size_of` casts.

## #125 — dead-code triage (follow-up to #67)
- **Removed**: `utils::DEFAULT_TIMESTAMP_FORMAT` (zero references).
- **Gated `#[cfg(test)]`**: `reporter::print_summary` and `UdpRecvStats::snapshot_omit` — each has a single caller, both in `#[cfg(test)]` modules.
- **Kept `#[allow(dead_code)]`** (intentional/parity, documented in #125): async `run_udp_sender`/`run_udp_receiver`, `tcp_info` snd_wnd/snd_mss, `cpu` remote_*, and the omit-accounting fields (prod-populated, test-read).

## Verification
- `cargo clippy --target x86_64-pc-windows-msvc --all-targets -- -D warnings`: 5 errors → clean.
- Host `cargo clippy --all-targets -- -D warnings`: clean.
- `cargo test`: 399 pass, 0 fail.
- `riperf3-xcheck`: 7/7 targets compile.

Closes #129
Closes #125