### PR TITLE
Bump to 0.7.1

### DIFF
--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -14,6 +14,17 @@ matrix below were measured on our two-VM sandbox with internal tooling (the
 [Reproducing](#reproducing) so the numbers stay auditable, but they are
 environment-specific.
 
+> **0.7.1 status.** Re-verified at the `0.7.1` patch: the compatibility matrix is
+> all-PASS (incl. iperf3 3.12 interop and the `-w 256K` cell that exercises #97) and
+> a fresh full N=30 throughput campaign reproduces the **same verdict** as 0.7.0 —
+> parity-or-faster vs iperf3 (12 riperf3 / 3 parity / 1 within-noise; the lone noise
+> cell is again TCP rev P1 v4, this run −1.8% at p=0.012). 0.7.1 is a batch of iperf3
+> output-faithfulness fixes (#100 client server-only rejection, #114/#107 report
+> fields, #37 `congestion_used` read-back, #97 `-w` clamp abort) plus internal
+> cleanup (#124/#125/#129) — all CLI / reporting / socket-setup, with **zero
+> throughput-data-path impact**, so the tables below carry forward from the 0.7.0
+> campaign and this re-run confirms them regression-free.
+>
 > **0.7.0 status.** Re-verified at the final 0.7.0 commit (post the breaking-API
 > set): the compatibility matrix is all-PASS and the throughput campaign was
 > **re-measured fresh** (full N=30) — the riperf3-vs-iperf3 verdict is stable
@@ -39,7 +50,7 @@ environment-specific.
 | Host | Intel i9-13900K, Linux 7.0.11-arch1-1 (Arch), KVM |
 | Guests | 2× Debian 13 (Trixie), Linux 6.12.90+deb13.1-cloud-amd64, 8 vCPU, 8 GB RAM each |
 | NIC | virtio-net (vhost=on), bridged, MTU 9000; IPv4 `172.20.0.0/24` + IPv6 `fd00:20::/64` |
-| riperf3 | 0.7.0 |
+| riperf3 | 0.7.1 |
 | iperf3 | 3.20+ (cJSON 1.7.15), built from source |
 
 ## Compatibility matrix (iperf3 interop)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,53 @@ This changelog begins at 0.6.0. For earlier releases (0.1.1–0.5.4), see the
 [git history](https://github.com/therealevanhenry/riperf3/commits/main) and
 release tags.
 
+## [0.7.1] - 2026-06-08
+
+The first non-breaking `0.7.x` patch — a batch of iperf3 **output-faithfulness**
+fixes (flags and report fields that diverged from iperf3) plus internal cleanup
+from the 0.7.0 API refactor. No public API change. The default data path is
+unchanged: the cross-tool compatibility matrix is all-PASS and a fresh full N=30
+throughput campaign vs iperf3 is regression-free (parity-or-faster) — see
+[BENCHMARKS.md](BENCHMARKS.md).
+
+### Added
+- **`congestion_used` now reports the congestion-control algorithm actually in
+  effect** (#37). Read back via `getsockopt(TCP_CONGESTION)` at stream creation
+  (the kernel default when `-C` is unset) and surfaced in the `end` block's
+  `sender_tcp_congestion`/`receiver_tcp_congestion`, matching iperf3; previously
+  it was always absent. TCP-only (Linux/FreeBSD).
+
+### Changed
+- **A `-w/--window` the kernel cannot satisfy now aborts the test** (#97),
+  matching iperf3's `IESETBUF2` ("socket buffer size not set correctly"). When the
+  realized `SO_SNDBUF`/`SO_RCVBUF` is smaller than requested (the kernel clamped to
+  `wmem_max`/`rmem_max`), riperf3 errors instead of silently running with a smaller
+  buffer. **Behavior change**: a previously-tolerated oversized `-w` now fails the
+  run, surfacing the misconfiguration rather than hiding it.
+- **The client rejects server-only options** (#100), like iperf3's `IESERVERONLY`.
+  `-D/--daemon`, `-1/--one-off`, `--idle-timeout`, `--server-bitrate-limit`,
+  `--server-max-duration`, `--rsa-private-key-path`, `--authorized-users-path`,
+  `--time-skew-threshold`, and `--use-pkcs1-padding` are now rejected on a client,
+  before any side effects. (`--use-pkcs1-padding` was previously accepted on the
+  client; it is server-only in iperf3.)
+
+### Fixed
+- **`-i 0` now emits one whole-test interval** (#107) covering `0.00`–`<duration>`,
+  matching iperf3's "one interval = the whole test"; riperf3 emitted none. Affects
+  text, `-J`, and `--json-stream`.
+- **`test_start.duration` is now `0` for byte/block-limited (`-n`/`-k`) runs**
+  (#114), matching iperf3 — the `-t` window doesn't apply; the limit is reported in
+  `bytes`/`blocks`. riperf3 reported the default `-t`.
+
+### Internal
+- Extracted the CLI arg→builder mapping into `Cli::build_client`/`build_server` so
+  the wiring tests exercise the real `main.rs` mapping instead of a hand-maintained
+  copy (#124) — closing the drift blind spot and covering every previously-untested
+  flag (49 → 80 CLI wiring tests).
+- Triaged dead/test-only code surfaced by the 0.7.0 module retraction (#125) and
+  dropped redundant Windows-target `as i32` casts flagged by clippy (#129). No
+  behavior change.
+
 ## [0.7.0] - 2026-06-08
 
 A minor bump (the first `0.x` minor since 0.6.0). The headline is a deliberate

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -793,7 +793,7 @@ dependencies = [
 
 [[package]]
 name = "riperf3"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "base64",
  "libc",
@@ -814,7 +814,7 @@ dependencies = [
 
 [[package]]
 name = "riperf3-cli"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "clap",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.7.0"
+version = "0.7.1"
 authors = ["Evan Henry"]
 edition = "2021"
 homepage = "https://github.com/therealevanhenry/riperf3"

--- a/riperf3-cli/Cargo.toml
+++ b/riperf3-cli/Cargo.toml
@@ -13,7 +13,7 @@ readme = "../README.md"
 
 [dependencies]
 # riperf3 workspace dependencies
-riperf3 = { path = "../riperf3", version = "0.7.0" }
+riperf3 = { path = "../riperf3", version = "0.7.1" }
 
 # external dependencies
 clap.workspace = true


### PR DESCRIPTION
Release-prep PR for **0.7.1** (version bump + CHANGELOG + BENCHMARKS refresh; no code change).

0.7.1 is the first non-breaking 0.7.x patch — a batch of iperf3 output-faithfulness fixes plus internal cleanup, all merged on main and each through ≥2 cold-review rounds + full CI:
- **#100** client rejects server-only options (IESERVERONLY)
- **#114** `-n/-k` zeroes `test_start.duration`
- **#107** `-i 0` emits one whole-test interval
- **#37** `congestion_used` read back and reported
- **#97** `-w` clamp aborts the test (iperf3 IESETBUF2) — *behavior change*
- **#129/#125/#124** Windows clippy + dead-code cleanup + CLI wiring-test extraction (49→80 tests)

**Gate:** compat matrix 100% PASS (incl. iperf3 3.12 interop and the `-w 256K`/#97 cell); a fresh full N=30 perf campaign is regression-free (parity-or-faster vs iperf3; 12/3/1, the lone noise cell TCP rev P1 v4). No public lib API change → patch bump (SemVer CI confirms).

Version bumped in root `Cargo.toml` + `riperf3-cli` path-dep + `Cargo.lock`. After merge: `gh release create v0.7.1` then `cargo publish` lib-first (held for Evan's go).