### PR TITLE
fix(report): split bidir -J interval sums per direction (#54) + dead-field cleanup (#139)

### DIFF
--- a/riperf3-cli/tests/bidir_intervals.rs
+++ b/riperf3-cli/tests/bidir_intervals.rs
@@ -1,0 +1,288 @@
+//! CLI integration test: `--bidir -J` intervals must split the two directions
+//! like iperf3 — `sum` for the forward (client→server) flow and
+//! `sum_bidir_reverse` for the reverse — instead of lumping both into one
+//! `sum` (#54). Per-stream interval entries and the end block were already
+//! split; this locks in the per-interval aggregates on both roles.
+
+use std::io::Read;
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+use serde_json::Value;
+
+fn free_port() -> u16 {
+    std::net::TcpListener::bind("127.0.0.1:0")
+        .expect("bind ephemeral port")
+        .local_addr()
+        .expect("local_addr")
+        .port()
+}
+
+/// Kills the wrapped child on drop so a spawned server is reaped on panic.
+struct ChildGuard(std::process::Child);
+impl Drop for ChildGuard {
+    fn drop(&mut self) {
+        let _ = self.0.kill();
+        let _ = self.0.wait();
+    }
+}
+
+/// See json_stream.rs: a generous fixed margin for the server to bind before the
+/// client connects, robust on loaded CI runners.
+const SERVER_BIND_WAIT: Duration = Duration::from_secs(2);
+
+/// Spawn `riperf3` with `args`, bound its run, and return captured stdout.
+fn run_capturing(args: &[&str], timeout: Duration, who: &str) -> String {
+    let bin = env!("CARGO_BIN_EXE_riperf3");
+    let mut child = Command::new(bin)
+        .args(args)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .unwrap_or_else(|e| panic!("{who}: spawn failed: {e}"));
+
+    let deadline = Instant::now() + timeout;
+    loop {
+        match child.try_wait().expect("try_wait") {
+            Some(_) => break,
+            None if Instant::now() >= deadline => {
+                let _ = child.kill();
+                let _ = child.wait();
+                panic!("{who}: timed out");
+            }
+            None => std::thread::sleep(Duration::from_millis(50)),
+        }
+    }
+    let mut out = String::new();
+    child
+        .stdout
+        .take()
+        .unwrap()
+        .read_to_string(&mut out)
+        .unwrap();
+    out
+}
+
+fn spawn_server(port_str: &str) -> ChildGuard {
+    let bin = env!("CARGO_BIN_EXE_riperf3");
+    let g = ChildGuard(
+        Command::new(bin)
+            .args(["-s", "-1", "-p", port_str])
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("spawn server"),
+    );
+    std::thread::sleep(SERVER_BIND_WAIT);
+    g
+}
+
+/// Every interval must carry the direction-split pair with the expected sender
+/// flags; returns the (forward, reverse) byte totals across all intervals.
+fn assert_split_intervals(v: &Value, fwd_sender: bool, who: &str) -> (u64, u64) {
+    let intervals = v["intervals"]
+        .as_array()
+        .unwrap_or_else(|| panic!("{who}: missing intervals array: {v}"));
+    assert!(!intervals.is_empty(), "{who}: no intervals: {v}");
+    let (mut fwd_bytes, mut rev_bytes) = (0u64, 0u64);
+    for (n, i) in intervals.iter().enumerate() {
+        assert_eq!(
+            i["sum"]["sender"].as_bool(),
+            Some(fwd_sender),
+            "{who}: interval {n} sum.sender: {i}"
+        );
+        let rev = i
+            .get("sum_bidir_reverse")
+            .unwrap_or_else(|| panic!("{who}: interval {n} missing sum_bidir_reverse: {i}"));
+        assert_eq!(
+            rev["sender"].as_bool(),
+            Some(!fwd_sender),
+            "{who}: interval {n} sum_bidir_reverse.sender: {rev}"
+        );
+        fwd_bytes += i["sum"]["bytes"].as_u64().unwrap_or(0);
+        rev_bytes += rev["bytes"].as_u64().unwrap_or(0);
+    }
+    (fwd_bytes, rev_bytes)
+}
+
+/// Client `--bidir -J`: forward (its senders) in `sum` with sender=true, the
+/// reverse flow in `sum_bidir_reverse` with sender=false and no retransmits.
+#[test]
+fn tcp_bidir_client_intervals_split_directions() {
+    let port = free_port();
+    let ps = port.to_string();
+    let mut server = spawn_server(&ps);
+
+    let out = run_capturing(
+        &[
+            "-c",
+            "127.0.0.1",
+            "-p",
+            &ps,
+            "--bidir",
+            "-t",
+            "2",
+            "-i",
+            "1",
+            "-J",
+        ],
+        Duration::from_secs(20),
+        "client",
+    );
+    let _ = server.0.wait();
+
+    let v: Value = serde_json::from_str(&out)
+        .unwrap_or_else(|e| panic!("client --bidir -J is not valid JSON ({e}): {out}"));
+    let (fwd, rev) = assert_split_intervals(&v, true, "client");
+    assert!(fwd > 0, "no forward bytes across intervals: {out}");
+    assert!(rev > 0, "no reverse bytes across intervals: {out}");
+
+    // A received-flow sum never carries a retransmit count, on any platform.
+    for i in v["intervals"].as_array().unwrap() {
+        assert!(
+            i["sum_bidir_reverse"].get("retransmits").is_none(),
+            "receive-direction sum must omit retransmits: {i}"
+        );
+    }
+
+    // Per-stream interval entries cover both directions.
+    let senders: Vec<bool> = v["intervals"][0]["streams"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|s| s["sender"].as_bool().unwrap())
+        .collect();
+    assert!(
+        senders.contains(&true) && senders.contains(&false),
+        "interval streams should span both directions: {senders:?}"
+    );
+}
+
+/// Server `-s -J` for the same bidir run: its forward flow is the received one,
+/// so the roles flip — `sum` sender=false, `sum_bidir_reverse` sender=true.
+#[test]
+fn tcp_bidir_server_intervals_split_directions() {
+    let port = free_port();
+    let ps = port.to_string();
+    let bin = env!("CARGO_BIN_EXE_riperf3");
+
+    let mut server = ChildGuard(
+        Command::new(bin)
+            .args(["-s", "-1", "-J", "-p", &ps])
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("spawn server"),
+    );
+    std::thread::sleep(SERVER_BIND_WAIT);
+
+    let _client = run_capturing(
+        &[
+            "-c",
+            "127.0.0.1",
+            "-p",
+            &ps,
+            "--bidir",
+            "-t",
+            "2",
+            "-i",
+            "1",
+        ],
+        Duration::from_secs(20),
+        "client",
+    );
+
+    let mut out = String::new();
+    server
+        .0
+        .stdout
+        .take()
+        .unwrap()
+        .read_to_string(&mut out)
+        .unwrap();
+    let _ = server.0.wait();
+
+    let v: Value = serde_json::from_str(&out)
+        .unwrap_or_else(|e| panic!("server --bidir -J is not valid JSON ({e}): {out}"));
+    let (fwd, rev) = assert_split_intervals(&v, false, "server");
+    assert!(fwd > 0, "no forward bytes across intervals: {out}");
+    assert!(rev > 0, "no reverse bytes across intervals: {out}");
+}
+
+/// UDP bidir: each direction's sum carries that direction's UDP detail — the
+/// receiving flow reports measured jitter/loss, the sending flow only a sent
+/// packet count, exactly like iperf3.
+#[test]
+fn udp_bidir_interval_sums_split_udp_stats() {
+    let port = free_port();
+    let ps = port.to_string();
+    let mut server = spawn_server(&ps);
+
+    let out = run_capturing(
+        &[
+            "-c",
+            "127.0.0.1",
+            "-p",
+            &ps,
+            "-u",
+            "--bidir",
+            "-t",
+            "2",
+            "-i",
+            "1",
+            "-J",
+        ],
+        Duration::from_secs(20),
+        "client",
+    );
+    let _ = server.0.wait();
+
+    let v: Value = serde_json::from_str(&out)
+        .unwrap_or_else(|e| panic!("client -u --bidir -J is not valid JSON ({e}): {out}"));
+    let (fwd, rev) = assert_split_intervals(&v, true, "client");
+    assert!(fwd > 0 && rev > 0, "bytes must flow both ways: {out}");
+
+    for i in v["intervals"].as_array().unwrap() {
+        let sum = &i["sum"];
+        // Client's forward direction sends: packet count only.
+        assert!(sum.get("packets").is_some(), "sending sum has packets: {i}");
+        assert!(
+            sum.get("jitter_ms").is_none() && sum.get("lost_packets").is_none(),
+            "sending sum must not carry measured receive stats: {i}"
+        );
+        // Reverse direction receives: measured jitter/loss.
+        let rev = &i["sum_bidir_reverse"];
+        assert!(
+            rev.get("jitter_ms").is_some() && rev.get("lost_packets").is_some(),
+            "receiving sum must carry measured stats: {i}"
+        );
+    }
+}
+
+/// A plain forward run must not grow a `sum_bidir_reverse` key.
+#[test]
+fn tcp_forward_intervals_have_no_bidir_reverse() {
+    let port = free_port();
+    let ps = port.to_string();
+    let mut server = spawn_server(&ps);
+
+    // `-t 2 -i 1` so at least one boundary tick fires mid-run; a run ending
+    // exactly on its only boundary can legitimately emit zero intervals (#55).
+    let out = run_capturing(
+        &["-c", "127.0.0.1", "-p", &ps, "-t", "2", "-i", "1", "-J"],
+        Duration::from_secs(20),
+        "client",
+    );
+    let _ = server.0.wait();
+
+    let v: Value = serde_json::from_str(&out)
+        .unwrap_or_else(|e| panic!("client -J is not valid JSON ({e}): {out}"));
+    let intervals = v["intervals"].as_array().expect("intervals");
+    assert!(!intervals.is_empty());
+    for i in intervals {
+        assert!(
+            i.get("sum_bidir_reverse").is_none(),
+            "forward run must not emit sum_bidir_reverse: {i}"
+        );
+    }
+}

--- a/riperf3/src/client.rs
+++ b/riperf3/src/client.rs
@@ -53,7 +53,7 @@ pub struct Client {
     pub(crate) dont_fragment: bool,
     pub(crate) cport: Option<u16>,
     // Set by the builder but not yet consumed by `run()`; to be wired into the
-    // library as non-breaking 0.7.x work — get_server_output (#33), dscp below.
+    // library as non-breaking 0.7.x work (#33).
     #[allow(dead_code)]
     pub(crate) get_server_output: bool,
     pub(crate) forceflush: bool,

--- a/riperf3/src/client.rs
+++ b/riperf3/src/client.rs
@@ -68,8 +68,6 @@ pub struct Client {
     pub(crate) rcv_timeout: Option<u64>,
     pub(crate) snd_timeout: Option<u64>,
     pub(crate) file: Option<String>,
-    #[allow(dead_code)] // not yet applied by `run()` (only `tos` is); wire in 0.7.x
-    pub(crate) dscp: Option<String>,
     pub(crate) format_char: char,
     pub(crate) interval: Option<f64>,
     pub(crate) cntl_ka: Option<String>,
@@ -1776,7 +1774,6 @@ impl ClientBuilder {
             rcv_timeout: self.rcv_timeout,
             snd_timeout: self.snd_timeout,
             file: self.file,
-            dscp: self.dscp,
             format_char: self.format_char,
             interval: self.interval,
             cntl_ka: self.cntl_ka,

--- a/riperf3/src/cpu.rs
+++ b/riperf3/src/cpu.rs
@@ -59,26 +59,18 @@ impl CpuSnapshot {
             host_total: (user_diff + system_diff) / wall_usec * 100.0,
             host_user: user_diff / wall_usec * 100.0,
             host_system: system_diff / wall_usec * 100.0,
-            remote_total: 0.0,
-            remote_user: 0.0,
-            remote_system: 0.0,
         }
     }
 }
 
-/// CPU utilization percentages for both local and remote hosts.
-/// Remote values are filled in from the peer's results JSON after exchange.
+/// This process's CPU utilization percentages. The peer's figures never pass
+/// through here — they flow from the results exchange straight into
+/// `json_report::CpuUtilization` (#139).
 #[derive(Debug, Clone, Default)]
 pub struct CpuUtilization {
     pub host_total: f64,
     pub host_user: f64,
     pub host_system: f64,
-    #[allow(dead_code)]
-    pub remote_total: f64,
-    #[allow(dead_code)]
-    pub remote_user: f64,
-    #[allow(dead_code)]
-    pub remote_system: f64,
 }
 
 #[cfg(test)]
@@ -105,7 +97,6 @@ mod tests {
         let util = after.utilization_since(&before);
         assert!(util.host_user >= 0.0);
         assert!(util.host_total >= 0.0);
-        assert_eq!(util.remote_total, 0.0);
     }
 
     #[test]

--- a/riperf3/src/json_report.rs
+++ b/riperf3/src/json_report.rs
@@ -247,6 +247,10 @@ pub struct TestStart {
 pub struct Interval {
     pub streams: Vec<IntervalStream>,
     pub sum: IntervalSum,
+    /// Bidir only (#54): the reverse direction's aggregate, split out of `sum`
+    /// per interval exactly like the end block's `sum_*_bidir_reverse` pair.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sum_bidir_reverse: Option<IntervalSum>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -1849,6 +1853,58 @@ mod tests {
     // ---- PR2: intervals + sender extremes -----------------------------------
 
     #[test]
+    fn interval_sum_bidir_reverse_serialized_only_when_present() {
+        // #54: bidir intervals carry `sum` + `sum_bidir_reverse` (forward /
+        // reverse split); non-bidir intervals must not emit the key at all.
+        let sum = IntervalSum {
+            start: 0.0,
+            end: 1.0,
+            seconds: 1.0,
+            bytes: 1000,
+            bits_per_second: 8000.0,
+            retransmits: None,
+            jitter_ms: None,
+            lost_packets: None,
+            packets: None,
+            lost_percent: None,
+            omitted: false,
+            sender: true,
+        };
+        let bidir = Interval {
+            streams: vec![],
+            sum: sum.clone(),
+            sum_bidir_reverse: Some(IntervalSum {
+                bytes: 2000,
+                sender: false,
+                ..sum.clone()
+            }),
+        };
+        let v = serde_json::to_value(&bidir).unwrap();
+        assert_eq!(v["sum"]["sender"], true);
+        assert_eq!(v["sum_bidir_reverse"]["bytes"], 2000);
+        assert_eq!(v["sum_bidir_reverse"]["sender"], false);
+        // iperf3 key order: streams, sum, sum_bidir_reverse.
+        let s = serde_json::to_string(&bidir).unwrap();
+        let (p_streams, p_sum, p_rev) = (
+            s.find("\"streams\"").unwrap(),
+            s.find("\"sum\"").unwrap(),
+            s.find("\"sum_bidir_reverse\"").unwrap(),
+        );
+        assert!(p_streams < p_sum && p_sum < p_rev, "key order: {s}");
+
+        let forward = Interval {
+            streams: vec![],
+            sum,
+            sum_bidir_reverse: None,
+        };
+        let v = serde_json::to_value(&forward).unwrap();
+        assert!(
+            v.get("sum_bidir_reverse").is_none(),
+            "non-bidir interval must omit the key: {v}"
+        );
+    }
+
+    #[test]
     fn intervals_and_sender_extremes_are_emitted() {
         let mut input = base_input();
         input.intervals = vec![Interval {
@@ -1887,6 +1943,7 @@ mod tests {
                 omitted: false,
                 sender: true,
             },
+            sum_bidir_reverse: None,
         }];
         let mut s = tcp_stream(1, true, 1000, 1000);
         s.retransmits = Some(2);

--- a/riperf3/src/reporter.rs
+++ b/riperf3/src/reporter.rs
@@ -16,12 +16,8 @@ pub struct StreamInterval {
     pub start: f64,
     pub end: f64,
     pub bytes: u64,
-    #[allow(dead_code)]
-    pub is_sender: bool,
     pub retransmits: Option<i64>,
     pub snd_cwnd: Option<u64>,
-    #[allow(dead_code)]
-    pub rtt: Option<u32>,
     // UDP specific
     pub jitter: Option<f64>,
     pub lost: Option<i64>,
@@ -687,10 +683,8 @@ pub fn spawn_interval_reporter(
                         start,
                         end,
                         bytes,
-                        is_sender: stream.is_sender,
                         retransmits,
                         snd_cwnd,
-                        rtt,
                         jitter,
                         lost,
                         total_packets: total,
@@ -782,14 +776,12 @@ pub fn spawn_interval_reporter(
                     start,
                     end,
                     bytes: fwd.bytes + rev.bytes,
-                    is_sender: fwd_is_sender,
                     retransmits: if has_retransmits {
                         Some(fwd.retransmits + rev.retransmits)
                     } else {
                         None
                     },
                     snd_cwnd: None,
-                    rtt: None,
                     jitter: if is_udp { Some(last_jitter) } else { None },
                     lost: if is_udp {
                         Some(fwd.lost + rev.lost)
@@ -944,10 +936,8 @@ mod tests {
             start: 0.0,
             end: 1.0,
             bytes: 1024 * 1024 * 1024,
-            is_sender: true,
             retransmits: None,
             snd_cwnd: None,
-            rtt: None,
             jitter: None,
             lost: None,
             total_packets: None,
@@ -979,10 +969,8 @@ mod tests {
             start: 0.0,
             end: 1.0,
             bytes: 1_000_000,
-            is_sender: true,
             retransmits: Some(3),
             snd_cwnd: None,
-            rtt: None,
             jitter: None,
             lost: None,
             total_packets: None,

--- a/riperf3/src/reporter.rs
+++ b/riperf3/src/reporter.rs
@@ -419,6 +419,76 @@ impl Default for ReporterEnd {
 /// normal run the driver calls [`ReporterEnd::finish`] to flush the final partial
 /// interval and stop the task; `done` is the fallback stop signal for error/early
 /// teardown paths. The handle should be awaited after `finish`/`done`.
+/// Per-direction interval aggregates (#54). In bidir both directions run
+/// concurrently; iperf3 sums each separately (`sum` + `sum_bidir_reverse`).
+#[derive(Default)]
+struct DirAcc {
+    count: usize,
+    bytes: u64,
+    retransmits: i64,
+    // UDP
+    lost: i64,
+    packets: i64,
+    last_jitter: f64,
+    udp_recv: bool,
+}
+
+/// Build the typed `-J` interval sum for one direction's aggregates.
+#[allow(clippy::too_many_arguments)] // interval geometry + direction flags, 1:1 with the emit site
+fn direction_interval_sum(
+    start: f64,
+    end: f64,
+    seconds: f64,
+    acc: &DirAcc,
+    dir_is_sender: bool,
+    has_retransmits: bool,
+    is_udp: bool,
+    blk: u64,
+    omitted: bool,
+) -> crate::json_report::IntervalSum {
+    let bps = if seconds > 0.0 {
+        acc.bytes as f64 * 8.0 / seconds
+    } else {
+        0.0
+    };
+    // UDP: a receiving direction reports measured loss/jitter; a pure sending
+    // direction reports only the sent packet count, like iperf3.
+    let (jitter_ms, lost_packets, packets, lost_pct) = if is_udp && acc.udp_recv {
+        (
+            Some(acc.last_jitter * 1000.0),
+            Some(acc.lost),
+            Some(acc.packets),
+            Some(lost_percent(acc.lost, acc.packets)),
+        )
+    } else if is_udp {
+        (None, None, Some((acc.bytes / blk) as i64), None)
+    } else {
+        (None, None, None, None)
+    };
+    crate::json_report::IntervalSum {
+        start,
+        end,
+        seconds,
+        bytes: acc.bytes,
+        bits_per_second: bps,
+        // iperf3 emits the sum's retransmits only on a sender-direction sum
+        // (sender_has_retransmits && stream_must_be_sender). On a received-flow
+        // sum (sender=false) it must be omitted, not just gated on "any stream
+        // sends" — otherwise the received-flow sum carries a spurious count.
+        retransmits: if has_retransmits && dir_is_sender {
+            Some(acc.retransmits)
+        } else {
+            None
+        },
+        jitter_ms,
+        lost_packets,
+        packets,
+        lost_percent: lost_pct,
+        omitted,
+        sender: dir_is_sender,
+    }
+}
+
 pub fn spawn_interval_reporter(
     config: IntervalReporterConfig,
     streams: Vec<IntervalStreamRef>,
@@ -512,12 +582,14 @@ pub fn spawn_interval_reporter(
                 header_printed = true;
             }
 
-            let mut sum_bytes: u64 = 0;
-            let mut sum_retransmits: i64 = 0;
-            // UDP sums
-            let mut sum_lost: i64 = 0;
-            let mut sum_packets: i64 = 0;
-            let mut last_jitter: f64 = 0.0;
+            // Per-direction aggregates (#54): `fwd` covers streams flowing the
+            // same way as the first stream — the forward (client→server) flow
+            // on both roles, since the client lists its senders first and the
+            // server its receivers — `rev` the opposite. Non-bidir runs leave
+            // `rev` empty.
+            let fwd_is_sender = streams.first().is_none_or(|s| s.is_sender);
+            let mut fwd = DirAcc::default();
+            let mut rev = DirAcc::default();
             let mut collected_streams: Vec<crate::json_report::IntervalStream> = Vec::new();
 
             for (i, stream) in streams.iter().enumerate() {
@@ -591,7 +663,6 @@ pub fn spawn_interval_reporter(
                         let delta_packets = st.packet_count - prev_packet_count[i];
                         prev_cnt_error[i] = st.cnt_error;
                         prev_packet_count[i] = st.packet_count;
-                        last_jitter = st.jitter;
                         (Some(st.jitter), Some(delta_error), Some(delta_packets))
                     } else {
                         (None, None, None)
@@ -672,89 +743,101 @@ pub fn spawn_interval_reporter(
                     });
                 }
 
-                sum_bytes += bytes;
+                let acc = if stream.is_sender == fwd_is_sender {
+                    &mut fwd
+                } else {
+                    &mut rev
+                };
+                acc.count += 1;
+                acc.bytes += bytes;
                 if let Some(r) = retransmits {
-                    sum_retransmits += r;
+                    acc.retransmits += r;
+                }
+                if stream.udp_recv_stats.is_some() {
+                    acc.udp_recv = true;
+                    if let Some(j) = jitter {
+                        acc.last_jitter = j;
+                    }
                 }
                 if let Some(l) = lost {
-                    sum_lost += l;
+                    acc.lost += l;
                 }
                 if let Some(p) = total {
-                    sum_packets += p;
+                    acc.packets += p;
                 }
             }
 
             // Print [SUM] line for parallel streams (text only; the json-stream
             // `interval` event below carries the typed `sum` instead).
             if config.print && !config.json_stream && config.num_streams > 1 {
+                // The text [SUM] stays one combined line (both directions in
+                // bidir); only the typed -J/json-stream sums split per direction.
+                let last_jitter = if rev.udp_recv {
+                    rev.last_jitter
+                } else {
+                    fwd.last_jitter
+                };
                 let sum_interval = StreamInterval {
                     stream_id: -1, // renders as "SUM"
                     start,
                     end,
-                    bytes: sum_bytes,
-                    is_sender: streams.first().is_none_or(|s| s.is_sender),
+                    bytes: fwd.bytes + rev.bytes,
+                    is_sender: fwd_is_sender,
                     retransmits: if has_retransmits {
-                        Some(sum_retransmits)
+                        Some(fwd.retransmits + rev.retransmits)
                     } else {
                         None
                     },
                     snd_cwnd: None,
                     rtt: None,
                     jitter: if is_udp { Some(last_jitter) } else { None },
-                    lost: if is_udp { Some(sum_lost) } else { None },
-                    total_packets: if is_udp { Some(sum_packets) } else { None },
+                    lost: if is_udp {
+                        Some(fwd.lost + rev.lost)
+                    } else {
+                        None
+                    },
+                    total_packets: if is_udp {
+                        Some(fwd.packets + rev.packets)
+                    } else {
+                        None
+                    },
                     omitted,
                 };
                 print_interval(&sum_interval, config.format_char);
             }
 
             if collecting {
-                let sum_bps = if seconds > 0.0 {
-                    sum_bytes as f64 * 8.0 / seconds
-                } else {
-                    0.0
-                };
-                // UDP sum: a receiving side reports measured loss/jitter; a pure
-                // sending side reports only the sent packet count, like iperf3.
-                let any_udp_recv = streams.iter().any(|s| s.udp_recv_stats.is_some());
-                let (sum_j, sum_lostp, sum_pkts, sum_lostpct) = if is_udp && any_udp_recv {
-                    (
-                        Some(last_jitter * 1000.0),
-                        Some(sum_lost),
-                        Some(sum_packets),
-                        Some(lost_percent(sum_lost, sum_packets)),
-                    )
-                } else if is_udp {
-                    (None, None, Some((sum_bytes / blk) as i64), None)
-                } else {
-                    (None, None, None, None)
-                };
-                // iperf3 emits the sum's retransmits only on a sender-direction
-                // sum (sender_has_retransmits && stream_must_be_sender). On the
-                // server's bidir `sum` (which describes the received flow, so
-                // sender=false) it must be omitted, not just gated on "any stream
-                // sends" — otherwise the received-flow sum carries a spurious count.
-                let sum_is_sender = streams.first().is_none_or(|s| s.is_sender);
-                let interval = crate::json_report::Interval {
-                    streams: collected_streams,
-                    sum: crate::json_report::IntervalSum {
+                // #54: iperf3 emits per-direction interval sums in bidir — `sum`
+                // for the forward flow, `sum_bidir_reverse` for the reverse —
+                // mirroring the end block's sum_*_bidir_reverse split.
+                let sum = direction_interval_sum(
+                    start,
+                    end,
+                    seconds,
+                    &fwd,
+                    fwd_is_sender,
+                    has_retransmits,
+                    is_udp,
+                    blk,
+                    omitted,
+                );
+                let sum_bidir_reverse = (rev.count > 0).then(|| {
+                    direction_interval_sum(
                         start,
                         end,
                         seconds,
-                        bytes: sum_bytes,
-                        bits_per_second: sum_bps,
-                        retransmits: if has_retransmits && sum_is_sender {
-                            Some(sum_retransmits)
-                        } else {
-                            None
-                        },
-                        jitter_ms: sum_j,
-                        lost_packets: sum_lostp,
-                        packets: sum_pkts,
-                        lost_percent: sum_lostpct,
+                        &rev,
+                        !fwd_is_sender,
+                        has_retransmits,
+                        is_udp,
+                        blk,
                         omitted,
-                        sender: sum_is_sender,
-                    },
+                    )
+                });
+                let interval = crate::json_report::Interval {
+                    streams: collected_streams,
+                    sum,
+                    sum_bidir_reverse,
                 };
                 // `-J` collects intervals for the final batched blob; `--json-stream`
                 // emits each one live as `{"event":"interval","data":{...}}`.
@@ -970,6 +1053,72 @@ mod tests {
         // Bidir -P 1: one sender + one receiver → neither direction gets a SUM.
         let streams = vec![tcp_summary(1, true, 1_000), tcp_summary(3, false, 2_000)];
         assert!(sum_summaries(&streams).is_empty());
+    }
+
+    // ---- direction_interval_sum (#54: bidir per-direction interval sums) ----
+
+    #[test]
+    fn direction_sum_tcp_sender_carries_retransmits() {
+        let acc = DirAcc {
+            count: 2,
+            bytes: 2_000,
+            retransmits: 3,
+            ..Default::default()
+        };
+        let s = direction_interval_sum(0.0, 1.0, 1.0, &acc, true, true, false, 128, false);
+        assert!(s.sender);
+        assert_eq!(s.bytes, 2_000);
+        assert_eq!(s.bits_per_second, 16_000.0);
+        assert_eq!(s.retransmits, Some(3));
+        assert!(
+            s.jitter_ms.is_none() && s.packets.is_none(),
+            "TCP sum has no UDP detail"
+        );
+    }
+
+    #[test]
+    fn direction_sum_tcp_receiver_omits_retransmits() {
+        // Even when the test HAS retransmit info (the other direction sends),
+        // a received-flow sum must not carry a retransmit count.
+        let acc = DirAcc {
+            count: 2,
+            bytes: 4_000,
+            retransmits: 0,
+            ..Default::default()
+        };
+        let s = direction_interval_sum(0.0, 1.0, 1.0, &acc, false, true, false, 128, false);
+        assert!(!s.sender);
+        assert_eq!(s.retransmits, None);
+    }
+
+    #[test]
+    fn direction_sum_udp_receiving_reports_measured_stats() {
+        let acc = DirAcc {
+            count: 1,
+            bytes: 14_480,
+            lost: 2,
+            packets: 10,
+            last_jitter: 0.0015,
+            udp_recv: true,
+            ..Default::default()
+        };
+        let s = direction_interval_sum(0.0, 1.0, 1.0, &acc, false, false, true, 1448, false);
+        assert_eq!(s.jitter_ms, Some(1.5));
+        assert_eq!(s.lost_packets, Some(2));
+        assert_eq!(s.packets, Some(10));
+        assert_eq!(s.lost_percent, Some(20.0));
+    }
+
+    #[test]
+    fn direction_sum_udp_sending_reports_sent_packet_count_only() {
+        let acc = DirAcc {
+            count: 1,
+            bytes: 14_480,
+            ..Default::default()
+        };
+        let s = direction_interval_sum(0.0, 1.0, 1.0, &acc, true, false, true, 1448, false);
+        assert_eq!(s.packets, Some(10), "sent packets = bytes / blksize");
+        assert!(s.jitter_ms.is_none() && s.lost_packets.is_none() && s.lost_percent.is_none());
     }
 
     #[test]

--- a/riperf3/src/reporter.rs
+++ b/riperf3/src/reporter.rs
@@ -409,12 +409,6 @@ impl Default for ReporterEnd {
     }
 }
 
-/// Spawn an async task that prints interval reports periodically.
-///
-/// Returns `None` if interval reporting is disabled (interval_secs <= 0). On a
-/// normal run the driver calls [`ReporterEnd::finish`] to flush the final partial
-/// interval and stop the task; `done` is the fallback stop signal for error/early
-/// teardown paths. The handle should be awaited after `finish`/`done`.
 /// Per-direction interval aggregates (#54). In bidir both directions run
 /// concurrently; iperf3 sums each separately (`sum` + `sum_bidir_reverse`).
 #[derive(Default)]
@@ -485,6 +479,12 @@ fn direction_interval_sum(
     }
 }
 
+/// Spawn an async task that prints interval reports periodically.
+///
+/// Returns `None` if interval reporting is disabled (interval_secs <= 0). On a
+/// normal run the driver calls [`ReporterEnd::finish`] to flush the final partial
+/// interval and stop the task; `done` is the fallback stop signal for error/early
+/// teardown paths. The handle should be awaited after `finish`/`done`.
 pub fn spawn_interval_reporter(
     config: IntervalReporterConfig,
     streams: Vec<IntervalStreamRef>,


### PR DESCRIPTION
## Summary

Two report-model faithfulness items for 0.7.2:

**#54 — bidir `-J` intervals now split per direction.** iperf3 emits three keys per bidir interval object — `streams`, `sum`, `sum_bidir_reverse` — but riperf3 lumped both directions into one `sum` (sender:true). The reporter now accumulates per direction (`DirAcc`), keyed off the first stream's direction (the client lists its senders first, the server its receivers — so `sum` carries the forward client→server flow on both roles, matching the end block's `sum_*_bidir_reverse` split):

- `sum` / `sum_bidir_reverse` sender flags: client `true`/`false`, server `false`/`true`.
- UDP detail follows each direction's own character: a receiving flow reports measured jitter/loss/lost_percent, a sending flow only its sent packet count. The old lumped bidir sum mixed receiver jitter with both directions' bytes.
- Retransmits stay sender-direction-only, now per direction (a received-flow sum never carries a count).
- The text `[SUM]` line stays one combined row (text scope unchanged); `--json-stream` interval events pick up the split for free.
- Non-bidir output is byte-identical (`sum_bidir_reverse` is `skip_serializing_if` None).

**#139 — dead duplicate fields deleted** (compiler-verified, no behavior change): `cpu::CpuUtilization::remote_*` (real remote-CPU data flows from the exchange straight into `json_report::CpuUtilization`), `reporter::StreamInterval::{is_sender,rtt}` (text printer never reads them; `-J` carries rtt/rttvar/pmtu via `json_report::IntervalStream`), and the `Client.dscp` field (dead since `build()` folds dscp into TOS; the `ClientBuilder::dscp()` setter is untouched).

## Tests

- New unit tests: `direction_interval_sum` ×4 (sender retransmits, receiver omission, UDP recv stats, UDP send packet count); `interval_sum_bidir_reverse_serialized_only_when_present` (key presence + iperf3 key order).
- New CLI integration suite `bidir_intervals.rs` ×4: client TCP bidir split + sender flags + per-stream direction coverage; server-role flip (`sum`.sender=false); UDP bidir per-direction stats; forward-run absence of the key.
- Full workspace suite green (265 lib + 75 integration + 80 wiring + CLI suites).

Closes #54. Closes #139.