### PR TITLE
fix(tcp_info): real macOS Retr/Cwnd via hand-rolled tcp_connection_info (#96)

### DIFF
--- a/riperf3/src/tcp_info.rs
+++ b/riperf3/src/tcp_info.rs
@@ -190,15 +190,53 @@ mod tests {
         }
     }
 
-    // #40: only platforms with a real sender retransmit *packet* count advertise
-    // retransmit info. macOS (bytes only) and other targets must report false so
-    // the Retr column isn't a misleading 0. Runs on every platform; the macOS
-    // assertion is validated by the macOS native CI job.
+    // #40/#96: only platforms with a real sender retransmit *packet* count
+    // advertise retransmit info. iperf3 shows Retr+Cwnd on macOS by reading
+    // tcp_connection_info.tcpi_txretransmitpackets, so macOS belongs on the
+    // "has" side (#96 restores it via the hand-rolled binding). Runs on every
+    // platform; the macOS assertion is validated by the macOS native CI job.
     #[test]
     fn retransmit_info_only_where_packet_count_exists() {
-        #[cfg(any(target_os = "linux", target_os = "freebsd"))]
+        #[cfg(any(target_os = "linux", target_os = "freebsd", target_os = "macos"))]
         assert!(has_retransmit_info());
-        #[cfg(not(any(target_os = "linux", target_os = "freebsd")))]
+        #[cfg(not(any(target_os = "linux", target_os = "freebsd", target_os = "macos")))]
         assert!(!has_retransmit_info());
+    }
+
+    // #96: on macOS the snapshot must come from the hand-rolled
+    // tcp_connection_info binding — sane prefix fields (maxseg) prove the
+    // struct layout lines up with what the kernel wrote (a mislaid struct
+    // reads garbage or zeros here), and total_retransmits comes from the real
+    // tcpi_txretransmitpackets counter (0 is the expected value on loopback).
+    // Validated by the macOS native CI job.
+    #[cfg(target_os = "macos")]
+    #[tokio::test]
+    async fn macos_snapshot_reads_sane_values() {
+        use std::os::unix::io::AsRawFd;
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let client =
+            tokio::spawn(async move { tokio::net::TcpStream::connect(addr).await.unwrap() });
+        let (server_stream, _) = listener.accept().await.unwrap();
+        let _client_stream = client.await.unwrap();
+
+        let info = get_tcp_info(server_stream.as_raw_fd()).expect("TCP_CONNECTION_INFO");
+        assert!(
+            info.snd_mss > 0 && info.snd_mss < 65_536,
+            "maxseg implausible — struct layout suspect: {}",
+            info.snd_mss
+        );
+        assert_eq!(
+            info.total_retransmits, 0,
+            "loopback handshake should have no retransmits"
+        );
+        // xnu reports tcpi_snd_cwnd in BYTES; iperf3 uses it raw. A cwnd below
+        // one segment or above 1 GiB would indicate a unit or layout error.
+        assert!(
+            info.snd_cwnd >= info.snd_mss as u64 && info.snd_cwnd < (1 << 30),
+            "snd_cwnd implausible: {}",
+            info.snd_cwnd
+        );
     }
 }

--- a/riperf3/src/tcp_info.rs
+++ b/riperf3/src/tcp_info.rs
@@ -63,16 +63,68 @@ pub fn get_tcp_info(fd: i32) -> Option<TcpInfoSnapshot> {
     })
 }
 
+/// Apple's `struct tcp_connection_info` (xnu `bsd/netinet/tcp.h`), hand-rolled
+/// because libc 0.2.x's binding is wrong twice over (#96): it omits the final
+/// `tcpi_txretransmitpackets` field — the sender retransmit packet count iperf3
+/// reads for the macOS Retr column — and it declares the 15 one-bit
+/// `tcpi_tfo_*` flags as fifteen separate `u32` fields where the kernel packs
+/// them (plus a 17-bit pad) into ONE `u32`, which shifts every trailing `u64`
+/// counter 60 bytes past where the kernel writes it. Layout pinned against the
+/// xnu header by the const asserts below; the `u64` block needs no explicit
+/// align attribute because offset 56 is already 8-aligned under `repr(C)`.
+#[cfg(target_os = "macos")]
+#[repr(C)]
+#[allow(dead_code)] // kernel ABI mirror — every field is required for layout
+struct TcpConnectionInfo {
+    tcpi_state: u8,
+    tcpi_snd_wscale: u8,
+    tcpi_rcv_wscale: u8,
+    __pad1: u8,
+    tcpi_options: u32,
+    tcpi_flags: u32,
+    tcpi_rto: u32,
+    tcpi_maxseg: u32,
+    tcpi_snd_ssthresh: u32,
+    tcpi_snd_cwnd: u32,
+    tcpi_snd_wnd: u32,
+    tcpi_snd_sbbytes: u32,
+    tcpi_rcv_wnd: u32,
+    tcpi_rttcur: u32,
+    tcpi_srtt: u32,
+    tcpi_rttvar: u32,
+    /// The 15 one-bit `tcpi_tfo_*` flags + `__pad2:17`, packed in one word.
+    tcpi_tfo_bits: u32,
+    tcpi_txpackets: u64,
+    tcpi_txbytes: u64,
+    tcpi_txretransmitbytes: u64,
+    tcpi_rxpackets: u64,
+    tcpi_rxbytes: u64,
+    tcpi_rxoutoforderbytes: u64,
+    tcpi_txretransmitpackets: u64,
+}
+
+#[cfg(target_os = "macos")]
+const _: () = {
+    // xnu's layout: 4×u8 + 13×u32 = 56, then seven 8-aligned u64s = 112 total.
+    assert!(std::mem::size_of::<TcpConnectionInfo>() == 112);
+    assert!(std::mem::offset_of!(TcpConnectionInfo, tcpi_txpackets) == 56);
+    assert!(std::mem::offset_of!(TcpConnectionInfo, tcpi_txretransmitpackets) == 104);
+};
+
 /// Query TCP_CONNECTION_INFO for a connected TCP socket (macOS).
 #[cfg(target_os = "macos")]
 pub fn get_tcp_info(fd: i32) -> Option<TcpInfoSnapshot> {
     use std::mem::{self, MaybeUninit};
 
-    // SAFETY: getsockopt(TCP_CONNECTION_INFO) is a read-only kernel query on a valid fd.
-    // Same irreducible kernel boundary as the Linux TCP_INFO variant.
+    // SAFETY: getsockopt(TCP_CONNECTION_INFO) is a read-only kernel query on a
+    // valid fd — the same irreducible kernel boundary as the Linux TCP_INFO
+    // variant, against the hand-rolled struct above (layout const-asserted).
+    // The buffer is ZEROED, not uninit: an older kernel that predates the
+    // trailing counters returns a shorter length and the unwritten tail must
+    // read as 0, not as uninitialized memory.
     let info = unsafe {
-        let mut info = MaybeUninit::<libc::tcp_connection_info>::uninit();
-        let mut len = mem::size_of::<libc::tcp_connection_info>() as libc::socklen_t;
+        let mut info = MaybeUninit::<TcpConnectionInfo>::zeroed();
+        let mut len = mem::size_of::<TcpConnectionInfo>() as libc::socklen_t;
         let ret = libc::getsockopt(
             fd,
             libc::IPPROTO_TCP,
@@ -87,8 +139,13 @@ pub fn get_tcp_info(fd: i32) -> Option<TcpInfoSnapshot> {
     };
 
     Some(TcpInfoSnapshot {
-        total_retransmits: 0, // macOS only has tcpi_txretransmitbytes, not packet count
-        snd_cwnd: info.tcpi_snd_cwnd as u64 * info.tcpi_maxseg as u64,
+        // The real sender retransmit packet count (#96) — the same field
+        // iperf3 reads on macOS. Saturate into the cross-platform u32.
+        total_retransmits: info.tcpi_txretransmitpackets.min(u32::MAX as u64) as u32,
+        // xnu reports tcpi_snd_cwnd in BYTES (unlike Linux's segments), and
+        // iperf3 uses it raw — multiplying by maxseg here would inflate the
+        // Cwnd column ~1500x (#96).
+        snd_cwnd: info.tcpi_snd_cwnd as u64,
         snd_wnd: info.tcpi_snd_wnd as u64,
         rtt: info.tcpi_srtt,
         rttvar: info.tcpi_rttvar,
@@ -141,20 +198,18 @@ pub fn get_tcp_info(_fd: i32) -> Option<TcpInfoSnapshot> {
 /// Whether this platform provides a usable TCP **retransmit packet count** for
 /// the sender (the `Retr` column / JSON `sender_has_retransmits`).
 ///
-/// macOS is deliberately excluded (#40). iperf3 *does* report retransmits on
-/// macOS — it reads `tcp_connection_info.tcpi_txretransmitpackets` (a sender
-/// retransmit packet count) and shows the Retr+Cwnd columns. But the Rust `libc`
-/// binding's `tcp_connection_info` does not expose that field — its sender-side
-/// retransmit member is `tcpi_txretransmitbytes` (retransmitted *bytes*) — so
-/// riperf3's `get_tcp_info` can only hard-code `total_retransmits: 0`. Rather
-/// than print a perpetual, misleading `Retr 0` (implying a loss-free transfer),
-/// we report no retransmit info on macOS. The Retr and Cwnd columns are gated
-/// together (iperf3 couples them on the same flag), so Cwnd is suppressed with
-/// it. This is a deliberate divergence from iperf3 for now; the faithful fix —
-/// reading `tcpi_txretransmitpackets` via a custom struct binding to show the
-/// real macOS Retr/Cwnd — is a deferred follow-up, not patch scope.
+/// macOS qualifies since #96: `get_tcp_info` reads the kernel's real
+/// `tcpi_txretransmitpackets` via the hand-rolled `TcpConnectionInfo` binding
+/// (the `libc` crate's `tcp_connection_info` both omits that field and mislays
+/// the struct's tail — see the binding's doc comment), restoring the Retr+Cwnd
+/// columns iperf3 shows on macOS. The columns are gated together (iperf3
+/// couples them on the same flag).
 pub fn has_retransmit_info() -> bool {
-    cfg!(any(target_os = "linux", target_os = "freebsd"))
+    cfg!(any(
+        target_os = "linux",
+        target_os = "freebsd",
+        target_os = "macos"
+    ))
 }
 
 #[cfg(test)]

--- a/riperf3/src/tcp_info.rs
+++ b/riperf3/src/tcp_info.rs
@@ -3,7 +3,8 @@
 pub struct TcpInfoSnapshot {
     /// Cumulative retransmissions over the connection lifetime.
     pub total_retransmits: u32,
-    /// Send congestion window in bytes (`tcpi_snd_cwnd * tcpi_snd_mss`).
+    /// Send congestion window in bytes (Linux/FreeBSD report segments, so
+    /// those readers multiply by mss; macOS reports bytes directly).
     pub snd_cwnd: u64,
     /// Send window advertised by the receiver, in bytes.
     #[allow(dead_code)]

--- a/riperf3/src/tcp_info.rs
+++ b/riperf3/src/tcp_info.rs
@@ -3,15 +3,20 @@
 pub struct TcpInfoSnapshot {
     /// Cumulative retransmissions over the connection lifetime.
     pub total_retransmits: u32,
-    /// Send congestion window in bytes (Linux/FreeBSD report segments, so
-    /// those readers multiply by mss; macOS reports bytes directly).
+    /// Send congestion window in bytes. Linux reports segments, so that
+    /// reader multiplies by mss; macOS reports bytes and is used raw, like
+    /// iperf3. (FreeBSD also reports bytes but its reader still multiplies —
+    /// pre-existing unit bug, #155.)
     pub snd_cwnd: u64,
     /// Send window advertised by the receiver, in bytes.
     #[allow(dead_code)]
     pub snd_wnd: u64,
-    /// Smoothed round-trip time in microseconds.
+    /// Smoothed round-trip time in microseconds. On macOS the kernel's
+    /// `tcpi_srtt` is MILLIseconds and is kept raw — iperf3 has the identical
+    /// quirk (its APPLE `get_rtt` feeds tcpi_srtt into a usec-treated field),
+    /// so converting here would diverge from iperf3's output.
     pub rtt: u32,
-    /// RTT variance in microseconds.
+    /// RTT variance in microseconds (macOS: milliseconds, raw — see `rtt`).
     pub rttvar: u32,
     /// Sender maximum segment size.
     #[allow(dead_code)]
@@ -65,14 +70,16 @@ pub fn get_tcp_info(fd: i32) -> Option<TcpInfoSnapshot> {
 }
 
 /// Apple's `struct tcp_connection_info` (xnu `bsd/netinet/tcp.h`), hand-rolled
-/// because libc 0.2.x's binding is wrong twice over (#96): it omits the final
-/// `tcpi_txretransmitpackets` field — the sender retransmit packet count iperf3
-/// reads for the macOS Retr column — and it declares the 15 one-bit
-/// `tcpi_tfo_*` flags as fifteen separate `u32` fields where the kernel packs
-/// them (plus a 17-bit pad) into ONE `u32`, which shifts every trailing `u64`
-/// counter 60 bytes past where the kernel writes it. Layout pinned against the
-/// xnu header by the const asserts below; the `u64` block needs no explicit
-/// align attribute because offset 56 is already 8-aligned under `repr(C)`.
+/// because libc 0.2.x's binding is wrong twice over (#96): it has no
+/// `tcpi_txretransmitpackets` — the sender retransmit packet count iperf3
+/// reads for the macOS Retr column; its seventh trailing u64 is misnamed
+/// `tcpi_rxretransmitpackets`, a field xnu does not have — and it declares the
+/// 15 one-bit `tcpi_tfo_*` flags as fifteen separate `u32` fields where the
+/// kernel packs them (plus a 17-bit pad) into ONE `u32`, which lands its u64
+/// tail at offset 120 where the kernel writes at 56 — every trailing counter
+/// read 64 bytes past the data. Layout pinned against the xnu header by the
+/// const asserts below; the `u64` block needs no explicit align attribute
+/// because offset 56 is already 8-aligned under `repr(C)`.
 #[cfg(target_os = "macos")]
 #[repr(C)]
 #[allow(dead_code)] // kernel ABI mirror — every field is required for layout


### PR DESCRIPTION
## Summary

iperf3 shows Retr+Cwnd on macOS with real data (`has_tcpinfo_retransmits()` is 1 under `__APPLE__ && TCP_CONNECTION_INFO`; `get_total_retransmits()` reads `tcpi_txretransmitpackets`, tcp_info.c:140-141). riperf3 suppressed both columns (#95) because the `libc` crate's binding can't express that read. This PR hand-rolls the struct per xnu's `bsd/netinet/tcp.h` and restores macOS to `has_retransmit_info()`.

**The libc 0.2.x binding is wrong twice over** (verified against the xnu header):
1. It omits the trailing `tcpi_txretransmitpackets` field entirely (the count iperf3 uses) — the premise of #96.
2. It declares the 15 one-bit `tcpi_tfo_*` flags as **fifteen separate `u32` fields** where the kernel packs them (plus a 17-bit pad) into **one** `u32` — shifting every trailing `u64` counter 60 bytes past where the kernel writes. Any libc consumer reading those counters on macOS gets zeros/garbage. riperf3's existing macOS reads only touched the agreeing prefix (offsets < 56), so they were safe; this may merit an upstream rust-lang/libc report.

The hand-rolled binding is layout-pinned by compile-time asserts (size 112; `tcpi_txpackets` at 56; `tcpi_txretransmitpackets` at 104) that fire on any apple-target `cargo check` — locally verified, no Mac needed.

**Also fixes a latent Cwnd unit error this un-suppression would have exposed:** xnu reports `tcpi_snd_cwnd` in **bytes** (Linux: segments) and iperf3 uses it raw (tcp_info.c:163); the old `snd_cwnd * maxseg` would have inflated the macOS Cwnd column ~1500×.

The getsockopt buffer is zeroed (not uninit), so an older kernel returning a shorter struct yields 0 counters rather than uninitialized reads.

## TDD

First commit carries the tests alone — red on the macOS native CI job at that commit (`retransmit_info_only_where_packet_count_exists` moves macOS to the "has" side; new `macos_snapshot_reads_sane_values` pins layout sanity via plausible maxseg/cwnd values, zero loopback retransmits, and the bytes-not-segments cwnd range). The macOS native CI run on this PR is the green proof; Linux/FreeBSD behavior is untouched.

xcheck: all 7 targets compile (the layout const-asserts evaluate on the apple targets).

Closes #96.