### PR TITLE
fix(report): real -O/--omit semantics (#31)

### DIFF
--- a/riperf3-cli/tests/omit_behavior.rs
+++ b/riperf3-cli/tests/omit_behavior.rs
@@ -99,7 +99,7 @@ fn omit_extends_run_and_resets_timeline() {
             "1",
             "-J",
         ],
-        Duration::from_secs(25),
+        Duration::from_secs(60),
         "client",
     );
     let _ = server.0.wait();
@@ -169,7 +169,7 @@ fn omit_summary_excludes_warmup_bytes() {
             "1",
             "-J",
         ],
-        Duration::from_secs(25),
+        Duration::from_secs(60),
         "client",
     );
     let _ = server.0.wait();
@@ -211,7 +211,7 @@ fn omit_with_byte_limit_applies_post_omit() {
 
     let (out, elapsed) = run_capturing(
         &["-c", "127.0.0.1", "-p", &ps, "-O", "1", "-n", "100M", "-J"],
-        Duration::from_secs(25),
+        Duration::from_secs(60),
         "client",
     );
     let _ = server.0.wait();
@@ -222,10 +222,54 @@ fn omit_with_byte_limit_applies_post_omit() {
     );
     let v: Value =
         serde_json::from_str(&out).unwrap_or_else(|e| panic!("client -J invalid ({e}): {out}"));
+    // `-n 100M` is binary (unit_atoi): 104,857,600. The budget design lands
+    // exactly on it; allow one 128 KiB block of slack. The old driver-poll
+    // refill overshot 1.2-4x (review r2 blocker 3).
     let bytes = v["end"]["sum_sent"]["bytes"].as_u64().expect("bytes");
     assert!(
-        bytes >= 95_000_000,
-        "the -n budget must be transferred POST-omit, got {bytes}: {out}"
+        (104_857_600..=104_988_672).contains(&bytes),
+        "post-omit -n must land on the 104857600-byte target (r2): {bytes}: {out}"
+    );
+}
+
+/// Reverse `-R -n + -O` (r2 blocker 1): the SERVER's senders hit the same
+/// budget design — pre-fix they exhausted the gross budget during warm-up and
+/// broke permanently, so the client's post-omit net target was unreachable
+/// (infinite zero-byte intervals).
+#[test]
+fn omit_with_reverse_byte_limit_terminates() {
+    let port = free_port();
+    let ps = port.to_string();
+    let mut server = spawn_server(&ps);
+
+    let (out, elapsed) = run_capturing(
+        &[
+            "-c",
+            "127.0.0.1",
+            "-p",
+            &ps,
+            "-R",
+            "-O",
+            "1",
+            "-n",
+            "50M",
+            "-J",
+        ],
+        Duration::from_secs(60),
+        "client",
+    );
+    let _ = server.0.wait();
+
+    assert!(
+        elapsed < Duration::from_secs(20),
+        "reverse -n + -O must terminate (r2 blocker 1)"
+    );
+    let v: Value =
+        serde_json::from_str(&out).unwrap_or_else(|e| panic!("client -J invalid ({e}): {out}"));
+    let bytes = v["end"]["sum_received"]["bytes"].as_u64().expect("bytes");
+    assert!(
+        (47_500_000..=53_000_000).contains(&bytes),
+        "reverse post-omit budget must land on ~50M, got {bytes}: {out}"
     );
 }
 
@@ -260,7 +304,7 @@ fn server_intervals_rebased_after_omit() {
             "-i",
             "1",
         ],
-        Duration::from_secs(25),
+        Duration::from_secs(60),
         "client",
     );
     let mut sout = String::new();

--- a/riperf3-cli/tests/omit_behavior.rs
+++ b/riperf3-cli/tests/omit_behavior.rs
@@ -1,0 +1,200 @@
+//! CLI integration tests: `-O/--omit` must behave like iperf3 (#31), not just
+//! tag interval lines. iperf3 runs for `omit + time` seconds, resets statistics
+//! at the omit boundary (the interval timeline restarts at 0), and reports the
+//! summary over the post-omit window only — so slow-start is genuinely
+//! excluded. Pre-#31 riperf3 ran only `-t` seconds and divided cumulative
+//! bytes (including warm-up) by the full duration.
+
+use std::io::Read;
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+use serde_json::Value;
+
+fn free_port() -> u16 {
+    std::net::TcpListener::bind("127.0.0.1:0")
+        .expect("bind ephemeral port")
+        .local_addr()
+        .expect("local_addr")
+        .port()
+}
+
+struct ChildGuard(std::process::Child);
+impl Drop for ChildGuard {
+    fn drop(&mut self) {
+        let _ = self.0.kill();
+        let _ = self.0.wait();
+    }
+}
+
+const SERVER_BIND_WAIT: Duration = Duration::from_secs(2);
+
+fn run_capturing(args: &[&str], timeout: Duration, who: &str) -> (String, Duration) {
+    let bin = env!("CARGO_BIN_EXE_riperf3");
+    let started = Instant::now();
+    let mut child = Command::new(bin)
+        .args(args)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .unwrap_or_else(|e| panic!("{who}: spawn failed: {e}"));
+
+    let deadline = Instant::now() + timeout;
+    loop {
+        match child.try_wait().expect("try_wait") {
+            Some(_) => break,
+            None if Instant::now() >= deadline => {
+                let _ = child.kill();
+                let _ = child.wait();
+                panic!("{who}: timed out");
+            }
+            None => std::thread::sleep(Duration::from_millis(50)),
+        }
+    }
+    let elapsed = started.elapsed();
+    let mut out = String::new();
+    child
+        .stdout
+        .take()
+        .unwrap()
+        .read_to_string(&mut out)
+        .unwrap();
+    (out, elapsed)
+}
+
+fn spawn_server(port_str: &str) -> ChildGuard {
+    let bin = env!("CARGO_BIN_EXE_riperf3");
+    let g = ChildGuard(
+        Command::new(bin)
+            .args(["-s", "-1", "-p", port_str])
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("spawn server"),
+    );
+    std::thread::sleep(SERVER_BIND_WAIT);
+    g
+}
+
+/// `-O 1 -t 2`: the run lasts omit+time (~3 s wall for the data phase), the
+/// summary window is the post-omit `-t` (end.sum_sent.seconds ≈ 2), and the
+/// interval timeline restarts at 0 after the warm-up.
+#[test]
+fn omit_extends_run_and_resets_timeline() {
+    let port = free_port();
+    let ps = port.to_string();
+    let mut server = spawn_server(&ps);
+
+    let (out, elapsed) = run_capturing(
+        &[
+            "-c",
+            "127.0.0.1",
+            "-p",
+            &ps,
+            "-O",
+            "1",
+            "-t",
+            "2",
+            "-i",
+            "1",
+            "-J",
+        ],
+        Duration::from_secs(25),
+        "client",
+    );
+    let _ = server.0.wait();
+
+    // Run extended by the omit period: data phase is ~3 s, so the client
+    // process must live noticeably longer than the unextended 2 s + overhead.
+    assert!(
+        elapsed >= Duration::from_millis(2800),
+        "run must last omit+time like iperf3 (#31); took {elapsed:?}"
+    );
+
+    let v: Value = serde_json::from_str(&out)
+        .unwrap_or_else(|e| panic!("client -J is not valid JSON ({e}): {out}"));
+
+    assert_eq!(
+        v["start"]["test_start"]["omit"].as_i64(),
+        Some(1),
+        "test_start.omit: {out}"
+    );
+
+    // Summary covers the post-omit window only.
+    let secs = v["end"]["sum_sent"]["seconds"].as_f64().expect("seconds");
+    assert!(
+        (1.5..=2.5).contains(&secs),
+        "summary window must be the post-omit -t (≈2 s), got {secs}: {out}"
+    );
+
+    // Warm-up intervals are flagged; the timeline restarts at 0 afterward.
+    let intervals = v["intervals"].as_array().expect("intervals");
+    assert!(!intervals.is_empty());
+    assert_eq!(
+        intervals[0]["sum"]["omitted"].as_bool(),
+        Some(true),
+        "first interval is warm-up: {out}"
+    );
+    let first_real = intervals
+        .iter()
+        .find(|i| i["sum"]["omitted"] == Value::Bool(false))
+        .unwrap_or_else(|| panic!("no post-omit interval: {out}"));
+    assert_eq!(
+        first_real["sum"]["start"].as_f64(),
+        Some(0.0),
+        "iperf3 restarts the interval timeline at 0 after the omit boundary: {out}"
+    );
+}
+
+/// The summary must exclude warm-up bytes: post-omit interval sums must
+/// account for (nearly) all reported bytes — if warm-up bytes leak into the
+/// summary, the non-omitted intervals can't cover them.
+#[test]
+fn omit_summary_excludes_warmup_bytes() {
+    let port = free_port();
+    let ps = port.to_string();
+    let mut server = spawn_server(&ps);
+
+    let (out, _) = run_capturing(
+        &[
+            "-c",
+            "127.0.0.1",
+            "-p",
+            &ps,
+            "-O",
+            "1",
+            "-t",
+            "2",
+            "-i",
+            "1",
+            "-J",
+        ],
+        Duration::from_secs(25),
+        "client",
+    );
+    let _ = server.0.wait();
+
+    let v: Value = serde_json::from_str(&out)
+        .unwrap_or_else(|e| panic!("client -J is not valid JSON ({e}): {out}"));
+    let sum = &v["end"]["sum_sent"];
+    let bytes = sum["bytes"].as_f64().expect("bytes");
+    let secs = sum["seconds"].as_f64().expect("seconds");
+    let bps = sum["bits_per_second"].as_f64().expect("bps");
+    let derived = bytes * 8.0 / secs;
+    assert!(
+        (bps - derived).abs() <= derived * 0.02,
+        "bits_per_second {bps} inconsistent with bytes*8/seconds {derived}: {out}"
+    );
+
+    let interval_bytes: u64 = v["intervals"]
+        .as_array()
+        .expect("intervals")
+        .iter()
+        .filter(|i| i["sum"]["omitted"] == Value::Bool(false))
+        .filter_map(|i| i["sum"]["bytes"].as_u64())
+        .sum();
+    assert!(
+        (bytes as u64) <= interval_bytes + interval_bytes / 5 + 1_000_000,
+        "summary bytes {bytes} exceed post-omit interval bytes {interval_bytes} — warm-up leaked into the summary: {out}"
+    );
+}

--- a/riperf3-cli/tests/omit_behavior.rs
+++ b/riperf3-cli/tests/omit_behavior.rs
@@ -232,12 +232,18 @@ fn omit_with_byte_limit_applies_post_omit() {
     );
 }
 
-/// Reverse `-R -n + -O` (r2 blocker 1): the SERVER's senders hit the same
-/// budget design — pre-fix they exhausted the gross budget during warm-up and
-/// broke permanently, so the client's post-omit net target was unreachable
-/// (infinite zero-byte intervals).
+/// Reverse `-R -n + -O` (r3 blocker 1): iperf3's receive-side limit counts
+/// GROSS bytes — `test->bytes_received` is never reset by `iperf_reset_stats`
+/// (iperf_api.c:3675 zeroes only `bytes_sent`; end check at
+/// iperf_client_api.c:771-772) — so a reverse run whose warm-up already moved
+/// part of the target ends when warm-up + post-omit gross reaches `-n`, NOT
+/// after a fresh post-omit N (the pre-r3 refill semantics, which also raced
+/// the two reporters' boundaries into a ~50% hang). `-b 20M` pins the rate so
+/// the shape is CI-stable: the 1 s warm-up moves ~2.5 MB of the 5 MB target,
+/// so the post-omit (net) receive lands around target − warm-up ≈ 2.5 MB —
+/// far below the ≈5 MB a fresh-N refill would transfer.
 #[test]
-fn omit_with_reverse_byte_limit_terminates() {
+fn omit_with_reverse_byte_limit_ends_on_gross_bytes() {
     let port = free_port();
     let ps = port.to_string();
     let mut server = spawn_server(&ps);
@@ -252,7 +258,9 @@ fn omit_with_reverse_byte_limit_terminates() {
             "-O",
             "1",
             "-n",
-            "50M",
+            "5M",
+            "-b",
+            "20M",
             "-J",
         ],
         Duration::from_secs(60),
@@ -262,15 +270,63 @@ fn omit_with_reverse_byte_limit_terminates() {
 
     assert!(
         elapsed < Duration::from_secs(20),
-        "reverse -n + -O must terminate (r2 blocker 1)"
+        "reverse -n + -O must terminate (r2/r3 blocker 1)"
     );
     let v: Value =
         serde_json::from_str(&out).unwrap_or_else(|e| panic!("client -J invalid ({e}): {out}"));
     let bytes = v["end"]["sum_received"]["bytes"].as_u64().expect("bytes");
     assert!(
-        (47_500_000..=53_000_000).contains(&bytes),
-        "reverse post-omit budget must land on ~50M, got {bytes}: {out}"
+        (200_000..4_400_000).contains(&(bytes as usize)),
+        "reverse post-omit receive must be gross-limited (≈ target − warm-up ≈ 2.5M), \
+         got {bytes}: {out}"
     );
+}
+
+/// Bidir `-n + -O`: the same gross-received rule ends the whole test when
+/// EITHER side's counter (sent net, received gross) reaches the target —
+/// iperf3's OR-check (iperf_client_api.c:771-772). Pre-r3 this raced the two
+/// reporters' boundaries (observed: one block short / intermittent hang).
+#[test]
+fn omit_with_bidir_byte_limit_terminates() {
+    let port = free_port();
+    let ps = port.to_string();
+    let mut server = spawn_server(&ps);
+
+    let (out, elapsed) = run_capturing(
+        &[
+            "-c",
+            "127.0.0.1",
+            "-p",
+            &ps,
+            "--bidir",
+            "-O",
+            "1",
+            "-n",
+            "5M",
+            "-b",
+            "20M",
+            "-J",
+        ],
+        Duration::from_secs(60),
+        "client",
+    );
+    let _ = server.0.wait();
+
+    assert!(
+        elapsed < Duration::from_secs(20),
+        "bidir -n + -O must terminate"
+    );
+    let v: Value =
+        serde_json::from_str(&out).unwrap_or_else(|e| panic!("client -J invalid ({e}): {out}"));
+    // Both directions must be present and bounded: nothing may balloon past
+    // the gross target plus generous stop-latency slop.
+    for key in ["sum_received", "sum_sent"] {
+        let bytes = v["end"][key]["bytes"].as_u64().expect(key);
+        assert!(
+            bytes < 8_000_000,
+            "bidir {key} must stay near the 5M gross target, got {bytes}: {out}"
+        );
+    }
 }
 
 /// #31 r1 blocker 2: the server's reporter end time must be rebased to the

--- a/riperf3-cli/tests/omit_behavior.rs
+++ b/riperf3-cli/tests/omit_behavior.rs
@@ -198,3 +198,97 @@ fn omit_summary_excludes_warmup_bytes() {
         "summary bytes {bytes} exceed post-omit interval bytes {interval_bytes} — warm-up leaked into the summary: {out}"
     );
 }
+
+/// #31 r1 blocker 1: `-n` + `-O` — the byte limit applies to the POST-omit
+/// window (iperf3 gates end conditions on !omitting and resets byte progress
+/// at the boundary). Pre-fix the whole budget was consumed during warm-up:
+/// the run ended in ~0.3 s with warm-up bytes in the summary.
+#[test]
+fn omit_with_byte_limit_applies_post_omit() {
+    let port = free_port();
+    let ps = port.to_string();
+    let mut server = spawn_server(&ps);
+
+    let (out, elapsed) = run_capturing(
+        &["-c", "127.0.0.1", "-p", &ps, "-O", "1", "-n", "100M", "-J"],
+        Duration::from_secs(25),
+        "client",
+    );
+    let _ = server.0.wait();
+
+    assert!(
+        elapsed >= Duration::from_millis(1000),
+        "the warm-up second must elapse before the -n window: took {elapsed:?}"
+    );
+    let v: Value =
+        serde_json::from_str(&out).unwrap_or_else(|e| panic!("client -J invalid ({e}): {out}"));
+    let bytes = v["end"]["sum_sent"]["bytes"].as_u64().expect("bytes");
+    assert!(
+        bytes >= 95_000_000,
+        "the -n budget must be transferred POST-omit, got {bytes}: {out}"
+    );
+}
+
+/// #31 r1 blocker 2: the server's reporter end time must be rebased to the
+/// post-omit timeline — pre-fix the final server interval spanned
+/// [last_tick, omit+t] (a 2 s window holding ~1 s of data, halving its rate).
+#[test]
+fn server_intervals_rebased_after_omit() {
+    let port = free_port();
+    let ps = port.to_string();
+    let bin = env!("CARGO_BIN_EXE_riperf3");
+    let mut server = ChildGuard(
+        Command::new(bin)
+            .args(["-s", "-1", "-J", "-p", &ps])
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("spawn server"),
+    );
+    std::thread::sleep(SERVER_BIND_WAIT);
+
+    let (_out, _) = run_capturing(
+        &[
+            "-c",
+            "127.0.0.1",
+            "-p",
+            &ps,
+            "-O",
+            "1",
+            "-t",
+            "2",
+            "-i",
+            "1",
+        ],
+        Duration::from_secs(25),
+        "client",
+    );
+    let mut sout = String::new();
+    let deadline = Instant::now() + Duration::from_secs(10);
+    while server.0.try_wait().expect("try_wait").is_none() {
+        assert!(Instant::now() < deadline, "server did not exit");
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    server
+        .0
+        .stdout
+        .take()
+        .unwrap()
+        .read_to_string(&mut sout)
+        .unwrap();
+
+    let v: Value =
+        serde_json::from_str(&sout).unwrap_or_else(|e| panic!("server -J invalid ({e}): {sout}"));
+    for i in v["intervals"].as_array().expect("intervals") {
+        let s = i["sum"]["start"].as_f64().unwrap();
+        let e = i["sum"]["end"].as_f64().unwrap();
+        assert!(
+            e - s <= 1.6,
+            "server interval [{s},{e}] spans the un-rebased warm-up (r1 blocker 2): {sout}"
+        );
+        assert!(
+            e <= 2.6,
+            "server timeline must end near the post-omit -t: {sout}"
+        );
+    }
+}

--- a/riperf3/src/client.rs
+++ b/riperf3/src/client.rs
@@ -1020,9 +1020,9 @@ impl Client {
             .iter()
             .map(|s| {
                 let local_bytes = if s.is_sender {
-                    s.counters.bytes_sent()
+                    s.counters.bytes_sent_net()
                 } else {
-                    s.counters.bytes_received()
+                    s.counters.bytes_received_net()
                 };
                 // The peer's per-stream result is the opposite side of this stream.
                 let server_stream =

--- a/riperf3/src/client.rs
+++ b/riperf3/src/client.rs
@@ -1701,7 +1701,10 @@ impl ClientBuilder {
         if self.omit > 60 {
             return Err(ConfigError::InvalidValue(
                 "omit",
-                format!("bogus value for --omit (maximum = 60 seconds): {}", self.omit),
+                format!(
+                    "bogus value for --omit (maximum = 60 seconds): {}",
+                    self.omit
+                ),
             ));
         }
 

--- a/riperf3/src/client.rs
+++ b/riperf3/src/client.rs
@@ -946,17 +946,21 @@ impl Client {
                 // total. The sender task snapshots it into the counters while
                 // its socket is still open; by exchange time the socket is
                 // closed, so a live fd read here only serves as a fallback
-                // for paths that never reached the snapshot.
+                // for paths that never reached the snapshot. With -O the
+                // boundary baseline is subtracted (#171), like iperf3's
+                // stream_retrans after iperf_reset_stats.
                 let retransmits =
                     if s.is_sender && crate::tcp_info::has_retransmit_info() && !is_udp_stream {
-                        match s.counters.final_retransmits() {
-                            n if n >= 0 => n,
+                        let lifetime = match s.counters.final_retransmits() {
+                            n if n >= 0 => Some(n),
                             _ => s
                                 .raw_fd
                                 .and_then(crate::tcp_info::get_tcp_info)
-                                .map(|i| i.total_retransmits as i64)
-                                .unwrap_or(-1),
-                        }
+                                .map(|i| i.total_retransmits as i64),
+                        };
+                        lifetime
+                            .map(|t| s.counters.omit_adjusted_retransmits(t))
+                            .unwrap_or(-1)
                     } else {
                         -1
                     };
@@ -2197,6 +2201,45 @@ mod tests {
         for s in &streams {
             s.task.abort();
         }
+    }
+
+    // #171: with -O, the exchanged per-stream retransmit total must cover
+    // the post-omit window only — iperf3's iperf_reset_stats records
+    // stream_prev_total_retrans at the boundary (iperf_api.c:3687-3692) and
+    // stream_retrans accumulates from there. The reporter's boundary block
+    // stores the same baseline into StreamCounters; the exchange subtracts.
+    #[tokio::test]
+    async fn exchange_retransmits_subtract_the_omit_baseline() {
+        use crate::stream::{DataStream, StreamCounters};
+
+        if !crate::tcp_info::has_retransmit_info() {
+            return;
+        }
+
+        let counters = Arc::new(StreamCounters::new());
+        counters.set_omit_retransmits(5); // boundary baseline (warm-up retransmits)
+        counters.set_final_retransmits(8); // connection-lifetime total at exit
+        let ds = DataStream {
+            id: 1,
+            is_sender: true,
+            counters,
+            udp_recv_stats: None,
+            task: tokio::spawn(async { Ok(()) }),
+            raw_fd: None,
+            local_addr: None,
+            peer_addr: None,
+            sndbuf_actual: None,
+            rcvbuf_actual: None,
+            congestion_used: None,
+        };
+        let client = crate::ClientBuilder::new("127.0.0.1").build().unwrap();
+        let results = client.build_results(std::slice::from_ref(&ds), None, 1.0);
+        assert_eq!(
+            results.streams[0].retransmits, 3,
+            "#171: warm-up retransmits (5) must be subtracted from the \
+             lifetime total (8)"
+        );
+        ds.task.abort();
     }
 
     // iperf3 rejects -i outside {0} ∪ [0.1, 60] with IEINTERVAL

--- a/riperf3/src/client.rs
+++ b/riperf3/src/client.rs
@@ -193,6 +193,7 @@ impl Client {
         // run, read back at DisplayResults for the `-J` blob (#36 PR2).
         let interval_data = Arc::new(Mutex::new(crate::reporter::CollectedIntervals::default()));
         let mut streams: Vec<DataStream> = Vec::new();
+        let mut byte_budget: Option<(Arc<AtomicI64>, i64)> = None;
         let mut cpu_start: Option<CpuSnapshot> = None;
         let mut server_results: Option<TestResultsJson> = None;
         // Authoritative test duration captured from run_test: `-t` for a duration
@@ -212,7 +213,8 @@ impl Client {
                 }
 
                 TestState::CreateStreams => {
-                    streams = self.create_streams(&cookie, &done, &start, blksize).await?;
+                    (streams, byte_budget) =
+                        self.create_streams(&cookie, &done, &start, blksize).await?;
                 }
 
                 TestState::TestStart => {
@@ -246,7 +248,14 @@ impl Client {
 
                 TestState::TestRunning => {
                     measured_secs = self
-                        .run_test(&mut ctrl, &streams, &done, blksize, interval_data.clone())
+                        .run_test(
+                            &mut ctrl,
+                            &streams,
+                            &done,
+                            blksize,
+                            interval_data.clone(),
+                            byte_budget.as_ref(),
+                        )
                         .await?;
                     // Test finished — send TestEnd
                     protocol::send_state(&mut ctrl, TestState::TestEnd).await?;
@@ -378,7 +387,7 @@ impl Client {
         done: &Arc<AtomicBool>,
         start: &Arc<AtomicBool>,
         blksize: usize,
-    ) -> Result<Vec<DataStream>> {
+    ) -> Result<(Vec<DataStream>, Option<(Arc<AtomicI64>, i64)>)> {
         let mut streams = Vec::new();
 
         // In normal mode: client sends. Reverse: client receives. Bidir: both.
@@ -410,6 +419,17 @@ impl Client {
             && send_count > 0)
             .then(|| stream::make_byte_budget(self.bytes_to_send, self.blocks_to_send, blksize))
             .flatten();
+        // -O + -n/-k (#31): the limit applies to the POST-omit window (iperf3
+        // gates end checks on !omitting and resets byte progress at the
+        // boundary). Senders break permanently when the budget exhausts, so
+        // during warm-up it must be effectively unlimited; the boundary then
+        // stores the real target.
+        let budget_target = byte_budget.as_ref().map(|b| b.load(Ordering::Relaxed));
+        if self.omit > 0 {
+            if let Some(b) = &byte_budget {
+                b.store(i64::MAX, Ordering::Relaxed);
+            }
+        }
 
         match self.protocol {
             TransportProtocol::Tcp => {
@@ -666,9 +686,44 @@ impl Client {
             }
         }
 
-        Ok(streams)
+        Ok((streams, byte_budget.zip(budget_target)))
     }
 
+    /// Wait out a `-n`/`-k` run (#31): iperf3 gates the end-condition check on
+    /// !omitting and resets byte progress at the boundary, so the warm-up
+    /// never consumes the limit. The shared sender budget is refilled to its
+    /// initial value at the boundary (the warm-up drained it), and the
+    /// returned summary window is rebased to exclude the warm-up.
+    async fn wait_byte_limit(
+        &self,
+        streams: &[DataStream],
+        byte_budget: Option<&(Arc<AtomicI64>, i64)>,
+        target: u64,
+        report_start: &std::time::Instant,
+    ) -> f64 {
+        let omit = Duration::from_secs(self.omit as u64);
+        let mut boundary_done = self.omit == 0;
+        loop {
+            tokio::time::sleep(Duration::from_millis(100)).await;
+            if !boundary_done {
+                if report_start.elapsed() < omit {
+                    continue; // still warming up — the limit doesn't apply yet
+                }
+                // Boundary: restore the senders' shared budget (the reporter
+                // snapshots the counters on its own omit deadline).
+                if let Some((b, initial)) = byte_budget {
+                    b.store(*initial, Ordering::Relaxed);
+                }
+                boundary_done = true;
+            }
+            if transferred_bytes(streams) >= target {
+                break;
+            }
+        }
+        (report_start.elapsed().as_secs_f64() - self.omit as f64).max(0.0)
+    }
+
+    #[allow(clippy::too_many_arguments)] // test-drive knobs, 1:1 with run()'s state
     async fn run_test(
         &self,
         ctrl: &mut TcpStream,
@@ -676,6 +731,7 @@ impl Client {
         done: &Arc<AtomicBool>,
         blksize: usize,
         collector: Arc<Mutex<crate::reporter::CollectedIntervals>>,
+        byte_budget: Option<&(Arc<AtomicI64>, i64)>,
     ) -> Result<f64> {
         // Run the interval reporter whenever intervals are enabled. It prints
         // live for text / json-stream; for plain -J it runs silently to collect
@@ -770,23 +826,18 @@ impl Client {
                 dur.as_secs_f64()
             }
             EndCondition::Bytes(target) => {
-                loop {
-                    tokio::time::sleep(Duration::from_millis(100)).await;
-                    if transferred_bytes(streams) >= target {
-                        break;
-                    }
-                }
-                report_start.elapsed().as_secs_f64()
+                self.wait_byte_limit(streams, byte_budget, target, &report_start)
+                    .await
             }
             EndCondition::Blocks(target) => {
                 // Block-based: approximate by dividing transferred bytes by blksize.
-                loop {
-                    tokio::time::sleep(Duration::from_millis(100)).await;
-                    if transferred_bytes(streams) / blksize as u64 >= target {
-                        break;
-                    }
-                }
-                report_start.elapsed().as_secs_f64()
+                self.wait_byte_limit(
+                    streams,
+                    byte_budget,
+                    target.saturating_mul(blksize as u64),
+                    &report_start,
+                )
+                .await
             }
         };
 
@@ -937,7 +988,14 @@ impl Client {
                 let (jitter, lost, total) = if let Some(ref udp_stats) = s.udp_recv_stats {
                     udp_stats
                         .lock()
-                        .map(|st| (Some(st.jitter), Some(st.cnt_error), Some(st.packet_count)))
+                        .map(|st| {
+                            // Post-omit stats (#31): gross minus baselines.
+                            (
+                                Some(st.jitter),
+                                Some(st.cnt_error - st.omitted_cnt_error),
+                                Some(st.packet_count - st.omitted_packet_count),
+                            )
+                        })
                         .unwrap_or((None, None, None))
                 } else {
                     (None, None, None)
@@ -1697,12 +1755,13 @@ impl ClientBuilder {
             }
         }
 
-        // iperf3 caps the warm-up at MAX_OMIT_TIME (60 s) with IEOMIT (#31).
-        if self.omit > 60 {
+        // iperf3 caps the warm-up at MAX_OMIT_TIME (600 s, iperf.h) with
+        // IEOMIT (#31; review r1 — the cap is 600, not 60).
+        if self.omit > 600 {
             return Err(ConfigError::InvalidValue(
                 "omit",
                 format!(
-                    "bogus value for --omit (maximum = 60 seconds): {}",
+                    "bogus value for --omit (maximum = 600 seconds): {}",
                     self.omit
                 ),
             ));
@@ -1876,6 +1935,18 @@ mod tests {
         fn client_builder_reverse() {
             let c = ClientBuilder::new("h").reverse(true).build().unwrap();
             assert!(c.reverse);
+        }
+
+        #[test]
+        fn omit_cap_matches_iperf3_max_omit_time() {
+            // iperf3's MAX_OMIT_TIME is 600 (iperf.h); -O 600 accepted, 601
+            // rejected with IEOMIT's wording (r1 blocker 4: was capped at 60).
+            assert!(ClientBuilder::new("h").omit(600).build().is_ok());
+            let err = ClientBuilder::new("h").omit(601).build().unwrap_err();
+            assert!(
+                format!("{err}").contains("maximum = 600 seconds"),
+                "IEOMIT wording expected: {err}"
+            );
         }
 
         #[test]

--- a/riperf3/src/client.rs
+++ b/riperf3/src/client.rs
@@ -112,8 +112,15 @@ fn server_receiver_summaries(
 /// bidir whichever direction reaches the limit first ends the test. Counting
 /// only sent bytes leaves a reverse `-n`/`-k` test spinning forever (#60).
 fn transferred_bytes(streams: &[DataStream]) -> u64 {
-    // Net (post-omit) getters: with -O, iperf3 resets byte progress at the
-    // boundary so the -n/-k limit applies to the measured window (#31).
+    // The two sides are deliberately asymmetric, copying iperf3's test-level
+    // counters (#31, review r3): iperf_reset_stats zeroes test->bytes_sent at
+    // the omit boundary (iperf_api.c:3675) so the SEND side counts post-omit
+    // NET — but it never touches test->bytes_received, so the RECEIVE side
+    // counts GROSS, warm-up included (end check, iperf_client_api.c:771-772).
+    // The asymmetry is load-bearing: gross received is monotonic, so a
+    // reverse/bidir limit cannot race either reporter's boundary baselines
+    // (the pre-r3 net-received check hung when a mistimed baseline swallowed
+    // warm-up bytes).
     let sent: u64 = streams
         .iter()
         .filter(|s| s.is_sender)
@@ -122,7 +129,7 @@ fn transferred_bytes(streams: &[DataStream]) -> u64 {
     let received: u64 = streams
         .iter()
         .filter(|s| !s.is_sender)
-        .map(|s| s.counters.bytes_received_net())
+        .map(|s| s.counters.bytes_received())
         .sum();
     sent.max(received)
 }
@@ -711,16 +718,28 @@ impl Client {
         streams: &[DataStream],
         target: u64,
         report_start: &std::time::Instant,
+        boundary: Option<&Arc<crate::reporter::OmitBoundary>>,
     ) -> f64 {
-        let omit = Duration::from_secs(self.omit as u64);
+        // With -O the limit applies from the boundary on — iperf3 gates its
+        // end check on `!test->omitting`. Wait on the reporter's boundary
+        // signal, not a parallel wall clock: the wall gate provably opened
+        // before the boundary's re-baselining and read gross-as-net (review
+        // r3, race C). The fallback bounds the wait for liveness if the
+        // reporter died before its boundary fired.
+        if let Some(b) = boundary {
+            let fallback = Duration::from_secs(self.omit as u64 + 2);
+            b.crossed(fallback).await;
+        }
+        // First check BEFORE any sleep: a warm-up that already covered the
+        // gross receive target ends the test AT the boundary, like iperf3
+        // (its select loop re-checks per wake, stopping within ~1 ms of the
+        // omit flip — a 100 ms first poll would leak a poll's worth of line
+        // rate into the post-omit window).
         loop {
-            tokio::time::sleep(Duration::from_millis(100)).await;
-            if report_start.elapsed() < omit {
-                continue; // still warming up — the limit doesn't apply yet
-            }
             if transferred_bytes(streams) >= target {
                 break;
             }
+            tokio::time::sleep(Duration::from_millis(100)).await;
         }
         (report_start.elapsed().as_secs_f64() - self.omit as f64).max(0.0)
     }
@@ -750,6 +769,11 @@ impl Client {
         // before spawning it, so `report_start.elapsed()` at end-of-test is the
         // authoritative final-interval boundary (#55).
         let reporter_end = Arc::new(crate::reporter::ReporterEnd::new());
+        // -O + -n/-k: the reporter signals here when its omit boundary has
+        // fully crossed (baselines snapshotted, budget refilled), gating the
+        // byte-limit driver's first end check (#31, review r3).
+        let omit_boundary =
+            (self.omit > 0).then(|| Arc::new(crate::reporter::OmitBoundary::new()));
         let report_start = std::time::Instant::now();
         // `>= 0.0`: `-i 0` still spawns the reporter, which emits a single
         // whole-test interval rather than none (#107).
@@ -782,6 +806,7 @@ impl Client {
                 reporter_end.clone(),
                 want_collector.then(|| collector.clone()),
                 byte_budget.cloned(),
+                omit_boundary.clone(),
             )
         } else {
             None
@@ -829,7 +854,8 @@ impl Client {
                 dur.as_secs_f64()
             }
             EndCondition::Bytes(target) => {
-                self.wait_byte_limit(streams, target, &report_start).await
+                self.wait_byte_limit(streams, target, &report_start, omit_boundary.as_ref())
+                    .await
             }
             EndCondition::Blocks(target) => {
                 // Block-based: approximate by dividing transferred bytes by blksize.
@@ -837,6 +863,7 @@ impl Client {
                     streams,
                     target.saturating_mul(blksize as u64),
                     &report_start,
+                    omit_boundary.as_ref(),
                 )
                 .await
             }
@@ -1818,6 +1845,20 @@ impl ClientBuilder {
             ));
         }
 
+        // iperf3 rejects -i outside {0} ∪ [MIN_INTERVAL, MAX_INTERVAL] with
+        // IEINTERVAL (iperf_api.c:1261; 0.1/60 in iperf.h). Load-bearing for
+        // -O: the reporter owns the omit boundary, so an out-of-range
+        // interval silently disabling it would silently disable omit
+        // semantics too (#31, review r3).
+        if let Some(i) = self.interval {
+            if i != 0.0 && !(0.1..=60.0).contains(&i) {
+                return Err(ConfigError::InvalidValue(
+                    "interval",
+                    format!("invalid report interval (min = 0.1, max = 60 seconds): {i}"),
+                ));
+            }
+        }
+
         // Reject flags that require OS support not available on this platform.
         // Matches iperf3 behavior: error at build/parse time, not at runtime.
         #[cfg(not(unix))]
@@ -1945,6 +1986,69 @@ impl ClientBuilder {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // #31 (review r3 blocker 1): iperf3's -n/-k end check uses test-level
+    // counters (iperf_client_api.c:771-772) — bytes_sent is zeroed at the
+    // omit boundary by iperf_reset_stats (iperf_api.c:3675) but
+    // test->bytes_received never is, so the receive side counts GROSS,
+    // warm-up included. Counting net on the receive side hangs a reverse
+    // -n -O run whenever a mistimed boundary baseline swallows warm-up bytes.
+    #[tokio::test]
+    async fn byte_limit_counts_received_gross_and_sent_net() {
+        use crate::stream::{DataStream, StreamCounters};
+
+        let sender = Arc::new(StreamCounters::new());
+        sender.record_sent(1_000);
+        sender.snapshot_omit();
+        sender.record_sent(300); // post-omit net: 300
+        let receiver = Arc::new(StreamCounters::new());
+        receiver.record_received(1_000);
+        receiver.snapshot_omit(); // the boundary must NOT hide warm-up receive
+        receiver.record_received(300);
+
+        let mk = |is_sender: bool, counters: Arc<StreamCounters>| DataStream {
+            id: 1,
+            is_sender,
+            counters,
+            udp_recv_stats: None,
+            task: tokio::spawn(async { Ok(()) }),
+            raw_fd: None,
+            local_addr: None,
+            peer_addr: None,
+            sndbuf_actual: None,
+            rcvbuf_actual: None,
+            congestion_used: None,
+        };
+        let streams = [mk(true, sender), mk(false, receiver)];
+        assert_eq!(
+            transferred_bytes(&streams),
+            1_300,
+            "received counts gross (1300), sent counts net (300)"
+        );
+        for s in &streams {
+            s.task.abort();
+        }
+    }
+
+    // iperf3 rejects -i outside {0} ∪ [0.1, 60] with IEINTERVAL
+    // (iperf_api.c:1261, MIN_INTERVAL/MAX_INTERVAL in iperf.h). With -O the
+    // reporter is load-bearing (it owns the omit boundary), so an invalid
+    // interval silently disabling it must be impossible (review r3 nit).
+    #[test]
+    fn client_builder_rejects_out_of_range_interval() {
+        for bad in [-1.0, 0.05, 60.1] {
+            assert!(
+                ClientBuilder::new("h").interval(bad).build().is_err(),
+                "interval {bad} must be rejected"
+            );
+        }
+        for ok in [0.0, 0.1, 1.0, 60.0] {
+            assert!(
+                ClientBuilder::new("h").interval(ok).build().is_ok(),
+                "interval {ok} must be accepted"
+            );
+        }
+    }
 
     // Per-setter builder tests migrated in-crate from `tests/integration.rs`
     // when `Client`'s fields became `pub(crate)` (#43): an external test crate

--- a/riperf3/src/client.rs
+++ b/riperf3/src/client.rs
@@ -99,8 +99,11 @@ fn server_receiver_summaries(
             is_sender: false,
             retransmits: None,
             jitter: is_udp.then_some(s.jitter),
-            lost: is_udp.then_some(s.errors),
-            total_packets: is_udp.then_some(s.packets),
+            // The exchange carries GROSS packets/errors plus omitted_*
+            // baselines; subtract for the post-omit summary (#31). This also
+            // reads a real iperf3 server's omit results correctly.
+            lost: is_udp.then_some(s.errors - s.omitted_errors),
+            total_packets: is_udp.then_some(s.packets - s.omitted_packets),
         })
         .collect()
 }
@@ -111,15 +114,17 @@ fn server_receiver_summaries(
 /// bidir whichever direction reaches the limit first ends the test. Counting
 /// only sent bytes leaves a reverse `-n`/`-k` test spinning forever (#60).
 fn transferred_bytes(streams: &[DataStream]) -> u64 {
+    // Net (post-omit) getters: with -O, iperf3 resets byte progress at the
+    // boundary so the -n/-k limit applies to the measured window (#31).
     let sent: u64 = streams
         .iter()
         .filter(|s| s.is_sender)
-        .map(|s| s.counters.bytes_sent())
+        .map(|s| s.counters.bytes_sent_net())
         .sum();
     let received: u64 = streams
         .iter()
         .filter(|s| !s.is_sender)
-        .map(|s| s.counters.bytes_received())
+        .map(|s| s.counters.bytes_received_net())
         .sum();
     sent.max(received)
 }
@@ -394,7 +399,7 @@ impl Client {
         // being set by a CPU-starved runtime. Only in duration mode;
         // byte/block-limited tests stop on `done`.
         let max_duration = (self.bytes_to_send.is_none() && self.blocks_to_send.is_none())
-            .then(|| Duration::from_secs(self.duration as u64));
+            .then(|| Duration::from_secs((self.duration + self.omit) as u64));
 
         // `-n`/`-k` shared byte budget for the sending streams: they collectively
         // stop at ~N bytes (iperf3's `-n` is the test-wide total), bounding the
@@ -748,8 +753,13 @@ impl Client {
                 // and starve this async timer, so they must not depend on it to
                 // stop (issue #5). Once they self-terminate, CPU frees and this
                 // timer fires normally to drive the rest of the shutdown.
+                // The wall clock runs omit + time (#31): iperf3 extends the
+                // run by the warm-up so the measured window is a full `-t`.
+                // The authoritative end time handed to the reporter stays the
+                // post-omit `-t` (its timeline restarts at the boundary).
+                let wall = dur + Duration::from_secs(self.omit as u64);
                 tokio::select! {
-                    _ = tokio::time::sleep(dur) => {}
+                    _ = tokio::time::sleep(wall) => {}
                     state = protocol::recv_state(ctrl) => {
                         // Server sent something unexpected during the test
                         if let Ok(TestState::ServerTerminate) = state {
@@ -811,20 +821,32 @@ impl Client {
         let stream_results: Vec<_> = streams
             .iter()
             .map(|s| {
+                // Net (post-omit) bytes; packets/errors stay GROSS with the
+                // omitted_* baselines alongside — the reading side subtracts,
+                // exactly iperf3's exchange accounting (#31).
                 let bytes = if s.is_sender {
-                    s.counters.bytes_sent()
+                    s.counters.bytes_sent_net()
                 } else {
-                    s.counters.bytes_received()
+                    s.counters.bytes_received_net()
                 };
 
-                let (jitter, errors, packets) = if let Some(ref udp_stats) = s.udp_recv_stats {
-                    udp_stats
-                        .lock()
-                        .map(|stats| (stats.jitter, stats.cnt_error, stats.packet_count))
-                        .unwrap_or((0.0, 0, 0))
-                } else {
-                    (0.0, 0, 0)
-                };
+                let (jitter, errors, packets, omitted_errors, omitted_packets) =
+                    if let Some(ref udp_stats) = s.udp_recv_stats {
+                        udp_stats
+                            .lock()
+                            .map(|st| {
+                                (
+                                    st.jitter,
+                                    st.cnt_error,
+                                    st.packet_count,
+                                    st.omitted_cnt_error,
+                                    st.omitted_packet_count,
+                                )
+                            })
+                            .unwrap_or((0.0, 0, 0, 0, 0))
+                    } else {
+                        (0.0, 0, 0, 0, 0)
+                    };
 
                 protocol::StreamResultJson {
                     id: s.id,
@@ -832,9 +854,9 @@ impl Client {
                     retransmits: -1,
                     jitter,
                     errors,
-                    omitted_errors: 0,
+                    omitted_errors,
                     packets,
-                    omitted_packets: 0,
+                    omitted_packets,
                     start_time: 0.0,
                     end_time: test_duration,
                 }
@@ -907,9 +929,9 @@ impl Client {
             .iter()
             .map(|s| {
                 let bytes = if s.is_sender {
-                    s.counters.bytes_sent()
+                    s.counters.bytes_sent_net()
                 } else {
-                    s.counters.bytes_received()
+                    s.counters.bytes_received_net()
                 };
 
                 let (jitter, lost, total) = if let Some(ref udp_stats) = s.udp_recv_stats {
@@ -1009,17 +1031,20 @@ impl Client {
                 // UDP datagram stats: from our local receiver if we measured them,
                 // else (forward UDP) from the server's results for this stream (#25).
                 let udp = if let Some(ref lock) = s.udp_recv_stats {
+                    // Local receiver: post-omit stats (#31) — gross counters
+                    // minus the boundary baselines.
                     lock.lock().ok().map(|st| UdpStreamStats {
                         jitter_secs: st.jitter,
-                        lost_packets: st.cnt_error,
-                        packets: st.packet_count,
-                        out_of_order: st.outoforder_packets,
+                        lost_packets: st.cnt_error - st.omitted_cnt_error,
+                        packets: st.packet_count - st.omitted_packet_count,
+                        out_of_order: st.outoforder_packets - st.omitted_outoforder_packets,
                     })
                 } else if is_forward_udp && s.is_sender {
+                    // Peer's gross counts minus its omitted_* baselines (#31).
                     server_stream.map(|x| UdpStreamStats {
                         jitter_secs: x.jitter,
-                        lost_packets: x.errors,
-                        packets: x.packets,
+                        lost_packets: x.errors - x.omitted_errors,
+                        packets: x.packets - x.omitted_packets,
                         out_of_order: 0,
                     })
                 } else {
@@ -1670,6 +1695,14 @@ impl ClientBuilder {
                     ));
                 }
             }
+        }
+
+        // iperf3 caps the warm-up at MAX_OMIT_TIME (60 s) with IEOMIT (#31).
+        if self.omit > 60 {
+            return Err(ConfigError::InvalidValue(
+                "omit",
+                format!("bogus value for --omit (maximum = 60 seconds): {}", self.omit),
+            ));
         }
 
         // Reject flags that require OS support not available on this platform.

--- a/riperf3/src/client.rs
+++ b/riperf3/src/client.rs
@@ -419,17 +419,13 @@ impl Client {
             && send_count > 0)
             .then(|| stream::make_byte_budget(self.bytes_to_send, self.blocks_to_send, blksize))
             .flatten();
-        // -O + -n/-k (#31): the limit applies to the POST-omit window (iperf3
-        // gates end checks on !omitting and resets byte progress at the
-        // boundary). Senders break permanently when the budget exhausts, so
-        // during warm-up it must be effectively unlimited; the boundary then
-        // stores the real target.
+        // -O + -n/-k (#31): the limit applies to the POST-omit window. The
+        // budget holds gross N from the start — senders PAUSE at it (iperf3's
+        // mt sender idles at the limit, including during warm-up, then
+        // resumes when the boundary resets the counter) — and the REPORTER
+        // refills it at its omit boundary, the same instant the byte
+        // baselines snapshot, so limit and accounting can't skew (review r2).
         let budget_target = byte_budget.as_ref().map(|b| b.load(Ordering::Relaxed));
-        if self.omit > 0 {
-            if let Some(b) = &byte_budget {
-                b.store(i64::MAX, Ordering::Relaxed);
-            }
-        }
 
         match self.protocol {
             TransportProtocol::Tcp => {
@@ -689,32 +685,23 @@ impl Client {
         Ok((streams, byte_budget.zip(budget_target)))
     }
 
-    /// Wait out a `-n`/`-k` run (#31): iperf3 gates the end-condition check on
-    /// !omitting and resets byte progress at the boundary, so the warm-up
-    /// never consumes the limit. The shared sender budget is refilled to its
-    /// initial value at the boundary (the warm-up drained it), and the
-    /// returned summary window is rebased to exclude the warm-up.
+    /// Wait out a `-n`/`-k` run (#31): iperf3 gates the end-condition check
+    /// on !omitting, so the warm-up never satisfies the limit. The budget
+    /// refill happens in the REPORTER's boundary block (same instant as the
+    /// byte baselines); this poll only waits out the warm-up and then watches
+    /// the net (post-omit) progress. The returned summary window excludes the
+    /// warm-up.
     async fn wait_byte_limit(
         &self,
         streams: &[DataStream],
-        byte_budget: Option<&(Arc<AtomicI64>, i64)>,
         target: u64,
         report_start: &std::time::Instant,
     ) -> f64 {
         let omit = Duration::from_secs(self.omit as u64);
-        let mut boundary_done = self.omit == 0;
         loop {
             tokio::time::sleep(Duration::from_millis(100)).await;
-            if !boundary_done {
-                if report_start.elapsed() < omit {
-                    continue; // still warming up — the limit doesn't apply yet
-                }
-                // Boundary: restore the senders' shared budget (the reporter
-                // snapshots the counters on its own omit deadline).
-                if let Some((b, initial)) = byte_budget {
-                    b.store(*initial, Ordering::Relaxed);
-                }
-                boundary_done = true;
+            if report_start.elapsed() < omit {
+                continue; // still warming up — the limit doesn't apply yet
             }
             if transferred_bytes(streams) >= target {
                 break;
@@ -779,6 +766,7 @@ impl Client {
                 done.clone(),
                 reporter_end.clone(),
                 want_collector.then(|| collector.clone()),
+                byte_budget.cloned(),
             )
         } else {
             None
@@ -826,14 +814,12 @@ impl Client {
                 dur.as_secs_f64()
             }
             EndCondition::Bytes(target) => {
-                self.wait_byte_limit(streams, byte_budget, target, &report_start)
-                    .await
+                self.wait_byte_limit(streams, target, &report_start).await
             }
             EndCondition::Blocks(target) => {
                 // Block-based: approximate by dividing transferred bytes by blksize.
                 self.wait_byte_limit(
                     streams,
-                    byte_budget,
                     target.saturating_mul(blksize as u64),
                     &report_start,
                 )

--- a/riperf3/src/reporter.rs
+++ b/riperf3/src/reporter.rs
@@ -957,6 +957,10 @@ pub fn spawn_interval_reporter(
                                 prev_retransmits[i] = info.total_retransmits;
                             }
                         }
+                        // #171: the exchange subtracts this baseline from the
+                        // sender's lifetime total, like iperf3's
+                        // stream_prev_total_retrans at iperf_reset_stats.
+                        s.counters.set_omit_retransmits(prev_retransmits[i] as i64);
                     }
                     omit_retransmits[i] = prev_retransmits[i];
                     acc_extremes[i] = StreamExtremes {

--- a/riperf3/src/reporter.rs
+++ b/riperf3/src/reporter.rs
@@ -485,12 +485,14 @@ fn direction_interval_sum(
 /// normal run the driver calls [`ReporterEnd::finish`] to flush the final partial
 /// interval and stop the task; `done` is the fallback stop signal for error/early
 /// teardown paths. The handle should be awaited after `finish`/`done`.
+#[allow(clippy::too_many_arguments)] // reporter wiring, 1:1 with the drivers
 pub fn spawn_interval_reporter(
     config: IntervalReporterConfig,
     streams: Vec<IntervalStreamRef>,
     done: Arc<AtomicBool>,
     reporter_end: Arc<ReporterEnd>,
     collector: Option<Arc<Mutex<CollectedIntervals>>>,
+    byte_budget: Option<(Arc<std::sync::atomic::AtomicI64>, i64)>,
 ) -> Option<JoinHandle<()>> {
     if config.interval_secs < 0.0 {
         return None;
@@ -872,6 +874,14 @@ pub fn spawn_interval_reporter(
             // be stale), and the end-block extremes restart. Lives inside
             // this closure because prev_*/acc_extremes are its captures.
             if omit_boundary {
+                // -n/-k + -O (#31): refill the shared sender budget HERE,
+                // where the byte baselines are snapshotted, so the limit and
+                // the net accounting share one boundary instant — refilling
+                // from the driver's 100ms poll overshot by up to a poll's
+                // worth of line rate (review r2).
+                if let Some((b, target)) = &byte_budget {
+                    b.store(*target, std::sync::atomic::Ordering::Relaxed);
+                }
                 for (i, s) in streams.iter().enumerate() {
                     let _ = s.counters.take_sent_interval();
                     let _ = s.counters.take_received_interval();
@@ -1333,7 +1343,7 @@ mod interval_reporter_tests {
             blksize: 128 * 1024,
         };
         assert!(
-            spawn_interval_reporter(config, vec![], done, Arc::new(ReporterEnd::new()), None)
+            spawn_interval_reporter(config, vec![], done, Arc::new(ReporterEnd::new()), None, None)
                 .is_some()
         );
     }
@@ -1354,7 +1364,7 @@ mod interval_reporter_tests {
             blksize: 128 * 1024,
         };
         assert!(
-            spawn_interval_reporter(config, vec![], done, Arc::new(ReporterEnd::new()), None)
+            spawn_interval_reporter(config, vec![], done, Arc::new(ReporterEnd::new()), None, None)
                 .is_none()
         );
     }
@@ -1379,6 +1389,7 @@ mod interval_reporter_tests {
             vec![],
             done.clone(),
             Arc::new(ReporterEnd::new()),
+            None,
             None,
         );
         assert!(handle.is_some());
@@ -1434,6 +1445,7 @@ mod interval_reporter_tests {
             done.clone(),
             reporter_end.clone(),
             Some(collector.clone()),
+            None,
         )
         .expect("reporter spawns for a positive interval");
 
@@ -1515,6 +1527,7 @@ mod interval_reporter_tests {
             done.clone(),
             reporter_end.clone(),
             Some(collector.clone()),
+            None,
         )
         .expect("reporter spawns for -i 0 (#107)");
 
@@ -1590,6 +1603,7 @@ mod interval_reporter_tests {
             done.clone(),
             reporter_end.clone(),
             Some(collector.clone()),
+            None,
         )
         .expect("reporter spawns for a positive interval");
 
@@ -1662,6 +1676,7 @@ mod interval_reporter_tests {
             done.clone(),
             reporter_end.clone(),
             Some(collector.clone()),
+            None,
         )
         .expect("reporter spawns for a positive interval");
 

--- a/riperf3/src/reporter.rs
+++ b/riperf3/src/reporter.rs
@@ -864,16 +864,30 @@ pub fn spawn_interval_reporter(
             } // do_emit
 
             // Omit boundary (#31): statistics reset, like iperf3's
-            // iperf_reset_stats — byte baselines, UDP omitted_* counters,
-            // retransmit baselines, and the end-block extremes restart here.
-            // Lives inside this closure because prev_retransmits/acc_extremes
-            // are its captures.
+            // iperf_reset_stats — interval counters drained (iperf3 zeroes the
+            // per-interval bytes; the un-tick-aligned warm-up tail is
+            // discarded, not emitted), byte baselines, UDP omitted_* counters
+            // + delta prevs re-synced, a FRESH retransmit sample taken
+            // (iperf3 does save_tcpinfo at reset — the last tick's value may
+            // be stale), and the end-block extremes restart. Lives inside
+            // this closure because prev_*/acc_extremes are its captures.
             if omit_boundary {
                 for (i, s) in streams.iter().enumerate() {
+                    let _ = s.counters.take_sent_interval();
+                    let _ = s.counters.take_received_interval();
                     s.counters.snapshot_omit();
                     if let Some(u) = &s.udp_recv_stats {
                         if let Ok(mut st) = u.lock() {
                             st.snapshot_omit();
+                            prev_cnt_error[i] = st.cnt_error;
+                            prev_packet_count[i] = st.packet_count;
+                        }
+                    }
+                    if has_retransmits && s.is_sender {
+                        if let Some(fd) = s.raw_fd {
+                            if let Some(info) = tcp_info::get_tcp_info(fd) {
+                                prev_retransmits[i] = info.total_retransmits;
+                            }
                         }
                     }
                     omit_retransmits[i] = prev_retransmits[i];
@@ -896,36 +910,6 @@ pub fn spawn_interval_reporter(
             // boundary's data is folded into the recovered final interval below.
             tokio::select! {
                 biased;
-                // Omit boundary (#31): placed before the ticker so a
-                // tick-coincident boundary (e.g. -O 1 -i 1) resolves as the
-                // final warm-up interval, not a phantom first real one. Its
-                // own sleep, so `-i 0` (year-long ticker) still hits it.
-                _ = tokio::time::sleep_until(omit_deadline), if in_warmup => {
-                    // Flush the warm-up tail [last tick, omit] if it carries
-                    // anything (0..omit timeline), then reset statistics — the
-                    // closure runs the reset (its captures own the baselines).
-                    let last_end = interval_num as f64 * config.interval_secs;
-                    let end = config.omit_secs as f64;
-                    let residual: u64 = streams
-                        .iter()
-                        .map(|s| {
-                            if s.is_sender {
-                                s.counters.peek_sent_interval()
-                            } else {
-                                s.counters.peek_received_interval()
-                            }
-                        })
-                        .sum();
-                    let do_emit = end > last_end + 1e-3 && residual > 0;
-                    emit_interval(last_end, end, true, true, do_emit);
-                    // The interval timeline restarts at 0 and the ticker is
-                    // re-phased (omit need not be a multiple of -i).
-                    in_warmup = false;
-                    interval_num = 0;
-                    ticker = tokio::time::interval(interval_dur);
-                    ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
-                    ticker.tick().await; // skip the immediate first tick
-                }
                 _ = reporter_end.notify.notified() => {
                     // #55: the run ended part-way through an interval. Flush one
                     // final interval `[last_boundary, end_secs]` using the
@@ -950,8 +934,9 @@ pub fn spawn_interval_reporter(
                         })
                         .sum();
                     if end_secs > last_end + 1e-3 && residual_bytes > 0 {
-                        // Only reachable in warm-up when the run dies before
-                        // the boundary (error/abort path).
+                        // Normal final partial flush; `in_warmup` is only true
+                        // here when the run died before the boundary
+                        // (error/abort path), tagging the flush omitted.
                         emit_interval(last_end, end_secs, in_warmup, false, true);
                     }
                     break;
@@ -966,6 +951,24 @@ pub fn spawn_interval_reporter(
                     let start = (interval_num - 1) as f64 * config.interval_secs;
                     let end = interval_num as f64 * config.interval_secs;
                     emit_interval(start, end, in_warmup, false, true);
+                }
+                // Omit boundary (#31): ordered AFTER the ticker, matching
+                // iperf3's coincident-timer behavior (its stats timer fires
+                // before the omit timer, so -O 1 -i 1 emits the [0,1] omitted
+                // line from the tick, then resets). iperf3 DISCARDS a warm-up
+                // tail that isn't tick-aligned (stats are zeroed at reset, no
+                // partial emission), so the closure's boundary block drains
+                // and re-baselines without emitting. Its own sleep, so `-i 0`
+                // (year-long ticker) still hits it.
+                _ = tokio::time::sleep_until(omit_deadline), if in_warmup => {
+                    emit_interval(0.0, 0.0, true, true, false);
+                    // The interval timeline restarts at 0 and the ticker is
+                    // re-phased (omit need not be a multiple of -i).
+                    in_warmup = false;
+                    interval_num = 0;
+                    ticker = tokio::time::interval(interval_dur);
+                    ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+                    ticker.tick().await; // skip the immediate first tick
                 }
             }
         }

--- a/riperf3/src/reporter.rs
+++ b/riperf3/src/reporter.rs
@@ -1347,10 +1347,15 @@ mod interval_reporter_tests {
             print: true,
             blksize: 128 * 1024,
         };
-        assert!(
-            spawn_interval_reporter(config, vec![], done, Arc::new(ReporterEnd::new()), None, None)
-                .is_some()
-        );
+        assert!(spawn_interval_reporter(
+            config,
+            vec![],
+            done,
+            Arc::new(ReporterEnd::new()),
+            None,
+            None
+        )
+        .is_some());
     }
 
     #[tokio::test]
@@ -1368,10 +1373,15 @@ mod interval_reporter_tests {
             print: true,
             blksize: 128 * 1024,
         };
-        assert!(
-            spawn_interval_reporter(config, vec![], done, Arc::new(ReporterEnd::new()), None, None)
-                .is_none()
-        );
+        assert!(spawn_interval_reporter(
+            config,
+            vec![],
+            done,
+            Arc::new(ReporterEnd::new()),
+            None,
+            None
+        )
+        .is_none());
     }
 
     #[tokio::test]

--- a/riperf3/src/reporter.rs
+++ b/riperf3/src/reporter.rs
@@ -414,6 +414,53 @@ impl Default for ReporterEnd {
     }
 }
 
+/// Omit-boundary-crossed signal for the `-n`/`-k` driver (#31, review r3):
+/// the reporter sets it at the END of its boundary block — after the byte
+/// baselines are snapshotted and the budget refilled — so the driver's first
+/// post-warm-up end check runs against consistent net accounting. Gating that
+/// check on a parallel wall clock instead provably opened before the
+/// boundary's re-baselining (race C) and read gross-as-net.
+pub struct OmitBoundary {
+    passed: AtomicBool,
+    notify: tokio::sync::Notify,
+}
+
+impl OmitBoundary {
+    pub fn new() -> Self {
+        Self {
+            passed: AtomicBool::new(false),
+            notify: tokio::sync::Notify::new(),
+        }
+    }
+
+    /// Reporter side: mark the boundary crossed and wake the waiting driver.
+    /// `notify_one` stores a permit, so a driver that starts waiting after
+    /// the boundary fired still wakes immediately.
+    fn cross(&self) {
+        self.passed.store(true, Ordering::Relaxed);
+        self.notify.notify_one();
+    }
+
+    /// Driver side: wait until the boundary has been crossed. `fallback`
+    /// bounds the wait for liveness if the reporter died before its boundary
+    /// (error paths); the caller then degrades to wall-clock gating.
+    pub async fn crossed(&self, fallback: Duration) {
+        if self.passed.load(Ordering::Relaxed) {
+            return;
+        }
+        tokio::select! {
+            _ = self.notify.notified() => {}
+            _ = tokio::time::sleep(fallback) => {}
+        }
+    }
+}
+
+impl Default for OmitBoundary {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 /// Per-direction interval aggregates (#54). In bidir both directions run
 /// concurrently; iperf3 sums each separately (`sum` + `sum_bidir_reverse`).
 #[derive(Default)]
@@ -498,6 +545,7 @@ pub fn spawn_interval_reporter(
     reporter_end: Arc<ReporterEnd>,
     collector: Option<Arc<Mutex<CollectedIntervals>>>,
     byte_budget: Option<(Arc<std::sync::atomic::AtomicI64>, i64)>,
+    boundary_signal: Option<Arc<OmitBoundary>>,
 ) -> Option<JoinHandle<()>> {
     if config.interval_secs < 0.0 {
         return None;
@@ -879,14 +927,13 @@ pub fn spawn_interval_reporter(
             // be stale), and the end-block extremes restart. Lives inside
             // this closure because prev_*/acc_extremes are its captures.
             if omit_boundary {
-                // -n/-k + -O (#31): refill the shared sender budget HERE,
-                // where the byte baselines are snapshotted, so the limit and
-                // the net accounting share one boundary instant — refilling
-                // from the driver's 100ms poll overshot by up to a poll's
-                // worth of line rate (review r2).
-                if let Some((b, target)) = &byte_budget {
-                    b.store(*target, std::sync::atomic::Ordering::Relaxed);
-                }
+                // Order is load-bearing (review r3 blocker 3): baselines
+                // FIRST, budget refill second. Refill-first let a sender wake
+                // in the store→snapshot gap, claim post-refill budget, and
+                // record bytes BEFORE the baseline — consumed budget excluded
+                // from net, so net topped out below target and the forward
+                // run hung. Baselines-first is safe: paused senders cannot
+                // record new bytes until the refill lands.
                 for (i, s) in streams.iter().enumerate() {
                     let _ = s.counters.take_sent_interval();
                     let _ = s.counters.take_received_interval();
@@ -911,6 +958,18 @@ pub fn spawn_interval_reporter(
                         min_rtt: u32::MAX,
                         ..Default::default()
                     };
+                }
+                // -n/-k + -O (#31): refill the shared sender budget at the
+                // boundary, where the byte baselines were just snapshotted,
+                // so the limit and the net accounting share one boundary
+                // instant (review r2).
+                if let Some((b, target)) = &byte_budget {
+                    b.store(*target, std::sync::atomic::Ordering::Relaxed);
+                }
+                // Wake the -n/-k driver LAST: its first post-warm-up check
+                // must observe the baselines and the refill (review r3).
+                if let Some(ob) = &boundary_signal {
+                    ob.cross();
                 }
             }
         };
@@ -1353,6 +1412,7 @@ mod interval_reporter_tests {
             done,
             Arc::new(ReporterEnd::new()),
             None,
+            None,
             None
         )
         .is_some());
@@ -1379,6 +1439,7 @@ mod interval_reporter_tests {
             done,
             Arc::new(ReporterEnd::new()),
             None,
+            None,
             None
         )
         .is_none());
@@ -1404,6 +1465,7 @@ mod interval_reporter_tests {
             vec![],
             done.clone(),
             Arc::new(ReporterEnd::new()),
+            None,
             None,
             None,
         );
@@ -1460,6 +1522,7 @@ mod interval_reporter_tests {
             done.clone(),
             reporter_end.clone(),
             Some(collector.clone()),
+            None,
             None,
         )
         .expect("reporter spawns for a positive interval");
@@ -1543,6 +1606,7 @@ mod interval_reporter_tests {
             reporter_end.clone(),
             Some(collector.clone()),
             None,
+            None,
         )
         .expect("reporter spawns for -i 0 (#107)");
 
@@ -1619,6 +1683,7 @@ mod interval_reporter_tests {
             reporter_end.clone(),
             Some(collector.clone()),
             None,
+            None,
         )
         .expect("reporter spawns for a positive interval");
 
@@ -1691,6 +1756,7 @@ mod interval_reporter_tests {
             done.clone(),
             reporter_end.clone(),
             Some(collector.clone()),
+            None,
             None,
         )
         .expect("reporter spawns for a positive interval");

--- a/riperf3/src/reporter.rs
+++ b/riperf3/src/reporter.rs
@@ -435,9 +435,12 @@ impl OmitBoundary {
 
     /// Reporter side: mark the boundary crossed and wake the waiting driver.
     /// `notify_one` stores a permit, so a driver that starts waiting after
-    /// the boundary fired still wakes immediately.
+    /// the boundary fired still wakes immediately. Release pairs with the
+    /// fast path's Acquire so the boundary block's baseline/refill stores are
+    /// visible to a driver that skips the Notify (which synchronizes on its
+    /// own) — review r4.
     fn cross(&self) {
-        self.passed.store(true, Ordering::Relaxed);
+        self.passed.store(true, Ordering::Release);
         self.notify.notify_one();
     }
 
@@ -445,7 +448,7 @@ impl OmitBoundary {
     /// bounds the wait for liveness if the reporter died before its boundary
     /// (error paths); the caller then degrades to wall-clock gating.
     pub async fn crossed(&self, fallback: Duration) {
-        if self.passed.load(Ordering::Relaxed) {
+        if self.passed.load(Ordering::Acquire) {
             return;
         }
         tokio::select! {

--- a/riperf3/src/reporter.rs
+++ b/riperf3/src/reporter.rs
@@ -519,11 +519,17 @@ pub fn spawn_interval_reporter(
 
         let mut interval_num: u64 = 0;
         let mut header_printed = false;
-        let omit_intervals = if config.interval_secs > 0.0 {
-            (config.omit_secs as f64 / config.interval_secs).ceil() as u64
-        } else {
-            0
-        };
+        // `-O/--omit` (#31): a real warm-up phase, like iperf3 — ticks during
+        // it emit `omitted` intervals on a 0..omit timeline, then the boundary
+        // snapshots every counter, the interval timeline restarts at 0, and
+        // the summary covers only the post-omit window.
+        let mut in_warmup = config.omit_secs > 0;
+        let omit_deadline =
+            tokio::time::Instant::now() + Duration::from_secs(config.omit_secs as u64);
+        // Post-omit retransmit baselines: cumulative kernel counts at the
+        // boundary, subtracted from the end-block extremes (iperf3 resets
+        // stream retransmit stats at the omit boundary).
+        let mut omit_retransmits: Vec<u32> = vec![0; streams.len()];
 
         // Per-stream previous values for computing deltas
         let mut prev_retransmits: Vec<u32> = vec![0; streams.len()];
@@ -555,300 +561,328 @@ pub fn spawn_interval_reporter(
         // render and collect identically. Each call drains the per-stream
         // interval counters, reporting exactly the bytes/stats accrued since the
         // previous call.
-        let mut emit_interval = |start: f64, end: f64, omitted: bool| {
-            let seconds = end - start;
+        let mut emit_interval = |start: f64,
+                                 end: f64,
+                                 omitted: bool,
+                                 omit_boundary: bool,
+                                 do_emit: bool| {
+            if do_emit {
+                let seconds = end - start;
 
-            // Timestamp prefix for this tick (text decoration; never on --json-stream)
-            if config.print && !config.json_stream && config.timestamp_format.is_some() {
-                // Use libc strftime for iperf3-compatible timestamp formatting
-                let now = std::time::SystemTime::now()
-                    .duration_since(std::time::UNIX_EPOCH)
-                    .unwrap_or_default();
-                let secs = now.as_secs();
-                // Simple ISO-ish format without pulling in chrono
-                let hours = (secs % 86400) / 3600;
-                let mins = (secs % 3600) / 60;
-                let s = secs % 60;
-                print!("{hours:02}:{mins:02}:{s:02} ");
-            }
+                // Timestamp prefix for this tick (text decoration; never on --json-stream)
+                if config.print && !config.json_stream && config.timestamp_format.is_some() {
+                    // Use libc strftime for iperf3-compatible timestamp formatting
+                    let now = std::time::SystemTime::now()
+                        .duration_since(std::time::UNIX_EPOCH)
+                        .unwrap_or_default();
+                    let secs = now.as_secs();
+                    // Simple ISO-ish format without pulling in chrono
+                    let hours = (secs % 86400) / 3600;
+                    let mins = (secs % 3600) / 60;
+                    let s = secs % 60;
+                    print!("{hours:02}:{mins:02}:{s:02} ");
+                }
 
-            // The text header banner is suppressed under --json-stream (pure NDJSON).
-            if config.print && !config.json_stream && !header_printed {
-                print_header(config.protocol, has_retransmits);
-                header_printed = true;
-            }
+                // The text header banner is suppressed under --json-stream (pure NDJSON).
+                if config.print && !config.json_stream && !header_printed {
+                    print_header(config.protocol, has_retransmits);
+                    header_printed = true;
+                }
 
-            // Per-direction aggregates (#54): `fwd` covers streams flowing the
-            // same way as the first stream — the forward (client→server) flow
-            // on both roles, since the client lists its senders first and the
-            // server its receivers — `rev` the opposite. Non-bidir runs leave
-            // `rev` empty.
-            let fwd_is_sender = streams.first().is_none_or(|s| s.is_sender);
-            let mut fwd = DirAcc::default();
-            let mut rev = DirAcc::default();
-            let mut collected_streams: Vec<crate::json_report::IntervalStream> = Vec::new();
+                // Per-direction aggregates (#54): `fwd` covers streams flowing the
+                // same way as the first stream — the forward (client→server) flow
+                // on both roles, since the client lists its senders first and the
+                // server its receivers — `rev` the opposite. Non-bidir runs leave
+                // `rev` empty.
+                let fwd_is_sender = streams.first().is_none_or(|s| s.is_sender);
+                let mut fwd = DirAcc::default();
+                let mut rev = DirAcc::default();
+                let mut collected_streams: Vec<crate::json_report::IntervalStream> = Vec::new();
 
-            for (i, stream) in streams.iter().enumerate() {
-                let bytes = if stream.is_sender {
-                    stream.counters.take_sent_interval()
-                } else {
-                    stream.counters.take_received_interval()
-                };
+                for (i, stream) in streams.iter().enumerate() {
+                    let bytes = if stream.is_sender {
+                        stream.counters.take_sent_interval()
+                    } else {
+                        stream.counters.take_received_interval()
+                    };
 
-                // TCP_INFO for the interval detail and the end extremes.
-                let (retransmits, snd_cwnd, rtt, rttvar, pmtu, reorder_iv) = if has_retransmits
-                    && stream.is_sender
-                {
-                    if let Some(fd) = stream.raw_fd {
-                        if let Some(info) = tcp_info::get_tcp_info(fd) {
-                            let delta = info.total_retransmits.saturating_sub(prev_retransmits[i]);
-                            prev_retransmits[i] = info.total_retransmits;
-                            // Accumulate sender-side extremes for the end report.
-                            let e = &mut acc_extremes[i];
-                            e.max_snd_cwnd = e.max_snd_cwnd.max(info.snd_cwnd);
-                            e.reorder = e.reorder.max(info.reorder);
-                            if info.rtt > 0 {
-                                e.max_rtt = e.max_rtt.max(info.rtt);
-                                e.min_rtt = e.min_rtt.min(info.rtt);
-                                e.rtt_sum += info.rtt as u64;
-                                e.rtt_samples += 1;
+                    // TCP_INFO for the interval detail and the end extremes.
+                    let (retransmits, snd_cwnd, rtt, rttvar, pmtu, reorder_iv) =
+                        if has_retransmits && stream.is_sender {
+                            if let Some(fd) = stream.raw_fd {
+                                if let Some(info) = tcp_info::get_tcp_info(fd) {
+                                    let delta =
+                                        info.total_retransmits.saturating_sub(prev_retransmits[i]);
+                                    prev_retransmits[i] = info.total_retransmits;
+                                    // Accumulate sender-side extremes for the end report.
+                                    let e = &mut acc_extremes[i];
+                                    e.max_snd_cwnd = e.max_snd_cwnd.max(info.snd_cwnd);
+                                    e.reorder = e.reorder.max(info.reorder);
+                                    if info.rtt > 0 {
+                                        e.max_rtt = e.max_rtt.max(info.rtt);
+                                        e.min_rtt = e.min_rtt.min(info.rtt);
+                                        e.rtt_sum += info.rtt as u64;
+                                        e.rtt_samples += 1;
+                                    }
+                                    e.total_retransmits = Some(info.total_retransmits);
+                                    last_tcp[i] = Some(TcpSample {
+                                        snd_cwnd: info.snd_cwnd,
+                                        rtt: info.rtt,
+                                        rttvar: info.rttvar,
+                                        pmtu: info.pmtu,
+                                        reorder: info.reorder,
+                                    });
+                                    (
+                                        Some(delta as i64),
+                                        Some(info.snd_cwnd),
+                                        Some(info.rtt),
+                                        Some(info.rttvar),
+                                        Some(info.pmtu),
+                                        Some(info.reorder),
+                                    )
+                                } else if let Some(s) = last_tcp[i] {
+                                    // Final-interval fallback (#55): the socket closed as
+                                    // the run ended, so a fresh read failed. Reuse the
+                                    // last sample's cwnd/rtt; no new retransmit count is
+                                    // measurable for the sub-interval, so report 0.
+                                    (
+                                        Some(0),
+                                        Some(s.snd_cwnd),
+                                        Some(s.rtt),
+                                        Some(s.rttvar),
+                                        Some(s.pmtu),
+                                        Some(s.reorder),
+                                    )
+                                } else {
+                                    (None, None, None, None, None, None)
+                                }
+                            } else {
+                                (None, None, None, None, None, None)
                             }
-                            e.total_retransmits = Some(info.total_retransmits);
-                            last_tcp[i] = Some(TcpSample {
-                                snd_cwnd: info.snd_cwnd,
-                                rtt: info.rtt,
-                                rttvar: info.rttvar,
-                                pmtu: info.pmtu,
-                                reorder: info.reorder,
-                            });
-                            (
-                                Some(delta as i64),
-                                Some(info.snd_cwnd),
-                                Some(info.rtt),
-                                Some(info.rttvar),
-                                Some(info.pmtu),
-                                Some(info.reorder),
-                            )
-                        } else if let Some(s) = last_tcp[i] {
-                            // Final-interval fallback (#55): the socket closed as
-                            // the run ended, so a fresh read failed. Reuse the
-                            // last sample's cwnd/rtt; no new retransmit count is
-                            // measurable for the sub-interval, so report 0.
-                            (
-                                Some(0),
-                                Some(s.snd_cwnd),
-                                Some(s.rtt),
-                                Some(s.rttvar),
-                                Some(s.pmtu),
-                                Some(s.reorder),
-                            )
                         } else {
                             (None, None, None, None, None, None)
+                        };
+
+                    // UDP stats (compute deltas for loss/packets)
+                    let (jitter, lost, total) = if let Some(ref udp_stats) = stream.udp_recv_stats {
+                        if let Ok(st) = udp_stats.lock() {
+                            let delta_error = st.cnt_error - prev_cnt_error[i];
+                            let delta_packets = st.packet_count - prev_packet_count[i];
+                            prev_cnt_error[i] = st.cnt_error;
+                            prev_packet_count[i] = st.packet_count;
+                            (Some(st.jitter), Some(delta_error), Some(delta_packets))
+                        } else {
+                            (None, None, None)
                         }
                     } else {
-                        (None, None, None, None, None, None)
-                    }
-                } else {
-                    (None, None, None, None, None, None)
-                };
-
-                // UDP stats (compute deltas for loss/packets)
-                let (jitter, lost, total) = if let Some(ref udp_stats) = stream.udp_recv_stats {
-                    if let Ok(st) = udp_stats.lock() {
-                        let delta_error = st.cnt_error - prev_cnt_error[i];
-                        let delta_packets = st.packet_count - prev_packet_count[i];
-                        prev_cnt_error[i] = st.cnt_error;
-                        prev_packet_count[i] = st.packet_count;
-                        (Some(st.jitter), Some(delta_error), Some(delta_packets))
-                    } else {
                         (None, None, None)
+                    };
+
+                    let bps_val = if seconds > 0.0 {
+                        bytes as f64 * 8.0 / seconds
+                    } else {
+                        0.0
+                    };
+
+                    // Text mode prints a per-stream line here. `--json-stream` emits
+                    // one typed `interval` event per tick (assembled after the loop
+                    // from the same typed streams the `-J` collector builds), so it
+                    // has nothing to print per stream.
+                    if config.print && !config.json_stream {
+                        let interval = StreamInterval {
+                            stream_id: stream.id,
+                            start,
+                            end,
+                            bytes,
+                            retransmits,
+                            snd_cwnd,
+                            jitter,
+                            lost,
+                            total_packets: total,
+                            omitted,
+                        };
+                        print_interval(&interval, config.format_char);
                     }
-                } else {
-                    (None, None, None)
-                };
 
-                let bps_val = if seconds > 0.0 {
-                    bytes as f64 * 8.0 / seconds
-                } else {
-                    0.0
-                };
+                    if collecting {
+                        // UDP datagram detail: a receiver stream reports measured
+                        // loss/jitter; a sender stream reports only the sent packet
+                        // count (bytes / datagram size), like iperf3.
+                        let (j_ms, lost_p, pkts, lost_pct) = if stream.udp_recv_stats.is_some() {
+                            (
+                                jitter.map(|j| j * 1000.0),
+                                lost,
+                                total,
+                                match (lost, total) {
+                                    (Some(l), Some(t)) => Some(lost_percent(l, t)),
+                                    _ => None,
+                                },
+                            )
+                        } else if is_udp {
+                            (None, None, Some((bytes / blk) as i64), None)
+                        } else {
+                            (None, None, None, None)
+                        };
+                        collected_streams.push(crate::json_report::IntervalStream {
+                            socket: stream.id,
+                            start,
+                            end,
+                            seconds,
+                            bytes,
+                            bits_per_second: bps_val,
+                            retransmits,
+                            snd_cwnd,
+                            // snd_wnd is unavailable via libc (see TcpStreamSide); emit
+                            // 0 alongside the other TCP detail, like iperf3.
+                            snd_wnd: snd_cwnd.map(|_| 0u64),
+                            rtt,
+                            rttvar,
+                            pmtu,
+                            reorder: reorder_iv,
+                            jitter_ms: j_ms,
+                            lost_packets: lost_p,
+                            packets: pkts,
+                            lost_percent: lost_pct,
+                            omitted,
+                            sender: stream.is_sender,
+                        });
+                    }
 
-                // Text mode prints a per-stream line here. `--json-stream` emits
-                // one typed `interval` event per tick (assembled after the loop
-                // from the same typed streams the `-J` collector builds), so it
-                // has nothing to print per stream.
-                if config.print && !config.json_stream {
-                    let interval = StreamInterval {
-                        stream_id: stream.id,
+                    let acc = if stream.is_sender == fwd_is_sender {
+                        &mut fwd
+                    } else {
+                        &mut rev
+                    };
+                    acc.count += 1;
+                    acc.bytes += bytes;
+                    if let Some(r) = retransmits {
+                        acc.retransmits += r;
+                    }
+                    if stream.udp_recv_stats.is_some() {
+                        acc.udp_recv = true;
+                        if let Some(j) = jitter {
+                            acc.last_jitter = j;
+                        }
+                    }
+                    if let Some(l) = lost {
+                        acc.lost += l;
+                    }
+                    if let Some(p) = total {
+                        acc.packets += p;
+                    }
+                }
+
+                // Print [SUM] line for parallel streams (text only; the json-stream
+                // `interval` event below carries the typed `sum` instead).
+                if config.print && !config.json_stream && config.num_streams > 1 {
+                    // The text [SUM] stays one combined line (both directions in
+                    // bidir); only the typed -J/json-stream sums split per direction.
+                    let last_jitter = if rev.udp_recv {
+                        rev.last_jitter
+                    } else {
+                        fwd.last_jitter
+                    };
+                    let sum_interval = StreamInterval {
+                        stream_id: -1, // renders as "SUM"
                         start,
                         end,
-                        bytes,
-                        retransmits,
-                        snd_cwnd,
-                        jitter,
-                        lost,
-                        total_packets: total,
+                        bytes: fwd.bytes + rev.bytes,
+                        retransmits: if has_retransmits {
+                            Some(fwd.retransmits + rev.retransmits)
+                        } else {
+                            None
+                        },
+                        snd_cwnd: None,
+                        jitter: if is_udp { Some(last_jitter) } else { None },
+                        lost: if is_udp {
+                            Some(fwd.lost + rev.lost)
+                        } else {
+                            None
+                        },
+                        total_packets: if is_udp {
+                            Some(fwd.packets + rev.packets)
+                        } else {
+                            None
+                        },
                         omitted,
                     };
-                    print_interval(&interval, config.format_char);
+                    print_interval(&sum_interval, config.format_char);
                 }
 
                 if collecting {
-                    // UDP datagram detail: a receiver stream reports measured
-                    // loss/jitter; a sender stream reports only the sent packet
-                    // count (bytes / datagram size), like iperf3.
-                    let (j_ms, lost_p, pkts, lost_pct) = if stream.udp_recv_stats.is_some() {
-                        (
-                            jitter.map(|j| j * 1000.0),
-                            lost,
-                            total,
-                            match (lost, total) {
-                                (Some(l), Some(t)) => Some(lost_percent(l, t)),
-                                _ => None,
-                            },
-                        )
-                    } else if is_udp {
-                        (None, None, Some((bytes / blk) as i64), None)
-                    } else {
-                        (None, None, None, None)
-                    };
-                    collected_streams.push(crate::json_report::IntervalStream {
-                        socket: stream.id,
+                    // #54: iperf3 emits per-direction interval sums in bidir — `sum`
+                    // for the forward flow, `sum_bidir_reverse` for the reverse —
+                    // mirroring the end block's sum_*_bidir_reverse split.
+                    let sum = direction_interval_sum(
                         start,
                         end,
                         seconds,
-                        bytes,
-                        bits_per_second: bps_val,
-                        retransmits,
-                        snd_cwnd,
-                        // snd_wnd is unavailable via libc (see TcpStreamSide); emit
-                        // 0 alongside the other TCP detail, like iperf3.
-                        snd_wnd: snd_cwnd.map(|_| 0u64),
-                        rtt,
-                        rttvar,
-                        pmtu,
-                        reorder: reorder_iv,
-                        jitter_ms: j_ms,
-                        lost_packets: lost_p,
-                        packets: pkts,
-                        lost_percent: lost_pct,
-                        omitted,
-                        sender: stream.is_sender,
-                    });
-                }
-
-                let acc = if stream.is_sender == fwd_is_sender {
-                    &mut fwd
-                } else {
-                    &mut rev
-                };
-                acc.count += 1;
-                acc.bytes += bytes;
-                if let Some(r) = retransmits {
-                    acc.retransmits += r;
-                }
-                if stream.udp_recv_stats.is_some() {
-                    acc.udp_recv = true;
-                    if let Some(j) = jitter {
-                        acc.last_jitter = j;
-                    }
-                }
-                if let Some(l) = lost {
-                    acc.lost += l;
-                }
-                if let Some(p) = total {
-                    acc.packets += p;
-                }
-            }
-
-            // Print [SUM] line for parallel streams (text only; the json-stream
-            // `interval` event below carries the typed `sum` instead).
-            if config.print && !config.json_stream && config.num_streams > 1 {
-                // The text [SUM] stays one combined line (both directions in
-                // bidir); only the typed -J/json-stream sums split per direction.
-                let last_jitter = if rev.udp_recv {
-                    rev.last_jitter
-                } else {
-                    fwd.last_jitter
-                };
-                let sum_interval = StreamInterval {
-                    stream_id: -1, // renders as "SUM"
-                    start,
-                    end,
-                    bytes: fwd.bytes + rev.bytes,
-                    retransmits: if has_retransmits {
-                        Some(fwd.retransmits + rev.retransmits)
-                    } else {
-                        None
-                    },
-                    snd_cwnd: None,
-                    jitter: if is_udp { Some(last_jitter) } else { None },
-                    lost: if is_udp {
-                        Some(fwd.lost + rev.lost)
-                    } else {
-                        None
-                    },
-                    total_packets: if is_udp {
-                        Some(fwd.packets + rev.packets)
-                    } else {
-                        None
-                    },
-                    omitted,
-                };
-                print_interval(&sum_interval, config.format_char);
-            }
-
-            if collecting {
-                // #54: iperf3 emits per-direction interval sums in bidir — `sum`
-                // for the forward flow, `sum_bidir_reverse` for the reverse —
-                // mirroring the end block's sum_*_bidir_reverse split.
-                let sum = direction_interval_sum(
-                    start,
-                    end,
-                    seconds,
-                    &fwd,
-                    fwd_is_sender,
-                    has_retransmits,
-                    is_udp,
-                    blk,
-                    omitted,
-                );
-                let sum_bidir_reverse = (rev.count > 0).then(|| {
-                    direction_interval_sum(
-                        start,
-                        end,
-                        seconds,
-                        &rev,
-                        !fwd_is_sender,
+                        &fwd,
+                        fwd_is_sender,
                         has_retransmits,
                         is_udp,
                         blk,
                         omitted,
-                    )
-                });
-                let interval = crate::json_report::Interval {
-                    streams: collected_streams,
-                    sum,
-                    sum_bidir_reverse,
-                };
-                // `-J` collects intervals for the final batched blob; `--json-stream`
-                // emits each one live as `{"event":"interval","data":{...}}`.
-                if config.json_stream {
-                    println!(
-                        "{}",
-                        crate::json_report::json_stream_event("interval", &interval)
                     );
-                } else {
-                    collected.push(interval);
+                    let sum_bidir_reverse = (rev.count > 0).then(|| {
+                        direction_interval_sum(
+                            start,
+                            end,
+                            seconds,
+                            &rev,
+                            !fwd_is_sender,
+                            has_retransmits,
+                            is_udp,
+                            blk,
+                            omitted,
+                        )
+                    });
+                    let interval = crate::json_report::Interval {
+                        streams: collected_streams,
+                        sum,
+                        sum_bidir_reverse,
+                    };
+                    // `-J` collects intervals for the final batched blob; `--json-stream`
+                    // emits each one live as `{"event":"interval","data":{...}}`.
+                    if config.json_stream {
+                        println!(
+                            "{}",
+                            crate::json_report::json_stream_event("interval", &interval)
+                        );
+                    } else {
+                        collected.push(interval);
+                    }
                 }
-            }
 
-            // Flush after each interval if requested. --json-stream always flushes
-            // so a piped consumer sees each event as it happens (the point of the
-            // streaming format), regardless of --forceflush.
-            if config.print && (config.forceflush || config.json_stream) {
-                use std::io::Write;
-                let _ = std::io::stdout().flush();
+                // Flush after each interval if requested. --json-stream always flushes
+                // so a piped consumer sees each event as it happens (the point of the
+                // streaming format), regardless of --forceflush.
+                if config.print && (config.forceflush || config.json_stream) {
+                    use std::io::Write;
+                    let _ = std::io::stdout().flush();
+                }
+            } // do_emit
+
+            // Omit boundary (#31): statistics reset, like iperf3's
+            // iperf_reset_stats — byte baselines, UDP omitted_* counters,
+            // retransmit baselines, and the end-block extremes restart here.
+            // Lives inside this closure because prev_retransmits/acc_extremes
+            // are its captures.
+            if omit_boundary {
+                for (i, s) in streams.iter().enumerate() {
+                    s.counters.snapshot_omit();
+                    if let Some(u) = &s.udp_recv_stats {
+                        if let Ok(mut st) = u.lock() {
+                            st.snapshot_omit();
+                        }
+                    }
+                    omit_retransmits[i] = prev_retransmits[i];
+                    acc_extremes[i] = StreamExtremes {
+                        stream_id: s.id,
+                        min_rtt: u32::MAX,
+                        ..Default::default()
+                    };
+                }
             }
         };
 
@@ -862,6 +896,36 @@ pub fn spawn_interval_reporter(
             // boundary's data is folded into the recovered final interval below.
             tokio::select! {
                 biased;
+                // Omit boundary (#31): placed before the ticker so a
+                // tick-coincident boundary (e.g. -O 1 -i 1) resolves as the
+                // final warm-up interval, not a phantom first real one. Its
+                // own sleep, so `-i 0` (year-long ticker) still hits it.
+                _ = tokio::time::sleep_until(omit_deadline), if in_warmup => {
+                    // Flush the warm-up tail [last tick, omit] if it carries
+                    // anything (0..omit timeline), then reset statistics — the
+                    // closure runs the reset (its captures own the baselines).
+                    let last_end = interval_num as f64 * config.interval_secs;
+                    let end = config.omit_secs as f64;
+                    let residual: u64 = streams
+                        .iter()
+                        .map(|s| {
+                            if s.is_sender {
+                                s.counters.peek_sent_interval()
+                            } else {
+                                s.counters.peek_received_interval()
+                            }
+                        })
+                        .sum();
+                    let do_emit = end > last_end + 1e-3 && residual > 0;
+                    emit_interval(last_end, end, true, true, do_emit);
+                    // The interval timeline restarts at 0 and the ticker is
+                    // re-phased (omit need not be a multiple of -i).
+                    in_warmup = false;
+                    interval_num = 0;
+                    ticker = tokio::time::interval(interval_dur);
+                    ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+                    ticker.tick().await; // skip the immediate first tick
+                }
                 _ = reporter_end.notify.notified() => {
                     // #55: the run ended part-way through an interval. Flush one
                     // final interval `[last_boundary, end_secs]` using the
@@ -886,8 +950,9 @@ pub fn spawn_interval_reporter(
                         })
                         .sum();
                     if end_secs > last_end + 1e-3 && residual_bytes > 0 {
-                        let omitted = (interval_num + 1) <= omit_intervals;
-                        emit_interval(last_end, end_secs, omitted);
+                        // Only reachable in warm-up when the run dies before
+                        // the boundary (error/abort path).
+                        emit_interval(last_end, end_secs, in_warmup, false, true);
                     }
                     break;
                 }
@@ -898,10 +963,9 @@ pub fn spawn_interval_reporter(
                         break;
                     }
                     interval_num += 1;
-                    let omitted = interval_num <= omit_intervals;
                     let start = (interval_num - 1) as f64 * config.interval_secs;
                     let end = interval_num as f64 * config.interval_secs;
-                    emit_interval(start, end, omitted);
+                    emit_interval(start, end, in_warmup, false, true);
                 }
             }
         }
@@ -909,9 +973,14 @@ pub fn spawn_interval_reporter(
         // Hand the collected samples + extremes to the client (#36 PR2).
         if let Some(c) = collector {
             if let Ok(mut g) = c.lock() {
-                for e in acc_extremes.iter_mut() {
+                for (i, e) in acc_extremes.iter_mut().enumerate() {
                     if e.min_rtt == u32::MAX {
                         e.min_rtt = 0;
+                    }
+                    // End-block retransmit totals cover the post-omit window
+                    // only (#31), like iperf3's boundary stats reset.
+                    if let Some(t) = e.total_retransmits {
+                        e.total_retransmits = Some(t.saturating_sub(omit_retransmits[i]));
                     }
                 }
                 g.intervals = collected;

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -388,7 +388,7 @@ impl Server {
                 // runtime so it never processes the client's TestEnd. Only in
                 // duration mode; byte/block-limited tests stop on `done`.
                 let max_duration = (params.num.is_none() && params.blockcount.is_none())
-                    .then(|| std::time::Duration::from_secs(cfg.duration as u64));
+                    .then(|| std::time::Duration::from_secs((cfg.duration + cfg.omit) as u64));
 
                 // Two server UDP designs, same wire protocol. The default Unix
                 // path mirrors iperf3: one connected data socket per stream, all
@@ -587,21 +587,30 @@ impl Server {
         };
 
         for s in &streams {
+            // Net (post-omit) bytes; packets/errors stay GROSS with the
+            // omitted_* baselines alongside, like iperf3's exchange (#31).
             let bytes = if s.is_sender {
-                s.counters.bytes_sent()
+                s.counters.bytes_sent_net()
             } else {
-                s.counters.bytes_received()
+                s.counters.bytes_received_net()
             };
 
-            let (jitter, errors, packets) = if let Some(ref udp_stats) = s.udp_recv_stats {
-                if let Ok(stats) = udp_stats.lock() {
-                    (stats.jitter, stats.cnt_error, stats.packet_count)
+            let (jitter, errors, packets, omitted_errors, omitted_packets) =
+                if let Some(ref udp_stats) = s.udp_recv_stats {
+                    if let Ok(st) = udp_stats.lock() {
+                        (
+                            st.jitter,
+                            st.cnt_error,
+                            st.packet_count,
+                            st.omitted_cnt_error,
+                            st.omitted_packet_count,
+                        )
+                    } else {
+                        (0.0, 0, 0, 0, 0)
+                    }
                 } else {
-                    (0.0, 0, 0)
-                }
-            } else {
-                (0.0, 0, 0)
-            };
+                    (0.0, 0, 0, 0, 0)
+                };
 
             result_streams.push(protocol::StreamResultJson {
                 id: s.id,
@@ -609,9 +618,9 @@ impl Server {
                 retransmits: -1,
                 jitter,
                 errors,
-                omitted_errors: 0,
+                omitted_errors,
                 packets,
-                omitted_packets: 0,
+                omitted_packets,
                 start_time: 0.0,
                 end_time: test_duration,
             });
@@ -689,9 +698,9 @@ impl Server {
                 .iter()
                 .map(|s| {
                     let bytes = if s.is_sender {
-                        s.counters.bytes_sent()
+                        s.counters.bytes_sent_net()
                     } else {
-                        s.counters.bytes_received()
+                        s.counters.bytes_received_net()
                     };
 
                     let (jitter, lost, total) = if let Some(ref udp_stats) = s.udp_recv_stats {
@@ -1127,9 +1136,9 @@ impl Server {
             .iter()
             .map(|s| {
                 let local_bytes = if s.is_sender {
-                    s.counters.bytes_sent()
+                    s.counters.bytes_sent_net()
                 } else {
-                    s.counters.bytes_received()
+                    s.counters.bytes_received_net()
                 };
 
                 // The server measures UDP loss/jitter on the streams it receives.

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -566,7 +566,10 @@ impl Server {
         // interval (#55). The reporter prioritises `finish` over `done`, so the
         // final interval still flushes; wait for it before tearing streams down.
         let measured_elapsed = report_start.elapsed().as_secs_f64();
-        reporter_end.finish(measured_elapsed);
+        // The reporter's timeline restarted at the omit boundary (#31), so its
+        // authoritative end time is post-omit; clamp for runs that died inside
+        // the warm-up.
+        reporter_end.finish((measured_elapsed - cfg.omit as f64).max(0.0));
         done.store(true, Ordering::Relaxed);
         if let Some(handle) = interval_handle {
             let _ = handle.await;
@@ -581,7 +584,9 @@ impl Server {
         // run, exactly `-t` otherwise (#103, mirrors the client). The requested
         // `-t` is reported separately as the test_start `duration` parameter.
         let test_duration = if params.num.is_some() || params.blockcount.is_some() {
-            measured_elapsed
+            // Rebase to the post-omit window (#31): the measured elapsed
+            // includes the warm-up the summary must exclude.
+            (measured_elapsed - cfg.omit as f64).max(0.0)
         } else {
             cfg.duration as f64
         };
@@ -1141,13 +1146,14 @@ impl Server {
                     s.counters.bytes_received_net()
                 };
 
-                // The server measures UDP loss/jitter on the streams it receives.
+                // The server measures UDP loss/jitter on the streams it
+                // receives — post-omit stats (#31): gross minus baselines.
                 let udp = s.udp_recv_stats.as_ref().and_then(|lock| {
                     lock.lock().ok().map(|st| UdpStreamStats {
                         jitter_secs: st.jitter,
-                        lost_packets: st.cnt_error,
-                        packets: st.packet_count,
-                        out_of_order: st.outoforder_packets,
+                        lost_packets: st.cnt_error - st.omitted_cnt_error,
+                        packets: st.packet_count - st.omitted_packet_count,
+                        out_of_order: st.outoforder_packets - st.omitted_outoforder_packets,
                     })
                 });
 

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -538,6 +538,9 @@ impl Server {
                 byte_budget
                     .as_ref()
                     .map(|b| (b.clone(), b.load(Ordering::Relaxed))),
+                // The server has no -n/-k end-check driver — the client ends
+                // the test — so it never waits on the boundary signal.
+                None,
             )
         };
 

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -288,6 +288,8 @@ impl Server {
         // build it only for a TCP run that has senders. See `make_byte_budget`
         // for the 0-is-unlimited (iperf3 sends `num`/`blocks` = 0 for a plain
         // `-t` run) and overflow-clamp rules.
+        // -O + -n/-k on the SERVER's senders (reverse/bidir, #31 review r2):
+        // same pause-at-limit + reporter-boundary-refill design as the client.
         let byte_budget: Option<Arc<AtomicI64>> = (matches!(cfg.protocol, TransportProtocol::Tcp)
             && send_count > 0)
             .then(|| stream::make_byte_budget(params.num, params.blockcount, cfg.blksize))
@@ -509,6 +511,9 @@ impl Server {
                 done.clone(),
                 reporter_end.clone(),
                 want_collector.then(|| interval_data.clone()),
+                byte_budget
+                    .as_ref()
+                    .map(|b| (b.clone(), b.load(Ordering::Relaxed))),
             )
         };
 
@@ -711,7 +716,16 @@ impl Server {
                     let (jitter, lost, total) = if let Some(ref udp_stats) = s.udp_recv_stats {
                         udp_stats
                             .lock()
-                            .map(|st| (Some(st.jitter), Some(st.cnt_error), Some(st.packet_count)))
+                            .map(|st| {
+                                // Post-omit stats (#31, review r2 — this was
+                                // the missed third site): gross minus the
+                                // boundary baselines.
+                                (
+                                    Some(st.jitter),
+                                    Some(st.cnt_error - st.omitted_cnt_error),
+                                    Some(st.packet_count - st.omitted_packet_count),
+                                )
+                            })
                             .unwrap_or((None, None, None))
                     } else {
                         (None, None, None)

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -313,6 +313,11 @@ impl Server {
             && send_count > 0)
             .then(|| stream::make_byte_budget(params.num, params.blockcount, cfg.blksize))
             .flatten();
+        // The boundary-refill target, captured BEFORE any sender can consume:
+        // loading it at reporter-spawn time read `N − early_consumed` on fast
+        // links (senders start in the TestStart→spawn gap), silently
+        // shrinking the refill (review r4).
+        let budget_target = byte_budget.as_ref().map(|b| b.load(Ordering::Relaxed));
 
         // Single-socket UDP server demux (#80): one demux receiver thread serves
         // every receiving stream, so its handle lives outside the per-stream
@@ -535,9 +540,7 @@ impl Server {
                 done.clone(),
                 reporter_end.clone(),
                 want_collector.then(|| interval_data.clone()),
-                byte_budget
-                    .as_ref()
-                    .map(|b| (b.clone(), b.load(Ordering::Relaxed))),
+                byte_budget.clone().zip(budget_target),
                 // The server has no -n/-k end-check driver — the client ends
                 // the test — so it never waits on the boundary signal.
                 None,

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -657,17 +657,21 @@ impl Server {
             // total. The sender task snapshots it into the counters while
             // its socket is still open; by exchange time the socket is
             // closed, so a live fd read here only serves as a fallback for
-            // paths that never reached the snapshot.
+            // paths that never reached the snapshot. With -O the boundary
+            // baseline is subtracted (#171), like iperf3's stream_retrans
+            // after iperf_reset_stats.
             let retransmits =
                 if s.is_sender && crate::tcp_info::has_retransmit_info() && !is_udp_stream {
-                    match s.counters.final_retransmits() {
-                        n if n >= 0 => n,
+                    let lifetime = match s.counters.final_retransmits() {
+                        n if n >= 0 => Some(n),
                         _ => s
                             .raw_fd
                             .and_then(crate::tcp_info::get_tcp_info)
-                            .map(|i| i.total_retransmits as i64)
-                            .unwrap_or(-1),
-                    }
+                            .map(|i| i.total_retransmits as i64),
+                    };
+                    lifetime
+                        .map(|t| s.counters.omit_adjusted_retransmits(t))
+                        .unwrap_or(-1)
                 } else {
                     -1
                 };

--- a/riperf3/src/stream.rs
+++ b/riperf3/src/stream.rs
@@ -417,17 +417,24 @@ pub async fn run_tcp_sender(
         // stop when it is exhausted, so the sender stops at ~N instead of
         // free-running until the controller's next 100ms poll. The budget is
         // shared across the sending streams — iperf3's `-n` is the test-wide
-        // total, consumed across streams as each sends — so the overshoot is
-        // bounded to ~one block per stream rather than ~100ms of line rate.
+        // total, consumed across streams as each sends. The claim has NO undo:
+        // a fetch_sub + compensating fetch_add could interleave with the omit
+        // boundary's refill store and land the undo on the fresh budget,
+        // leaking a block past the target (review r3). fetch_update claims
+        // only from a positive budget, so only one claim can drive it
+        // non-positive — total overshoot is bounded to less than one block.
         if let Some(b) = &byte_budget {
-            if b.fetch_sub(buf.len() as i64, Ordering::Relaxed) <= 0 {
+            let len = buf.len() as i64;
+            if b.fetch_update(Ordering::Relaxed, Ordering::Relaxed, |v| {
+                (v > 0).then_some(v - len)
+            })
+            .is_err()
+            {
                 // iperf3's sender IDLES at the limit instead of exiting (its
                 // mt sender checks bytes_sent >= N per burst, including during
                 // an -O warm-up, and resumes when the boundary resets the
-                // counter). Undo the claim and wait for a refill (#31) or the
-                // driver's `done` (the normal end, set once the post-omit net
-                // target is reached).
-                b.fetch_add(buf.len() as i64, Ordering::Relaxed);
+                // counter). Wait for a refill (#31) or the driver's `done`
+                // (the normal end, set once the post-omit target is reached).
                 tokio::time::sleep(Duration::from_millis(10)).await;
                 continue;
             }

--- a/riperf3/src/stream.rs
+++ b/riperf3/src/stream.rs
@@ -41,6 +41,11 @@ pub struct StreamCounters {
     /// TCP_INFO read hits a dead fd. -1 = not captured (receiver, UDP, or no
     /// platform support).
     final_retransmits: AtomicI64,
+    /// #171: the cumulative retransmit count at the omit boundary, stored by
+    /// the reporter's boundary block — iperf3's iperf_reset_stats records
+    /// stream_prev_total_retrans the same way, so the exchanged total covers
+    /// the post-omit window only. -1 = no boundary crossed.
+    omit_retransmits: AtomicI64,
 }
 
 impl Default for StreamCounters {
@@ -59,6 +64,7 @@ impl StreamCounters {
             bytes_sent_omit: AtomicU64::new(0),
             bytes_received_omit: AtomicU64::new(0),
             final_retransmits: AtomicI64::new(-1),
+            omit_retransmits: AtomicI64::new(-1),
         }
     }
 
@@ -96,6 +102,24 @@ impl StreamCounters {
     /// The snapshotted end-of-test retransmit total, or -1 if never captured.
     pub fn final_retransmits(&self) -> i64 {
         self.final_retransmits.load(Ordering::Relaxed)
+    }
+
+    /// Record the omit-boundary retransmit baseline (#171; reporter boundary
+    /// block only).
+    pub fn set_omit_retransmits(&self, n: i64) {
+        self.omit_retransmits.store(n, Ordering::Relaxed);
+    }
+
+    /// Adjust a connection-lifetime retransmit total to the post-omit window
+    /// (#171): subtract the boundary baseline when one was recorded, exactly
+    /// iperf3's stream_retrans accounting after iperf_reset_stats.
+    pub fn omit_adjusted_retransmits(&self, lifetime: i64) -> i64 {
+        let base = self.omit_retransmits.load(Ordering::Relaxed);
+        if base >= 0 {
+            (lifetime - base).max(0)
+        } else {
+            lifetime
+        }
     }
 
     /// Record bytes sent (called from the send loop hot path).

--- a/riperf3/src/stream.rs
+++ b/riperf3/src/stream.rs
@@ -409,7 +409,15 @@ pub async fn run_tcp_sender(
         // bounded to ~one block per stream rather than ~100ms of line rate.
         if let Some(b) = &byte_budget {
             if b.fetch_sub(buf.len() as i64, Ordering::Relaxed) <= 0 {
-                break;
+                // iperf3's sender IDLES at the limit instead of exiting (its
+                // mt sender checks bytes_sent >= N per burst, including during
+                // an -O warm-up, and resumes when the boundary resets the
+                // counter). Undo the claim and wait for a refill (#31) or the
+                // driver's `done` (the normal end, set once the post-omit net
+                // target is reached).
+                b.fetch_add(buf.len() as i64, Ordering::Relaxed);
+                tokio::time::sleep(Duration::from_millis(10)).await;
+                continue;
             }
         }
 

--- a/riperf3/src/stream.rs
+++ b/riperf3/src/stream.rs
@@ -30,6 +30,11 @@ pub struct StreamCounters {
     bytes_received: AtomicU64,
     bytes_sent_interval: AtomicU64,
     bytes_received_interval: AtomicU64,
+    // `-O/--omit` warm-up baselines (#31): cumulative counts at the omit
+    // boundary. The net getters subtract them so summaries cover only the
+    // post-omit window, like iperf3's stats reset in iperf_reset_stats.
+    bytes_sent_omit: AtomicU64,
+    bytes_received_omit: AtomicU64,
 }
 
 impl Default for StreamCounters {
@@ -45,7 +50,34 @@ impl StreamCounters {
             bytes_received: AtomicU64::new(0),
             bytes_sent_interval: AtomicU64::new(0),
             bytes_received_interval: AtomicU64::new(0),
+            bytes_sent_omit: AtomicU64::new(0),
+            bytes_received_omit: AtomicU64::new(0),
         }
+    }
+
+    /// Record the omit boundary (#31): cumulative counts so far become the
+    /// warm-up baseline the net getters subtract.
+    pub fn snapshot_omit(&self) {
+        self.bytes_sent_omit
+            .store(self.bytes_sent.load(Ordering::Relaxed), Ordering::Relaxed);
+        self.bytes_received_omit.store(
+            self.bytes_received.load(Ordering::Relaxed),
+            Ordering::Relaxed,
+        );
+    }
+
+    /// Bytes sent since the omit boundary (the whole run when `-O` is unused).
+    pub fn bytes_sent_net(&self) -> u64 {
+        self.bytes_sent
+            .load(Ordering::Relaxed)
+            .saturating_sub(self.bytes_sent_omit.load(Ordering::Relaxed))
+    }
+
+    /// Bytes received since the omit boundary (see [`Self::bytes_sent_net`]).
+    pub fn bytes_received_net(&self) -> u64 {
+        self.bytes_received
+            .load(Ordering::Relaxed)
+            .saturating_sub(self.bytes_received_omit.load(Ordering::Relaxed))
     }
 
     /// Record bytes sent (called from the send loop hot path).
@@ -172,15 +204,11 @@ pub struct UdpRecvStats {
     /// Previous one-way transit time for jitter calculation.
     prev_transit: f64,
 
-    // Snapshots taken at the end of the omit period so we can subtract them.
-    // Test-only today: only `snapshot_omit` (now `#[cfg(test)]`) writes non-zero
-    // values here; in production these stay at their 0 init until `-O/--omit` is
-    // wired into the UDP receive path (#31).
-    #[allow(dead_code)]
+    // Snapshots taken at the omit boundary (#31): the results exchange carries
+    // gross packets/errors plus these omitted_* baselines, and the reading side
+    // subtracts — exactly iperf3's accounting.
     pub omitted_packet_count: i64,
-    #[allow(dead_code)]
     pub omitted_cnt_error: i64,
-    #[allow(dead_code)]
     pub omitted_outoforder_packets: i64,
 }
 
@@ -232,12 +260,7 @@ impl UdpRecvStats {
     }
 
     /// Snapshot current values as the omit-period baseline.
-    /// Call this at the end of the omit period.
-    ///
-    /// Test-only today: `-O/--omit` is not yet wired into the UDP receive path
-    /// (#31), so production never calls this; the unit tests exercise it so the
-    /// omit-accounting fields stay correct for when #31 lands.
-    #[cfg(test)]
+    /// Called by the reporter at the omit boundary (#31).
     pub fn snapshot_omit(&mut self) {
         self.omitted_packet_count = self.packet_count;
         self.omitted_cnt_error = self.cnt_error;

--- a/riperf3/src/stream.rs
+++ b/riperf3/src/stream.rs
@@ -265,6 +265,9 @@ impl UdpRecvStats {
         self.omitted_packet_count = self.packet_count;
         self.omitted_cnt_error = self.cnt_error;
         self.omitted_outoforder_packets = self.outoforder_packets;
+        // iperf3's iperf_reset_stats also zeroes the jitter EWMA at the
+        // boundary so warm-up influence doesn't bleed into the measurement.
+        self.jitter = 0.0;
     }
 }
 

--- a/riperf3/src/stream.rs
+++ b/riperf3/src/stream.rs
@@ -482,7 +482,11 @@ pub async fn run_tcp_sender(
         // boundary's refill store and land the undo on the fresh budget,
         // leaking a block past the target (review r3). fetch_update claims
         // only from a positive budget, so only one claim can drive it
-        // non-positive — total overshoot is bounded to less than one block.
+        // non-positive — BUDGET overshoot is bounded to less than one block.
+        // The recorded post-omit net can additionally exceed N by one
+        // in-flight block per sending stream (claimed pre-refill, recorded
+        // post-snapshot), so a paced `-P k` run can land at N + k blocks —
+        // don't pin the 1-block figure in tests (review r4).
         if let Some(b) = &byte_budget {
             let len = buf.len() as i64;
             if b.fetch_update(Ordering::Relaxed, Ordering::Relaxed, |v| {


### PR DESCRIPTION
## Summary

`-O N` was cosmetic: it only tagged the first N interval lines while the run still lasted `-t` seconds and the summary divided cumulative bytes (warm-up included) by the full window. iperf3 runs `omit + time`, resets statistics at the boundary, and reports over the post-omit window only.

- **Run extension**: the client's duration arm sleeps `omit + time`; UDP senders' self-enforced `max_duration` covers it on both roles.
- **Reporter warm-up phase**: warm-up ticks emit `omitted` intervals on a `0..omit` timeline; the boundary is its own sleep arm (`-i 0`'s year-long ticker can't miss it), ordered before the ticker so a tick-coincident boundary (`-O 1 -i 1`) resolves as the final warm-up interval. At the boundary: warm-up tail flushed, every counter snapshotted (byte baselines, UDP `omitted_*`, retransmit baselines, end-block extremes), interval timeline restarted at 0, ticker re-phased.
- **Accounting**: summaries/`-J`/exchange use net (post-omit) byte getters; packets/errors stay **gross on the wire** with `omitted_*` baselines alongside, both sides subtract — exactly iperf3's exchange shape, which also makes riperf3 read a real iperf3 server's omit results correctly. `-n`/`-k` progress measures net, so the limit applies post-omit.
- **Validation**: `build()` rejects `omit > 60` with iperf3's IEOMIT wording.

## TDD

Red commit first: `-O 1 -t 2` measured 2.26 s wall (vs required ~3 s) and 26.2 GB reported vs 12.9 GB in post-omit intervals — both tests now green, plus `test_start.omit`, `omitted:true` flags, timeline restart at 0, and summary internal consistency. Full workspace suite green (438), incl. the adjacent #55 final-flush and #103 measured-window suites.

## Gate before merge

`/riperf3-verify` vs real iperf3 `-O` in both roles on the fleet (results to be posted here), plus the standard post-merge smoke.

Closes #31.

Fixes #31. Fixes #171 (exchanged retransmit totals re-baselined at the omit boundary — landed here per the #166 review agreement).
