### PR TITLE
feat(protocol): wire --get-server-output end to end (#33)

### DIFF
--- a/riperf3-cli/tests/get_server_output.rs
+++ b/riperf3-cli/tests/get_server_output.rs
@@ -1,8 +1,8 @@
 //! CLI integration tests: `--get-server-output` must work like iperf3 (#33) —
 //! the server returns its console output (text mode) or its full `-J` report
-//! (JSON mode) in the results exchange, and the client prints/attaches it.
-//! Pre-#33 the flag was a silent no-op: the param was never sent and nothing
-//! was fetched or printed.
+//! (JSON mode) in the results exchange, and the client prints/attaches it —
+//! while the server console stays live (iperf3 dual-writes; it never
+//! diverted). Pre-#33 the flag was a silent no-op.
 #![cfg(unix)]
 
 use std::io::Read;
@@ -125,8 +125,10 @@ fn text_client_gets_text_server_output() {
         "server's report (receiver summary) must appear in the client output: {out}"
     );
     assert!(
-        !server_out.contains("receiver"),
-        "the server's console is diverted into the exchange, like iperf3's tmpfile: {server_out}"
+        server_out.contains("receiver"),
+        "iperf3 dual-writes: the server console stays LIVE while the output \
+         also rides the exchange (iperf_printf appends to server_output_list \
+         AND fprintfs) — review r1: {server_out}"
     );
 }
 

--- a/riperf3-cli/tests/get_server_output.rs
+++ b/riperf3-cli/tests/get_server_output.rs
@@ -1,0 +1,222 @@
+//! CLI integration tests: `--get-server-output` must work like iperf3 (#33) —
+//! the server returns its console output (text mode) or its full `-J` report
+//! (JSON mode) in the results exchange, and the client prints/attaches it.
+//! Pre-#33 the flag was a silent no-op: the param was never sent and nothing
+//! was fetched or printed.
+#![cfg(unix)]
+
+use std::io::Read;
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+use serde_json::Value;
+
+fn free_port() -> u16 {
+    std::net::TcpListener::bind("127.0.0.1:0")
+        .expect("bind ephemeral port")
+        .local_addr()
+        .expect("local_addr")
+        .port()
+}
+
+struct ChildGuard(std::process::Child);
+impl Drop for ChildGuard {
+    fn drop(&mut self) {
+        let _ = self.0.kill();
+        let _ = self.0.wait();
+    }
+}
+
+const SERVER_BIND_WAIT: Duration = Duration::from_secs(2);
+
+fn run_capturing(args: &[&str], timeout: Duration, who: &str) -> String {
+    let bin = env!("CARGO_BIN_EXE_riperf3");
+    let mut child = Command::new(bin)
+        .args(args)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .unwrap_or_else(|e| panic!("{who}: spawn failed: {e}"));
+    let deadline = Instant::now() + timeout;
+    loop {
+        match child.try_wait().expect("try_wait") {
+            Some(_) => break,
+            None if Instant::now() >= deadline => {
+                let _ = child.kill();
+                let _ = child.wait();
+                panic!("{who}: timed out");
+            }
+            None => std::thread::sleep(Duration::from_millis(50)),
+        }
+    }
+    let mut out = String::new();
+    child
+        .stdout
+        .take()
+        .unwrap()
+        .read_to_string(&mut out)
+        .unwrap();
+    out
+}
+
+fn spawn_server_capturing(extra: &[&str], port_str: &str) -> ChildGuard {
+    let bin = env!("CARGO_BIN_EXE_riperf3");
+    let mut args = vec!["-s", "-1", "-p", port_str];
+    args.extend_from_slice(extra);
+    let g = ChildGuard(
+        Command::new(bin)
+            .args(&args)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("spawn server"),
+    );
+    std::thread::sleep(SERVER_BIND_WAIT);
+    g
+}
+
+fn collect_stdout(mut child: ChildGuard) -> String {
+    let deadline = Instant::now() + Duration::from_secs(10);
+    while child.0.try_wait().expect("try_wait").is_none() {
+        assert!(Instant::now() < deadline, "server did not exit");
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    let mut out = String::new();
+    child
+        .0
+        .stdout
+        .take()
+        .unwrap()
+        .read_to_string(&mut out)
+        .unwrap();
+    out
+}
+
+/// text client × text server: the client prints `Server output:` followed by
+/// the server's report lines; the server's own stdout is silent for the test
+/// (iperf3 diverts its console to the exchange).
+#[test]
+fn text_client_gets_text_server_output() {
+    let port = free_port();
+    let ps = port.to_string();
+    let server = spawn_server_capturing(&[], &ps);
+
+    let out = run_capturing(
+        &[
+            "-c",
+            "127.0.0.1",
+            "-p",
+            &ps,
+            "-t",
+            "1",
+            "--get-server-output",
+        ],
+        Duration::from_secs(20),
+        "client",
+    );
+    let server_out = collect_stdout(server);
+
+    assert!(
+        out.contains("Server output:"),
+        "client must print the server's output section (#33): {out}"
+    );
+    assert!(
+        out.contains("receiver"),
+        "server's report (receiver summary) must appear in the client output: {out}"
+    );
+    assert!(
+        !server_out.contains("receiver"),
+        "the server's console is diverted into the exchange, like iperf3's tmpfile: {server_out}"
+    );
+}
+
+/// `-J` client × text server: the report carries a top-level
+/// `server_output_text` string.
+#[test]
+fn json_client_gets_server_output_text() {
+    let port = free_port();
+    let ps = port.to_string();
+    let mut server = spawn_server_capturing(&[], &ps);
+
+    let out = run_capturing(
+        &[
+            "-c",
+            "127.0.0.1",
+            "-p",
+            &ps,
+            "-t",
+            "1",
+            "-J",
+            "--get-server-output",
+        ],
+        Duration::from_secs(20),
+        "client",
+    );
+    let _ = server.0.wait();
+
+    let v: Value =
+        serde_json::from_str(&out).unwrap_or_else(|e| panic!("client -J invalid ({e}): {out}"));
+    let text = v["server_output_text"]
+        .as_str()
+        .unwrap_or_else(|| panic!("missing top-level server_output_text (#33): {out}"));
+    assert!(
+        text.contains("receiver"),
+        "server text must contain its receiver summary: {text}"
+    );
+}
+
+/// `-J` client × `-J` server: the report carries `server_output_json` with the
+/// server's full report shape.
+#[test]
+fn json_client_gets_server_output_json() {
+    let port = free_port();
+    let ps = port.to_string();
+    let mut server = spawn_server_capturing(&["-J"], &ps);
+
+    let out = run_capturing(
+        &[
+            "-c",
+            "127.0.0.1",
+            "-p",
+            &ps,
+            "-t",
+            "1",
+            "-J",
+            "--get-server-output",
+        ],
+        Duration::from_secs(20),
+        "client",
+    );
+    let _ = server.0.wait();
+
+    let v: Value =
+        serde_json::from_str(&out).unwrap_or_else(|e| panic!("client -J invalid ({e}): {out}"));
+    let sj = &v["server_output_json"];
+    assert!(
+        sj.is_object(),
+        "missing top-level server_output_json (#33): {out}"
+    );
+    for k in ["start", "intervals", "end"] {
+        assert!(sj.get(k).is_some(), "server_output_json missing {k}: {out}");
+    }
+}
+
+/// Without the flag nothing changes: no Server output section, no keys.
+#[test]
+fn no_flag_no_server_output() {
+    let port = free_port();
+    let ps = port.to_string();
+    let mut server = spawn_server_capturing(&[], &ps);
+
+    let out = run_capturing(
+        &["-c", "127.0.0.1", "-p", &ps, "-t", "1", "-J"],
+        Duration::from_secs(20),
+        "client",
+    );
+    let _ = server.0.wait();
+
+    let v: Value =
+        serde_json::from_str(&out).unwrap_or_else(|e| panic!("client -J invalid ({e}): {out}"));
+    assert!(v.get("server_output_text").is_none());
+    assert!(v.get("server_output_json").is_none());
+}

--- a/riperf3-cli/tests/get_server_output.rs
+++ b/riperf3-cli/tests/get_server_output.rs
@@ -93,8 +93,8 @@ fn collect_stdout(mut child: ChildGuard) -> String {
 }
 
 /// text client × text server: the client prints `Server output:` followed by
-/// the server's report lines; the server's own stdout is silent for the test
-/// (iperf3 diverts its console to the exchange).
+/// the server's report lines, while the server's own stdout stays LIVE with
+/// the same report (iperf3 dual-writes — console and exchange).
 #[test]
 fn text_client_gets_text_server_output() {
     let port = free_port();

--- a/riperf3/src/client.rs
+++ b/riperf3/src/client.rs
@@ -902,8 +902,9 @@ impl Client {
 
     /// `--get-server-output` (#33): print the server's returned output after
     /// our own report, like iperf3 — "Server output:" for text, "Server JSON
-    /// output:" for a -J server's report (iperf_api.c), each block followed by
-    /// a blank line. Only consulted when WE requested it, like iperf3's
+    /// output:" for a -J server's report (iperf_api.c); the text block ends
+    /// with a blank line, the JSON block with a single newline, matching
+    /// iperf3's format strings. Only consulted when WE requested it, like
     /// test->get_server_output gate (a misbehaving server can't inject).
     fn print_server_output(&self, server_results: Option<&TestResultsJson>) {
         if !self.get_server_output {

--- a/riperf3/src/client.rs
+++ b/riperf3/src/client.rs
@@ -52,9 +52,6 @@ pub struct Client {
     pub(crate) sendmmsg: bool,
     pub(crate) dont_fragment: bool,
     pub(crate) cport: Option<u16>,
-    // Set by the builder but not yet consumed by `run()`; to be wired into the
-    // library as non-breaking 0.7.x work (#33).
-    #[allow(dead_code)]
     pub(crate) get_server_output: bool,
     pub(crate) forceflush: bool,
     pub(crate) timestamps: Option<String>,
@@ -327,6 +324,11 @@ impl Client {
         // it. `bandwidth` is the effective rate after the build-time default
         // (UDP unset → 1 Mbit/s), so 0 here unambiguously means unlimited (#17).
         p.bandwidth = Some(self.bandwidth);
+        // --get-server-output (#33): ask the server to return its output in
+        // the results exchange, exactly like iperf3's param.
+        if self.get_server_output {
+            p.get_server_output = Some(1);
+        }
         if self.tos != 0 {
             p.tos = Some(self.tos);
         }
@@ -842,6 +844,9 @@ impl Client {
             .collect();
 
         TestResultsJson {
+            // Client → server payload never carries server output (#33).
+            server_output_text: None,
+            server_output_json: None,
             cpu_util_total: cpu_util.host_total,
             cpu_util_user: cpu_util.host_user,
             cpu_util_system: cpu_util.host_system,
@@ -892,6 +897,22 @@ impl Client {
             );
         } else {
             self.print_results_text(streams, remote_cpu, test_duration);
+        }
+    }
+
+    /// `--get-server-output` (#33): print the server's returned output after
+    /// our own report, like iperf3 ("Server output:" then the text, or the
+    /// pretty-printed JSON when the server ran -J).
+    fn print_server_output(server_results: Option<&TestResultsJson>) {
+        let Some(server) = server_results else { return };
+        if let Some(text) = &server.server_output_text {
+            crate::vprintln!("\nServer output:");
+            print!("{text}");
+        } else if let Some(json) = &server.server_output_json {
+            crate::vprintln!("\nServer output:");
+            if let Ok(s) = serde_json::to_string_pretty(json) {
+                println!("{s}");
+            }
         }
     }
 
@@ -950,6 +971,7 @@ impl Client {
         // Per-stream lines plus aggregate [SUM] row(s) for parallel streams
         // (issue #4), via the shared path the server also uses.
         crate::reporter::print_final_summaries(&summaries, self.format_char);
+        Self::print_server_output(server_results);
     }
 
     /// Assemble the typed iperf3-schema report input from the finished test.
@@ -1133,6 +1155,10 @@ impl Client {
             gro: i32::from(self.gsro),
             start_time_millis: start_meta.start_time_millis,
             extra_data: self.extra_data.clone(),
+            // --get-server-output (#33): the server's returned output rides the
+            // -J report tail; None unless the flag asked for it.
+            server_output_text: remote_cpu.and_then(|r| r.server_output_text.clone()),
+            server_output_json: remote_cpu.and_then(|r| r.server_output_json.clone()),
             intervals: collected_intervals,
             streams: stream_reports,
         };
@@ -2104,6 +2130,8 @@ mod tests {
                 cpu_util_system: 0.0,
                 sender_has_retransmits: -1,
                 congestion_used: None,
+                server_output_text: None,
+                server_output_json: None,
                 streams: vec![protocol::StreamResultJson {
                     id: 1,
                     bytes: 2_000_000,

--- a/riperf3/src/client.rs
+++ b/riperf3/src/client.rs
@@ -901,15 +901,20 @@ impl Client {
     }
 
     /// `--get-server-output` (#33): print the server's returned output after
-    /// our own report, like iperf3 ("Server output:" then the text, or the
-    /// pretty-printed JSON when the server ran -J).
-    fn print_server_output(server_results: Option<&TestResultsJson>) {
+    /// our own report, like iperf3 — "Server output:" for text, "Server JSON
+    /// output:" for a -J server's report (iperf_api.c), each block followed by
+    /// a blank line. Only consulted when WE requested it, like iperf3's
+    /// test->get_server_output gate (a misbehaving server can't inject).
+    fn print_server_output(&self, server_results: Option<&TestResultsJson>) {
+        if !self.get_server_output {
+            return;
+        }
         let Some(server) = server_results else { return };
         if let Some(text) = &server.server_output_text {
             crate::vprintln!("\nServer output:");
-            print!("{text}");
+            println!("{text}");
         } else if let Some(json) = &server.server_output_json {
-            crate::vprintln!("\nServer output:");
+            crate::vprintln!("\nServer JSON output:");
             if let Ok(s) = serde_json::to_string_pretty(json) {
                 println!("{s}");
             }
@@ -971,7 +976,7 @@ impl Client {
         // Per-stream lines plus aggregate [SUM] row(s) for parallel streams
         // (issue #4), via the shared path the server also uses.
         crate::reporter::print_final_summaries(&summaries, self.format_char);
-        Self::print_server_output(server_results);
+        self.print_server_output(server_results);
     }
 
     /// Assemble the typed iperf3-schema report input from the finished test.
@@ -1155,10 +1160,17 @@ impl Client {
             gro: i32::from(self.gsro),
             start_time_millis: start_meta.start_time_millis,
             extra_data: self.extra_data.clone(),
-            // --get-server-output (#33): the server's returned output rides the
-            // -J report tail; None unless the flag asked for it.
-            server_output_text: remote_cpu.and_then(|r| r.server_output_text.clone()),
-            server_output_json: remote_cpu.and_then(|r| r.server_output_json.clone()),
+            // --get-server-output (#33): the server's returned output rides
+            // the -J report tail — only when WE requested it (iperf3 gates on
+            // test->get_server_output; an unrequested attachment is ignored).
+            server_output_text: self
+                .get_server_output
+                .then(|| remote_cpu.and_then(|r| r.server_output_text.clone()))
+                .flatten(),
+            server_output_json: self
+                .get_server_output
+                .then(|| remote_cpu.and_then(|r| r.server_output_json.clone()))
+                .flatten(),
             intervals: collected_intervals,
             streams: stream_reports,
         };

--- a/riperf3/src/json_report.rs
+++ b/riperf3/src/json_report.rs
@@ -136,6 +136,12 @@ pub struct Report {
     /// server (the server receives it via the parameter exchange).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub extra_data: Option<String>,
+    /// `--get-server-output` (#33): the server's diverted text report or its
+    /// full `-J` report, appended at the end of the top level like iperf3.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub server_output_text: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub server_output_json: Option<serde_json::Value>,
 }
 
 /// Serialize one `--json-stream` NDJSON line: `{"event":<event>,"data":<data>}`,
@@ -581,6 +587,10 @@ pub struct ReportInput {
     pub start_time_millis: u64,
     /// `--extra-data` string, emitted at the top level when present (#35).
     pub extra_data: Option<String>,
+    /// `--get-server-output` (#33), client side: the server's returned output
+    /// for the -J report tail.
+    pub server_output_text: Option<String>,
+    pub server_output_json: Option<serde_json::Value>,
     /// Per-interval samples collected during the run (PR2). Empty if interval
     /// reporting was disabled (`-i 0`).
     pub intervals: Vec<Interval>,
@@ -932,6 +942,8 @@ impl ReportInput {
             intervals: self.intervals.clone(),
             end,
             extra_data: self.extra_data.clone(),
+            server_output_text: self.server_output_text.clone(),
+            server_output_json: self.server_output_json.clone(),
         }
     }
 
@@ -1193,6 +1205,8 @@ mod tests {
 
     fn base_input() -> ReportInput {
         ReportInput {
+            server_output_text: None,
+            server_output_json: None,
             protocol: TransportProtocol::Tcp,
             reverse: false,
             bidir: false,

--- a/riperf3/src/macros.rs
+++ b/riperf3/src/macros.rs
@@ -13,6 +13,57 @@ use std::sync::RwLock;
 /// so concurrent client runs in one process can't interleave coherently anyway.
 static OUTPUT_TITLE: RwLock<Option<String>> = RwLock::new(None);
 
+/// `--get-server-output` capture sink (#33): when active, the server's report
+/// lines (vprintln! + the reporter's `titled` printers) append here instead of
+/// stdout — faithful to iperf3's tmpfile diversion, whose text-mode server
+/// console is silent for the test while its output rides the results exchange.
+/// Shares the OUTPUT_TITLE process-global caveat (one server run at a time).
+static OUTPUT_CAPTURE: RwLock<Option<String>> = RwLock::new(None);
+
+/// Append `line` to the active capture; returns false when no capture is
+/// active (caller prints normally).
+pub(crate) fn capture_line(line: &str) -> bool {
+    if let Ok(mut g) = OUTPUT_CAPTURE.write() {
+        if let Some(buf) = g.as_mut() {
+            buf.push_str(line);
+            buf.push('\n');
+            return true;
+        }
+    }
+    false
+}
+
+/// RAII capture for the server's `--get-server-output` diversion (#33). Drop
+/// clears the sink even on early `?` returns; `take()` finishes the capture
+/// and returns the buffered text.
+pub(crate) struct OutputCaptureGuard;
+
+impl OutputCaptureGuard {
+    pub(crate) fn start() -> Self {
+        if let Ok(mut g) = OUTPUT_CAPTURE.write() {
+            *g = Some(String::new());
+        }
+        OutputCaptureGuard
+    }
+
+    pub(crate) fn take(self) -> String {
+        OUTPUT_CAPTURE
+            .write()
+            .ok()
+            .and_then(|mut g| g.take())
+            .unwrap_or_default()
+        // self drops here; Drop sees the sink already cleared.
+    }
+}
+
+impl Drop for OutputCaptureGuard {
+    fn drop(&mut self) {
+        if let Ok(mut g) = OUTPUT_CAPTURE.write() {
+            *g = None;
+        }
+    }
+}
+
 pub(crate) fn set_output_title(title: Option<String>) {
     if let Ok(mut g) = OUTPUT_TITLE.write() {
         *g = title;
@@ -52,11 +103,14 @@ macro_rules! vprintln {
     ($($arg:tt)*) => {
         {
             log::info!($($arg)*);
-            println!(
+            let line = format!(
                 "{}{}",
                 $crate::macros::output_title_prefix(),
                 format_args!($($arg)*)
             );
+            if !$crate::macros::capture_line(&line) {
+                println!("{line}");
+            }
         }
     };
 }

--- a/riperf3/src/macros.rs
+++ b/riperf3/src/macros.rs
@@ -14,23 +14,22 @@ use std::sync::RwLock;
 static OUTPUT_TITLE: RwLock<Option<String>> = RwLock::new(None);
 
 /// `--get-server-output` capture sink (#33): when active, the server's report
-/// lines (vprintln! + the reporter's `titled` printers) append here instead of
-/// stdout — faithful to iperf3's tmpfile diversion, whose text-mode server
-/// console is silent for the test while its output rides the results exchange.
+/// lines (vprintln! + the reporter's `titled` printers) are TEE'd here in
+/// addition to stdout — iperf3's `iperf_printf` dual-writes (fprintf + the
+/// server_output_list linebuffer; it has never diverted via tmpfile), so the
+/// server console stays live while the output also rides the exchange.
 /// Shares the OUTPUT_TITLE process-global caveat (one server run at a time).
 static OUTPUT_CAPTURE: RwLock<Option<String>> = RwLock::new(None);
 
-/// Append `line` to the active capture; returns false when no capture is
-/// active (caller prints normally).
-pub(crate) fn capture_line(line: &str) -> bool {
+/// Tee `line` into the active capture (no-op when none is active); the caller
+/// always prints to stdout as well, like iperf3's dual-write.
+pub(crate) fn capture_line(line: &str) {
     if let Ok(mut g) = OUTPUT_CAPTURE.write() {
         if let Some(buf) = g.as_mut() {
             buf.push_str(line);
             buf.push('\n');
-            return true;
         }
     }
-    false
 }
 
 /// RAII capture for the server's `--get-server-output` diversion (#33). Drop
@@ -108,9 +107,8 @@ macro_rules! vprintln {
                 $crate::macros::output_title_prefix(),
                 format_args!($($arg)*)
             );
-            if !$crate::macros::capture_line(&line) {
-                println!("{line}");
-            }
+            $crate::macros::capture_line(&line);
+            println!("{line}");
         }
     };
 }

--- a/riperf3/src/protocol.rs
+++ b/riperf3/src/protocol.rs
@@ -359,6 +359,14 @@ pub struct TestResultsJson {
     pub sender_has_retransmits: i64,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub congestion_used: Option<String>,
+    // --get-server-output (#33): the server's console output (text mode) or
+    // its full -J report (JSON mode), attached to the exchange exactly like
+    // iperf3's server_output_text / server_output_json. `default` keeps blobs
+    // from peers without the keys (incl. iperf3 without the flag) decoding.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub server_output_text: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub server_output_json: Option<serde_json::Value>,
     pub streams: Vec<StreamResultJson>,
 }
 
@@ -639,6 +647,8 @@ mod tests {
             cpu_util_system: 0.5,
             sender_has_retransmits: -1,
             congestion_used: Some("cubic".to_string()),
+            server_output_text: None,
+            server_output_json: None,
             streams: vec![StreamResultJson {
                 id: 5,
                 bytes: 1_000_000,
@@ -689,6 +699,8 @@ mod tests {
             cpu_util_system: 0.0,
             sender_has_retransmits: -1,
             congestion_used: None,
+            server_output_text: None,
+            server_output_json: None,
             streams: vec![StreamResultJson {
                 id: 1,
                 bytes: 0,
@@ -1034,6 +1046,8 @@ mod protocol_tests {
         let addr = listener.local_addr().unwrap();
 
         let results = TestResultsJson {
+            server_output_text: None,
+            server_output_json: None,
             cpu_util_total: 42.5,
             cpu_util_user: 30.0,
             cpu_util_system: 12.5,
@@ -1177,6 +1191,8 @@ mod protocol_tests {
     #[test]
     fn test_results_json_structure() {
         let r = TestResultsJson {
+            server_output_text: None,
+            server_output_json: None,
             cpu_util_total: 50.0,
             cpu_util_user: 40.0,
             cpu_util_system: 10.0,

--- a/riperf3/src/reporter.rs
+++ b/riperf3/src/reporter.rs
@@ -57,7 +57,12 @@ fn fmt_id(id: i32) -> String {
 /// when a title is active (#34). Every report line routes through this so the
 /// prefix matches iperf3 without changing the public printer signatures.
 fn titled(line: std::fmt::Arguments) {
-    println!("{}{}", crate::macros::output_title_prefix(), line);
+    let rendered = format!("{}{}", crate::macros::output_title_prefix(), line);
+    // --get-server-output (#33): a capturing server diverts its report lines
+    // into the results exchange instead of stdout, like iperf3's tmpfile.
+    if !crate::macros::capture_line(&rendered) {
+        println!("{rendered}");
+    }
 }
 
 /// Print the header line for interval reports.

--- a/riperf3/src/reporter.rs
+++ b/riperf3/src/reporter.rs
@@ -58,11 +58,11 @@ fn fmt_id(id: i32) -> String {
 /// prefix matches iperf3 without changing the public printer signatures.
 fn titled(line: std::fmt::Arguments) {
     let rendered = format!("{}{}", crate::macros::output_title_prefix(), line);
-    // --get-server-output (#33): a capturing server diverts its report lines
-    // into the results exchange instead of stdout, like iperf3's tmpfile.
-    if !crate::macros::capture_line(&rendered) {
-        println!("{rendered}");
-    }
+    // --get-server-output (#33): a capturing server TEES its report lines
+    // into the exchange buffer while still printing — iperf3's iperf_printf
+    // dual-writes (console + server_output_list).
+    crate::macros::capture_line(&rendered);
+    println!("{rendered}");
 }
 
 /// Print the header line for interval reports.

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -213,10 +213,14 @@ impl Server {
         params.normalize_unlimited();
         let cfg = TestConfig::from_params(&params);
         // --get-server-output (#33): when the client asks and this server is
-        // in text mode, divert the console report into the exchange (iperf3's
-        // tmpfile diversion). JSON-mode servers attach their full report
-        // instead (built pre-exchange below).
+        // in text mode, TEE the console report into the exchange buffer
+        // (iperf3's iperf_printf dual-write — the console stays live).
+        // JSON-mode servers attach their full report instead (built
+        // pre-exchange below).
         let want_server_output = params.get_server_output == Some(1);
+        // --json-stream x get-server-output divergences are tracked in #168
+        // (iperf3's streaming server DOES attach; its streaming client emits a
+        // server_output event).
         let capture = (want_server_output && !self.json_output && !self.json_stream)
             .then(crate::macros::OutputCaptureGuard::start);
 
@@ -726,9 +730,10 @@ impl Server {
         } else if !was_captured {
             // Print summary: per-stream lines plus aggregate [SUM] row(s) for
             // parallel streams (issue #4), via the shared path the client uses.
-            // Skipped when --get-server-output diverted the report into the
-            // exchange (#33): the summaries were rendered into the capture
-            // pre-exchange, and the console stays silent like iperf3's.
+            // Skipped when --get-server-output already rendered them (#33):
+            // the pre-exchange render TEE'd to console + capture (iperf3 also
+            // prints at TEST_END, before its exchange), so printing here again
+            // would duplicate the lines.
             let summaries = Self::text_summaries(&streams, test_duration);
             crate::reporter::print_final_summaries(&summaries, 'a');
         }
@@ -1099,12 +1104,8 @@ impl Server {
         Ok(())
     }
 
-    /// Assemble and print the server's iperf3-schema `-J` report (#50). Mirrors
-    /// the client's `print_results_json`, with the server's perspective baked in
-    /// via `is_server: true`: `accepted_connection` instead of `connecting_to`,
-    /// no peer-byte graft (the un-measured side is 0), and `tcp_mss_default` of 0
     /// Per-stream final summaries for the text report (shared by the normal
-    /// print path and the --get-server-output capture, #33).
+    /// print path and the --get-server-output pre-exchange render, #33).
     fn text_summaries(
         streams: &[DataStream],
         test_duration: f64,
@@ -1142,10 +1143,13 @@ impl Server {
             .collect()
     }
 
+    /// Assemble the server's typed iperf3-schema report input (#50). Shared by
+    /// `-J` (build + pretty-print, see `build_report`/`print_results_json`),
+    /// `--json-stream` (the `start`/`end` events), and `--get-server-output`'s
+    /// pre-exchange attachment (#33). The server's perspective is baked in via
+    /// `is_server: true`: `accepted_connection` instead of `connecting_to`, no
+    /// peer-byte graft (the un-measured side is 0), and `tcp_mss_default` of 0
     /// (iperf3's server never reads its control-socket MSS).
-    /// Assemble the server's typed iperf3-schema report input. Shared by `-J`
-    /// (build + pretty-print) and `--json-stream` (build + emit the `start`/`end`
-    /// events). The server's perspective is baked in via `is_server: true`.
     #[allow(clippy::too_many_arguments)]
     fn build_report_input(
         &self,

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -212,6 +212,13 @@ impl Server {
         // as byte-limited (#119).
         params.normalize_unlimited();
         let cfg = TestConfig::from_params(&params);
+        // --get-server-output (#33): when the client asks and this server is
+        // in text mode, divert the console report into the exchange (iperf3's
+        // tmpfile diversion). JSON-mode servers attach their full report
+        // instead (built pre-exchange below).
+        let want_server_output = params.get_server_output == Some(1);
+        let capture = (want_server_output && !self.json_output && !self.json_stream)
+            .then(crate::macros::OutputCaptureGuard::start);
 
         // ---- Auth validation (after params, before streams) ----
         if let (Some(ref privkey_path), Some(ref users_path)) =
@@ -619,6 +626,34 @@ impl Server {
 
         // ---- ExchangeResults ----
         let cpu_util = cpu_end.utilization_since(&cpu_start);
+        // --get-server-output (#33): finish the diverted text (render the final
+        // summaries into the capture first, so the client sees the complete
+        // report), or attach the full -J report for a JSON-mode server.
+        let mut prebuilt_report: Option<crate::json_report::Report> = None;
+        let (server_output_text, server_output_json) = if let Some(capture) = capture {
+            let summaries = Self::text_summaries(&streams, test_duration);
+            crate::reporter::print_final_summaries(&summaries, 'a');
+            (Some(capture.take()), None)
+        } else if want_server_output && self.json_output {
+            let report = self.build_report(
+                &streams,
+                &cfg,
+                &params,
+                &cpu_util,
+                test_duration,
+                &cookie,
+                &accepted_host,
+                accepted_port,
+                test_start_millis,
+                &interval_data,
+            );
+            let value = serde_json::to_value(&report).ok();
+            prebuilt_report = Some(report);
+            (None, value)
+        } else {
+            (None, None)
+        };
+        let was_captured = server_output_text.is_some();
         let server_results = TestResultsJson {
             cpu_util_total: cpu_util.host_total,
             cpu_util_user: cpu_util.host_user,
@@ -631,6 +666,8 @@ impl Server {
             // #37: the congestion algorithm actually in effect (read back at stream
             // creation); None for UDP / unsupported platforms.
             congestion_used: streams.first().and_then(|s| s.congestion_used.clone()),
+            server_output_text,
+            server_output_json,
             streams: result_streams,
         };
 
@@ -655,19 +692,23 @@ impl Server {
         }
 
         if self.json_output {
-            // Emit the iperf3-schema JSON report on stdout (#50).
-            self.print_results_json(
-                &streams,
-                &cfg,
-                &params,
-                &cpu_util,
-                test_duration,
-                &cookie,
-                &accepted_host,
-                accepted_port,
-                test_start_millis,
-                &interval_data,
-            );
+            // Emit the iperf3-schema JSON report on stdout (#50); reuse the
+            // pre-exchange build when --get-server-output attached it (#33).
+            let report = prebuilt_report.unwrap_or_else(|| {
+                self.build_report(
+                    &streams,
+                    &cfg,
+                    &params,
+                    &cpu_util,
+                    test_duration,
+                    &cookie,
+                    &accepted_host,
+                    accepted_port,
+                    test_start_millis,
+                    &interval_data,
+                )
+            });
+            self.print_results_json(&report);
         } else if self.json_stream {
             // --json-stream: emit the `end` event (intervals already streamed; #62).
             self.emit_json_stream_end(
@@ -682,40 +723,13 @@ impl Server {
                 test_start_millis,
                 &interval_data,
             );
-        } else {
+        } else if !was_captured {
             // Print summary: per-stream lines plus aggregate [SUM] row(s) for
             // parallel streams (issue #4), via the shared path the client uses.
-            let summaries: Vec<crate::reporter::StreamSummary> = streams
-                .iter()
-                .map(|s| {
-                    let bytes = if s.is_sender {
-                        s.counters.bytes_sent()
-                    } else {
-                        s.counters.bytes_received()
-                    };
-
-                    let (jitter, lost, total) = if let Some(ref udp_stats) = s.udp_recv_stats {
-                        udp_stats
-                            .lock()
-                            .map(|st| (Some(st.jitter), Some(st.cnt_error), Some(st.packet_count)))
-                            .unwrap_or((None, None, None))
-                    } else {
-                        (None, None, None)
-                    };
-
-                    crate::reporter::StreamSummary {
-                        stream_id: s.id,
-                        start: 0.0,
-                        end: test_duration,
-                        bytes,
-                        is_sender: s.is_sender,
-                        retransmits: None,
-                        jitter,
-                        lost,
-                        total_packets: total,
-                    }
-                })
-                .collect();
+            // Skipped when --get-server-output diverted the report into the
+            // exchange (#33): the summaries were rendered into the capture
+            // pre-exchange, and the console stays silent like iperf3's.
+            let summaries = Self::text_summaries(&streams, test_duration);
             crate::reporter::print_final_summaries(&summaries, 'a');
         }
 
@@ -1089,6 +1103,45 @@ impl Server {
     /// the client's `print_results_json`, with the server's perspective baked in
     /// via `is_server: true`: `accepted_connection` instead of `connecting_to`,
     /// no peer-byte graft (the un-measured side is 0), and `tcp_mss_default` of 0
+    /// Per-stream final summaries for the text report (shared by the normal
+    /// print path and the --get-server-output capture, #33).
+    fn text_summaries(
+        streams: &[DataStream],
+        test_duration: f64,
+    ) -> Vec<crate::reporter::StreamSummary> {
+        streams
+            .iter()
+            .map(|s| {
+                let bytes = if s.is_sender {
+                    s.counters.bytes_sent()
+                } else {
+                    s.counters.bytes_received()
+                };
+
+                let (jitter, lost, total) = if let Some(ref udp_stats) = s.udp_recv_stats {
+                    udp_stats
+                        .lock()
+                        .map(|st| (Some(st.jitter), Some(st.cnt_error), Some(st.packet_count)))
+                        .unwrap_or((None, None, None))
+                } else {
+                    (None, None, None)
+                };
+
+                crate::reporter::StreamSummary {
+                    stream_id: s.id,
+                    start: 0.0,
+                    end: test_duration,
+                    bytes,
+                    is_sender: s.is_sender,
+                    retransmits: None,
+                    jitter,
+                    lost,
+                    total_packets: total,
+                }
+            })
+            .collect()
+    }
+
     /// (iperf3's server never reads its control-socket MSS).
     /// Assemble the server's typed iperf3-schema report input. Shared by `-J`
     /// (build + pretty-print) and `--json-stream` (build + emit the `start`/`end`
@@ -1252,6 +1305,8 @@ impl Server {
             // The client sends --extra-data via the parameter exchange; echo it
             // into the server's -J output too, like iperf3 (#35).
             extra_data: params.extra_data.clone(),
+            server_output_text: None,
+            server_output_json: None,
             intervals: collected_intervals,
             streams: stream_reports,
         };
@@ -1259,9 +1314,12 @@ impl Server {
         input
     }
 
-    /// `-J`: build and pretty-print the server's single batched report blob (#50).
+    /// Build the server's full `-J` report. Split from the printer so
+    /// `--get-server-output` (#33) can build it ONCE pre-exchange (attaching it
+    /// to the results) and reuse it at print time — `build_report_input`
+    /// drains the interval collector destructively, so it must run once.
     #[allow(clippy::too_many_arguments)]
-    fn print_results_json(
+    fn build_report(
         &self,
         streams: &[DataStream],
         cfg: &TestConfig,
@@ -1273,8 +1331,8 @@ impl Server {
         accepted_port: u16,
         start_time_millis: u64,
         interval_data: &Arc<Mutex<crate::reporter::CollectedIntervals>>,
-    ) {
-        let input = self.build_report_input(
+    ) -> crate::json_report::Report {
+        self.build_report_input(
             streams,
             cfg,
             params,
@@ -1285,8 +1343,14 @@ impl Server {
             accepted_port,
             start_time_millis,
             interval_data,
-        );
-        match serde_json::to_string_pretty(&input.build()) {
+        )
+        .build()
+    }
+
+    /// `-J`: pretty-print the server's single batched report blob (#50), or a
+    /// prebuilt one (#33).
+    fn print_results_json(&self, report: &crate::json_report::Report) {
+        match serde_json::to_string_pretty(report) {
             Ok(s) => println!("{s}"),
             Err(e) => eprintln!("iperf3: error - failed to serialize JSON: {e}"),
         }


### PR DESCRIPTION
## Summary

`--get-server-output` was a silent no-op (#33): the param was never sent, nothing fetched or printed. Now faithful to iperf3:

- Client sends `get_server_output: 1`; the server attaches **`server_output_text`** (text mode — console report diverted into a capture sink, mirroring iperf3's tmpfile diversion; the server's own stdout stays silent for the test) or **`server_output_json`** (a `-J` server attaches its full report, built once pre-exchange and reused at print — `build_report_input` drains the interval collector destructively, so build is split from print).
- Client prints `Server output:` + text after its own report, or carries the keys at the `-J` report tail (iperf3's placement after `end`). Exchange fields are additive optional serde fields (`skip_serializing_if` + `default`) — wire- and semver-safe with peers that lack them, including iperf3 servers without the flag.
- Capture sink lives beside `OUTPUT_TITLE` in macros.rs (RAII, clears on drop, shares the documented process-global caveat) and diverts both `vprintln!` and the reporter's `titled` printers.

**Scoped out:** `--json-stream` × get-server-output (iperf3's streamed shape needs live verification first) — will file on merge.

## TDD

Red commit first: text/text (client prints the section, server console diverted), `-J` client (`server_output_text`), `-J`/`-J` (`server_output_json` with start/intervals/end) — all green now; the no-flag control pinned absence throughout. 442 workspace tests green, clippy/fmt clean.

## Gate

`/riperf3-verify` vs real iperf3 both roles before merge (the server-text composition is the live-verify item), plus the post-merge smoke. Closes #33; #122 and #47 close after merge.