### PR TITLE
Bump to 0.7.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -793,7 +793,7 @@ dependencies = [
 
 [[package]]
 name = "riperf3"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "base64",
  "libc",
@@ -814,7 +814,7 @@ dependencies = [
 
 [[package]]
 name = "riperf3-cli"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "clap",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.7.1"
+version = "0.7.2"
 authors = ["Evan Henry"]
 edition = "2021"
 # MSRV floor 1.85 (review r1, verified empirically): the locked base64ct 1.8

--- a/riperf3-cli/Cargo.toml
+++ b/riperf3-cli/Cargo.toml
@@ -14,7 +14,7 @@ readme = "../README.md"
 
 [dependencies]
 # riperf3 workspace dependencies
-riperf3 = { path = "../riperf3", version = "0.7.1" }
+riperf3 = { path = "../riperf3", version = "0.7.2" }
 
 # external dependencies
 clap.workspace = true


### PR DESCRIPTION
Version-only bump for the 0.7.2 release.

Non-breaking patch covering 10 merged PRs: real `-O/--omit` semantics (#162), `--pacing-timer` + cumulative-average `-b` throttle (#157), `--get-server-output` (#164), sockopt error policy + end-condition conflicts (#153), bidir `-J` interval splits (#141), pre-connect `--bind-dev` (#148), real macOS Retr/Cwnd (#152), pidfile unlink (#150), review-findings batch (#166), governance/MSRV docs (#165).

Release gate: compat 48/48; N=30 campaign 12 faster / 3 parity / 1 noise cell (cleared by a controlled same-environment 0.7.1-vs-main A/B at parity, p=0.375); `-O` cross-tool 7/7; cargo-semver-checks reports no semver update required vs 0.7.1.