### PR TITLE
fix(report): -i 0 whole-test interval + -n/-k start.duration (#107, #114)

### DIFF
--- a/riperf3-cli/tests/byte_limit_summary.rs
+++ b/riperf3-cli/tests/byte_limit_summary.rs
@@ -120,14 +120,15 @@ fn json_byte_limited_summary_uses_measured_elapsed() {
         "bits_per_second {bps} should match bytes*8/seconds {expected_bps}"
     );
 
-    // The `-t` parameter under start.test_start is unchanged (still the nominal
-    // default), distinct from the measured summary window.
+    // For a byte-limited (-n) run, iperf3 zeroes start.test_start.duration — the
+    // -t window doesn't apply (#114). Distinct from the measured summary window
+    // above, which uses the real elapsed (#103).
     let param = v["start"]["test_start"]["duration"]
         .as_f64()
         .unwrap_or_else(|| panic!("missing start.test_start.duration: {out}"));
-    assert!(
-        param >= 5.0,
-        "test_start.duration {param} should stay the nominal -t param, not the measured elapsed"
+    assert_eq!(
+        param, 0.0,
+        "test_start.duration should be 0 for a byte-limited (-n) run (#114), got {param}"
     );
 }
 
@@ -179,9 +180,9 @@ fn server_json_byte_limited_summary_uses_measured_elapsed() {
     let param = v["start"]["test_start"]["duration"]
         .as_f64()
         .unwrap_or_else(|| panic!("missing start.test_start.duration: {out}"));
-    assert!(
-        param >= 5.0,
-        "server test_start.duration {param} should stay the nominal -t param"
+    assert_eq!(
+        param, 0.0,
+        "server test_start.duration should be 0 for a byte-limited (-n) run (#114), got {param}"
     );
 }
 

--- a/riperf3/src/client.rs
+++ b/riperf3/src/client.rs
@@ -682,7 +682,9 @@ impl Client {
         // authoritative final-interval boundary (#55).
         let reporter_end = Arc::new(crate::reporter::ReporterEnd::new());
         let report_start = std::time::Instant::now();
-        let interval_handle = if interval_secs > 0.0 {
+        // `>= 0.0`: `-i 0` still spawns the reporter, which emits a single
+        // whole-test interval rather than none (#107).
+        let interval_handle = if interval_secs >= 0.0 {
             let stream_refs: Vec<_> = streams
                 .iter()
                 .map(|s| crate::reporter::IntervalStreamRef {

--- a/riperf3/src/json_report.rs
+++ b/riperf3/src/json_report.rs
@@ -905,7 +905,14 @@ impl ReportInput {
                     num_streams: self.num_streams,
                     blksize: self.blksize,
                     omit: self.omit,
-                    duration: dur as i32,
+                    // #114: iperf3 zeroes test_start.duration for byte/block-limited
+                    // (-n/-k) runs — the -t window doesn't apply. bytes/blocks below
+                    // carry the actual limit, mirroring iperf3.
+                    duration: if self.bytes > 0 || self.blocks > 0 {
+                        0
+                    } else {
+                        dur as i32
+                    },
                     bytes: self.bytes,
                     blocks: self.blocks,
                     reverse: self.reverse as i32,
@@ -1412,6 +1419,35 @@ mod tests {
         assert_eq!(test_start["interval"], 1.0);
         assert_eq!(test_start["gso"], 0);
         assert_eq!(test_start["gro"], 0);
+    }
+
+    #[test]
+    fn byte_block_limited_zeroes_test_start_duration() {
+        // #114: iperf3 reports test_start.duration=0 for byte/block-limited
+        // (-n/-k) runs — the -t window doesn't apply; the limit lives in
+        // bytes/blocks. A plain -t run keeps the nominal duration.
+        let mk = || {
+            let mut i = base_input();
+            i.streams = vec![tcp_stream(1, true, 10, 10)];
+            i
+        };
+
+        // -n (byte-limited): duration zeroed, bytes carry the limit.
+        let mut n = mk();
+        n.bytes = 50 * 1024 * 1024;
+        let v = serde_json::to_value(n.build()).unwrap();
+        assert_eq!(v["start"]["test_start"]["duration"], 0);
+        assert_eq!(v["start"]["test_start"]["bytes"], 50 * 1024 * 1024);
+
+        // -k (block-limited): duration zeroed.
+        let mut k = mk();
+        k.blocks = 1000;
+        let v = serde_json::to_value(k.build()).unwrap();
+        assert_eq!(v["start"]["test_start"]["duration"], 0);
+
+        // Control: a plain -t run keeps the nominal -t (base_input duration = 10).
+        let v = serde_json::to_value(mk().build()).unwrap();
+        assert_eq!(v["start"]["test_start"]["duration"], 10);
     }
 
     #[test]

--- a/riperf3/src/reporter.rs
+++ b/riperf3/src/reporter.rs
@@ -426,11 +426,20 @@ pub fn spawn_interval_reporter(
     reporter_end: Arc<ReporterEnd>,
     collector: Option<Arc<Mutex<CollectedIntervals>>>,
 ) -> Option<JoinHandle<()>> {
-    if config.interval_secs <= 0.0 {
+    if config.interval_secs < 0.0 {
         return None;
     }
 
-    let interval_dur = Duration::from_secs_f64(config.interval_secs);
+    // `-i 0` (#107) means "one interval = the whole test" in iperf3, not "no
+    // intervals". Use a period that won't fire within any realistic test so the
+    // periodic tick never runs; the end-of-test flush (#55, below) then emits a
+    // single [0, duration] interval (interval_num stays 0). A zero tokio
+    // interval period panics, so it can't be `from_secs_f64(0.0)`.
+    let interval_dur = if config.interval_secs > 0.0 {
+        Duration::from_secs_f64(config.interval_secs)
+    } else {
+        Duration::from_secs(365 * 24 * 60 * 60)
+    };
     let has_retransmits = tcp_info::has_retransmit_info()
         && config.protocol == TransportProtocol::Tcp
         && streams.iter().any(|s| s.is_sender);
@@ -1096,7 +1105,11 @@ mod interval_reporter_tests {
     use std::sync::Arc;
 
     #[tokio::test]
-    async fn disabled_returns_none() {
+    async fn zero_interval_spawns_whole_test_reporter() {
+        // #107: `-i 0` means "one interval = the whole test" (iperf3 parity), so
+        // the reporter IS spawned — it flushes a single [0, duration] interval at
+        // end rather than ticking periodically. Only a negative interval is
+        // rejected (see negative_interval_returns_none).
         let done = Arc::new(AtomicBool::new(false));
         let config = IntervalReporterConfig {
             interval_secs: 0.0,
@@ -1112,7 +1125,7 @@ mod interval_reporter_tests {
         };
         assert!(
             spawn_interval_reporter(config, vec![], done, Arc::new(ReporterEnd::new()), None)
-                .is_none()
+                .is_some()
         );
     }
 
@@ -1248,6 +1261,79 @@ mod interval_reporter_tests {
             "final interval must be a sub-interval partial; start={} end={} dur={dur}",
             last.sum.start,
             last.sum.end
+        );
+    }
+
+    /// #107: with `-i 0`, the reporter must emit exactly ONE interval covering
+    /// the whole test (`[0, duration]`, all bytes) — not zero, and not periodic
+    /// samples. Drives bytes across what would be several 1s intervals, then ends;
+    /// no periodic tick may fire, and the single flushed interval carries the lot.
+    #[tokio::test]
+    async fn zero_interval_emits_single_whole_test_interval() {
+        use crate::reporter::{CollectedIntervals, IntervalStreamRef};
+        use crate::stream::StreamCounters;
+        use std::sync::Mutex;
+        use std::time::Duration;
+
+        let counters = Arc::new(StreamCounters::new());
+        let done = Arc::new(AtomicBool::new(false));
+        let collector = Arc::new(Mutex::new(CollectedIntervals::default()));
+
+        let stream_ref = IntervalStreamRef {
+            id: 1,
+            is_sender: true,
+            counters: counters.clone(),
+            udp_recv_stats: None,
+            raw_fd: None,
+        };
+        let config = IntervalReporterConfig {
+            interval_secs: 0.0, // -i 0
+            protocol: TransportProtocol::Tcp,
+            format_char: 'a',
+            omit_secs: 0,
+            num_streams: 1,
+            forceflush: false,
+            timestamp_format: None,
+            json_stream: false,
+            print: false, // collect-only; assert on the collector
+            blksize: 128 * 1024,
+        };
+        let reporter_end = Arc::new(ReporterEnd::new());
+        let report_start = std::time::Instant::now();
+        let handle = spawn_interval_reporter(
+            config,
+            vec![stream_ref],
+            done.clone(),
+            reporter_end.clone(),
+            Some(collector.clone()),
+        )
+        .expect("reporter spawns for -i 0 (#107)");
+
+        // Accrue bytes across ~600ms (would be several 1s ticks); none must fire.
+        counters.record_sent(1000);
+        tokio::time::sleep(Duration::from_millis(300)).await;
+        counters.record_sent(2000);
+        tokio::time::sleep(Duration::from_millis(300)).await;
+        reporter_end.finish(report_start.elapsed().as_secs_f64());
+        let _ = handle.await;
+
+        let g = collector.lock().unwrap();
+        assert_eq!(
+            g.intervals.len(),
+            1,
+            "-i 0 must emit exactly one whole-test interval, got {}",
+            g.intervals.len()
+        );
+        let only = &g.intervals[0];
+        assert_eq!(
+            only.sum.bytes, 3000,
+            "whole-test interval carries all bytes"
+        );
+        assert_eq!(only.sum.start, 0.0, "whole-test interval starts at 0");
+        assert!(
+            only.sum.end > 0.0,
+            "whole-test interval ends at the measured duration; got {}",
+            only.sum.end
         );
     }
 


### PR DESCRIPTION
Two low-risk iperf3 output-faithfulness fixes for 0.7.1. Both are reporting/JSON only — **no data-path change**.

## #114 — `test_start.duration` for byte/block-limited runs
iperf3 zeroes `test_start.duration` for `-n`/`-k` runs (the `-t` window doesn't apply; the limit is carried in `bytes`/`blocks`). riperf3 reported the default `-t` (10). Fixed in `ReportInput::build` — a single site that covers both client and server `-J`.

## #107 — `-i 0` emits one whole-test interval
iperf3 treats `-i 0` as *one interval = the whole test* (a single `[0, duration]` sample), not *no intervals*. riperf3 skipped the interval reporter entirely when `interval_secs == 0`, emitting none (empty `-J` `intervals`, no `--json-stream` interval event, no text interval line).

Fix: spawn the reporter for `interval_secs == 0` too, but give its ticker a period that can't fire within a test, so only the end-of-test flush (#55) runs — and with `interval_num == 0` that naturally produces the single `[0, duration]` interval carrying the whole-test bytes. **Reuses the battle-tested #55 path**; no new emit logic. Covers text, `-J`, and `--json-stream` identically.

## Verification
- New unit tests: `byte_block_limited_zeroes_test_start_duration` (#114, incl. `-t` control + `-k`), `zero_interval_emits_single_whole_test_interval` (#107, drives the real reporter via the #55 harness, asserts exactly 1 interval `[0, end]` with all bytes). Updated the old `disabled_returns_none` → `zero_interval_spawns_whole_test_reporter` (new contract; negative interval still rejected).
- `cargo test`: lib 258, integration 75, all green. clippy + fmt clean.
- **End-to-end (real binary):** `-c … -t 1 -i 0 -J` → `intervals: 1, sum [0,1]`; `-c … -n 1M -J` → `test_start.duration: 0, bytes: 1048576`.

Closes #114
Closes #107