### PR TITLE
docs: re-date 0.7.1 to 2026-06-09 (publish day)

### DIFF
--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -46,7 +46,7 @@ environment-specific.
 
 | | |
 |---|---|
-| Date | 2026-06-08 |
+| Date | 2026-06-09 |
 | Host | Intel i9-13900K, Linux 7.0.11-arch1-1 (Arch), KVM |
 | Guests | 2× Debian 13 (Trixie), Linux 6.12.90+deb13.1-cloud-amd64, 8 vCPU, 8 GB RAM each |
 | NIC | virtio-net (vhost=on), bridged, MTU 9000; IPv4 `172.20.0.0/24` + IPv6 `fd00:20::/64` |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ This changelog begins at 0.6.0. For earlier releases (0.1.1–0.5.4), see the
 [git history](https://github.com/therealevanhenry/riperf3/commits/main) and
 release tags.
 
-## [0.7.1] - 2026-06-08
+## [0.7.1] - 2026-06-09
 
 The first non-breaking `0.7.x` patch — a batch of iperf3 **output-faithfulness**
 fixes (flags and report fields that diverged from iperf3) plus internal cleanup


### PR DESCRIPTION
Trivial date-only fix: the date rolled to 2026-06-09 during the N=30 perf campaign, so re-date the CHANGELOG `[0.7.1]` entry and the BENCHMARKS env stamp to the publish day (release convention; matches the GitHub-release + crates.io timestamps). No code, no other content change.