### PR TITLE
fix(stream): UDP receivers survive connection-reset-class ICMP noise (#178)

### DIFF
--- a/riperf3/src/stream.rs
+++ b/riperf3/src/stream.rs
@@ -1436,6 +1436,20 @@ pub(crate) fn run_udp_server_demux_receiver(
             {
                 continue
             }
+            // #178: ConnectionReset on a UDP socket is ICMP port-unreachable
+            // noise from something WE sent (Windows surfaces it as
+            // WSAECONNRESET/ConnectionReset; Linux connected-UDP as
+            // ECONNREFUSED/ConnectionRefused) — not EOF. On this
+            // SHARED demux socket a break here would silently end reception
+            // for every stream at once.
+            Err(e)
+                if matches!(
+                    e.kind(),
+                    std::io::ErrorKind::ConnectionReset | std::io::ErrorKind::ConnectionRefused
+                ) =>
+            {
+                continue
+            }
             Err(_) => break,
         }
     }
@@ -1551,6 +1565,21 @@ pub fn run_udp_receiver_blocking(
             {
                 continue
             }
+            // #178: ConnectionReset on a UDP socket is ICMP port-unreachable
+            // noise from something WE sent (Windows: WSAECONNRESET after a
+            // connect-magic retransmit hit a closed port; Linux: ECONNREFUSED
+            // for the same class) — not EOF. Breaking
+            // here silently ended the reverse flow: a bidir run completed
+            // "normally" with sum_bidir_reverse 0 throughout (windows-latest
+            // CI signature).
+            Err(e)
+                if matches!(
+                    e.kind(),
+                    std::io::ErrorKind::ConnectionReset | std::io::ErrorKind::ConnectionRefused
+                ) =>
+            {
+                continue
+            }
             Err(_) => break,
         }
     }
@@ -1570,6 +1599,66 @@ pub fn run_udp_receiver_blocking(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // #178: a connection-reset-class error on a UDP socket is ICMP
+    // port-unreachable noise from something WE sent — Windows surfaces it as
+    // WSAECONNRESET/ConnectionReset on a connected socket (e.g. after a
+    // connect-magic retransmit hits a closed port); Linux connected UDP
+    // surfaces the same class as ECONNREFUSED/ConnectionRefused, which is
+    // what makes this test portable. It is NOT EOF, and the receiver must
+    // keep receiving. Pre-fix, the blocking receiver's `Err(_) => break`
+    // silently ended reception on the first such event: a complete bidir run
+    // with `sum_bidir_reverse: 0` throughout, the windows-latest CI
+    // signature.
+    #[test]
+    #[cfg_attr(not(target_os = "linux"), ignore)] // poison injection relies on Linux loopback ICMP
+    fn udp_receiver_survives_connection_reset() {
+        use std::net::UdpSocket as StdUdp;
+        use std::sync::atomic::AtomicBool;
+
+        // Receiver socket, connected to a peer that immediately vanishes.
+        let receiver = StdUdp::bind("127.0.0.1:0").expect("bind receiver");
+        let doomed = StdUdp::bind("127.0.0.1:0").expect("bind doomed peer");
+        let peer_addr = doomed.local_addr().unwrap();
+        receiver.connect(peer_addr).expect("connect");
+        drop(doomed);
+
+        // Poison: send to the now-closed port → ICMP unreachable → the next
+        // recv on this connected socket reports ConnectionReset.
+        receiver.send(b"poison").expect("send to dead port");
+        std::thread::sleep(Duration::from_millis(50));
+
+        // The peer "comes back" on the same port (as a still-sending peer
+        // would simply keep existing) and delivers real datagrams.
+        let revived = StdUdp::bind(peer_addr).expect("rebind peer port");
+        let dest = receiver.local_addr().unwrap();
+        let done = Arc::new(AtomicBool::new(false));
+        let counters = Arc::new(StreamCounters::new());
+        let stats = Arc::new(Mutex::new(UdpRecvStats::new()));
+
+        let sender = std::thread::spawn(move || {
+            for _ in 0..20 {
+                let _ = revived.send_to(&[0u8; 64], dest);
+                std::thread::sleep(Duration::from_millis(25));
+            }
+        });
+
+        let recv_counters = counters.clone();
+        let recv_done = done.clone();
+        let receiver_thread = std::thread::spawn(move || {
+            run_udp_receiver_blocking(receiver, recv_counters, stats, 1024, recv_done, false)
+        });
+
+        sender.join().unwrap();
+        done.store(true, Ordering::Relaxed);
+        receiver_thread.join().unwrap().unwrap();
+
+        assert!(
+            counters.bytes_received() > 0,
+            "#178: the receiver must survive a ConnectionReset (ICMP noise) \
+             and keep counting datagrams; it received nothing"
+        );
+    }
 
     #[test]
     fn byte_budget_zero_is_unlimited() {

--- a/riperf3/src/stream.rs
+++ b/riperf3/src/stream.rs
@@ -1436,12 +1436,12 @@ pub(crate) fn run_udp_server_demux_receiver(
             {
                 continue
             }
-            // #178: ConnectionReset on a UDP socket is ICMP port-unreachable
-            // noise from something WE sent (Windows surfaces it as
-            // WSAECONNRESET/ConnectionReset; Linux connected-UDP as
-            // ECONNREFUSED/ConnectionRefused) — not EOF. On this
-            // SHARED demux socket a break here would silently end reception
-            // for every stream at once.
+            // #178: reset-class errors on a UDP socket are port-unreachable
+            // noise from something WE sent — not EOF. This demux socket is
+            // UNCONNECTED, so on Linux it never even surfaces ICMP errors
+            // (that needs IP_RECVERR); the arm is live on Windows, where
+            // winsock latches WSAECONNRESET per send_to target. A break here
+            // would silently end reception for EVERY stream at once.
             Err(e)
                 if matches!(
                     e.kind(),
@@ -1611,7 +1611,13 @@ mod tests {
     // with `sum_bidir_reverse: 0` throughout, the windows-latest CI
     // signature.
     #[test]
-    #[cfg_attr(not(target_os = "linux"), ignore)] // poison injection relies on Linux loopback ICMP
+    // Runs where the poison injection is verified: Linux (loopback ICMP →
+    // ECONNREFUSED on the connected socket) and Windows (winsock latches
+    // WSAECONNRESET locally for loopback sends to closed ports — no ICMP
+    // path needed; it is the canonical home of the mechanism AND the only
+    // platform exercising the ConnectionReset arm). macOS/FreeBSD are
+    // ignored as unverified, not impossible.
+    #[cfg_attr(not(any(target_os = "linux", target_os = "windows")), ignore)]
     fn udp_receiver_survives_connection_reset() {
         use std::net::UdpSocket as StdUdp;
         use std::sync::atomic::AtomicBool;
@@ -1654,9 +1660,10 @@ mod tests {
         receiver_thread.join().unwrap().unwrap();
 
         assert!(
-            counters.bytes_received() > 0,
+            counters.bytes_received() >= 10 * 64,
             "#178: the receiver must survive a ConnectionReset (ICMP noise) \
-             and keep counting datagrams; it received nothing"
+             and KEEP receiving (>= half the 20 x 64B datagrams); got {}",
+            counters.bytes_received()
         );
     }
 


### PR DESCRIPTION
Hardening for #178 (NOT a fix — see the issue thread: the live mechanism is upstream of recv error handling; the server sends reverse datagrams that never reach the client socket) — the windows-latest `udp_bidir_interval_sums_split_udp_stats` failure (2/2 on main today): a UDP bidir run completing "normally" with `sum_bidir_reverse: 0` in every interval.

**Mechanism:** a connected UDP socket reports ICMP port-unreachable for datagrams it previously *sent* as a recv error (`WSAECONNRESET`/ConnectionReset on Windows; `ECONNREFUSED`/ConnectionRefused on Linux). Both live UDP receive loops — `run_udp_receiver_blocking` (client reverse flow) and `run_udp_server_demux_receiver` (server shared socket, where one event would kill *every* stream's receive) — treated any non-timeout error as terminal and silently stopped receiving. One connect-magic retransmit hitting a closed port in the setup→data transition suffices, which is why it's load/timing-sensitive (GitHub runners reproduce; an idle Windows 11 VM ran it 10/10 green).

**Fix:** the class is transient ICMP noise, not EOF — `continue`. Post-test drain loops keep their `break` (test already over).

**Red-first portable test** (`udp_receiver_survives_connection_reset`): poisons a connected receiver via a send to a just-closed port — Linux surfaces the identical class — then delivers real datagrams from the rebound port. Red on `break` (received nothing), green on `continue`. Linux-only via `cfg_attr(ignore)` since the injection relies on loopback ICMP determinism.

**Faithfulness note:** iperf3 has no handling for this class (the error surfaces loudly as a test failure); `continue` is a deliberate, documented robustness divergence — strictly better than riperf3's prior *silent* zero-data behavior, same precedent as the UDP connect-magic retransmit.

Gates: fmt/clippy clean, 466/466 workspace, msvc/freebsd/darwin cross-checks pass. The windows-latest CI job on this PR (and post-merge main) is the live referendum.