### PR TITLE
docs: 0.7.2 governance + accuracy ride-alongs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,17 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - run: cargo test --workspace
 
+  msrv:
+    name: MSRV (1.77)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@1.77
+      - uses: Swatinem/rust-cache@v2
+      # Check (not test) on the declared floor: proves the rust-version claim
+      # in Cargo.toml without doubling the test wall-clock.
+      - run: cargo check --workspace --all-targets
+
   lint:
     name: Lint
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,11 +20,11 @@ jobs:
       - run: cargo test --workspace
 
   msrv:
-    name: MSRV (1.77)
+    name: MSRV (1.85)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@1.77
+      - uses: dtolnay/rust-toolchain@1.85
       - uses: Swatinem/rust-cache@v2
       # Check (not test) on the declared floor: proves the rust-version claim
       # in Cargo.toml without doubling the test wall-clock.
@@ -80,11 +80,10 @@ jobs:
   # tcp_connection_info path, winsock) is unverified. These jobs run the real test
   # suite on native runners.
   #
-  # INFORMATIONAL for now: they are deliberately NOT in branch protection's
-  # required checks, because turning native tests on may surface pre-existing
-  # platform bugs (e.g. #40, macOS retransmits always 0). They report without
-  # blocking merges; issues get filed + fixed, then the checks are promoted to
-  # required. fail-fast: false so a failure on one OS doesn't cancel the other.
+  # Status (review of the live main ruleset, 2026-06): Native test
+  # (windows-latest) IS a required branch-protection check; macOS remains
+  # informational (reports without blocking; promoted when consistently
+  # clean). fail-fast: false so a failure on one OS doesn't cancel the other.
   native-test:
     name: Native test (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
@@ -127,9 +126,8 @@ jobs:
   # FreeBSD `rust` package). `release` is pinned for reproducibility.
   #
   # REQUIRED check (added informational in 0.6.1, promoted the same release once
-  # the first runs were clean): it gates merges like the Linux jobs. The
-  # macOS/Windows native jobs above stay informational for now — Windows has the
-  # open UDP multi-stream issue (#80) and macOS isn't promoted yet.
+  # the first runs were clean): it gates merges like the Linux and Windows
+  # native jobs. macOS stays informational for now.
   freebsd-test:
     name: Native test (FreeBSD)
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,40 @@
+# Contributing to riperf3
+
+Thanks for your interest! riperf3 is a faithful, wire-compatible iperf3 drop-in — the ethos is **fidelity first**: where iperf3 accepts an option, riperf3 implements it to behave the same way (quirks included); it never rejects, renames, or works around iperf3's semantics. Behavioral claims in PRs should cite the iperf3 source (file/function) or a live run against a real iperf3 binary.
+
+## Workflow
+
+1. **Open or pick an issue first** for anything non-trivial, so scope is agreed before code.
+2. Branch from `main` (it is protected: PRs only, required CI, linear history — squash merges).
+3. **Tests before fixes**: write a failing test that captures the defect or missing behavior, commit it (red), then make it pass (green). Where the behavior genuinely can't be exercised in CI (e.g. routing effects invisible on loopback), say so in the PR and name the external verification you ran.
+4. Keep PRs tightly scoped — one issue (or one tight cluster) per PR.
+
+## Before pushing
+
+```bash
+cargo fmt --check
+cargo clippy --workspace --all-targets   # CI denies warnings
+cargo test --workspace                   # runs every integration binary, not just --test integration
+```
+
+If you touched `#[cfg(...)]`-gated or platform code, cross-check every supported target compiles:
+
+```bash
+for t in x86_64-unknown-linux-gnu x86_64-unknown-linux-musl x86_64-pc-windows-msvc \
+         x86_64-apple-darwin aarch64-apple-darwin x86_64-unknown-freebsd x86_64-unknown-netbsd; do
+  rustup target add "$t" >/dev/null 2>&1
+  cargo check --workspace --all-targets --target "$t" || break
+done
+```
+
+## CI gates
+
+Required: Linux full suite, FreeBSD native suite, lint (fmt + clippy -D warnings), SemVer (cargo-semver-checks), cross-platform `cargo check`s, and a **real-iperf3 interop matrix** (current + 3.12). macOS/Windows native suites run informationally. The lib crate is API-only (no clap); CLI↔builder wiring is tested by comparing built `Client`s, not by lib test backdoors.
+
+## Releases
+
+SemVer (0.y.z: y = breaking, z = additive/fixes), `cargo-semver-checks` gated, changelog written at release prep, `riperf3` (lib) publishes before `riperf3-cli`.
+
+## Security
+
+See [SECURITY.md](SECURITY.md) — please do not open public issues for vulnerabilities.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,7 @@ done
 
 ## CI gates
 
-Required: Linux full suite, FreeBSD native suite, lint (fmt + clippy -D warnings), SemVer (cargo-semver-checks), cross-platform `cargo check`s, and a **real-iperf3 interop matrix** (current + 3.12). macOS/Windows native suites run informationally. The lib crate is API-only (no clap); CLI↔builder wiring is tested by comparing built `Client`s, not by lib test backdoors.
+Required: Linux full suite, FreeBSD and Windows native suites, lint (fmt + clippy -D warnings), SemVer (cargo-semver-checks), cross-platform `cargo check`s, and a **real-iperf3 interop matrix** (current + 3.12). The macOS native suite runs informationally. The lib crate is API-only (no clap); CLI↔builder wiring is tested by comparing built `Client`s, not by lib test backdoors.
 
 ## Releases
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,9 +10,11 @@ members = [
 version = "0.7.1"
 authors = ["Evan Henry"]
 edition = "2021"
-# MSRV floor: std::mem::offset_of! (1.77) in tcp_info's layout asserts is the
-# newest language feature in use; verified by the pinned-MSRV CI job.
-rust-version = "1.77"
+# MSRV floor 1.85 (review r1, verified empirically): the committed Cargo.lock
+# is lockfile v4 and the locked base64ct 1.8 (rsa chain) is edition 2024,
+# both requiring Cargo >= 1.85; our own code's floor is 1.82
+# (Option::is_none_or). Verified by the pinned-MSRV CI check job.
+rust-version = "1.85"
 homepage = "https://github.com/therealevanhenry/riperf3"
 repository = "https://github.com/therealevanhenry/riperf3"
 keywords = ["riperf3", "iperf3", "iperf", "network", "speedtest"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,9 @@ members = [
 version = "0.7.1"
 authors = ["Evan Henry"]
 edition = "2021"
+# MSRV floor: std::mem::offset_of! (1.77) in tcp_info's layout asserts is the
+# newest language feature in use; verified by the pinned-MSRV CI job.
+rust-version = "1.77"
 homepage = "https://github.com/therealevanhenry/riperf3"
 repository = "https://github.com/therealevanhenry/riperf3"
 keywords = ["riperf3", "iperf3", "iperf", "network", "speedtest"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,10 +10,10 @@ members = [
 version = "0.7.1"
 authors = ["Evan Henry"]
 edition = "2021"
-# MSRV floor 1.85 (review r1, verified empirically): the committed Cargo.lock
-# is lockfile v4 and the locked base64ct 1.8 (rsa chain) is edition 2024,
-# both requiring Cargo >= 1.85; our own code's floor is 1.82
-# (Option::is_none_or). Verified by the pinned-MSRV CI check job.
+# MSRV floor 1.85 (review r1, verified empirically): the locked base64ct 1.8
+# (rsa chain) is edition 2024, which needs Cargo >= 1.85. Our own code's floor
+# is 1.82 (Option::is_none_or); the v4 lockfile itself parses fine on older
+# Cargo (>= 1.78). Enforced by the pinned-MSRV CI check job.
 rust-version = "1.85"
 homepage = "https://github.com/therealevanhenry/riperf3"
 repository = "https://github.com/therealevanhenry/riperf3"

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ riperf3 speaks iperf3's exact wire protocol: a riperf3 client interoperates with
 - **Safe Rust** — `unsafe` is used only for platform-specific kernel syscalls (`setsockopt`/`getsockopt`) with no safe wrapper. No unsafe in any application logic or public API. See the [audit table](https://github.com/therealevanhenry/riperf3/blob/main/riperf3/src/lib.rs) for the full inventory.
 - **Single static binary** with no runtime dependencies.
 - **Idiomatic Rust** — not a C port. Uses tokio for async I/O, serde for JSON, clap for CLI parsing, nix for safe Unix syscalls.
-- **369 tests** — unit, integration, and full client-server loopback with interchange verification.
+- **430+ tests** — unit, integration, and full client-server loopback with interchange verification.
 
 ## Quick Start
 
@@ -72,7 +72,7 @@ tests, the compatibility matrix, and full methodology.
 
 ## Platform Support
 
-riperf3 builds on Linux, macOS, FreeBSD, and Windows. Linux is the reference platform (full feature set, primary CI); macOS is verified in native CI; Windows compiles and is cross-checked in CI, with a few runtime gaps still under triage in the [issue tracker](https://github.com/therealevanhenry/riperf3/issues); FreeBSD is supported via conditional compilation but is not yet exercised in CI. Platform-specific features use safe Rust wrappers where available, with graceful degradation or a clear error message where a flag is unavailable.
+riperf3 builds on Linux, macOS, FreeBSD, and Windows. Linux is the reference platform (full feature set; the required CI gate runs the full suite plus a real-iperf3 interop matrix). FreeBSD runs the full native test suite as a required CI check. macOS and Windows run the full native suite in CI as informational checks — they are tested on every change but do not block a merge; Windows has a small number of runtime gaps under triage in the [issue tracker](https://github.com/therealevanhenry/riperf3/issues). Platform-specific features use safe Rust wrappers where available, with graceful degradation or a clear error message where a flag is unavailable.
 
 | Feature | Linux | macOS | FreeBSD | Windows |
 |---|:---:|:---:|:---:|:---:|
@@ -225,7 +225,7 @@ cargo clippy --all-targets -- -D warnings      # lint
 
 ## Status
 
-Feature-complete for the core iperf3 flag set, with full interchange compatibility verified against real iperf3 (current and 3.12) in both directions across all modes. Linux and macOS are fully supported and exercised in native CI; Windows compiles and cross-checks but has a few runtime gaps under active triage; FreeBSD is supported via conditional compilation. Platform-specific flags match iperf3's support matrix (see [Platform Support](#platform-support)).
+Feature-complete for the core iperf3 flag set, with full interchange compatibility verified against real iperf3 (current and 3.12) in both directions across all modes. Linux (required CI: full suite + interop matrix) and FreeBSD (required CI: native suite) gate every merge; macOS and Windows run the full native suite as informational CI, with a small number of Windows runtime gaps under triage. Platform-specific flags match iperf3's support matrix (see [Platform Support](#platform-support)).
 
 See [CHANGELOG.md](CHANGELOG.md) for the release notes and current known issues — including a handful of options that are accepted but not yet fully effective.
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ tests, the compatibility matrix, and full methodology.
 
 ## Platform Support
 
-riperf3 builds on Linux, macOS, FreeBSD, and Windows. Linux is the reference platform (full feature set; the required CI gate runs the full suite plus a real-iperf3 interop matrix). FreeBSD runs the full native test suite as a required CI check. macOS and Windows run the full native suite in CI as informational checks — they are tested on every change but do not block a merge; Windows has a small number of runtime gaps under triage in the [issue tracker](https://github.com/therealevanhenry/riperf3/issues). Platform-specific features use safe Rust wrappers where available, with graceful degradation or a clear error message where a flag is unavailable.
+riperf3 builds on Linux, macOS, FreeBSD, and Windows. Linux is the reference platform (full feature set; the required CI gate runs the full suite plus a real-iperf3 interop matrix). FreeBSD and Windows run the full native test suite as **required** CI checks that gate every merge. macOS runs the full native suite in CI as an informational check — tested on every change, promoted to required once consistently clean. Platform-specific features use safe Rust wrappers where available, with graceful degradation or a clear error message where a flag is unavailable.
 
 | Feature | Linux | macOS | FreeBSD | Windows |
 |---|:---:|:---:|:---:|:---:|
@@ -225,7 +225,7 @@ cargo clippy --all-targets -- -D warnings      # lint
 
 ## Status
 
-Feature-complete for the core iperf3 flag set, with full interchange compatibility verified against real iperf3 (current and 3.12) in both directions across all modes. Linux (required CI: full suite + interop matrix) and FreeBSD (required CI: native suite) gate every merge; macOS and Windows run the full native suite as informational CI, with a small number of Windows runtime gaps under triage. Platform-specific flags match iperf3's support matrix (see [Platform Support](#platform-support)).
+Feature-complete for the core iperf3 flag set, with full interchange compatibility verified against real iperf3 (current and 3.12) in both directions across all modes. Linux (full suite + interop matrix), FreeBSD, and Windows (native suites) are required CI checks gating every merge; macOS runs the full native suite as informational CI. Platform-specific flags match iperf3's support matrix (see [Platform Support](#platform-support)).
 
 See [CHANGELOG.md](CHANGELOG.md) for the release notes and current known issues — including a handful of options that are accepted but not yet fully effective.
 

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ riperf3 builds on Linux, macOS, FreeBSD, and Windows. Linux is the reference pla
 | `--gsro` UDP GSO/GRO | yes | | | |
 | `--sendmmsg` batched UDP | yes | | yes | |
 
-All platform-specific flags match iperf3's support matrix exactly for flags shared with iperf3. `--sendmmsg` is a riperf3-exclusive experimental optimization. Blank cells indicate the feature is unavailable on that platform in both riperf3 and iperf3. Unsupported flags return a clear error at startup.
+All platform-specific flags match iperf3's support matrix exactly for flags shared with iperf3. `--sendmmsg` is a riperf3-exclusive experimental optimization. Blank cells indicate the feature is unavailable on that platform in both riperf3 and iperf3. On Windows, unsupported flags return a clear error at startup; on Unix platforms a blank cell means the option is silently unavailable (the underlying call is a no-op).
 
 ## CLI Reference
 

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ riperf3 builds on Linux, macOS, FreeBSD, and Windows. Linux is the reference pla
 | `--gsro` UDP GSO/GRO | yes | | | |
 | `--sendmmsg` batched UDP | yes | | yes | |
 
-All platform-specific flags match iperf3's support matrix exactly for flags shared with iperf3. `--sendmmsg` is a riperf3-exclusive experimental optimization. Blank cells indicate the feature is unavailable on that platform in both riperf3 and iperf3. On Windows, unsupported flags return a clear error at startup; on Unix platforms a blank cell means the option is silently unavailable (the underlying call is a no-op).
+All platform-specific flags match iperf3's support matrix exactly for flags shared with iperf3. `--sendmmsg` is a riperf3-exclusive experimental optimization. Blank cells indicate the feature is unavailable on that platform in both riperf3 and iperf3. On Windows, unsupported flags return a clear error at startup; on Unix platforms a blank cell is a silent no-op at the socket layer, except `-D` and `--sendmmsg`, which error at startup wherever unsupported.
 
 ## CLI Reference
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,13 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+Please use [GitHub private vulnerability reporting](https://github.com/therealevanhenry/riperf3/security/advisories/new) — do **not** open a public issue for security problems.
+
+If you cannot use GitHub's reporting flow, email evan.henry@gmail.com with "riperf3 security" in the subject.
+
+You can expect an acknowledgement within a few days. Fixes ship as a patch release; credit is given unless you ask otherwise.
+
+## Scope notes
+
+riperf3 parses untrusted network input (the iperf3 control protocol, length-prefixed JSON) and is commonly run as a long-lived server. Parsing robustness, resource exhaustion on the control channel, and the RSA authentication path are all in scope. The `unsafe` inventory is documented in `riperf3/src/lib.rs`.

--- a/riperf3-cli/Cargo.toml
+++ b/riperf3-cli/Cargo.toml
@@ -2,6 +2,7 @@
 name = "riperf3-cli"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 authors.workspace = true
 description = "Wire-compatible Rust implementation of iperf3 — network performance testing CLI"
 homepage.workspace = true

--- a/riperf3/Cargo.toml
+++ b/riperf3/Cargo.toml
@@ -2,6 +2,7 @@
 name = "riperf3"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 authors.workspace = true
 description = "Wire-compatible Rust implementation of iperf3 — safe, cross-platform network performance testing library"
 homepage.workspace = true

--- a/riperf3/src/client.rs
+++ b/riperf3/src/client.rs
@@ -1529,14 +1529,16 @@ impl ClientBuilder {
     }
 
     /// `-Z/--zerocopy`: use a zero-copy (`sendfile`) method of sending data;
-    /// Linux/FreeBSD only; silently unavailable elsewhere on unix, rejected at `build()` on non-unix.
+    /// Linux/macOS/FreeBSD only. Elsewhere — and whenever `-b` pacing or an
+    /// `-n`/`-k` byte budget is in effect — it silently falls back to the
+    /// normal copying sender.
     pub fn zerocopy(mut self, enabled: bool) -> Self {
         self.zerocopy = enabled;
         self
     }
 
     /// `--gsro`: enable UDP GSO/GRO (generic segmentation/receive offload);
-    /// Linux/FreeBSD only; silently unavailable elsewhere on unix, rejected at `build()` on non-unix.
+    /// Linux only; a silent no-op elsewhere.
     pub fn gsro(mut self, enabled: bool) -> Self {
         self.gsro = enabled;
         self
@@ -1588,8 +1590,8 @@ impl ClientBuilder {
         self
     }
 
-    /// `--bind-dev`: bind to a network interface with `SO_BINDTODEVICE`;
-    /// Linux/FreeBSD only; silently unavailable elsewhere on unix, rejected at `build()` on non-unix.
+    /// `--bind-dev`: bind to a network interface — `SO_BINDTODEVICE` on Linux,
+    /// `IP_BOUND_IF`/`IPV6_BOUND_IF` on macOS; a silent no-op elsewhere.
     pub fn bind_dev(mut self, dev: &str) -> Self {
         self.bind_dev = Some(dev.to_string());
         self
@@ -1642,7 +1644,7 @@ impl ClientBuilder {
     }
 
     /// `--snd-timeout`: timeout for unacknowledged TCP data, in milliseconds
-    /// (`TCP_USER_TIMEOUT`).
+    /// (`TCP_USER_TIMEOUT`, Linux only).
     pub fn snd_timeout(mut self, ms: u64) -> Self {
         self.snd_timeout = Some(ms);
         self

--- a/riperf3/src/client.rs
+++ b/riperf3/src/client.rs
@@ -1357,66 +1357,85 @@ impl ClientBuilder {
         Self::default().host(host)
     }
 
+    /// `-c/--client <host>`: the server to connect to (hostname or IP literal).
     pub fn host(mut self, host: &str) -> Self {
         self.host = Some(host.to_string());
         self
     }
 
+    /// `-p/--port`: server control port to connect to (default 5201); `None`
+    /// resolves back to the default at `build()`.
     pub fn port(mut self, port: Option<u16>) -> Self {
         self.port = port;
         self
     }
 
+    /// `-u/--udp`: transport protocol for the data streams (default TCP).
     pub fn protocol(mut self, protocol: TransportProtocol) -> Self {
         self.protocol = protocol;
         self
     }
 
+    /// `-t/--time`: time in seconds to transmit for (default 10).
     pub fn duration(mut self, secs: u32) -> Self {
         self.duration = secs;
         self
     }
 
+    /// `-P/--parallel`: number of parallel data streams (default 1).
     pub fn num_streams(mut self, n: u32) -> Self {
         self.num_streams = n;
         self
     }
 
+    /// `-l/--length`: length of the read/write buffer in bytes (default 128 KB
+    /// for TCP; unset UDP derives the datagram size from the control-socket MSS).
     pub fn blksize(mut self, size: usize) -> Self {
         self.blksize = Some(size);
         self
     }
 
+    /// `-R/--reverse`: reverse mode — the server sends, the client receives.
     pub fn reverse(mut self, reverse: bool) -> Self {
         self.reverse = reverse;
         self
     }
 
+    /// `--bidir`: bidirectional mode — client and server send and receive
+    /// simultaneously.
     pub fn bidir(mut self, bidir: bool) -> Self {
         self.bidir = bidir;
         self
     }
 
+    /// `-O/--omit`: omit the first `secs` seconds of the test (e.g. TCP
+    /// slow-start) from the results (default 0).
     pub fn omit(mut self, secs: u32) -> Self {
         self.omit = secs;
         self
     }
 
+    /// `-N/--no-delay`: set `TCP_NODELAY`, disabling Nagle's algorithm.
     pub fn no_delay(mut self, no_delay: bool) -> Self {
         self.no_delay = no_delay;
         self
     }
 
+    /// `-M/--set-mss`: TCP maximum segment size (MTU - 40 bytes).
     pub fn mss(mut self, mss: i32) -> Self {
         self.mss = Some(mss);
         self
     }
 
+    /// `-w/--window`: socket buffer size in bytes (indirectly sets the TCP
+    /// window size).
     pub fn window(mut self, window: i32) -> Self {
         self.window = Some(window);
         self
     }
 
+    /// `-b/--bitrate`: target bitrate in bits/sec; 0 = unlimited. Unset resolves
+    /// at `build()` to the iperf3 default: unlimited for TCP, 1 Mbit/sec for UDP.
     pub fn bandwidth(mut self, bps: u64) -> Self {
         // `Some` even for 0: an explicit `-b 0` means unlimited and must be
         // distinguishable from "unset" (which resolves to the UDP default) (#17).
@@ -1424,21 +1443,28 @@ impl ClientBuilder {
         self
     }
 
+    /// `-S/--tos`: IP type-of-service value (0-255). Symbolic DSCP names go
+    /// through [`Self::dscp`] instead.
     pub fn tos(mut self, tos: i32) -> Self {
         self.tos = tos;
         self
     }
 
+    /// `-C/--congestion`: TCP congestion control algorithm (e.g. `cubic`,
+    /// `bbr`); rejected at `build()` on platforms without support.
     pub fn congestion(mut self, algo: &str) -> Self {
         self.congestion = Some(algo.to_string());
         self
     }
 
+    /// `--udp-counters-64bit`: use 64-bit sequence counters in UDP test packets.
     pub fn udp_counters_64bit(mut self, enabled: bool) -> Self {
         self.udp_counters_64bit = enabled;
         self
     }
 
+    /// `--connect-timeout`: timeout for establishing the control connection
+    /// (the CLI flag takes milliseconds).
     pub fn connect_timeout(mut self, timeout: Duration) -> Self {
         self.connect_timeout = Some(timeout);
         self
@@ -1456,101 +1482,134 @@ impl ClientBuilder {
         self
     }
 
+    /// `--extra-data`: extra data string to include in the JSON output.
     pub fn extra_data(mut self, data: &str) -> Self {
         self.extra_data = Some(data.to_string());
         self
     }
 
+    /// `-V/--verbose`: enable verbose output.
     pub fn verbose(mut self, verbose: bool) -> Self {
         self.verbose = verbose;
         self
     }
 
+    /// `-J/--json`: emit the results as iperf3-schema JSON on stdout instead
+    /// of text.
     pub fn json_output(mut self, enabled: bool) -> Self {
         self.json_output = enabled;
         self
     }
 
+    /// `-n/--bytes`: number of bytes to transmit, instead of running for a set
+    /// time (`-t`).
     pub fn bytes(mut self, bytes: u64) -> Self {
         self.bytes_to_send = Some(bytes);
         self
     }
 
+    /// `-k/--blockcount`: number of blocks (packets) to transmit, instead of
+    /// `-t` or `-n`.
     pub fn blocks(mut self, blocks: u64) -> Self {
         self.blocks_to_send = Some(blocks);
         self
     }
 
+    /// `--json-stream`: stream line-delimited interval JSON during the test.
     pub fn json_stream(mut self, enabled: bool) -> Self {
         self.json_stream = enabled;
         self
     }
 
+    /// `--repeating-payload`: use a repeating pattern in the payload instead
+    /// of zeros.
     pub fn repeating_payload(mut self, enabled: bool) -> Self {
         self.repeating_payload = enabled;
         self
     }
 
+    /// `-Z/--zerocopy`: use a zero-copy (`sendfile`) method of sending data;
+    /// rejected at `build()` on platforms without support.
     pub fn zerocopy(mut self, enabled: bool) -> Self {
         self.zerocopy = enabled;
         self
     }
 
+    /// `--gsro`: enable UDP GSO/GRO (generic segmentation/receive offload);
+    /// rejected at `build()` on platforms without support.
     pub fn gsro(mut self, enabled: bool) -> Self {
         self.gsro = enabled;
         self
     }
 
+    /// `--sendmmsg`: batched UDP sends via `sendmmsg(2)` (experimental,
+    /// Linux/FreeBSD/NetBSD). riperf3 extension with no iperf3 equivalent.
     pub fn sendmmsg(mut self, enabled: bool) -> Self {
         self.sendmmsg = enabled;
         self
     }
 
+    /// `--dont-fragment`: set the IPv4 Don't Fragment flag on UDP packets.
     pub fn dont_fragment(mut self, enabled: bool) -> Self {
         self.dont_fragment = enabled;
         self
     }
 
+    /// `--cport`: bind to a specific local client port (default: ephemeral).
     pub fn cport(mut self, port: u16) -> Self {
         self.cport = Some(port);
         self
     }
 
+    /// `--get-server-output`: retrieve the server-side output and include it
+    /// in the client's results.
     pub fn get_server_output(mut self, enabled: bool) -> Self {
         self.get_server_output = enabled;
         self
     }
 
+    /// `--forceflush`: force flushing output at every interval.
     pub fn forceflush(mut self, enabled: bool) -> Self {
         self.forceflush = enabled;
         self
     }
 
+    /// `--timestamps`: prefix each output line with a timestamp in the given
+    /// `strftime` format (the CLI defaults to `"%c "` when no format is given).
     pub fn timestamps(mut self, fmt: &str) -> Self {
         self.timestamps = Some(fmt.to_string());
         self
     }
 
+    /// `-B/--bind`: bind to a specific local source address (interface binding
+    /// is [`Self::bind_dev`]).
     pub fn bind_address(mut self, addr: &str) -> Self {
         self.bind_address = Some(addr.to_string());
         self
     }
 
+    /// `--bind-dev`: bind to a network interface with `SO_BINDTODEVICE`;
+    /// rejected at `build()` on platforms without support.
     pub fn bind_dev(mut self, dev: &str) -> Self {
         self.bind_dev = Some(dev.to_string());
         self
     }
 
+    /// `--fq-rate`: fair-queuing based socket pacing rate in bits/sec
+    /// (Linux only).
     pub fn fq_rate(mut self, rate: u64) -> Self {
         self.fq_rate = Some(rate);
         self
     }
 
+    /// `-L/--flowlabel`: IPv6 flow label (Linux only).
     pub fn flowlabel(mut self, label: i32) -> Self {
         self.flowlabel = Some(label);
         self
     }
 
+    /// `-4`/`-6`: only use IPv4 (`4`) or IPv6 (`6`) when connecting. Leave
+    /// unset to use whichever family the host resolves to.
     pub fn ip_version(mut self, version: u8) -> Self {
         debug_assert!(
             matches!(version, 4 | 6),
@@ -1560,66 +1619,91 @@ impl ClientBuilder {
         self
     }
 
+    /// `-m/--mptcp`: use MPTCP rather than plain TCP.
     pub fn mptcp(mut self, enabled: bool) -> Self {
         self.mptcp = enabled;
         self
     }
 
+    /// `--skip-rx-copy`: discard received data in the kernel with `MSG_TRUNC`,
+    /// skipping the copy to userspace.
     pub fn skip_rx_copy(mut self, enabled: bool) -> Self {
         self.skip_rx_copy = enabled;
         self
     }
 
+    /// `--rcv-timeout`: idle timeout for receiving data, in milliseconds
+    /// (`SO_RCVTIMEO`).
     pub fn rcv_timeout(mut self, ms: u64) -> Self {
         self.rcv_timeout = Some(ms);
         self
     }
 
+    /// `--snd-timeout`: timeout for unacknowledged TCP data, in milliseconds
+    /// (`TCP_USER_TIMEOUT`).
     pub fn snd_timeout(mut self, ms: u64) -> Self {
         self.snd_timeout = Some(ms);
         self
     }
 
+    /// `-F/--file`: sending streams read the payload from this file instead of
+    /// generated data; receiving streams write received data to it.
     pub fn file(mut self, path: &str) -> Self {
         self.file = Some(path.to_string());
         self
     }
 
+    /// `--dscp`: IP DSCP value, numeric (0-63) or symbolic (e.g. `CS5`);
+    /// overrides [`Self::tos`] at `build()`.
     pub fn dscp(mut self, val: &str) -> Self {
         self.dscp = Some(val.to_string());
         self
     }
 
+    /// `-f/--format`: report units — `k`/`m`/`g`/`t` for bits, uppercase for
+    /// bytes; the default `'a'` picks adaptively.
     pub fn format_char(mut self, c: char) -> Self {
         self.format_char = c;
         self
     }
 
+    /// `-i/--interval`: seconds between periodic throughput reports (default 1).
     pub fn interval(mut self, secs: f64) -> Self {
         self.interval = Some(secs);
         self
     }
 
+    /// `--cntl-ka`: enable TCP keepalive on the control connection; `spec` is
+    /// `idle/intv/cnt`.
     pub fn cntl_ka(mut self, spec: &str) -> Self {
         self.cntl_ka = Some(spec.to_string());
         self
     }
 
+    /// `--username`: username for authentication (used with a password and
+    /// [`Self::rsa_public_key_path`]).
     pub fn username(mut self, name: &str) -> Self {
         self.username = Some(name.to_string());
         self
     }
 
+    /// Password for authentication. iperf3 has no flag for this; the CLI reads
+    /// the `RIPERF3_PASSWORD`/`IPERF3_PASSWORD` environment variables or prompts.
     pub fn password(mut self, pass: &str) -> Self {
         self.password = Some(pass.to_string());
         self
     }
 
+    /// `--rsa-public-key-path`: path to the RSA public key used to encrypt the
+    /// authentication credentials.
     pub fn rsa_public_key_path(mut self, path: &str) -> Self {
         self.rsa_public_key_path = Some(path.to_string());
         self
     }
 
+    /// `--use-pkcs1-padding`: encrypt credentials with PKCS#1 v1.5 padding
+    /// instead of OAEP (for pre-3.17 iperf3 servers). The CLI rejects this flag
+    /// for clients, matching iperf3 (#100); only embedders can set it here.
     pub fn use_pkcs1_padding(mut self, enabled: bool) -> Self {
         self.use_pkcs1_padding = enabled;
         self
@@ -1628,27 +1712,39 @@ impl ClientBuilder {
     // String-accepting variants — parse KMG suffixes (e.g., "1M", "512K", "10G")
     // so callers don't need to import parse_kmg/parse_bitrate.
 
+    /// Like [`Self::bytes`], accepting a KMG-suffixed size string
+    /// (`-n 100M`; binary, 1024-based).
     pub fn bytes_str(self, s: &str) -> std::result::Result<Self, ConfigError> {
         Ok(self.bytes(parse_kmg(s)?))
     }
 
+    /// Like [`Self::blocks`], accepting a KMG-suffixed count string
+    /// (`-k 10K`; binary, 1024-based).
     pub fn blocks_str(self, s: &str) -> std::result::Result<Self, ConfigError> {
         Ok(self.blocks(parse_kmg(s)?))
     }
 
+    /// Like [`Self::blksize`], accepting a KMG-suffixed size string
+    /// (`-l 128K`; binary, 1024-based).
     pub fn blksize_str(self, s: &str) -> std::result::Result<Self, ConfigError> {
         Ok(self.blksize(parse_kmg(s)? as usize))
     }
 
+    /// Like [`Self::window`], accepting a KMG-suffixed size string
+    /// (`-w 4M`; binary, 1024-based).
     pub fn window_str(self, s: &str) -> std::result::Result<Self, ConfigError> {
         Ok(self.window(parse_kmg(s)? as i32))
     }
 
+    /// Like [`Self::bandwidth`], accepting an iperf3 rate string (`-b 10M`;
+    /// decimal, 1000-based). A `/burst` suffix is parsed but not applied.
     pub fn bandwidth_str(self, s: &str) -> std::result::Result<Self, ConfigError> {
         let (rate, _burst) = parse_bitrate(s)?;
         Ok(self.bandwidth(rate))
     }
 
+    /// Like [`Self::fq_rate`], accepting an iperf3 rate string
+    /// (`--fq-rate 1G`; decimal, 1000-based).
     pub fn fq_rate_str(self, s: &str) -> std::result::Result<Self, ConfigError> {
         // --fq-rate is a rate: decimal (1000-based) suffixes, like iperf3 (#56).
         Ok(self.fq_rate(crate::utils::parse_rate(s)?))

--- a/riperf3/src/client.rs
+++ b/riperf3/src/client.rs
@@ -1451,7 +1451,7 @@ impl ClientBuilder {
     }
 
     /// `-C/--congestion`: TCP congestion control algorithm (e.g. `cubic`,
-    /// `bbr`); rejected at `build()` on platforms without support.
+    /// `bbr`); Linux/FreeBSD only; silently unavailable elsewhere on unix, rejected at `build()` on non-unix.
     pub fn congestion(mut self, algo: &str) -> Self {
         self.congestion = Some(algo.to_string());
         self
@@ -1529,14 +1529,14 @@ impl ClientBuilder {
     }
 
     /// `-Z/--zerocopy`: use a zero-copy (`sendfile`) method of sending data;
-    /// rejected at `build()` on platforms without support.
+    /// Linux/FreeBSD only; silently unavailable elsewhere on unix, rejected at `build()` on non-unix.
     pub fn zerocopy(mut self, enabled: bool) -> Self {
         self.zerocopy = enabled;
         self
     }
 
     /// `--gsro`: enable UDP GSO/GRO (generic segmentation/receive offload);
-    /// rejected at `build()` on platforms without support.
+    /// Linux/FreeBSD only; silently unavailable elsewhere on unix, rejected at `build()` on non-unix.
     pub fn gsro(mut self, enabled: bool) -> Self {
         self.gsro = enabled;
         self
@@ -1589,7 +1589,7 @@ impl ClientBuilder {
     }
 
     /// `--bind-dev`: bind to a network interface with `SO_BINDTODEVICE`;
-    /// rejected at `build()` on platforms without support.
+    /// Linux/FreeBSD only; silently unavailable elsewhere on unix, rejected at `build()` on non-unix.
     pub fn bind_dev(mut self, dev: &str) -> Self {
         self.bind_dev = Some(dev.to_string());
         self
@@ -1632,8 +1632,10 @@ impl ClientBuilder {
         self
     }
 
-    /// `--rcv-timeout`: idle timeout for receiving data, in milliseconds
-    /// (`SO_RCVTIMEO`).
+    /// `--rcv-timeout`: idle-receive timeout in ms. Sets `SO_RCVTIMEO` on the
+    /// data socket; note tokio sockets are nonblocking, where the kernel
+    /// timeout does not fire on reads — parity with iperf3's flag surface,
+    /// effective behavior under review.
     pub fn rcv_timeout(mut self, ms: u64) -> Self {
         self.rcv_timeout = Some(ms);
         self

--- a/riperf3/src/client.rs
+++ b/riperf3/src/client.rs
@@ -1529,16 +1529,18 @@ impl ClientBuilder {
     }
 
     /// `-Z/--zerocopy`: use a zero-copy (`sendfile`) method of sending data;
-    /// Linux/macOS/FreeBSD only. Elsewhere — and whenever `-b` pacing or an
-    /// `-n`/`-k` byte budget is in effect — it silently falls back to the
-    /// normal copying sender.
+    /// Linux/macOS/FreeBSD only. On other unix — and on any platform whenever
+    /// `-b` pacing or an `-n`/`-k` byte budget is in effect — it silently
+    /// falls back to the normal copying sender; rejected at `build()` on
+    /// non-unix.
     pub fn zerocopy(mut self, enabled: bool) -> Self {
         self.zerocopy = enabled;
         self
     }
 
     /// `--gsro`: enable UDP GSO/GRO (generic segmentation/receive offload);
-    /// Linux only; a silent no-op elsewhere.
+    /// Linux only; a silent no-op elsewhere on unix, rejected at `build()` on
+    /// non-unix.
     pub fn gsro(mut self, enabled: bool) -> Self {
         self.gsro = enabled;
         self
@@ -1591,7 +1593,8 @@ impl ClientBuilder {
     }
 
     /// `--bind-dev`: bind to a network interface — `SO_BINDTODEVICE` on Linux,
-    /// `IP_BOUND_IF`/`IPV6_BOUND_IF` on macOS; a silent no-op elsewhere.
+    /// `IP_BOUND_IF`/`IPV6_BOUND_IF` on macOS; a silent no-op elsewhere on
+    /// unix, rejected at `build()` on non-unix.
     pub fn bind_dev(mut self, dev: &str) -> Self {
         self.bind_dev = Some(dev.to_string());
         self

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -1413,16 +1413,20 @@ impl ServerBuilder {
         Self::default()
     }
 
+    /// `-p/--port`: server port to listen on (default 5201); `None` resolves
+    /// back to the default at `build()`.
     pub fn port(mut self, port: Option<u16>) -> Self {
         self.port = port;
         self
     }
 
+    /// `-1/--one-off`: handle one client connection, then exit.
     pub fn one_off(mut self, one_off: bool) -> Self {
         self.one_off = one_off;
         self
     }
 
+    /// `-V/--verbose`: enable verbose output.
     pub fn verbose(mut self, verbose: bool) -> Self {
         self.verbose = verbose;
         self
@@ -1440,26 +1444,34 @@ impl ServerBuilder {
         self
     }
 
+    /// `--idle-timeout`: restart the listener if no client connects within
+    /// `secs` seconds (with `-1/--one-off`, exit instead).
     pub fn idle_timeout(mut self, secs: u32) -> Self {
         self.idle_timeout = Some(secs);
         self
     }
 
+    /// `--server-bitrate-limit`: abort a test whose aggregate throughput
+    /// exceeds `rate` bits/sec (unset: no limit).
     pub fn server_bitrate_limit(mut self, rate: u64) -> Self {
         self.server_bitrate_limit = Some(rate);
         self
     }
 
+    /// `--server-max-duration`: abort any test that runs longer than `secs`
+    /// seconds (unset: no limit).
     pub fn server_max_duration(mut self, secs: u32) -> Self {
         self.server_max_duration = Some(secs);
         self
     }
 
+    /// `--forceflush`: force flushing output at every interval.
     pub fn forceflush(mut self, enabled: bool) -> Self {
         self.forceflush = enabled;
         self
     }
 
+    /// `-B/--bind`: bind the listener to a specific local address.
     pub fn bind_address(mut self, addr: &str) -> Self {
         self.bind_address = Some(addr.to_string());
         self
@@ -1477,36 +1489,50 @@ impl ServerBuilder {
         self
     }
 
+    /// `--timestamps`: prefix each output line with a timestamp in the given
+    /// `strftime` format (the CLI defaults to `"%c "` when no format is given).
     pub fn timestamps(mut self, fmt: &str) -> Self {
         self.timestamps = Some(fmt.to_string());
         self
     }
 
+    /// `-F/--file`: receiving streams write received data to this file;
+    /// sending streams (reverse mode) read the payload from it.
     pub fn file(mut self, path: &str) -> Self {
         self.file = Some(path.to_string());
         self
     }
 
+    /// `--rsa-private-key-path`: path to the RSA private key used to decrypt
+    /// client authentication credentials.
     pub fn rsa_private_key_path(mut self, path: &str) -> Self {
         self.rsa_private_key_path = Some(path.to_string());
         self
     }
 
+    /// `--authorized-users-path`: path to the file of users authorized to run
+    /// authenticated tests.
     pub fn authorized_users_path(mut self, path: &str) -> Self {
         self.authorized_users_path = Some(path.to_string());
         self
     }
 
+    /// `--time-skew-threshold`: allowed clock skew in seconds when validating
+    /// an authentication token's timestamp (default 10).
     pub fn time_skew_threshold(mut self, secs: u32) -> Self {
         self.time_skew_threshold = secs;
         self
     }
 
+    /// `--use-pkcs1-padding`: decrypt credentials with PKCS#1 v1.5 padding
+    /// instead of OAEP (for tokens from pre-3.17 iperf3 clients).
     pub fn use_pkcs1_padding(mut self, enabled: bool) -> Self {
         self.use_pkcs1_padding = enabled;
         self
     }
 
+    /// Like [`Self::server_bitrate_limit`], accepting an iperf3 rate string
+    /// (`--server-bitrate-limit 1G`; decimal, 1000-based).
     pub fn server_bitrate_limit_str(self, s: &str) -> std::result::Result<Self, ConfigError> {
         // A bitrate limit is a rate: decimal (1000-based) suffixes, like iperf3 (#56).
         use crate::utils::parse_rate;


### PR DESCRIPTION
## Summary

The non-code ride-alongs for 0.7.2 (from the holistic project review):

- **README accuracy**: "369 tests" → 430+ (tree has 439 test fns and growing); platform wording right-sized to what CI actually enforces — the old text claimed FreeBSD had no CI, stale since the required FreeBSD job landed; macOS/Windows are full native suites, informational.
- **CONTRIBUTING.md**: fidelity ethos (cite iperf3 source for behavioral claims), tests-before-fixes, the full local gate (fmt/clippy/test + the 7-target cross-check loop), CI gate inventory, semver/release discipline, lib-API-only convention.
- **SECURITY.md**: GitHub private vulnerability reporting + email fallback; scope notes (untrusted control-channel parsing, RSA auth path, unsafe inventory pointer).
- **MSRV declared**: `rust-version = "1.85"` — the floor is set by the dependency tree (locked base64ct 1.8 via the rsa chain is edition 2024, needing Cargo >= 1.85); our own code's floor is 1.82 (`Option::is_none_or`). Inherited by both crates, proven empirically (1.85 passes, 1.84 fails on base64ct) and enforced by a new pinned-toolchain CI `cargo check` job.
- **rustdoc for all 71 builder setters** (56 client, 15 server): each names its iperf3 flag and load-bearing semantics, grounded in the CLI wiring. `cargo doc` zero warnings — docs.rs UX for #137's library audience before 0.8.0 stabilizes this surface.

Docs/metadata only — no behavior change (the MSRV CI job is additive).
