### PR TITLE
fix(report): report applied congestion (#37) + abort on -w clamp (#97)

### DIFF
--- a/riperf3/src/client.rs
+++ b/riperf3/src/client.rs
@@ -469,6 +469,12 @@ impl Client {
                     let sock = socket2::SockRef::from(&data_stream);
                     let sndbuf_actual = sock.send_buffer_size().ok().map(|v| v as u64);
                     let rcvbuf_actual = sock.recv_buffer_size().ok().map(|v| v as u64);
+                    // #97: abort if the kernel clamped -w below the request, like
+                    // iperf3 (IESETBUF2). Before the stream moves into its task.
+                    net::check_socket_window(self.window, sndbuf_actual, rcvbuf_actual)?;
+                    // #37: the congestion algorithm actually in effect (the kernel
+                    // default when -C is unset), for `congestion_used`.
+                    let congestion_used = net::tcp_congestion_used(&data_stream);
 
                     let stream_id = iperf3_stream_id(i);
                     let is_sender = i < send_count;
@@ -538,6 +544,7 @@ impl Client {
                         peer_addr,
                         sndbuf_actual,
                         rcvbuf_actual,
+                        congestion_used,
                     });
                 }
             }
@@ -588,6 +595,8 @@ impl Client {
                     net::apply_socket_window(&sock, self.window);
                     let sndbuf_actual = sock.send_buffer_size().ok().map(|v| v as u64);
                     let rcvbuf_actual = sock.recv_buffer_size().ok().map(|v| v as u64);
+                    // #97: abort if -w was clamped below the request (iperf3 IESETBUF2).
+                    net::check_socket_window(self.window, sndbuf_actual, rcvbuf_actual)?;
 
                     // Convert tokio UdpSocket to std for blocking I/O
                     let std_sock = udp_sock.into_std().map_err(RiperfError::Io)?;
@@ -635,6 +644,7 @@ impl Client {
                             peer_addr,
                             sndbuf_actual,
                             rcvbuf_actual,
+                            congestion_used: None,
                         });
                         continue;
                     };
@@ -650,6 +660,7 @@ impl Client {
                         peer_addr,
                         sndbuf_actual,
                         rcvbuf_actual,
+                        congestion_used: None,
                     });
                 }
             }
@@ -844,7 +855,9 @@ impl Client {
             } else {
                 -1
             },
-            congestion_used: None,
+            // #37: the congestion algorithm actually in effect (read back at stream
+            // creation); None for UDP / unsupported platforms.
+            congestion_used: streams.first().and_then(|s| s.congestion_used.clone()),
             streams: stream_results,
         }
     }
@@ -1102,10 +1115,10 @@ impl Client {
                 remote_user,
                 remote_system,
             },
-            // Reporting the *actually-applied* congestion algorithm is #37; omit
-            // the field until that read-back lands rather than emit the requested
-            // value (which may differ from what the kernel used).
-            congestion_used: None,
+            // #37: the congestion algorithm actually in effect on the data socket,
+            // read back via getsockopt(TCP_CONGESTION) at stream creation (the
+            // kernel default when -C is unset). None for UDP / unsupported platforms.
+            congestion_used: streams.first().and_then(|s| s.congestion_used.clone()),
             cookie: start_meta.cookie.clone(),
             tcp_mss_default: start_meta.tcp_mss_default,
             // -M/--set-mss request: emitted as start.tcp_mss (TCP only), which

--- a/riperf3/src/json_report.rs
+++ b/riperf3/src/json_report.rs
@@ -822,11 +822,11 @@ impl ReportInput {
             (None, None)
         } else if self.is_server {
             // The peer's (client's) congestion algorithm is never exchanged to the
-            // server, so only one side is emitted — the server's local algorithm,
-            // on the side matching its role: receiver in forward, sender in reverse
-            // and bidir (iperf_api.c:4544 swaps by stream_must_be_sender). Until
-            // #37 reads the applied algorithm back, `congestion_used` is None on
-            // both client and server, so both currently omit the field.
+            // server, so only one side is emitted — the server's local algorithm
+            // (read back via getsockopt(TCP_CONGESTION), #37), on the side matching
+            // its role: receiver in forward, sender in reverse and bidir
+            // (iperf_api.c:4544 swaps by stream_must_be_sender). None for UDP /
+            // platforms without TCP_CONGESTION, in which case the field is omitted.
             let local = self.congestion_used.clone();
             if self.reverse || self.bidir {
                 (local, None)

--- a/riperf3/src/net.rs
+++ b/riperf3/src/net.rs
@@ -363,6 +363,58 @@ pub(crate) fn apply_socket_window(sock: &socket2::SockRef<'_>, window: Option<i3
     }
 }
 
+/// Verify the kernel granted at least the requested `-w/--window` size. iperf3
+/// sets `SO_SNDBUF`/`SO_RCVBUF` to the requested value and ABORTS the test
+/// (IESETBUF2, "socket buffer size not set correctly") when the realized size is
+/// smaller — i.e. the kernel clamped below the request (`wmem_max`/`rmem_max`).
+/// Mirror that: error when `requested > realized` on either buffer. A `None`
+/// window or an unreadable realized size is a no-op (best-effort, like the
+/// readback the values come from). The kernel doubles the set value, so this
+/// only fires on a genuine clamp, exactly as in iperf3. (#97)
+pub(crate) fn check_socket_window(
+    window: Option<i32>,
+    sndbuf_actual: Option<u64>,
+    rcvbuf_actual: Option<u64>,
+) -> Result<()> {
+    if let Some(req) = window {
+        if req > 0 {
+            let req = req as u64;
+            if sndbuf_actual.is_some_and(|a| req > a) || rcvbuf_actual.is_some_and(|a| req > a) {
+                return Err(RiperfError::Aborted(
+                    "socket buffer size not set correctly".to_string(),
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Read the TCP congestion-control algorithm actually in effect on a connected
+/// stream, via `getsockopt(TCP_CONGESTION)`, for the `congestion_used` report
+/// (#37). Returns the algorithm name (e.g. "cubic", "bbr"); iperf3 reports the
+/// in-effect CC, which defaults to the kernel default when `-C` is unset. `None`
+/// when unreadable or on a platform without TCP_CONGESTION.
+#[cfg(any(target_os = "linux", target_os = "freebsd"))]
+pub(crate) fn tcp_congestion_used(stream: &TcpStream) -> Option<String> {
+    use nix::sys::socket::{self, sockopt};
+    // getsockopt(TCP_CONGESTION) returns a fixed-size, nul-padded buffer (e.g.
+    // "bbr\0\0…"); trim to the C-string so we emit a clean "bbr" like iperf3.
+    socket::getsockopt(stream, sockopt::TcpCongestion)
+        .ok()
+        .map(|os| {
+            os.to_string_lossy()
+                .trim_end_matches('\0')
+                .trim()
+                .to_string()
+        })
+        .filter(|s| !s.is_empty())
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "freebsd")))]
+pub(crate) fn tcp_congestion_used(_stream: &TcpStream) -> Option<String> {
+    None
+}
+
 /// Configure a connected TCP stream with all negotiated socket options.
 pub fn configure_tcp_stream_full(
     stream: &TcpStream,
@@ -1277,6 +1329,54 @@ mod tests {
             "TCP_MAXSEG should be readable on a connected socket"
         );
         assert!(mss.unwrap() > 0, "MSS should be positive, got {mss:?}");
+    }
+
+    #[cfg(any(target_os = "linux", target_os = "freebsd"))]
+    #[tokio::test]
+    async fn tcp_congestion_used_returns_clean_name() {
+        // #37: a connected TCP stream reports its in-effect congestion algorithm,
+        // trimmed to a clean C-string (no nul padding / trailing whitespace) like
+        // iperf3 — getsockopt(TCP_CONGESTION) returns a fixed-size padded buffer.
+        let listener = tcp_listen(Some("127.0.0.1"), 0, None).await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let client_task = tokio::spawn(async move {
+            tcp_connect("127.0.0.1", port, None, None, None, false, None)
+                .await
+                .unwrap()
+        });
+        let (_server, _) = listener.accept().await.unwrap();
+        let client = client_task.await.unwrap();
+
+        let cc =
+            tcp_congestion_used(&client).expect("TCP_CONGESTION readable on a connected socket");
+        assert!(!cc.is_empty(), "congestion name must be non-empty");
+        assert!(
+            !cc.contains('\0'),
+            "must be trimmed of nul padding, got {cc:?}"
+        );
+        assert_eq!(cc, cc.trim(), "no leading/trailing whitespace, got {cc:?}");
+    }
+
+    #[test]
+    fn check_socket_window_errors_only_when_clamped() {
+        // #97: error iff the realized buffer is smaller than the requested -w
+        // (the kernel clamped below the request); otherwise proceed.
+        assert!(check_socket_window(None, Some(1024), Some(1024)).is_ok());
+        assert!(check_socket_window(Some(0), Some(1), Some(1)).is_ok());
+        // realized >= requested (the common case; the kernel doubles the set value).
+        assert!(check_socket_window(Some(1000), Some(2000), Some(2000)).is_ok());
+        assert!(check_socket_window(Some(1000), Some(1000), Some(1000)).is_ok());
+        // either buffer clamped below the request -> error.
+        assert!(check_socket_window(Some(1000), Some(999), Some(2000)).is_err());
+        assert!(check_socket_window(Some(1000), Some(2000), Some(999)).is_err());
+        // an unreadable realized size is a no-op (best-effort).
+        assert!(check_socket_window(Some(1000), None, None).is_ok());
+        // matches iperf3's IESETBUF2 text.
+        let e = check_socket_window(Some(1000), Some(10), Some(10)).unwrap_err();
+        assert!(
+            format!("{e}").contains("socket buffer size not set correctly"),
+            "unexpected error: {e}"
+        );
     }
 
     #[cfg(unix)]

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -341,6 +341,10 @@ impl Server {
                     let sock = socket2::SockRef::from(&data_stream);
                     let sndbuf_actual = sock.send_buffer_size().ok().map(|v| v as u64);
                     let rcvbuf_actual = sock.recv_buffer_size().ok().map(|v| v as u64);
+                    // #97: abort if the kernel clamped -w below the request (iperf3 IESETBUF2).
+                    net::check_socket_window(cfg.window, sndbuf_actual, rcvbuf_actual)?;
+                    // #37: congestion algorithm actually in effect on this stream.
+                    let congestion_used = net::tcp_congestion_used(&data_stream);
 
                     let task = if is_sender {
                         let buf = make_send_buffer(cfg.blksize, false);
@@ -373,6 +377,7 @@ impl Server {
                         peer_addr: peer_addr_s,
                         sndbuf_actual,
                         rcvbuf_actual,
+                        congestion_used,
                     });
                 }
             }
@@ -623,7 +628,9 @@ impl Server {
             } else {
                 -1
             },
-            congestion_used: None,
+            // #37: the congestion algorithm actually in effect (read back at stream
+            // creation); None for UDP / unsupported platforms.
+            congestion_used: streams.first().and_then(|s| s.congestion_used.clone()),
             streams: result_streams,
         };
 
@@ -795,6 +802,8 @@ impl Server {
                     sock.recv_buffer_size().ok().map(|v| v as u64),
                 )
             };
+            // #97: abort if -w was clamped below the request (iperf3 IESETBUF2).
+            net::check_socket_window(cfg.window, sndbuf_actual, rcvbuf_actual)?;
 
             let std_sock = data_sock.into_std().map_err(RiperfError::Io)?;
 
@@ -821,6 +830,7 @@ impl Server {
                     peer_addr: peer_addr_s,
                     sndbuf_actual,
                     rcvbuf_actual,
+                    congestion_used: None,
                 });
             } else {
                 let c = counters.clone();
@@ -843,6 +853,7 @@ impl Server {
                     peer_addr: peer_addr_s,
                     sndbuf_actual,
                     rcvbuf_actual,
+                    congestion_used: None,
                 });
             }
         }
@@ -969,6 +980,10 @@ impl Server {
                 sock.recv_buffer_size().ok().map(|v| v as u64),
             )
         };
+        // #97: abort if -w was clamped below the request (iperf3 IESETBUF2). On the
+        // single-socket demux path the recv buffer is sized to the aggregate, but a
+        // genuine wmem/rmem_max clamp still drives the readback below the request.
+        net::check_socket_window(cfg.window, sndbuf_actual, rcvbuf_actual)?;
         // The connected recycling path reports each stream's local_host as the
         // kernel-selected source IP for that client. The demux socket is never
         // connect()'d, so its own local_addr is the wildcard bind — only on a
@@ -1027,6 +1042,7 @@ impl Server {
                     peer_addr: Some(client_addr),
                     sndbuf_actual,
                     rcvbuf_actual,
+                    congestion_used: None,
                 });
             } else {
                 let stats = Arc::new(Mutex::new(UdpRecvStats::new()));
@@ -1052,6 +1068,7 @@ impl Server {
                     peer_addr: Some(client_addr),
                     sndbuf_actual,
                     rcvbuf_actual,
+                    congestion_used: None,
                 });
             }
         }
@@ -1213,9 +1230,10 @@ impl Server {
                 remote_user: 0.0,
                 remote_system: 0.0,
             },
-            // Reporting the server's actually-applied congestion is #37; until then
-            // it stays None (omitted), consistent with the client.
-            congestion_used: None,
+            // #37: the congestion algorithm actually in effect on the server's data
+            // socket, read back via getsockopt(TCP_CONGESTION). None for UDP /
+            // unsupported platforms.
+            congestion_used: streams.first().and_then(|s| s.congestion_used.clone()),
             cookie: String::from_utf8_lossy(&cookie[..protocol::COOKIE_SIZE - 1]).to_string(),
             // iperf3's server emits tcp_mss_default = 0 (it never reads the control
             // socket MSS); the requested -M (via params) still surfaces as tcp_mss.

--- a/riperf3/src/stream.rs
+++ b/riperf3/src/stream.rs
@@ -325,6 +325,10 @@ pub struct DataStream {
     /// for the `-J` `start.sndbuf_actual`/`rcvbuf_actual` fields (#36 PR3).
     pub sndbuf_actual: Option<u64>,
     pub rcvbuf_actual: Option<u64>,
+    /// The TCP congestion-control algorithm actually in effect on this stream's
+    /// socket (read back via `getsockopt(TCP_CONGESTION)`), for the `congestion_used`
+    /// report field (#37). `None` for UDP and on platforms without TCP_CONGESTION.
+    pub congestion_used: Option<String>,
 }
 
 /// Build the shared `-n`/`-k` byte budget the sending streams decrement, or


### PR DESCRIPTION
Two iperf3 socket-option faithfulness fixes, both verified live against the iperf3 binary.

## #37 — `congestion_used` was always None
Read back the actually-applied congestion algorithm via `getsockopt(TCP_CONGESTION)` at stream creation (the kernel default when `-C` is unset), trimmed to a clean C-string (the syscall returns a nul-padded fixed buffer — riperf3 was about to emit `bbr\0\0…`). Threaded through `DataStream` alongside `sndbuf_actual`; flows to the `end` block's `sender/receiver_tcp_congestion`. `None` for UDP / platforms without TCP_CONGESTION. **iperf3 omits `congestion_used` from the `start` block — confirmed via the binary — so riperf3 keeps it absent there too** (the field I edited at the report level feeds `end`, not `start`).

## #97 — `-w` clamp silently honored
A `-w/--window` the kernel can't satisfy was silently honored with a smaller buffer. iperf3 instead **aborts the test** (`IESETBUF2`, "socket buffer size not set correctly") when the realized `SO_SNDBUF`/`SO_RCVBUF` is smaller than requested (`iperf_tcp.c:348-370`). Decided with the maintainer: **match iperf3** (the issue's "warn" premise was wrong). `net::check_socket_window` errors when `requested > realized` on either buffer, at every TCP/UDP stream-creation readback (client + server). The kernel doubles the set value, so it only fires on a genuine `wmem_max`/`rmem_max` clamp — exactly iperf3's threshold.

## Verification
- `cargo test` (full, both crates): lib 260, all suites green. `xcheck` 7/7 (congestion readback is cfg-gated linux/freebsd). clippy + fmt clean.
- Unit tests: `check_socket_window_errors_only_when_clamped` (clamp logic + iperf3 message), `tcp_congestion_used_returns_clean_name` (connected socket, no nul padding).
- **Live parity vs iperf3:** `-w 16M` (> 2×wmem_max) aborts on both tools; `-w 1M` proceeds; `congestion_used` = clean `"bbr"` in `end`, absent from `start`.

## Reviewer note — cross-platform `-w` risk
#97 makes `-w` aborts environment-sensitive (threshold = 2×wmem_max on Linux). The CLI tests only parse/build (no real socket → no abort). The one real-run `-w` test is `integration.rs:742` (`-w 256K`), which is under `2×212992` (default Linux wmem_max) so it's safe on standard Linux CI — but please scrutinize the **macOS/Windows/FreeBSD native** jobs, where SO_*BUF readback semantics differ and could in principle abort a 256K request.

Closes #37
Closes #97