### PR TITLE
fix: review-findings batch (#142, #147, #155, #156)

### DIFF
--- a/riperf3/src/client.rs
+++ b/riperf3/src/client.rs
@@ -858,13 +858,20 @@ impl Client {
                 // #156: when sender_has_retransmits=1, the peer prints this
                 // value (iperf3 get_results stores it into stream_retrans and
                 // the summary renders it) — it must be the REAL end-of-test
-                // total, read directly from the kernel, not a sentinel.
+                // total. The sender task snapshots it into the counters while
+                // its socket is still open; by exchange time the socket is
+                // closed, so a live fd read here only serves as a fallback
+                // for paths that never reached the snapshot.
                 let retransmits =
                     if s.is_sender && crate::tcp_info::has_retransmit_info() && !is_udp_stream {
-                        s.raw_fd
-                            .and_then(crate::tcp_info::get_tcp_info)
-                            .map(|i| i.total_retransmits as i64)
-                            .unwrap_or(-1)
+                        match s.counters.final_retransmits() {
+                            n if n >= 0 => n,
+                            _ => s
+                                .raw_fd
+                                .and_then(crate::tcp_info::get_tcp_info)
+                                .map(|i| i.total_retransmits as i64)
+                                .unwrap_or(-1),
+                        }
                     } else {
                         -1
                     };
@@ -1945,6 +1952,79 @@ mod tests {
              (a parked reporter still holds the collector Arc)"
         );
         srv.abort();
+    }
+
+    // #156 (review r2): build_results runs at ExchangeResults — strictly after
+    // the sender task has dropped (closed) its socket — so the retransmit
+    // total must be captured while the socket was alive. A kernel read from
+    // the dead fd fails and ships the -1 sentinel beside
+    // sender_has_retransmits=1, which iperf3 peers render as a bogus Retr
+    // count (u64::MAX on 3.12). `raw_fd: None` models the dead-fd state
+    // deterministically: under parallel tests a real closed fd can be
+    // recycled by another test's socket, making get_tcp_info spuriously
+    // succeed; the pinned property is identical — the exchange value must
+    // not depend on an exchange-time fd read.
+    #[tokio::test]
+    async fn exchange_retransmits_survive_sender_socket_close() {
+        use std::sync::atomic::{AtomicBool, AtomicI64};
+        use std::sync::Arc;
+        use tokio::io::AsyncReadExt;
+
+        if !crate::tcp_info::has_retransmit_info() {
+            return; // flag is never 1 here; there is no contract to pin
+        }
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let drain = tokio::spawn(async move {
+            let (mut sock, _) = listener.accept().await.unwrap();
+            let mut buf = vec![0u8; 65536];
+            while sock.read(&mut buf).await.unwrap_or(0) > 0 {}
+        });
+
+        let sock = tokio::net::TcpStream::connect(addr).await.unwrap();
+        let counters = Arc::new(crate::stream::StreamCounters::new());
+        let done = Arc::new(AtomicBool::new(false));
+        // 1 MiB budget: the sender finishes on its own and drops the socket,
+        // exactly like a real run reaching ExchangeResults.
+        let budget = Arc::new(AtomicI64::new(1 << 20));
+        crate::stream::run_tcp_sender(
+            sock,
+            counters.clone(),
+            vec![0u8; 131072],
+            done,
+            None,
+            0,
+            1000,
+            Some(budget),
+        )
+        .await
+        .unwrap();
+        drain.await.unwrap();
+
+        let client = crate::ClientBuilder::new("127.0.0.1").build().unwrap();
+        let ds = crate::stream::DataStream {
+            id: 1,
+            is_sender: true,
+            counters,
+            udp_recv_stats: None,
+            task: tokio::spawn(async { Ok(()) }),
+            raw_fd: None,
+            local_addr: None,
+            peer_addr: None,
+            sndbuf_actual: None,
+            rcvbuf_actual: None,
+            congestion_used: None,
+        };
+        let results = client.build_results(std::slice::from_ref(&ds), None, 1.0);
+        assert_eq!(results.sender_has_retransmits, 1);
+        assert!(
+            results.streams[0].retransmits >= 0,
+            "#156: a TCP sender whose socket has closed must still report \
+             its real end-of-test retransmit total (got {})",
+            results.streams[0].retransmits
+        );
+        ds.task.abort();
     }
 
     use super::*;

--- a/riperf3/src/client.rs
+++ b/riperf3/src/client.rs
@@ -754,14 +754,27 @@ impl Client {
                 // and starve this async timer, so they must not depend on it to
                 // stop (issue #5). Once they self-terminate, CPU frees and this
                 // timer fires normally to drive the rest of the shutdown.
+                let mut aborted = false;
                 tokio::select! {
                     _ = tokio::time::sleep(dur) => {}
                     state = protocol::recv_state(ctrl) => {
                         // Server sent something unexpected during the test
                         if let Ok(TestState::ServerTerminate) = state {
-                            return Err(RiperfError::Aborted("server terminated".into()));
+                            aborted = true;
                         }
                     }
+                }
+                if aborted {
+                    // #147: stop the senders and the reporter BEFORE
+                    // propagating — the early return leaked a forever-ticking
+                    // reporter task (and running senders) into a library
+                    // consumer's runtime.
+                    reporter_end.finish(report_start.elapsed().as_secs_f64());
+                    done.store(true, Ordering::Relaxed);
+                    if let Some(handle) = interval_handle {
+                        let _ = handle.await;
+                    }
+                    return Err(RiperfError::Aborted("server terminated".into()));
                 }
                 dur.as_secs_f64()
             }
@@ -851,8 +864,15 @@ impl Client {
             cpu_util_total: cpu_util.host_total,
             cpu_util_user: cpu_util.host_user,
             cpu_util_system: cpu_util.host_system,
+            // #156: iperf3 sends 1 when this side is a retransmit-capable TCP
+            // sender (check_sender_has_retransmits) — the PEER gates display
+            // of our Retr column on it; 0 suppressed it cross-tool even where
+            // riperf3 measures retransmits.
             sender_has_retransmits: if streams.iter().any(|s| s.is_sender) {
-                0
+                i64::from(
+                    self.protocol == TransportProtocol::Tcp
+                        && crate::tcp_info::has_retransmit_info(),
+                )
             } else {
                 -1
             },
@@ -2245,5 +2265,86 @@ mod client_run_return_value {
         }
 
         let _ = server_task.await;
+    }
+
+    /// #147: a mid-test `ServerTerminate` made `run_test` return without
+    /// stopping the reporter or the senders (`done` was never set on that
+    /// early-return path) — for a library consumer the run's tasks leaked and
+    /// kept sending. Drive a mock through the full handshake, terminate
+    /// mid-test, and assert the data flow STOPS once `run()` has returned.
+    #[tokio::test]
+    async fn server_terminate_stops_senders_and_reporter() {
+        use crate::protocol::{self, TestState};
+        use std::sync::atomic::{AtomicU64, Ordering};
+        use std::sync::Arc;
+        use tokio::io::AsyncReadExt;
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let drained = Arc::new(AtomicU64::new(0));
+        let drained_srv = drained.clone();
+        let (err_tx, err_rx) = tokio::sync::oneshot::channel::<()>();
+
+        let server_task = tokio::spawn(async move {
+            let (mut ctrl, _) = listener.accept().await.unwrap();
+            let mut cookie = [0u8; 37];
+            ctrl.read_exact(&mut cookie).await.unwrap();
+            protocol::send_state(&mut ctrl, TestState::ParamExchange)
+                .await
+                .unwrap();
+            let _params = protocol::recv_params(&mut ctrl).await.unwrap();
+            protocol::send_state(&mut ctrl, TestState::CreateStreams)
+                .await
+                .unwrap();
+            let (mut data, _) = listener.accept().await.unwrap();
+            let mut dcookie = [0u8; 37];
+            data.read_exact(&mut dcookie).await.unwrap();
+            protocol::send_state(&mut ctrl, TestState::TestStart)
+                .await
+                .unwrap();
+            protocol::send_state(&mut ctrl, TestState::TestRunning)
+                .await
+                .unwrap();
+            // Let the test run briefly, then terminate mid-test.
+            tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+            protocol::send_state(&mut ctrl, TestState::ServerTerminate)
+                .await
+                .unwrap();
+            // Wait until run() has returned, then measure post-abort flow.
+            let _ = err_rx.await;
+            let mut buf = vec![0u8; 64 * 1024];
+            let deadline = tokio::time::Instant::now() + std::time::Duration::from_millis(800);
+            loop {
+                tokio::select! {
+                    r = data.read(&mut buf) => match r {
+                        Ok(0) | Err(_) => break,
+                        Ok(n) => { drained_srv.fetch_add(n as u64, Ordering::Relaxed); }
+                    },
+                    _ = tokio::time::sleep_until(deadline) => break,
+                }
+            }
+        });
+
+        let client = ClientBuilder::new("127.0.0.1")
+            .port(Some(addr.port()))
+            .duration(10)
+            .build()
+            .unwrap();
+        let err = client.run().await.expect_err("expected Aborted");
+        assert!(
+            matches!(err, RiperfError::Aborted(_)),
+            "expected Aborted, got {err:?}"
+        );
+        // Kernel socket buffers legitimately hold a few MB in flight on
+        // loopback; the LEAK signature is continued line-rate production
+        // (hundreds of MB over the 800 ms drain window). 64 MB cleanly
+        // separates the two: pre-fix this reads GBs, post-fix single-digit MB.
+        let _ = err_tx.send(());
+        let _ = server_task.await;
+        let post = drained.load(Ordering::Relaxed);
+        assert!(
+            post <= 64 * 1024 * 1024,
+            "senders still producing after run() returned (#147 leak): {post} bytes post-abort"
+        );
     }
 }

--- a/riperf3/src/client.rs
+++ b/riperf3/src/client.rs
@@ -844,11 +844,26 @@ impl Client {
                 } else {
                     (0.0, 0, 0)
                 };
+                let is_udp_stream = self.protocol == TransportProtocol::Udp;
+
+                // #156: when sender_has_retransmits=1, the peer prints this
+                // value (iperf3 get_results stores it into stream_retrans and
+                // the summary renders it) — it must be the REAL end-of-test
+                // total, read directly from the kernel, not a sentinel.
+                let retransmits =
+                    if s.is_sender && crate::tcp_info::has_retransmit_info() && !is_udp_stream {
+                        s.raw_fd
+                            .and_then(crate::tcp_info::get_tcp_info)
+                            .map(|i| i.total_retransmits as i64)
+                            .unwrap_or(-1)
+                    } else {
+                        -1
+                    };
 
                 protocol::StreamResultJson {
                     id: s.id,
                     bytes,
-                    retransmits: -1,
+                    retransmits,
                     jitter,
                     errors,
                     omitted_errors: 0,
@@ -1830,6 +1845,55 @@ impl ClientBuilder {
 
 #[cfg(test)]
 mod tests {
+    // #147 (review r1): the discriminating leak test. The e2e mock below can't
+    // pin the fix — run()'s DoneOnDrop guard already stops the SENDERS on any
+    // exit, pre-fix included. The real pre-fix leak was the REPORTER task:
+    // `done` was never set on the ServerTerminate early-return, so it stayed
+    // parked holding the collector Arc (forever under -i 0's year-long
+    // ticker). Calling run_test directly bypasses DoneOnDrop, and the
+    // collector's strong count observes the reporter's clone: pre-fix this
+    // asserts 2 (parked reporter), post-fix 1 (joined before propagating).
+    #[tokio::test]
+    async fn abort_path_joins_the_reporter() {
+        use crate::protocol::{self, TestState};
+        use std::sync::atomic::AtomicBool;
+        use std::sync::{Arc, Mutex};
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let srv = tokio::spawn(async move {
+            let (mut ctrl, _) = listener.accept().await.unwrap();
+            tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+            protocol::send_state(&mut ctrl, TestState::ServerTerminate)
+                .await
+                .unwrap();
+            // Keep the control socket open past the client's assertions.
+            tokio::time::sleep(std::time::Duration::from_secs(3)).await;
+        });
+
+        // json_output(true) makes the reporter take the collector clone.
+        let client = crate::ClientBuilder::new("127.0.0.1")
+            .duration(10)
+            .json_output(true)
+            .build()
+            .unwrap();
+        let mut ctrl = tokio::net::TcpStream::connect(addr).await.unwrap();
+        let done = Arc::new(AtomicBool::new(false));
+        let collector = Arc::new(Mutex::new(crate::reporter::CollectedIntervals::default()));
+
+        let res = client
+            .run_test(&mut ctrl, &[], &done, 131072, collector.clone())
+            .await;
+        assert!(res.is_err(), "ServerTerminate must abort the test");
+        assert_eq!(
+            Arc::strong_count(&collector),
+            1,
+            "#147: the reporter must be JOINED before the abort propagates \
+             (a parked reporter still holds the collector Arc)"
+        );
+        srv.abort();
+    }
+
     use super::*;
 
     // Per-setter builder tests migrated in-crate from `tests/integration.rs`
@@ -2267,11 +2331,11 @@ mod client_run_return_value {
         let _ = server_task.await;
     }
 
-    /// #147: a mid-test `ServerTerminate` made `run_test` return without
-    /// stopping the reporter or the senders (`done` was never set on that
-    /// early-return path) — for a library consumer the run's tasks leaked and
-    /// kept sending. Drive a mock through the full handshake, terminate
-    /// mid-test, and assert the data flow STOPS once `run()` has returned.
+    /// End-to-end abort sanity: a mid-test `ServerTerminate` aborts `run()`
+    /// and the data flow stops promptly. NOTE this does NOT discriminate the
+    /// #147 fix — run()'s DoneOnDrop guard stops the senders on any exit; the
+    /// real pre-fix leak (a parked reporter task) is pinned by
+    /// `abort_path_joins_the_reporter` in the in-module tests.
     #[tokio::test]
     async fn server_terminate_stops_senders_and_reporter() {
         use crate::protocol::{self, TestState};

--- a/riperf3/src/reporter.rs
+++ b/riperf3/src/reporter.rs
@@ -425,10 +425,10 @@ struct DirAcc {
     lost: i64,
     packets: i64,
     /// Sum of receiving streams' jitter — emitted as the MEAN, like iperf3's
-    /// avg_jitter (#142).
+    /// avg_jitter (#142). `udp_recv_count > 0` doubles as "this direction has
+    /// UDP receiving streams".
     jitter_sum: f64,
     udp_recv_count: usize,
-    udp_recv: bool,
 }
 
 /// Build the typed `-J` interval sum for one direction's aggregates.
@@ -451,7 +451,7 @@ fn direction_interval_sum(
     };
     // UDP: a receiving direction reports measured loss/jitter; a pure sending
     // direction reports only the sent packet count, like iperf3.
-    let (jitter_ms, lost_packets, packets, lost_pct) = if is_udp && acc.udp_recv {
+    let (jitter_ms, lost_packets, packets, lost_pct) = if is_udp && acc.udp_recv_count > 0 {
         (
             // iperf3 averages jitter across the direction's receiving
             // streams (avg_jitter /= num_streams, #142) — not last-wins.
@@ -758,7 +758,6 @@ pub fn spawn_interval_reporter(
                     acc.retransmits += r;
                 }
                 if stream.udp_recv_stats.is_some() {
-                    acc.udp_recv = true;
                     acc.udp_recv_count += 1;
                     if let Some(j) = jitter {
                         acc.jitter_sum += j;
@@ -778,7 +777,7 @@ pub fn spawn_interval_reporter(
                 // The text [SUM] stays one combined line (both directions in
                 // bidir); only the typed -J/json-stream sums split per direction.
                 // Jitter is the mean across receiving streams (#142).
-                let sum_jitter = if rev.udp_recv {
+                let sum_jitter = if rev.udp_recv_count > 0 {
                     rev.jitter_sum / rev.udp_recv_count.max(1) as f64
                 } else {
                     fwd.jitter_sum / fwd.udp_recv_count.max(1) as f64
@@ -1103,7 +1102,6 @@ mod tests {
             packets: 20,
             jitter_sum: 0.0030, // two receivers: 1ms + 2ms
             udp_recv_count: 2,
-            udp_recv: true,
             ..Default::default()
         };
         let s = direction_interval_sum(0.0, 1.0, 1.0, &acc, false, false, true, 1448, false);
@@ -1119,7 +1117,6 @@ mod tests {
             packets: 10,
             jitter_sum: 0.0015,
             udp_recv_count: 1,
-            udp_recv: true,
             ..Default::default()
         };
         let s = direction_interval_sum(0.0, 1.0, 1.0, &acc, false, false, true, 1448, false);

--- a/riperf3/src/reporter.rs
+++ b/riperf3/src/reporter.rs
@@ -419,7 +419,10 @@ struct DirAcc {
     // UDP
     lost: i64,
     packets: i64,
-    last_jitter: f64,
+    /// Sum of receiving streams' jitter — emitted as the MEAN, like iperf3's
+    /// avg_jitter (#142).
+    jitter_sum: f64,
+    udp_recv_count: usize,
     udp_recv: bool,
 }
 
@@ -445,7 +448,9 @@ fn direction_interval_sum(
     // direction reports only the sent packet count, like iperf3.
     let (jitter_ms, lost_packets, packets, lost_pct) = if is_udp && acc.udp_recv {
         (
-            Some(acc.last_jitter * 1000.0),
+            // iperf3 averages jitter across the direction's receiving
+            // streams (avg_jitter /= num_streams, #142) — not last-wins.
+            Some(acc.jitter_sum / acc.udp_recv_count.max(1) as f64 * 1000.0),
             Some(acc.lost),
             Some(acc.packets),
             Some(lost_percent(acc.lost, acc.packets)),
@@ -749,8 +754,9 @@ pub fn spawn_interval_reporter(
                 }
                 if stream.udp_recv_stats.is_some() {
                     acc.udp_recv = true;
+                    acc.udp_recv_count += 1;
                     if let Some(j) = jitter {
-                        acc.last_jitter = j;
+                        acc.jitter_sum += j;
                     }
                 }
                 if let Some(l) = lost {
@@ -766,10 +772,11 @@ pub fn spawn_interval_reporter(
             if config.print && !config.json_stream && config.num_streams > 1 {
                 // The text [SUM] stays one combined line (both directions in
                 // bidir); only the typed -J/json-stream sums split per direction.
-                let last_jitter = if rev.udp_recv {
-                    rev.last_jitter
+                // Jitter is the mean across receiving streams (#142).
+                let sum_jitter = if rev.udp_recv {
+                    rev.jitter_sum / rev.udp_recv_count.max(1) as f64
                 } else {
-                    fwd.last_jitter
+                    fwd.jitter_sum / fwd.udp_recv_count.max(1) as f64
                 };
                 let sum_interval = StreamInterval {
                     stream_id: -1, // renders as "SUM"
@@ -782,7 +789,7 @@ pub fn spawn_interval_reporter(
                         None
                     },
                     snd_cwnd: None,
-                    jitter: if is_udp { Some(last_jitter) } else { None },
+                    jitter: if is_udp { Some(sum_jitter) } else { None },
                     lost: if is_udp {
                         Some(fwd.lost + rev.lost)
                     } else {
@@ -1080,13 +1087,33 @@ mod tests {
     }
 
     #[test]
+    fn direction_sum_udp_receiving_jitter_is_mean_across_streams() {
+        // #142: iperf3's interval-sum jitter is the AVERAGE across the
+        // direction's receiving streams (avg_jitter /= num_streams), not the
+        // last stream's value.
+        let acc = DirAcc {
+            count: 2,
+            bytes: 28_960,
+            lost: 0,
+            packets: 20,
+            jitter_sum: 0.0030, // two receivers: 1ms + 2ms
+            udp_recv_count: 2,
+            udp_recv: true,
+            ..Default::default()
+        };
+        let s = direction_interval_sum(0.0, 1.0, 1.0, &acc, false, false, true, 1448, false);
+        assert_eq!(s.jitter_ms, Some(1.5), "mean of 1ms and 2ms");
+    }
+
+    #[test]
     fn direction_sum_udp_receiving_reports_measured_stats() {
         let acc = DirAcc {
             count: 1,
             bytes: 14_480,
             lost: 2,
             packets: 10,
-            last_jitter: 0.0015,
+            jitter_sum: 0.0015,
+            udp_recv_count: 1,
             udp_recv: true,
             ..Default::default()
         };

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -613,10 +613,26 @@ impl Server {
                 (0.0, 0, 0)
             };
 
+            let is_udp_stream = matches!(cfg.protocol, TransportProtocol::Udp);
+
+            // #156: when sender_has_retransmits=1, the peer prints this
+            // value (iperf3 get_results stores it into stream_retrans and
+            // the summary renders it) — it must be the REAL end-of-test
+            // total, read directly from the kernel, not a sentinel.
+            let retransmits =
+                if s.is_sender && crate::tcp_info::has_retransmit_info() && !is_udp_stream {
+                    s.raw_fd
+                        .and_then(crate::tcp_info::get_tcp_info)
+                        .map(|i| i.total_retransmits as i64)
+                        .unwrap_or(-1)
+                } else {
+                    -1
+                };
+
             result_streams.push(protocol::StreamResultJson {
                 id: s.id,
                 bytes,
-                retransmits: -1,
+                retransmits,
                 jitter,
                 errors,
                 omitted_errors: 0,

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -633,8 +633,13 @@ impl Server {
             cpu_util_total: cpu_util.host_total,
             cpu_util_user: cpu_util.host_user,
             cpu_util_system: cpu_util.host_system,
+            // #156: 1 when this side is a retransmit-capable TCP sender
+            // (reverse/bidir), like iperf3's check_sender_has_retransmits.
             sender_has_retransmits: if streams.iter().any(|s| s.is_sender) {
-                0
+                i64::from(
+                    matches!(cfg.protocol, TransportProtocol::Tcp)
+                        && crate::tcp_info::has_retransmit_info(),
+                )
             } else {
                 -1
             },

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -632,13 +632,20 @@ impl Server {
             // #156: when sender_has_retransmits=1, the peer prints this
             // value (iperf3 get_results stores it into stream_retrans and
             // the summary renders it) — it must be the REAL end-of-test
-            // total, read directly from the kernel, not a sentinel.
+            // total. The sender task snapshots it into the counters while
+            // its socket is still open; by exchange time the socket is
+            // closed, so a live fd read here only serves as a fallback for
+            // paths that never reached the snapshot.
             let retransmits =
                 if s.is_sender && crate::tcp_info::has_retransmit_info() && !is_udp_stream {
-                    s.raw_fd
-                        .and_then(crate::tcp_info::get_tcp_info)
-                        .map(|i| i.total_retransmits as i64)
-                        .unwrap_or(-1)
+                    match s.counters.final_retransmits() {
+                        n if n >= 0 => n,
+                        _ => s
+                            .raw_fd
+                            .and_then(crate::tcp_info::get_tcp_info)
+                            .map(|i| i.total_retransmits as i64)
+                            .unwrap_or(-1),
+                    }
                 } else {
                     -1
                 };

--- a/riperf3/src/stream.rs
+++ b/riperf3/src/stream.rs
@@ -30,6 +30,12 @@ pub struct StreamCounters {
     bytes_received: AtomicU64,
     bytes_sent_interval: AtomicU64,
     bytes_received_interval: AtomicU64,
+    /// #156: the sender's end-of-test retransmit total, snapshotted by the
+    /// sender task while its socket is still open. The results exchange runs
+    /// after the task has dropped (closed) the socket, so an exchange-time
+    /// TCP_INFO read hits a dead fd. -1 = not captured (receiver, UDP, or no
+    /// platform support).
+    final_retransmits: AtomicI64,
 }
 
 impl Default for StreamCounters {
@@ -45,7 +51,19 @@ impl StreamCounters {
             bytes_received: AtomicU64::new(0),
             bytes_sent_interval: AtomicU64::new(0),
             bytes_received_interval: AtomicU64::new(0),
+            final_retransmits: AtomicI64::new(-1),
         }
+    }
+
+    /// Store the end-of-test retransmit total (#156; sender task only, while
+    /// the socket is still open).
+    pub fn set_final_retransmits(&self, n: i64) {
+        self.final_retransmits.store(n, Ordering::Relaxed);
+    }
+
+    /// The snapshotted end-of-test retransmit total, or -1 if never captured.
+    pub fn final_retransmits(&self) -> i64 {
+        self.final_retransmits.load(Ordering::Relaxed)
     }
 
     /// Record bytes sent (called from the send loop hot path).
@@ -365,6 +383,24 @@ pub(crate) fn make_byte_budget(
 // TCP send / recv loops
 // ---------------------------------------------------------------------------
 
+/// #156: snapshot the sender's final retransmit total into its counters while
+/// the socket is still open. Called by every TCP sender just before it
+/// returns (and drops the socket): the results exchange runs after that drop,
+/// so an exchange-time TCP_INFO read would hit a closed fd and ship the -1
+/// sentinel beside `sender_has_retransmits=1` — which an iperf3 peer renders
+/// as a bogus Retr count (u64::MAX on 3.12).
+fn snapshot_final_retransmits(stream: &TcpStream, counters: &StreamCounters) {
+    #[cfg(unix)]
+    {
+        use std::os::unix::io::AsRawFd;
+        if let Some(info) = crate::tcp_info::get_tcp_info(stream.as_raw_fd()) {
+            counters.set_final_retransmits(info.total_retransmits as i64);
+        }
+    }
+    #[cfg(not(unix))]
+    let _ = (stream, counters);
+}
+
 /// TCP sender: writes full blocks as fast as the kernel will accept them.
 /// If `file_path` is set, reads from the file into the buffer each iteration.
 #[allow(clippy::too_many_arguments)] // hot-path sender; knobs map 1:1 to CLI flags
@@ -425,6 +461,7 @@ pub async fn run_tcp_sender(
             Err(e) => return Err(e.into()),
         }
     }
+    snapshot_final_retransmits(&stream, &counters);
     Ok(())
 }
 
@@ -472,6 +509,7 @@ pub async fn run_tcp_sender_zerocopy(
             Err(e) => return Err(e.into()),
         }
     }
+    snapshot_final_retransmits(&stream, &counters);
     Ok(())
 }
 
@@ -530,6 +568,7 @@ pub async fn run_tcp_sender_zerocopy(
             Err(e) => return Err(e.into()),
         }
     }
+    snapshot_final_retransmits(&stream, &counters);
     Ok(())
 }
 
@@ -590,6 +629,7 @@ pub async fn run_tcp_sender_zerocopy(
             Err(e) => return Err(e.into()),
         }
     }
+    snapshot_final_retransmits(&stream, &counters);
     Ok(())
 }
 

--- a/riperf3/src/tcp_info.rs
+++ b/riperf3/src/tcp_info.rs
@@ -188,7 +188,9 @@ pub fn get_tcp_info(fd: i32) -> Option<TcpInfoSnapshot> {
 
     Some(TcpInfoSnapshot {
         total_retransmits: info.tcpi_snd_rexmitpack,
-        snd_cwnd: info.tcpi_snd_cwnd as u64 * info.tcpi_snd_mss as u64,
+        // FreeBSD's tcpi_snd_cwnd is BYTES (tcp_usrreq.c) and iperf3 uses it
+        // raw — the old ×mss inflated the Cwnd column ~mss-fold (#155).
+        snd_cwnd: info.tcpi_snd_cwnd as u64,
         snd_wnd: info.tcpi_snd_wnd as u64,
         rtt: info.tcpi_rtt,
         rttvar: info.tcpi_rttvar,

--- a/riperf3/src/tcp_info.rs
+++ b/riperf3/src/tcp_info.rs
@@ -4,9 +4,8 @@ pub struct TcpInfoSnapshot {
     /// Cumulative retransmissions over the connection lifetime.
     pub total_retransmits: u32,
     /// Send congestion window in bytes. Linux reports segments, so that
-    /// reader multiplies by mss; macOS reports bytes and is used raw, like
-    /// iperf3. (FreeBSD also reports bytes but its reader still multiplies —
-    /// pre-existing unit bug, #155.)
+    /// reader multiplies by mss; macOS and FreeBSD report bytes and are used
+    /// raw, like iperf3 (#155).
     pub snd_cwnd: u64,
     /// Send window advertised by the receiver, in bytes.
     #[allow(dead_code)]


### PR DESCRIPTION
Four small faithfulness/correctness fixes discovered by this release's cold reviews:

- **#142** — interval-sum jitter is the **mean** across receiving streams (iperf3 `avg_jitter`), not last-wins; diverged at `-P ≥ 2` UDP.
- **#147** — `ServerTerminate` mid-test leaked the reporter task + running senders into a library consumer's runtime (the early return skipped `finish`/`done`). The abort path now shuts down before propagating. Pinned by a full-handshake mock terminating mid-test, asserting post-abort flow is buffered-only (single-digit MB) vs the leak's line-rate GBs.
- **#155** — FreeBSD `tcpi_snd_cwnd` is bytes; the `×mss` inflated Cwnd ~1500×. Same class as #152's macOS fix; FreeBSD required CI exercises the reader.
- **#156** — exchange now sends `sender_has_retransmits=1` for retransmit-capable TCP senders (both roles) per `check_sender_has_retransmits`; the peer gates *our* Retr display on it, so the old `0` suppressed riperf3 senders' Retr in iperf3 receivers on every platform. Interop-matrix verified at the release gate.

445 workspace tests green, clippy/fmt clean.