### PR TITLE
fix(cli): unlink pidfile on every exit path (#105)

### DIFF
--- a/riperf3-cli/src/main.rs
+++ b/riperf3-cli/src/main.rs
@@ -103,25 +103,83 @@ fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
         .enable_all()
         .build()?;
 
-    rt.block_on(async_main(cli))
+    // The pidfile (written above) must be unlinked on EVERY exit path —
+    // normal completion, error, or termination signal — like iperf3, which
+    // deletes it after the server/client loop and in its sigend path (#105).
+    // Keep one cleanup point here, after the runtime returns.
+    let pidfile = cli.pidfile.clone();
+    let is_server = cli.server;
+    let outcome = rt.block_on(async_main(cli));
+    if let Some(ref path) = pidfile {
+        let _ = std::fs::remove_file(path);
+    }
+    match outcome {
+        // iperf3 treats SIGTERM/SIGINT/SIGHUP as a NORMAL exit
+        // (iperf_got_sigend → iperf_signormalexit → exit 0), printing an
+        // interrupt notice first.
+        Ok(Exit::Signal(sig)) => {
+            let role = if is_server { "server" } else { "client" };
+            eprintln!("riperf3: interrupt - the {role} has terminated by signal {sig}");
+            Ok(())
+        }
+        Ok(Exit::Normal) => Ok(()),
+        Err(e) => Err(e),
+    }
 }
 
-async fn async_main(cli: Cli) -> std::result::Result<(), Box<dyn std::error::Error>> {
-    if cli.client.is_some() {
-        // Client mode. Client-only options on a server and server-only options
-        // on a client are both rejected up front in `main` (#65/#100), before
-        // any side effects. The arg→builder mapping lives in `Cli::build_client`
-        // (cli.rs) so the wiring tests exercise the same code path (#124).
-        cli.build_client()?.run().await?;
-    } else if cli.server {
-        // Server mode. See `Cli::build_server` (cli.rs). `-D`/`--daemon` is
-        // handled before the runtime is built (daemonize block in `main`).
-        cli.build_server()?.run().await?;
-    } else {
-        eprintln!("No mode specified. Use -s for server or -c <host> for client.");
-    }
+/// How the async role future ended: normally, or cut short by a termination
+/// signal (which iperf3 reports and treats as a clean exit — see `main`).
+enum Exit {
+    Normal,
+    #[cfg_attr(not(unix), allow(dead_code))]
+    Signal(&'static str),
+}
 
-    Ok(())
+/// Resolves when a termination signal arrives — the same set iperf3 catches
+/// in `iperf_catch_sigend` (SIGTERM/SIGINT/SIGHUP). Returns iperf3's
+/// `strsignal(sig)(num)` rendering for the interrupt notice.
+#[cfg(unix)]
+async fn sigend() -> &'static str {
+    use tokio::signal::unix::{signal, SignalKind};
+    let mut term = signal(SignalKind::terminate()).expect("install SIGTERM handler");
+    let mut int = signal(SignalKind::interrupt()).expect("install SIGINT handler");
+    let mut hup = signal(SignalKind::hangup()).expect("install SIGHUP handler");
+    tokio::select! {
+        _ = term.recv() => "Terminated(15)",
+        _ = int.recv() => "Interrupt(2)",
+        _ = hup.recv() => "Hangup(1)",
+    }
+}
+
+async fn async_main(cli: Cli) -> std::result::Result<Exit, Box<dyn std::error::Error>> {
+    let role = async {
+        if cli.client.is_some() {
+            // Client mode. Client-only options on a server and server-only options
+            // on a client are both rejected up front in `main` (#65/#100), before
+            // any side effects. The arg→builder mapping lives in `Cli::build_client`
+            // (cli.rs) so the wiring tests exercise the same code path (#124).
+            cli.build_client()?.run().await?;
+        } else if cli.server {
+            // Server mode. See `Cli::build_server` (cli.rs). `-D`/`--daemon` is
+            // handled before the runtime is built (daemonize block in `main`).
+            cli.build_server()?.run().await?;
+        } else {
+            eprintln!("No mode specified. Use -s for server or -c <host> for client.");
+        }
+        Ok(Exit::Normal)
+    };
+
+    #[cfg(unix)]
+    {
+        tokio::select! {
+            r = role => r,
+            sig = sigend() => Ok(Exit::Signal(sig)),
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        role.await
+    }
 }
 
 fn configure_log4rs(verbosity: u8) {

--- a/riperf3-cli/src/main.rs
+++ b/riperf3-cli/src/main.rs
@@ -62,12 +62,6 @@ fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
         return Err("daemon mode is not supported on this platform".into());
     }
 
-    // Write the PID file (after daemonizing, so it records the daemon child's
-    // pid — the long-lived server — not the foreground process that forked away).
-    if let Some(ref path) = cli.pidfile {
-        std::fs::write(path, format!("{}\n", std::process::id()))?;
-    }
-
     // Redirect stdout to logfile if requested. Must run after daemonizing so the
     // redirect isn't clobbered by daemon()'s stdout->/dev/null.
     if let Some(ref path) = cli.logfile {
@@ -103,12 +97,37 @@ fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
         .enable_all()
         .build()?;
 
-    // The pidfile (written above) must be unlinked on EVERY exit path —
-    // normal completion, error, or termination signal — like iperf3, which
-    // deletes it after the server/client loop and in its sigend path (#105).
-    // Keep one cleanup point here, after the runtime returns.
+    // Install the termination-signal handlers BEFORE writing the pidfile,
+    // matching iperf3's run() order (iperf_catch_sigend first, create_pidfile
+    // after): once the pidfile exists, a SIGTERM is guaranteed to take the
+    // clean unlink path — there is no startup window where it gets default
+    // disposition and strands a fresh pidfile (#105 review). Stream creation
+    // registers the OS sigactions immediately; it needs the runtime context.
+    #[cfg(unix)]
+    let mut sigend = Sigend::install(&rt).map_err(|e| format!("signal handler setup: {e}"))?;
+
+    // Write the PID file LAST before entering the runtime: after daemonizing
+    // (it must record the daemon child's pid), after the logfile/affinity
+    // fallible setup (their `?` exits can no longer leak a fresh pidfile),
+    // and after the signal handlers above.
+    if let Some(ref path) = cli.pidfile {
+        std::fs::write(path, format!("{}\n", std::process::id()))?;
+    }
+
+    // The pidfile must be unlinked on EVERY exit path — normal completion,
+    // error, or termination signal — like iperf3, which deletes it after the
+    // server/client loop and in its sigend path (#105). One cleanup point,
+    // after the runtime returns.
     let pidfile = cli.pidfile.clone();
     let is_server = cli.server;
+    #[cfg(unix)]
+    let outcome = rt.block_on(async {
+        tokio::select! {
+            r = async_main(cli) => r,
+            sig = sigend.recv() => Ok(Exit::Signal(sig)),
+        }
+    });
+    #[cfg(not(unix))]
     let outcome = rt.block_on(async_main(cli));
     if let Some(ref path) = pidfile {
         let _ = std::fs::remove_file(path);
@@ -135,51 +154,54 @@ enum Exit {
     Signal(&'static str),
 }
 
-/// Resolves when a termination signal arrives — the same set iperf3 catches
-/// in `iperf_catch_sigend` (SIGTERM/SIGINT/SIGHUP). Returns iperf3's
-/// `strsignal(sig)(num)` rendering for the interrupt notice.
+/// The termination-signal set iperf3 catches in `iperf_catch_sigend`
+/// (SIGTERM/SIGINT/SIGHUP). The streams are created — and the OS sigactions
+/// registered — in `install`, so handler installation can be ordered before
+/// pidfile creation; `recv` resolves with iperf3's `strsignal(sig)(num)`
+/// rendering for the interrupt notice.
 #[cfg(unix)]
-async fn sigend() -> &'static str {
-    use tokio::signal::unix::{signal, SignalKind};
-    let mut term = signal(SignalKind::terminate()).expect("install SIGTERM handler");
-    let mut int = signal(SignalKind::interrupt()).expect("install SIGINT handler");
-    let mut hup = signal(SignalKind::hangup()).expect("install SIGHUP handler");
-    tokio::select! {
-        _ = term.recv() => "Terminated(15)",
-        _ = int.recv() => "Interrupt(2)",
-        _ = hup.recv() => "Hangup(1)",
+struct Sigend {
+    term: tokio::signal::unix::Signal,
+    int: tokio::signal::unix::Signal,
+    hup: tokio::signal::unix::Signal,
+}
+
+#[cfg(unix)]
+impl Sigend {
+    fn install(rt: &tokio::runtime::Runtime) -> std::io::Result<Self> {
+        use tokio::signal::unix::{signal, SignalKind};
+        let _guard = rt.enter();
+        Ok(Self {
+            term: signal(SignalKind::terminate())?,
+            int: signal(SignalKind::interrupt())?,
+            hup: signal(SignalKind::hangup())?,
+        })
+    }
+
+    async fn recv(&mut self) -> &'static str {
+        tokio::select! {
+            _ = self.term.recv() => "Terminated(15)",
+            _ = self.int.recv() => "Interrupt(2)",
+            _ = self.hup.recv() => "Hangup(1)",
+        }
     }
 }
 
 async fn async_main(cli: Cli) -> std::result::Result<Exit, Box<dyn std::error::Error>> {
-    let role = async {
-        if cli.client.is_some() {
-            // Client mode. Client-only options on a server and server-only options
-            // on a client are both rejected up front in `main` (#65/#100), before
-            // any side effects. The arg→builder mapping lives in `Cli::build_client`
-            // (cli.rs) so the wiring tests exercise the same code path (#124).
-            cli.build_client()?.run().await?;
-        } else if cli.server {
-            // Server mode. See `Cli::build_server` (cli.rs). `-D`/`--daemon` is
-            // handled before the runtime is built (daemonize block in `main`).
-            cli.build_server()?.run().await?;
-        } else {
-            eprintln!("No mode specified. Use -s for server or -c <host> for client.");
-        }
-        Ok(Exit::Normal)
-    };
-
-    #[cfg(unix)]
-    {
-        tokio::select! {
-            r = role => r,
-            sig = sigend() => Ok(Exit::Signal(sig)),
-        }
+    if cli.client.is_some() {
+        // Client mode. Client-only options on a server and server-only options
+        // on a client are both rejected up front in `main` (#65/#100), before
+        // any side effects. The arg→builder mapping lives in `Cli::build_client`
+        // (cli.rs) so the wiring tests exercise the same code path (#124).
+        cli.build_client()?.run().await?;
+    } else if cli.server {
+        // Server mode. See `Cli::build_server` (cli.rs). `-D`/`--daemon` is
+        // handled before the runtime is built (daemonize block in `main`).
+        cli.build_server()?.run().await?;
+    } else {
+        eprintln!("No mode specified. Use -s for server or -c <host> for client.");
     }
-    #[cfg(not(unix))]
-    {
-        role.await
-    }
+    Ok(Exit::Normal)
 }
 
 fn configure_log4rs(verbosity: u8) {

--- a/riperf3-cli/tests/pidfile.rs
+++ b/riperf3-cli/tests/pidfile.rs
@@ -1,0 +1,144 @@
+//! CLI integration test: the pidfile (`-I`/`--pidfile`) must be unlinked on
+//! exit like iperf3 (#105) — both on a clean one-off (`-1`) completion and on
+//! SIGTERM (iperf3's `iperf_got_sigend` → `iperf_signormalexit(0)` path, which
+//! deletes the pidfile and exits 0). Pre-#105 riperf3 left the stale pidfile
+//! behind in both cases.
+#![cfg(unix)]
+
+use std::io::Read;
+use std::path::Path;
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+fn free_port() -> u16 {
+    std::net::TcpListener::bind("127.0.0.1:0")
+        .expect("bind ephemeral port")
+        .local_addr()
+        .expect("local_addr")
+        .port()
+}
+
+/// Kills the wrapped child on drop so a spawned server is reaped on panic.
+struct ChildGuard(std::process::Child);
+impl Drop for ChildGuard {
+    fn drop(&mut self) {
+        let _ = self.0.kill();
+        let _ = self.0.wait();
+    }
+}
+
+fn wait_for(cond: impl Fn() -> bool, timeout: Duration, what: &str) {
+    let deadline = Instant::now() + timeout;
+    while !cond() {
+        assert!(Instant::now() < deadline, "timed out waiting for {what}");
+        std::thread::sleep(Duration::from_millis(50));
+    }
+}
+
+/// `riperf3 -s -I <file>` then SIGTERM → the pidfile must be gone and the
+/// exit status 0 (iperf3 treats SIGTERM as a normal signal exit).
+#[test]
+fn pidfile_unlinked_on_sigterm() {
+    let bin = env!("CARGO_BIN_EXE_riperf3");
+    let port = free_port().to_string();
+    let dir = std::env::temp_dir();
+    let pidfile = dir.join(format!("riperf3-pidfile-sigterm-{port}.pid"));
+    let _ = std::fs::remove_file(&pidfile);
+
+    let mut server = ChildGuard(
+        Command::new(bin)
+            .args(["-s", "-p", &port, "-I", pidfile.to_str().unwrap()])
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("spawn server"),
+    );
+
+    wait_for(
+        || pidfile.exists(),
+        Duration::from_secs(5),
+        "pidfile creation",
+    );
+
+    // SIGTERM specifically — Child::kill() sends SIGKILL, which bypasses any
+    // handler and proves nothing.
+    let rc = unsafe { libc::kill(server.0.id() as libc::pid_t, libc::SIGTERM) };
+    assert_eq!(rc, 0, "kill(SIGTERM) failed");
+
+    let deadline = Instant::now() + Duration::from_secs(5);
+    let status = loop {
+        if let Some(st) = server.0.try_wait().expect("try_wait") {
+            break st;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "server did not exit within 5s of SIGTERM"
+        );
+        std::thread::sleep(Duration::from_millis(50));
+    };
+
+    assert!(
+        !Path::new(&pidfile).exists(),
+        "pidfile must be unlinked on SIGTERM like iperf3 (#105)"
+    );
+    assert_eq!(
+        status.code(),
+        Some(0),
+        "iperf3 exits 0 on SIGTERM (iperf_signormalexit); got {status:?}"
+    );
+}
+
+/// A one-off server (`-s -1 -I <file>`) that completes a test and returns
+/// normally must unlink its pidfile on the way out.
+#[test]
+fn pidfile_unlinked_after_one_off_run() {
+    let bin = env!("CARGO_BIN_EXE_riperf3");
+    let port = free_port().to_string();
+    let dir = std::env::temp_dir();
+    let pidfile = dir.join(format!("riperf3-pidfile-oneoff-{port}.pid"));
+    let _ = std::fs::remove_file(&pidfile);
+
+    let mut server = ChildGuard(
+        Command::new(bin)
+            .args(["-s", "-1", "-p", &port, "-I", pidfile.to_str().unwrap()])
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("spawn server"),
+    );
+
+    wait_for(
+        || pidfile.exists(),
+        Duration::from_secs(5),
+        "pidfile creation",
+    );
+
+    // Quick client run so the one-off server completes and exits on its own.
+    let mut client = Command::new(bin)
+        .args(["-c", "127.0.0.1", "-p", &port, "-t", "1"])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn client");
+    let deadline = Instant::now() + Duration::from_secs(20);
+    while client.try_wait().expect("client try_wait").is_none() {
+        assert!(Instant::now() < deadline, "client timed out");
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    let mut out = String::new();
+    let _ = client.stdout.take().unwrap().read_to_string(&mut out);
+
+    let deadline = Instant::now() + Duration::from_secs(10);
+    while server.0.try_wait().expect("server try_wait").is_none() {
+        assert!(
+            Instant::now() < deadline,
+            "one-off server did not exit after the test"
+        );
+        std::thread::sleep(Duration::from_millis(50));
+    }
+
+    assert!(
+        !Path::new(&pidfile).exists(),
+        "pidfile must be unlinked when a one-off server exits normally (#105)"
+    );
+}


### PR DESCRIPTION
## Summary

riperf3 wrote the pidfile (`-I`/`--pidfile`) and never removed it; iperf3 unlinks on clean exit and on its SIGTERM/SIGINT/SIGHUP sigend path (`iperf_delete_pidfile`, `iperf_signormalexit` → exit 0). Most visible with `-s -D`, where the stale pidfile points at a possibly-recycled pid after the daemon dies.

- One cleanup point in `main()` after `block_on` returns: pidfile unlinked on normal completion, error, **and** termination signal.
- `async_main` selects the role future against a `sigend()` future (SIGTERM/SIGINT/SIGHUP — the exact set from `iperf_catch_sigend`). A signal exit prints iperf3's interrupt notice (`riperf3: interrupt - the server has terminated by signal Terminated(15)`) and exits **0**, matching `iperf_signormalexit`.
- Daemon case works because `daemon(nochdir=true)` keeps CWD, so a relative `-I` path resolves identically at unlink time (pre-existing design, noted in the daemonize comment).
- Non-unix: no signal path (unchanged behavior) but gains the normal-exit unlink.

Scope note: iperf3's sigend also dumps accumulated stats when a test is mid-flight and notifies the peer (`SERVER_TERMINATE`). That's a separate, larger faithfulness item — this PR is scoped to #105 (pidfile + clean signal exit).

## TDD

Both tests red before the fix (pidfile remained), green after:
- `pidfile_unlinked_on_sigterm` — SIGTERM via `libc::kill` (NOT `Child::kill`, which sends SIGKILL and bypasses the handler); asserts the pidfile is gone **and** exit code 0.
- `pidfile_unlinked_after_one_off_run` — `-s -1` completes a test, exits normally, pidfile gone.

xcheck: all 7 targets compile (linux gnu/musl, windows-msvc, mac x86/arm, freebsd, netbsd). Full workspace suite green.

Closes #105.