### PR TITLE
fix(cli): reject server-only options on the client, matching iperf3 IESERVERONLY (#100)

### DIFF
--- a/riperf3-cli/src/cli.rs
+++ b/riperf3-cli/src/cli.rs
@@ -390,11 +390,20 @@ impl Cli {
         let checks: [(bool, &'static str); 9] = [
             (self.daemon, "-D/--daemon"),
             (self.one_off, "-1/--one-off"),
-            (self.server_bitrate_limit.is_some(), "--server-bitrate-limit"),
+            (
+                self.server_bitrate_limit.is_some(),
+                "--server-bitrate-limit",
+            ),
             (self.idle_timeout.is_some(), "--idle-timeout"),
             (self.server_max_duration.is_some(), "--server-max-duration"),
-            (self.rsa_private_key_path.is_some(), "--rsa-private-key-path"),
-            (self.authorized_users_path.is_some(), "--authorized-users-path"),
+            (
+                self.rsa_private_key_path.is_some(),
+                "--rsa-private-key-path",
+            ),
+            (
+                self.authorized_users_path.is_some(),
+                "--authorized-users-path",
+            ),
             (self.time_skew_threshold.is_some(), "--time-skew-threshold"),
             (self.use_pkcs1_padding, "--use-pkcs1-padding"),
         ];
@@ -646,11 +655,20 @@ mod cli_tests {
             for (args, want) in [
                 (vec!["-D"], "-D/--daemon"),
                 (vec!["-1"], "-1/--one-off"),
-                (vec!["--server-bitrate-limit", "100M"], "--server-bitrate-limit"),
+                (
+                    vec!["--server-bitrate-limit", "100M"],
+                    "--server-bitrate-limit",
+                ),
                 (vec!["--idle-timeout", "30"], "--idle-timeout"),
                 (vec!["--server-max-duration", "60"], "--server-max-duration"),
-                (vec!["--rsa-private-key-path", "/tmp/priv.pem"], "--rsa-private-key-path"),
-                (vec!["--authorized-users-path", "/tmp/users"], "--authorized-users-path"),
+                (
+                    vec!["--rsa-private-key-path", "/tmp/priv.pem"],
+                    "--rsa-private-key-path",
+                ),
+                (
+                    vec!["--authorized-users-path", "/tmp/users"],
+                    "--authorized-users-path",
+                ),
                 (vec!["--time-skew-threshold", "5"], "--time-skew-threshold"),
                 (vec!["--use-pkcs1-padding"], "--use-pkcs1-padding"),
             ] {

--- a/riperf3-cli/src/cli.rs
+++ b/riperf3-cli/src/cli.rs
@@ -369,6 +369,37 @@ impl Cli {
         ];
         checks.iter().find(|(set, _)| *set).map(|(_, name)| *name)
     }
+
+    /// The first server-only option set on the command line, or `None`.
+    ///
+    /// iperf3 raises `IESERVERONLY` when a client (`-c`) is given an option that
+    /// only makes sense on the server — every option whose parse arm sets
+    /// `server_flag`, plus `--authorized-users-path` (caught by a separate role
+    /// check). This mirrors that exact set so a riperf3 client rejects the same
+    /// options iperf3 would, before any side effects. Companion to
+    /// `first_client_only_violation` (#65); see #100.
+    ///
+    /// `--use-pkcs1-padding` is included deliberately: iperf3 marks it
+    /// server-only (the server uses PKCS#1 v1.5 to decode tokens from legacy
+    /// clients; modern clients always send OAEP), so a client passing it is an
+    /// error in iperf3 too. The library `ClientBuilder::use_pkcs1_padding` stays
+    /// available to embedders; only the CLI client path matches iperf3.
+    pub fn first_server_only_violation(&self) -> Option<&'static str> {
+        // (was-it-set, canonical flag name) — order is the report priority.
+        // Cross-checked against iperf3's `server_flag` set in iperf_api.c.
+        let checks: [(bool, &'static str); 9] = [
+            (self.daemon, "-D/--daemon"),
+            (self.one_off, "-1/--one-off"),
+            (self.server_bitrate_limit.is_some(), "--server-bitrate-limit"),
+            (self.idle_timeout.is_some(), "--idle-timeout"),
+            (self.server_max_duration.is_some(), "--server-max-duration"),
+            (self.rsa_private_key_path.is_some(), "--rsa-private-key-path"),
+            (self.authorized_users_path.is_some(), "--authorized-users-path"),
+            (self.time_skew_threshold.is_some(), "--time-skew-threshold"),
+            (self.use_pkcs1_padding, "--use-pkcs1-padding"),
+        ];
+        checks.iter().find(|(set, _)| *set).map(|(_, name)| *name)
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, ValueEnum)]
@@ -571,6 +602,63 @@ mod cli_tests {
                 let cli = Cli::parse_from(&argv);
                 assert_eq!(
                     cli.first_client_only_violation(),
+                    Some(want),
+                    "expected {want} flagged for args {args:?}"
+                );
+            }
+        }
+
+        // #100: the client rejects server-only options, like iperf3 (IESERVERONLY).
+        #[test]
+        fn client_flags_server_only_violation() {
+            // A bare client, and a client with only client/common-valid
+            // options (including the client-side auth options), are clean.
+            assert_eq!(
+                Cli::parse_from(["riperf3", "-c", "host"]).first_server_only_violation(),
+                None
+            );
+            let clean = Cli::parse_from([
+                "riperf3",
+                "-c",
+                "host",
+                "-t",
+                "5",
+                "-u",
+                "-R",
+                "-P",
+                "4",
+                "-b",
+                "100M",
+                "-p",
+                "5201",
+                "-i",
+                "1",
+                "-J",
+                "--username",
+                "alice",
+                "--rsa-public-key-path",
+                "/tmp/key.pem",
+            ]);
+            assert_eq!(clean.first_server_only_violation(), None);
+
+            // Each server-only option is flagged on the client. Cross-checked
+            // against iperf3's `server_flag` set (raises IESERVERONLY).
+            for (args, want) in [
+                (vec!["-D"], "-D/--daemon"),
+                (vec!["-1"], "-1/--one-off"),
+                (vec!["--server-bitrate-limit", "100M"], "--server-bitrate-limit"),
+                (vec!["--idle-timeout", "30"], "--idle-timeout"),
+                (vec!["--server-max-duration", "60"], "--server-max-duration"),
+                (vec!["--rsa-private-key-path", "/tmp/priv.pem"], "--rsa-private-key-path"),
+                (vec!["--authorized-users-path", "/tmp/users"], "--authorized-users-path"),
+                (vec!["--time-skew-threshold", "5"], "--time-skew-threshold"),
+                (vec!["--use-pkcs1-padding"], "--use-pkcs1-padding"),
+            ] {
+                let mut argv = vec!["riperf3", "-c", "host"];
+                argv.extend(args.iter().copied());
+                let cli = Cli::parse_from(&argv);
+                assert_eq!(
+                    cli.first_server_only_violation(),
                     Some(want),
                     "expected {want} flagged for args {args:?}"
                 );

--- a/riperf3-cli/src/main.rs
+++ b/riperf3-cli/src/main.rs
@@ -30,6 +30,21 @@ fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
         }
     }
 
+    // Reject server-only options on the client (#100), symmetric to the
+    // client-only check above. iperf3 raises IESERVERONLY at parse time for any
+    // option whose parse arm sets `server_flag` (e.g. -D, -1, --idle-timeout,
+    // --rsa-private-key-path, --use-pkcs1-padding); mirror that exact set so a
+    // riperf3 client rejects the same options, before any side effects.
+    if cli.client.is_some() {
+        if let Some(flag) = cli.first_server_only_violation() {
+            return Err(format!(
+                "some option you are trying to set is server only: \
+                 {flag} cannot be used with -c/--client"
+            )
+            .into());
+        }
+    }
+
     // Daemonize BEFORE building the tokio runtime. `daemon()` forks, and forking
     // a process that already has a multi-threaded runtime leaves the child with
     // only the calling thread — no tokio workers — so the daemon would accept the
@@ -251,9 +266,10 @@ async fn async_main(cli: Cli) -> std::result::Result<(), Box<dyn std::error::Err
         if let Some(ref path) = cli.rsa_public_key_path {
             builder = builder.rsa_public_key_path(path);
         }
-        if cli.use_pkcs1_padding {
-            builder = builder.use_pkcs1_padding(true);
-        }
+        // `--use-pkcs1-padding` is server-only and is rejected for clients in
+        // `main` (#100), mirroring iperf3, so it is intentionally not wired on
+        // the client here. The library `ClientBuilder::use_pkcs1_padding` stays
+        // available to embedders.
 
         let client = builder.build()?;
         client.run().await?;


### PR DESCRIPTION
Mirror of #65. iperf3 raises `IESERVERONLY` when a **client** (`-c`) is given an option that only makes sense on the server. riperf3's client silently accepted (and mostly ignored) these, diverging from iperf3's drop-in behavior.

## Change
- New `Cli::first_server_only_violation()` (cli.rs), mirroring `first_client_only_violation()` (#65). Rejects in `main()` **before any side effects** (daemonize, runtime, sockets), with iperf3's canonical text plus the offending flag name:
  `some option you are trying to set is server only: <flag> cannot be used with -c/--client`
- The set is **9 flags, cross-checked against iperf3 `iperf_api.c`** (every `server_flag = 1` arm + the `server_authorized_users` role check): `-D/--daemon`, `-1/--one-off`, `--server-bitrate-limit`, `--idle-timeout`, `--server-max-duration`, `--rsa-private-key-path`, `--authorized-users-path`, `--time-skew-threshold`, `--use-pkcs1-padding`.

## Note on `--use-pkcs1-padding`
It was the one server-only flag previously wired on the riperf3 **client** (main.rs). iperf3 marks it server-only (PKCS#1 v1.5 is the server's path for decoding tokens from *legacy* clients; modern clients always send OAEP), so a client passing it is an error in iperf3 too. The client-side CLI wiring is dropped to match. The library `ClientBuilder::use_pkcs1_padding` setter is **unchanged** and still available to embedders — only the CLI client path matches iperf3.

## Verification
- New unit test `client_flags_server_only_violation`: all 9 flags flagged on a client; bare/clean clients (incl. `--username`/`--rsa-public-key-path`) clean.
- `cargo test`: 400 pass, 0 fail. Host clippy `-D warnings`: clean.
- Manual smoke (real binary): `-c host -D`, `-c host --use-pkcs1-padding`, `-c host --idle-timeout 5` all rejected before connecting; `-s -t 5` still rejected as client-only (#65 intact); a clean client fails only at connection.

Closes #100