### PR TITLE
perf(stream): cumulative-average -b throttle + wire --pacing-timer (#32/#116)

### DIFF
--- a/riperf3-cli/src/cli.rs
+++ b/riperf3-cli/src/cli.rs
@@ -1531,6 +1531,14 @@ mod cli_tests {
             assert_eq!(c, expected_client("h").cntl_ka("10/5/3").build().unwrap());
         }
 
+        // #32: --pacing-timer was parsed but never wired — a silent no-op.
+        #[test]
+        fn pacing_timer_wired() {
+            let cli = Cli::parse_from(["riperf3", "-c", "h", "--pacing-timer", "500"]);
+            let c = build_client_from_cli(&cli);
+            assert_eq!(c, expected_client("h").pacing_timer(500).build().unwrap());
+        }
+
         #[test]
         fn format_wired() {
             // The CLI always sets a format (default 'm'); `-f g` must propagate.

--- a/riperf3-cli/src/cli.rs
+++ b/riperf3-cli/src/cli.rs
@@ -199,7 +199,9 @@ pub struct Cli {
     pub cport: Option<u16>,
 
     /// Set the server timing for pacing in microseconds (deprecated)
-    #[arg(long, value_name = "usec")]
+    // Capped at i32::MAX: the wire TestParams field is i32 (a larger u32
+    // would wrap negative on the wire — review r1).
+    #[arg(long, value_name = "usec", value_parser = clap::value_parser!(u32).range(..=i32::MAX as i64))]
     pub pacing_timer: Option<u32>,
 
     /// Only use IPv4

--- a/riperf3-cli/src/cli.rs
+++ b/riperf3-cli/src/cli.rs
@@ -442,6 +442,9 @@ impl Cli {
         if let Some(t) = self.time {
             builder = builder.duration(t);
         }
+        if let Some(us) = self.pacing_timer {
+            builder = builder.pacing_timer(us);
+        }
         if let Some(ref s) = self.bytes {
             builder = builder.bytes_str(s)?;
         }

--- a/riperf3/src/client.rs
+++ b/riperf3/src/client.rs
@@ -328,6 +328,9 @@ impl Client {
         // it. `bandwidth` is the effective rate after the build-time default
         // (UDP unset → 1 Mbit/s), so 0 here unambiguously means unlimited (#17).
         p.bandwidth = Some(self.bandwidth);
+        // Always sent, like iperf3 (default 1000 µs): the server's
+        // reverse/bidir sender paces on the client's quantum (#32).
+        p.pacing_timer = Some(self.pacing_timer as i32);
         if self.tos != 0 {
             p.tos = Some(self.tos);
         }
@@ -483,6 +486,7 @@ impl Client {
                         let d = done.clone();
                         let zc = self.zerocopy;
                         let rate = self.bandwidth;
+                        let pt = self.pacing_timer;
                         let bb = byte_budget.clone();
                         tokio::spawn(async move {
                             // Zerocopy (sendfile) is used only for an unlimited,
@@ -512,11 +516,12 @@ impl Client {
                                     target_os = "freebsd"
                                 )))]
                                 {
-                                    stream::run_tcp_sender(data_stream, c, buf, d, fp, rate, bb)
+                                    stream::run_tcp_sender(data_stream, c, buf, d, fp, rate, pt, bb)
                                         .await
                                 }
                             } else {
-                                stream::run_tcp_sender(data_stream, c, buf, d, fp, rate, bb).await
+                                stream::run_tcp_sender(data_stream, c, buf, d, fp, rate, pt, bb)
+                                    .await
                             }
                         })
                     } else {

--- a/riperf3/src/client.rs
+++ b/riperf3/src/client.rs
@@ -35,6 +35,7 @@ pub struct Client {
     pub(crate) mss: Option<i32>,
     pub(crate) window: Option<i32>,
     pub(crate) bandwidth: u64,
+    pub(crate) pacing_timer: u32,
     pub(crate) tos: i32,
     pub(crate) congestion: Option<String>,
     pub(crate) udp_counters_64bit: bool,
@@ -1254,6 +1255,7 @@ pub struct ClientBuilder {
     mss: Option<i32>,
     window: Option<i32>,
     bandwidth: Option<u64>,
+    pacing_timer: u32,
     tos: i32,
     congestion: Option<String>,
     udp_counters_64bit: bool,
@@ -1310,6 +1312,7 @@ impl Default for ClientBuilder {
             mss: None,
             window: None,
             bandwidth: None,
+            pacing_timer: 0,
             tos: 0,
             congestion: None,
             udp_counters_64bit: false,
@@ -1421,6 +1424,13 @@ impl ClientBuilder {
         // `Some` even for 0: an explicit `-b 0` means unlimited and must be
         // distinguishable from "unset" (which resolves to the UDP default) (#17).
         self.bandwidth = Some(bps);
+        self
+    }
+
+    /// `--pacing-timer`: the `-b` throttle's wakeup quantum in microseconds
+    /// (iperf3 default 1000). 0 falls back to the default.
+    pub fn pacing_timer(mut self, us: u32) -> Self {
+        self.pacing_timer = us;
         self
     }
 
@@ -1741,6 +1751,13 @@ impl ClientBuilder {
                 TransportProtocol::Udp => DEFAULT_UDP_RATE,
                 TransportProtocol::Tcp => 0,
             }),
+            // 0 = unset → iperf3's default quantum, like its pacing_timer
+            // option parsing (it never sends 0).
+            pacing_timer: if self.pacing_timer == 0 {
+                crate::utils::DEFAULT_PACING_TIMER_US
+            } else {
+                self.pacing_timer
+            },
             tos,
             congestion: self.congestion,
             udp_counters_64bit: self.udp_counters_64bit,
@@ -2088,6 +2105,17 @@ mod tests {
                 .build()
                 .unwrap();
             assert_eq!(c.build_params(1460).bandwidth, Some(0));
+        }
+
+        // #32: iperf3 ALWAYS sends pacing_timer in the param exchange (default
+        // 1000 µs), so the server's reverse/bidir sender paces on the same
+        // quantum. riperf3 left it unset.
+        #[test]
+        fn build_params_always_sends_pacing_timer() {
+            let c = ClientBuilder::new("h").build().unwrap();
+            assert_eq!(c.build_params(1460).pacing_timer, Some(1000));
+            let c = ClientBuilder::new("h").pacing_timer(500).build().unwrap();
+            assert_eq!(c.build_params(1460).pacing_timer, Some(500));
         }
 
         // -- forward UDP receiver-loss reporting (issue #25) --

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -23,6 +23,7 @@ pub(crate) struct TestConfig {
     pub mss: Option<i32>,
     pub window: Option<i32>,
     pub bandwidth: u64,
+    pub pacing_timer: u32,
     pub tos: i32,
     pub congestion: Option<String>,
     pub udp_counters_64bit: bool,
@@ -63,6 +64,7 @@ impl TestConfig {
             // 1 Mbit/s throttled an iperf3 -b 0 reverse/bidir sender (#21). The
             // 1 Mbit/s UDP default is a client-side concern, resolved at build.
             bandwidth: params.bandwidth.unwrap_or(0),
+            pacing_timer: crate::utils::DEFAULT_PACING_TIMER_US,
             tos: params.tos.unwrap_or(0),
             congestion: params.congestion.clone(),
             udp_counters_64bit: params.udp_counters_64bit.unwrap_or(0) != 0,
@@ -1727,6 +1729,25 @@ mod test_config_tests {
         assert_eq!(cfg.tos, 0x10);
         assert_eq!(cfg.congestion, Some("bbr".to_string()));
         assert!(cfg.udp_counters_64bit);
+    }
+
+    // #32: the server's reverse/bidir sender must pace on the CLIENT's
+    // pacing-timer quantum — iperf3 always sends it and the server honors it.
+    // Absent/zero (older peers) falls back to iperf3's 1000 µs default.
+    #[test]
+    fn from_params_honors_peer_pacing_timer() {
+        let p = TestParams {
+            pacing_timer: Some(250),
+            ..Default::default()
+        };
+        assert_eq!(TestConfig::from_params(&p).pacing_timer, 250);
+        let p = TestParams::default();
+        assert_eq!(TestConfig::from_params(&p).pacing_timer, 1000);
+        let p = TestParams {
+            pacing_timer: Some(0),
+            ..Default::default()
+        };
+        assert_eq!(TestConfig::from_params(&p).pacing_timer, 1000);
     }
 
     // -- server mirrors the client's rate resolution (#17) --

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -64,7 +64,13 @@ impl TestConfig {
             // 1 Mbit/s throttled an iperf3 -b 0 reverse/bidir sender (#21). The
             // 1 Mbit/s UDP default is a client-side concern, resolved at build.
             bandwidth: params.bandwidth.unwrap_or(0),
-            pacing_timer: crate::utils::DEFAULT_PACING_TIMER_US,
+            // The client's --pacing-timer quantum (#32); iperf3 always sends
+            // it. Absent/non-positive (older peers) → iperf3's 1000 µs default.
+            pacing_timer: params
+                .pacing_timer
+                .filter(|&us| us > 0)
+                .map(|us| us as u32)
+                .unwrap_or(crate::utils::DEFAULT_PACING_TIMER_US),
             tos: params.tos.unwrap_or(0),
             congestion: params.congestion.clone(),
             udp_counters_64bit: params.udp_counters_64bit.unwrap_or(0) != 0,
@@ -353,11 +359,13 @@ impl Server {
                         let c = counters.clone();
                         let d = done.clone();
                         // `-b` paces the sender in reverse/bidir too (negotiated
-                        // rate; 0 = unlimited). #102
+                        // rate; 0 = unlimited), on the client's pacing-timer
+                        // quantum. #102/#32
                         let rate = cfg.bandwidth;
+                        let pt = cfg.pacing_timer;
                         let bb = byte_budget.clone();
                         tokio::spawn(async move {
-                            stream::run_tcp_sender(data_stream, c, buf, d, fp, rate, bb).await
+                            stream::run_tcp_sender(data_stream, c, buf, d, fp, rate, pt, bb).await
                         })
                     } else {
                         let c = counters.clone();

--- a/riperf3/src/stream.rs
+++ b/riperf3/src/stream.rs
@@ -1729,6 +1729,31 @@ mod tests {
 
     // -- RateLimiter --
 
+    // #116: with TCP's 128 KiB default block, the old token bucket's burst
+    // floor (max(rate*0.1, 4*blksize) = 512 KiB, granted instantly) overshoots
+    // a low -b by ~2x at 1 Mbit/s. iperf3's cumulative-average throttle bounds
+    // total sent to elapsed*rate + one in-flight block at any rate/blksize.
+    #[tokio::test]
+    async fn rate_limiter_total_accuracy_low_rate_large_blocks() {
+        let rate_bits: u64 = 1_000_000; // 1 Mbit/s
+        let blk: u64 = 128 * 1024; // TCP default block
+        let mut limiter = RateLimiter::new(rate_bits, 0, blk as usize);
+        let start = Instant::now();
+        let mut sent: u64 = 0;
+        while start.elapsed() < Duration::from_millis(1000) {
+            limiter.acquire(blk).await;
+            sent += blk;
+        }
+        let budget = (rate_bits as f64 / 8.0) * start.elapsed().as_secs_f64();
+        let bound = budget * 1.25 + blk as f64;
+        assert!(
+            (sent as f64) <= bound,
+            "sent {sent} bytes in {:?}; budget {budget:.0} (+25% + one block = {bound:.0}) — \
+             initial burst overshoots the target rate (#116)",
+            start.elapsed()
+        );
+    }
+
     #[tokio::test]
     async fn rate_limiter_allows_burst() {
         let mut limiter = RateLimiter::new(1_000_000, 0, 1000); // 1 Mbit/s, 1000-byte blocks

--- a/riperf3/src/stream.rs
+++ b/riperf3/src/stream.rs
@@ -246,10 +246,10 @@ impl UdpRecvStats {
 }
 
 // ---------------------------------------------------------------------------
-// Rate limiter (token bucket for UDP pacing)
+// Rate limiter (cumulative-average throttle for `-b` pacing, TCP path)
 // ---------------------------------------------------------------------------
 
-/// Token-bucket rate limiter for application-level send pacing.
+/// Cumulative-average rate limiter for application-level send pacing.
 pub struct RateLimiter {
     rate_bytes_per_sec: f64,
     /// Wakeup quantum when behind schedule (`--pacing-timer`, iperf3 default
@@ -268,7 +268,9 @@ impl RateLimiter {
     /// with TCP's 128 KiB default block (#116). High rates self-correct the
     /// other way: after an oversleep the average is behind, so blocks go out
     /// back-to-back with no sleep — burstiness ≈ rate × pacing quantum,
-    /// exactly iperf3's behavior.
+    /// matching the documented `--pacing-timer` semantics (iperf3 <= 3.15's
+    /// timer-driven throttle; 3.17+ deprecated the quantum and sleeps exactly
+    /// to the green-light instant — same long-run average either way).
     ///
     /// - `rate_bits_per_sec`: target send rate
     /// - `pacing_timer_us`: wakeup quantum when behind (`--pacing-timer`,
@@ -298,8 +300,9 @@ impl RateLimiter {
                 break;
             }
             // Sleep to the green-light instant, but never less than the pacing
-            // quantum — iperf3's minimum wakeup is one pacing-timer tick, and
-            // the cumulative math absorbs any oversleep.
+            // quantum — the documented --pacing-timer semantics (iperf3
+            // <= 3.15's minimum wakeup was one tick; 3.17+ deprecated the
+            // quantum). The cumulative math absorbs any oversleep.
             let to_green = Duration::from_secs_f64(behind / self.rate_bytes_per_sec);
             tokio::time::sleep(to_green.max(self.pacing)).await;
         }

--- a/riperf3/src/stream.rs
+++ b/riperf3/src/stream.rs
@@ -252,52 +252,58 @@ impl UdpRecvStats {
 /// Token-bucket rate limiter for application-level send pacing.
 pub struct RateLimiter {
     rate_bytes_per_sec: f64,
-    burst_bytes: f64,
-    tokens: f64,
-    last_refill: Instant,
+    /// Wakeup quantum when behind schedule (`--pacing-timer`, iperf3 default
+    /// 1000 µs).
+    pacing: Duration,
+    start: tokio::time::Instant,
+    sent: u64,
 }
 
 impl RateLimiter {
-    /// Create a rate limiter.
+    /// Create a rate limiter using iperf3's cumulative-average throttle
+    /// (`iperf_check_throttle`): a send is green-lit whenever the cumulative
+    /// bytes are at or below `elapsed * rate`, so total overshoot is bounded
+    /// by ONE in-flight block at any rate — the old token bucket's burst floor
+    /// (max(rate*0.1, 4*blksize), granted up front) overshot a low `-b` by 2x
+    /// with TCP's 128 KiB default block (#116). High rates self-correct the
+    /// other way: after an oversleep the average is behind, so blocks go out
+    /// back-to-back with no sleep — burstiness ≈ rate × pacing quantum,
+    /// exactly iperf3's behavior.
     ///
     /// - `rate_bits_per_sec`: target send rate
-    /// - `burst_packets`: how many packets to send per burst (0 = auto)
-    /// - `blksize`: datagram/block size in bytes
-    pub fn new(rate_bits_per_sec: u64, burst_packets: u32, blksize: usize) -> Self {
-        let rate_bytes = rate_bits_per_sec as f64 / 8.0;
-        // Default burst: ~100ms worth of data, minimum 4 packets.
-        // This avoids per-packet tokio::sleep overhead which has ~1ms granularity.
-        let burst = if burst_packets > 0 {
-            burst_packets as f64 * blksize as f64
+    /// - `pacing_timer_us`: wakeup quantum when behind (`--pacing-timer`,
+    ///   0 → iperf3's 1000 µs default)
+    pub fn new(rate_bits_per_sec: u64, pacing_timer_us: u32) -> Self {
+        let pacing_us = if pacing_timer_us == 0 {
+            crate::utils::DEFAULT_PACING_TIMER_US
         } else {
-            (rate_bytes * 0.1).max(4.0 * blksize as f64)
+            pacing_timer_us
         };
         Self {
-            rate_bytes_per_sec: rate_bytes,
-            burst_bytes: burst,
-            tokens: burst,
-            last_refill: Instant::now(),
+            rate_bytes_per_sec: rate_bits_per_sec as f64 / 8.0,
+            pacing: Duration::from_micros(pacing_us as u64),
+            // tokio's Instant so the accuracy tests can run under start_paused.
+            start: tokio::time::Instant::now(),
+            sent: 0,
         }
     }
 
-    /// Wait until enough tokens are available for `bytes`, then consume them.
+    /// Wait until the cumulative average is at or below the target rate, then
+    /// account `bytes` as sent.
     pub async fn acquire(&mut self, bytes: u64) {
-        self.refill();
-        let needed = bytes as f64;
-        while self.tokens < needed {
-            let deficit = needed - self.tokens;
-            let wait = Duration::from_secs_f64(deficit / self.rate_bytes_per_sec);
-            tokio::time::sleep(wait).await;
-            self.refill();
+        loop {
+            let allowed = self.start.elapsed().as_secs_f64() * self.rate_bytes_per_sec;
+            let behind = self.sent as f64 - allowed;
+            if behind <= 0.0 {
+                break;
+            }
+            // Sleep to the green-light instant, but never less than the pacing
+            // quantum — iperf3's minimum wakeup is one pacing-timer tick, and
+            // the cumulative math absorbs any oversleep.
+            let to_green = Duration::from_secs_f64(behind / self.rate_bytes_per_sec);
+            tokio::time::sleep(to_green.max(self.pacing)).await;
         }
-        self.tokens -= needed;
-    }
-
-    fn refill(&mut self) {
-        let now = Instant::now();
-        let elapsed = now.duration_since(self.last_refill).as_secs_f64();
-        self.tokens = (self.tokens + elapsed * self.rate_bytes_per_sec).min(self.burst_bytes);
-        self.last_refill = now;
+        self.sent += bytes;
     }
 }
 
@@ -358,6 +364,7 @@ pub(crate) fn make_byte_budget(
 
 /// TCP sender: writes full blocks as fast as the kernel will accept them.
 /// If `file_path` is set, reads from the file into the buffer each iteration.
+#[allow(clippy::too_many_arguments)] // hot-path sender; knobs map 1:1 to CLI flags
 pub async fn run_tcp_sender(
     mut stream: TcpStream,
     counters: Arc<StreamCounters>,
@@ -365,14 +372,16 @@ pub async fn run_tcp_sender(
     done: Arc<AtomicBool>,
     file_path: Option<std::path::PathBuf>,
     rate: u64,
+    pacing_timer_us: u32,
     byte_budget: Option<Arc<AtomicI64>>,
 ) -> Result<()> {
     use std::io::Read;
     let mut file = file_path.as_ref().map(std::fs::File::open).transpose()?;
-    // `-b` pacing: a token bucket caps the application send rate, matching
-    // iperf3's TCP throttle. 0 = unlimited → no limiter, so the default TCP
-    // path is unchanged (#102; mirrors UDP's `-b 0` per #17).
-    let mut limiter = (rate > 0).then(|| RateLimiter::new(rate, 0, buf.len().max(1)));
+    // `-b` pacing: iperf3's cumulative-average throttle caps the application
+    // send rate, waking on the `--pacing-timer` quantum (#32/#116). 0 =
+    // unlimited → no limiter, so the default TCP path is unchanged (#102;
+    // mirrors UDP's `-b 0` per #17).
+    let mut limiter = (rate > 0).then(|| RateLimiter::new(rate, pacing_timer_us));
 
     while !done.load(Ordering::Relaxed) {
         // `-n`/`-k` byte/block limit: claim this block from the shared budget and
@@ -1737,7 +1746,7 @@ mod tests {
     async fn rate_limiter_total_accuracy_low_rate_large_blocks() {
         let rate_bits: u64 = 1_000_000; // 1 Mbit/s
         let blk: u64 = 128 * 1024; // TCP default block
-        let mut limiter = RateLimiter::new(rate_bits, 0, blk as usize);
+        let mut limiter = RateLimiter::new(rate_bits, 0);
         let start = Instant::now();
         let mut sent: u64 = 0;
         while start.elapsed() < Duration::from_millis(1000) {
@@ -1755,23 +1764,21 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn rate_limiter_allows_burst() {
-        let mut limiter = RateLimiter::new(1_000_000, 0, 1000); // 1 Mbit/s, 1000-byte blocks
+    async fn rate_limiter_first_acquire_is_instant() {
+        let mut limiter = RateLimiter::new(1_000_000, 0); // 1 Mbit/s
         let start = Instant::now();
-        // First acquire should be instant (burst tokens available)
+        // Cumulative average: nothing sent yet → always green-lit.
         limiter.acquire(1000).await;
         assert!(start.elapsed() < Duration::from_millis(10));
     }
 
     #[tokio::test]
-    async fn rate_limiter_paces() {
-        // 80_000 bits/sec = 10_000 bytes/sec, 1000-byte blocks
-        // burst = max(10000*0.1, 4*1000) = 4000 bytes
-        let mut limiter = RateLimiter::new(80_000, 0, 1000);
-        // Drain the burst (4 packets)
-        for _ in 0..4 {
-            limiter.acquire(1000).await;
-        }
+    async fn rate_limiter_paces_from_the_second_block() {
+        // 80_000 bits/sec = 10_000 bytes/sec, 1000-byte blocks: after block 1
+        // the average is 1000 bytes ahead of schedule, so block 2 waits ~100ms
+        // — there is no up-front burst grant (#116).
+        let mut limiter = RateLimiter::new(80_000, 0);
+        limiter.acquire(1000).await; // instant
         let start = Instant::now();
         limiter.acquire(1000).await; // must wait ~100ms
         let elapsed = start.elapsed();
@@ -1781,60 +1788,42 @@ mod tests {
 
     #[tokio::test]
     async fn rate_limiter_high_rate_precision() {
-        // At 10 Gbps with 1460-byte packets, drain the burst first,
-        // then verify paced throughput is within 50% of target.
-        // Before fix: tokio::time::sleep caps at ~1 Gbps after burst.
-        // After fix: clock_nanosleep should approach 10 Gbps.
+        // At 10 Gbps the cumulative average is almost always at-or-behind
+        // schedule, so acquires release back-to-back with no sleep; catch-up
+        // after any oversleep keeps throughput within 50% of target.
         let rate = 10_000_000_000u64; // 10 Gbps
-        let blksize = 1460usize;
-        let mut limiter = RateLimiter::new(rate, 0, blksize);
+        let blksize = 1460u64;
+        let mut limiter = RateLimiter::new(rate, 0);
 
-        // Drain the burst completely
-        let burst_bytes = (rate as f64 / 8.0 * 0.1).max(4.0 * blksize as f64) as u64;
-        let burst_packets = burst_bytes / blksize as u64 + 1;
-        for _ in 0..burst_packets {
-            limiter.acquire(blksize as u64).await;
-        }
-
-        // Now measure paced throughput (no burst tokens left)
         let start = Instant::now();
         let mut total_bytes: u64 = 0;
-        let target_duration = Duration::from_millis(100);
-
-        while start.elapsed() < target_duration {
-            limiter.acquire(blksize as u64).await;
-            total_bytes += blksize as u64;
+        while start.elapsed() < Duration::from_millis(100) {
+            limiter.acquire(blksize).await;
+            total_bytes += blksize;
         }
 
         let elapsed = start.elapsed().as_secs_f64();
         let achieved_bps = total_bytes as f64 * 8.0 / elapsed;
-        let target_bps = rate as f64;
-
-        // Should achieve at least 50% of target rate
         assert!(
-            achieved_bps > target_bps * 0.5,
-            "high-rate pacing too slow: {:.1} Gbps achieved, {:.1} Gbps target",
+            achieved_bps > rate as f64 * 0.5,
+            "high-rate pacing too slow: {:.1} Gbps achieved, 10.0 Gbps target",
             achieved_bps / 1e9,
-            target_bps / 1e9,
         );
     }
 
     #[tokio::test]
     async fn rate_limiter_low_rate_still_works() {
-        // Verify that the clock_nanosleep path doesn't break low-rate pacing
-        let mut limiter = RateLimiter::new(1_000_000, 0, 1000); // 1 Mbps
+        let mut limiter = RateLimiter::new(1_000_000, 0); // 1 Mbps
         let start = Instant::now();
         let mut total_bytes: u64 = 0;
 
-        // Send 10 packets at 1 Mbps = ~10ms
+        // 10 × 1000-byte blocks at 125 KB/s ≈ 72ms of pacing after block 1.
         for _ in 0..10 {
             limiter.acquire(1000).await;
             total_bytes += 1000;
         }
 
         let elapsed = start.elapsed();
-        // Should take at least some time (not instant)
-        // Burst covers first ~4 packets, remaining 6 need pacing
         assert!(total_bytes == 10_000);
         // Should complete in under 1 second (generously)
         assert!(elapsed < Duration::from_secs(1));
@@ -1858,7 +1847,7 @@ mod tests {
                 .await
                 .unwrap();
             let buf = vec![0u8; 1024];
-            run_tcp_sender(stream, sc, buf, d, None, 0, None).await
+            run_tcp_sender(stream, sc, buf, d, None, 0, 1000, None).await
         });
 
         let rc = recv_counters.clone();

--- a/riperf3/src/stream.rs
+++ b/riperf3/src/stream.rs
@@ -268,8 +268,8 @@ impl RateLimiter {
     /// with TCP's 128 KiB default block (#116). High rates self-correct the
     /// other way: after an oversleep the average is behind, so blocks go out
     /// back-to-back with no sleep — burstiness ≈ rate × pacing quantum,
-    /// matching the documented `--pacing-timer` semantics (iperf3 <= 3.15's
-    /// timer-driven throttle; 3.17+ deprecated the quantum and sleeps exactly
+    /// matching the documented `--pacing-timer` semantics (iperf3 <= 3.17's
+    /// timer-driven throttle; 3.18+ deprecated the quantum and sleeps exactly
     /// to the green-light instant — same long-run average either way).
     ///
     /// - `rate_bits_per_sec`: target send rate
@@ -301,7 +301,7 @@ impl RateLimiter {
             }
             // Sleep to the green-light instant, but never less than the pacing
             // quantum — the documented --pacing-timer semantics (iperf3
-            // <= 3.15's minimum wakeup was one tick; 3.17+ deprecated the
+            // <= 3.17's minimum wakeup was one tick; 3.18+ deprecated the
             // quantum). The cumulative math absorbs any oversleep.
             let to_green = Duration::from_secs_f64(behind / self.rate_bytes_per_sec);
             tokio::time::sleep(to_green.max(self.pacing)).await;

--- a/riperf3/src/utils.rs
+++ b/riperf3/src/utils.rs
@@ -11,6 +11,9 @@ pub const DEFAULT_NUM_STREAMS: u32 = 1;
 pub const DEFAULT_TCP_BLKSIZE: usize = 128 * 1024; // 128 KiB
 pub const DEFAULT_UDP_BLKSIZE: usize = 1460;
 pub const DEFAULT_UDP_RATE: u64 = 1024 * 1024; // 1 Mbit/sec in bits
+/// iperf3's default `--pacing-timer` interval (µs): the wakeup quantum of its
+/// cumulative-average `-b` throttle (`iperf_check_throttle`).
+pub const DEFAULT_PACING_TIMER_US: u32 = 1000;
 
 /// Minimum UDP datagram size: 4 (sec) + 4 (usec) + 8 (64-bit counter)
 pub const MIN_UDP_BLKSIZE: usize = 16;

--- a/riperf3/tests/integration.rs
+++ b/riperf3/tests/integration.rs
@@ -561,6 +561,44 @@ async fn tcp_bitrate_is_paced() {
     let _ = server_task.await;
 }
 
+/// #116: at a LOW -b with TCP's 128 KiB default block, the old token bucket's
+/// 512 KiB burst floor doubled the achieved rate (verified ~2.10 Mbit/s for
+/// -b 1M against iperf3's 1.05M). iperf3's cumulative-average throttle keeps
+/// the total within one block of elapsed*rate; allow +25% + one block.
+#[tokio::test]
+async fn tcp_low_bitrate_no_overshoot() {
+    let port = next_port();
+    let server = ServerBuilder::new()
+        .port(Some(port))
+        .one_off(true)
+        .build()
+        .unwrap();
+    let server_task = tokio::spawn(async move { server.run().await });
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    let target: u64 = 1_000_000; // 1 Mbit/s — far below the old burst floor
+    let secs: u64 = 2;
+    let client = ClientBuilder::new("127.0.0.1")
+        .port(Some(port))
+        .duration(secs as u32)
+        .bandwidth(target)
+        .build()
+        .unwrap();
+
+    let result = tokio::time::timeout(Duration::from_secs(20), client.run())
+        .await
+        .expect("client hung")
+        .expect("client errored");
+    let bytes: u64 = result.streams.iter().map(|s| s.bytes).sum();
+    let budget = (target / 8 * secs) as f64; // 250 KB
+    let bound = budget * 1.25 + (128 * 1024) as f64;
+    assert!(
+        (bytes as f64) <= bound,
+        "low -b overshoot (#116): sent {bytes} bytes, budget {budget:.0} (bound {bound:.0})"
+    );
+    let _ = server_task.await;
+}
+
 #[tokio::test]
 async fn tcp_unlimited_is_not_paced() {
     // Regression guard: default TCP (no -b ⇒ rate 0) must stay unthrottled.


### PR DESCRIPTION
## Summary

Replaces the token-bucket rate limiter with **iperf3's cumulative-average throttle** (`iperf_check_throttle`): a send is green-lit whenever cumulative bytes ≤ elapsed×rate, bounding total overshoot to one in-flight block at any rate. The old bucket granted a `max(rate×0.1, 4×blksize)` burst up front — 512 KiB at TCP's 128 KiB default block — overshooting `-b 1M` by ~2× (#116, verified vs iperf3). High rates self-correct (post-oversleep catch-up sends back-to-back; burstiness ≈ rate × pacing quantum), exactly iperf3's behavior.

`--pacing-timer` is wired end-to-end (#32): CLI → `ClientBuilder::pacing_timer` (additive) → `TestParams` (**always sent**, like iperf3, default 1000 µs) → the server's reverse/bidir sender paces on the client's quantum (absent/0 from older peers → 1000 µs). Wakeups clamp to the quantum, matching iperf3's minimum tick.

**UDP senders untouched**: the blocking/sendmmsg paths use absolute-schedule pacing with no initial-burst defect, and they're the benchmark hot path.

## TDD

Commit 1 is five red tests with the measured defects in the commit message (unit: 655 KB sent vs 295 KB bound at 1 Mbit; integration: 786 KB end-to-end vs 250 KB budget; params/config/CLI wiring all unwired). Commit 2 turns them green; the pre-existing pacing tests (`tcp_bitrate_is_paced` fwd/rev, `tcp_unlimited_is_not_paced`) stay green. 441 tests, clippy/fmt clean.

## Benchmark gate (BEFORE merge — do not merge on CI alone)

This touches the `-b` data path. Gate: standard N=1 matrix (unlimited cells must be drift-free — the limiter is entirely off at `-b 0`) + targeted `-b` accuracy cells vs iperf3 at 1M/200M/5G/10G including the high-rate catch-up check. Results will be posted on this PR.

Closes #32. Closes #116.