### PR TITLE
fix(#178): hold the test window until UDP stream data threads exist

### DIFF
--- a/riperf3/src/client.rs
+++ b/riperf3/src/client.rs
@@ -594,6 +594,11 @@ impl Client {
                     ),
                     None => None,
                 };
+                // #178: every UDP stream gets a dedicated spawn_blocking OS
+                // thread; each checks in here as its first action so the
+                // barrier below can hold the test window until the data plane
+                // actually exists.
+                let threads_entered = Arc::new(std::sync::atomic::AtomicU32::new(0));
                 for i in 0..total {
                     let udp_sock = net::udp_bind(bind_ip.as_deref(), 0, remote.is_ipv6()).await?;
                     if let Some(ref dev) = self.bind_dev {
@@ -650,7 +655,9 @@ impl Client {
                         let use_sendmmsg = self.sendmmsg;
                         let st = start.clone();
                         let md = max_duration;
+                        let te = threads_entered.clone();
                         tokio::task::spawn_blocking(move || {
+                            te.fetch_add(1, std::sync::atomic::Ordering::Release);
                             if use_sendmmsg {
                                 stream::run_udp_sender_sendmmsg(
                                     std_sock, c, bs, d, rate, u64bit, st, md,
@@ -668,7 +675,9 @@ impl Client {
                         let stats = Arc::new(Mutex::new(UdpRecvStats::new()));
                         let sc = stats.clone();
                         let u64bit = self.udp_counters_64bit;
+                        let te = threads_entered.clone();
                         let task = tokio::task::spawn_blocking(move || {
+                            te.fetch_add(1, std::sync::atomic::Ordering::Release);
                             stream::run_udp_receiver_blocking(std_sock, c, sc, bs, d, u64bit)
                         });
                         streams.push(DataStream {
@@ -701,6 +710,17 @@ impl Client {
                         congestion_used: None,
                     });
                 }
+                // #178: hold CreateStreams until every data thread is running
+                // (parked at its start gate). The server's TestStart — and with
+                // it this side's test clock — must not outrun OS-thread
+                // creation, which stalls for seconds on loaded hosts. On
+                // timeout proceed anyway (degraded = pre-fix behavior).
+                stream::await_stream_threads_entered(
+                    &threads_entered,
+                    total,
+                    stream::STREAM_THREAD_START_TIMEOUT,
+                )
+                .await;
             }
         }
 

--- a/riperf3/src/client.rs
+++ b/riperf3/src/client.rs
@@ -595,10 +595,9 @@ impl Client {
                     None => None,
                 };
                 // #178: every UDP stream gets a dedicated spawn_blocking OS
-                // thread; each checks in here as its first action so the
-                // barrier below can hold the test window until the data plane
-                // actually exists.
-                let threads_entered = Arc::new(std::sync::atomic::AtomicU32::new(0));
+                // thread, spawned through the gate so the barrier below can
+                // hold this side's test window until the data plane exists.
+                let mut thread_gate = stream::StreamThreadGate::new();
                 for i in 0..total {
                     let udp_sock = net::udp_bind(bind_ip.as_deref(), 0, remote.is_ipv6()).await?;
                     if let Some(ref dev) = self.bind_dev {
@@ -655,9 +654,7 @@ impl Client {
                         let use_sendmmsg = self.sendmmsg;
                         let st = start.clone();
                         let md = max_duration;
-                        let te = threads_entered.clone();
-                        tokio::task::spawn_blocking(move || {
-                            te.fetch_add(1, std::sync::atomic::Ordering::Release);
+                        thread_gate.spawn(move || {
                             if use_sendmmsg {
                                 stream::run_udp_sender_sendmmsg(
                                     std_sock, c, bs, d, rate, u64bit, st, md,
@@ -675,9 +672,7 @@ impl Client {
                         let stats = Arc::new(Mutex::new(UdpRecvStats::new()));
                         let sc = stats.clone();
                         let u64bit = self.udp_counters_64bit;
-                        let te = threads_entered.clone();
-                        let task = tokio::task::spawn_blocking(move || {
-                            te.fetch_add(1, std::sync::atomic::Ordering::Release);
+                        let task = thread_gate.spawn(move || {
                             stream::run_udp_receiver_blocking(std_sock, c, sc, bs, d, u64bit)
                         });
                         streams.push(DataStream {
@@ -711,16 +706,18 @@ impl Client {
                     });
                 }
                 // #178: hold CreateStreams until every data thread is running
-                // (parked at its start gate). The server's TestStart — and with
-                // it this side's test clock — must not outrun OS-thread
-                // creation, which stalls for seconds on loaded hosts. On
-                // timeout proceed anyway (degraded = pre-fix behavior).
-                stream::await_stream_threads_entered(
-                    &threads_entered,
-                    total,
-                    stream::STREAM_THREAD_START_TIMEOUT,
-                )
-                .await;
+                // (parked at its start gate). This gates the CLIENT's side
+                // only — TestStart isn't read (so this side's clock doesn't
+                // start and its senders stay parked) until the data plane
+                // exists. The server sends TestStart on its own schedule once
+                // the last UDP handshake arrives; the wire protocol has no
+                // post-handshake signal to hold it back, so a *cross-host*
+                // stall confined to the client can still cost the start of
+                // the window (bounded by SO_RCVBUF for receivers — and iperf3
+                // has the identical exposure). Same-host, both gates release
+                // together. On timeout proceed anyway (degraded = pre-fix
+                // behavior).
+                thread_gate.wait(stream::STREAM_THREAD_START_TIMEOUT).await;
             }
         }
 

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -847,6 +847,9 @@ impl Server {
 
         protocol::send_state(ctrl, TestState::CreateStreams).await?;
 
+        // #178: each stream's spawn_blocking data thread checks in here; the
+        // barrier below holds TestStart until the data plane actually exists.
+        let threads_entered = Arc::new(std::sync::atomic::AtomicU32::new(0));
         for i in 0..total {
             // Accept: recv magic, connect() to client, send reply.
             // Bounded so a client that never connects fails the test
@@ -905,7 +908,9 @@ impl Server {
                 let u64bit = cfg.udp_counters_64bit;
                 let st = start.clone();
                 let md = max_duration;
+                let te = threads_entered.clone();
                 let task = tokio::task::spawn_blocking(move || {
+                    te.fetch_add(1, std::sync::atomic::Ordering::Release);
                     stream::run_udp_sender_blocking(std_sock, c, bs, d, rate, u64bit, st, md)
                 });
                 streams.push(DataStream {
@@ -928,7 +933,9 @@ impl Server {
                 let stats = Arc::new(Mutex::new(UdpRecvStats::new()));
                 let stats_clone = stats.clone();
                 let u64bit = cfg.udp_counters_64bit;
+                let te = threads_entered.clone();
                 let task = tokio::task::spawn_blocking(move || {
+                    te.fetch_add(1, std::sync::atomic::Ordering::Release);
                     stream::run_udp_receiver_blocking(std_sock, c, stats_clone, bs, d, u64bit)
                 });
                 streams.push(DataStream {
@@ -946,6 +953,16 @@ impl Server {
                 });
             }
         }
+        // #178: hold TestStart (sent by the caller right after this returns)
+        // until every data thread is running — the test clock must not outrun
+        // OS-thread creation, which stalls for seconds on loaded hosts. On
+        // timeout proceed anyway (degraded = pre-fix behavior).
+        stream::await_stream_threads_entered(
+            &threads_entered,
+            total,
+            stream::STREAM_THREAD_START_TIMEOUT,
+        )
+        .await;
         Ok(())
     }
 
@@ -1090,6 +1107,11 @@ impl Server {
         let bs = cfg.blksize;
         let rate = cfg.bandwidth;
         let u64bit = cfg.udp_counters_64bit;
+        // #178: every spawn_blocking data thread (each sender + the one demux
+        // receiver) checks in here; the barrier below holds TestStart until
+        // the data plane actually exists.
+        let threads_entered = Arc::new(std::sync::atomic::AtomicU32::new(0));
+        let mut threads_expected: u32 = 0;
         for i in 0..total {
             let stream_id = iperf3_stream_id(i);
             let is_sender = i >= recv_count;
@@ -1107,7 +1129,10 @@ impl Server {
                 let d = done.clone();
                 let st = start.clone();
                 let md = max_duration;
+                let te = threads_entered.clone();
+                threads_expected += 1;
                 let task = tokio::task::spawn_blocking(move || {
+                    te.fetch_add(1, std::sync::atomic::Ordering::Release);
                     stream::run_udp_server_demux_sender(
                         s,
                         client_addr,
@@ -1167,10 +1192,23 @@ impl Server {
         if !routes.is_empty() {
             let s = shared.clone();
             let d = done.clone();
+            let te = threads_entered.clone();
+            threads_expected += 1;
             *demux_handle = Some(tokio::task::spawn_blocking(move || {
+                te.fetch_add(1, std::sync::atomic::Ordering::Release);
                 stream::run_udp_server_demux_receiver(s, routes, d, u64bit)
             }));
         }
+        // #178: hold TestStart (sent by the caller right after this returns)
+        // until every data thread is running — the test clock must not outrun
+        // OS-thread creation, which stalls for seconds on loaded hosts. On
+        // timeout proceed anyway (degraded = pre-fix behavior).
+        stream::await_stream_threads_entered(
+            &threads_entered,
+            threads_expected,
+            stream::STREAM_THREAD_START_TIMEOUT,
+        )
+        .await;
         Ok(())
     }
 

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -847,9 +847,10 @@ impl Server {
 
         protocol::send_state(ctrl, TestState::CreateStreams).await?;
 
-        // #178: each stream's spawn_blocking data thread checks in here; the
-        // barrier below holds TestStart until the data plane actually exists.
-        let threads_entered = Arc::new(std::sync::atomic::AtomicU32::new(0));
+        // #178: each stream's spawn_blocking data thread is spawned through
+        // the gate; the barrier below holds TestStart until the data plane
+        // actually exists.
+        let mut thread_gate = stream::StreamThreadGate::new();
         for i in 0..total {
             // Accept: recv magic, connect() to client, send reply.
             // Bounded so a client that never connects fails the test
@@ -908,9 +909,7 @@ impl Server {
                 let u64bit = cfg.udp_counters_64bit;
                 let st = start.clone();
                 let md = max_duration;
-                let te = threads_entered.clone();
-                let task = tokio::task::spawn_blocking(move || {
-                    te.fetch_add(1, std::sync::atomic::Ordering::Release);
+                let task = thread_gate.spawn(move || {
                     stream::run_udp_sender_blocking(std_sock, c, bs, d, rate, u64bit, st, md)
                 });
                 streams.push(DataStream {
@@ -933,9 +932,7 @@ impl Server {
                 let stats = Arc::new(Mutex::new(UdpRecvStats::new()));
                 let stats_clone = stats.clone();
                 let u64bit = cfg.udp_counters_64bit;
-                let te = threads_entered.clone();
-                let task = tokio::task::spawn_blocking(move || {
-                    te.fetch_add(1, std::sync::atomic::Ordering::Release);
+                let task = thread_gate.spawn(move || {
                     stream::run_udp_receiver_blocking(std_sock, c, stats_clone, bs, d, u64bit)
                 });
                 streams.push(DataStream {
@@ -957,12 +954,7 @@ impl Server {
         // until every data thread is running — the test clock must not outrun
         // OS-thread creation, which stalls for seconds on loaded hosts. On
         // timeout proceed anyway (degraded = pre-fix behavior).
-        stream::await_stream_threads_entered(
-            &threads_entered,
-            total,
-            stream::STREAM_THREAD_START_TIMEOUT,
-        )
-        .await;
+        thread_gate.wait(stream::STREAM_THREAD_START_TIMEOUT).await;
         Ok(())
     }
 
@@ -1108,10 +1100,9 @@ impl Server {
         let rate = cfg.bandwidth;
         let u64bit = cfg.udp_counters_64bit;
         // #178: every spawn_blocking data thread (each sender + the one demux
-        // receiver) checks in here; the barrier below holds TestStart until
-        // the data plane actually exists.
-        let threads_entered = Arc::new(std::sync::atomic::AtomicU32::new(0));
-        let mut threads_expected: u32 = 0;
+        // receiver) is spawned through the gate; the barrier below holds
+        // TestStart until the data plane actually exists.
+        let mut thread_gate = stream::StreamThreadGate::new();
         for i in 0..total {
             let stream_id = iperf3_stream_id(i);
             let is_sender = i >= recv_count;
@@ -1129,10 +1120,7 @@ impl Server {
                 let d = done.clone();
                 let st = start.clone();
                 let md = max_duration;
-                let te = threads_entered.clone();
-                threads_expected += 1;
-                let task = tokio::task::spawn_blocking(move || {
-                    te.fetch_add(1, std::sync::atomic::Ordering::Release);
+                let task = thread_gate.spawn(move || {
                     stream::run_udp_server_demux_sender(
                         s,
                         client_addr,
@@ -1192,23 +1180,16 @@ impl Server {
         if !routes.is_empty() {
             let s = shared.clone();
             let d = done.clone();
-            let te = threads_entered.clone();
-            threads_expected += 1;
-            *demux_handle = Some(tokio::task::spawn_blocking(move || {
-                te.fetch_add(1, std::sync::atomic::Ordering::Release);
-                stream::run_udp_server_demux_receiver(s, routes, d, u64bit)
-            }));
+            *demux_handle = Some(
+                thread_gate
+                    .spawn(move || stream::run_udp_server_demux_receiver(s, routes, d, u64bit)),
+            );
         }
         // #178: hold TestStart (sent by the caller right after this returns)
         // until every data thread is running — the test clock must not outrun
         // OS-thread creation, which stalls for seconds on loaded hosts. On
         // timeout proceed anyway (degraded = pre-fix behavior).
-        stream::await_stream_threads_entered(
-            &threads_entered,
-            threads_expected,
-            stream::STREAM_THREAD_START_TIMEOUT,
-        )
-        .await;
+        thread_gate.wait(stream::STREAM_THREAD_START_TIMEOUT).await;
         Ok(())
     }
 

--- a/riperf3/src/stream.rs
+++ b/riperf3/src/stream.rs
@@ -1015,37 +1015,77 @@ fn await_start(start: &AtomicBool, done: &AtomicBool) -> bool {
 /// in before opening the test window anyway (#178). Generous: the worst stall
 /// observed on loaded windows-latest runners was ~3.5 s; a barrier timeout
 /// only recreates the pre-fix behavior, so erring long costs nothing in the
-/// normal case (the wait ends the moment the threads are up).
+/// normal case (the wait ends the moment the threads are up). Note a blocking
+/// pool persistently sized below the stream count (an embedder's custom
+/// runtime) burns this in full on every setup — the queued threads cannot
+/// enter until earlier streams finish, which is the whole test.
 pub(crate) const STREAM_THREAD_START_TIMEOUT: Duration = Duration::from_secs(10);
 
-/// Wait (bounded) until `expected` stream data threads have checked in (#178).
+/// Readiness gate for stream data threads (#178).
 ///
 /// The UDP data plane runs on `spawn_blocking` OS threads while the `-t` test
 /// clock is driven by the async control plane. On a loaded host (2-core CI
 /// runners), OS-thread creation can stall for seconds — the whole test window
 /// can elapse before a single data thread runs, completing a run "normally"
 /// with zero bytes (the late receiver goes straight to its post-test drain and
-/// discards everything the peer sent). Each blocking task bumps `entered` as
-/// its first action; the control plane calls this before letting the test
-/// window open, so the duration clock cannot start ahead of the data plane.
+/// discards everything the peer sent). Spawning through the gate makes each
+/// task release a permit as its first action; the control plane awaits the
+/// full permit count before letting the test window open, so the duration
+/// clock cannot start ahead of the data plane. The gate owns both the check-in
+/// and the expected count, so a future spawn site cannot desynchronize them.
 ///
-/// Returns whether all threads checked in. On timeout the caller proceeds
-/// anyway — a degraded run (today's behavior) beats failing a test that would
-/// have moved most of its bytes.
-pub(crate) async fn await_stream_threads_entered(
-    entered: &std::sync::atomic::AtomicU32,
+/// UDP-only by design: TCP data tasks are `tokio::spawn` async tasks (no
+/// OS-thread creation to stall), and a late TCP reader still gets its bytes
+/// from the kernel buffer instead of discarding them like the late UDP drain.
+pub(crate) struct StreamThreadGate {
+    sem: Arc<tokio::sync::Semaphore>,
     expected: u32,
-    timeout: Duration,
-) -> bool {
-    let deadline = tokio::time::Instant::now() + timeout;
-    while entered.load(Ordering::Acquire) < expected {
-        if tokio::time::Instant::now() >= deadline {
-            log::debug!("stream data threads not all started within {timeout:?} (#178)");
-            return false;
+}
+
+impl StreamThreadGate {
+    pub(crate) fn new() -> Self {
+        Self {
+            sem: Arc::new(tokio::sync::Semaphore::new(0)),
+            expected: 0,
         }
-        tokio::time::sleep(Duration::from_millis(2)).await;
     }
-    true
+
+    /// `tokio::task::spawn_blocking` with a check-in: the spawned closure
+    /// releases its gate permit the moment its OS thread actually runs.
+    pub(crate) fn spawn<T, F>(&mut self, f: F) -> tokio::task::JoinHandle<T>
+    where
+        F: FnOnce() -> T + Send + 'static,
+        T: Send + 'static,
+    {
+        self.expected += 1;
+        let sem = self.sem.clone();
+        tokio::task::spawn_blocking(move || {
+            sem.add_permits(1);
+            f()
+        })
+    }
+
+    /// Wait (bounded) until every gate-spawned thread has checked in.
+    ///
+    /// Returns whether all threads checked in. On timeout the caller proceeds
+    /// anyway — a degraded run (pre-#178 behavior) beats failing a test that
+    /// would have moved most of its bytes.
+    pub(crate) async fn wait(&self, timeout: Duration) -> bool {
+        if self.expected == 0 {
+            return true;
+        }
+        match tokio::time::timeout(timeout, self.sem.acquire_many(self.expected)).await {
+            Ok(Ok(_permits)) => true,
+            _ => {
+                log::warn!(
+                    "{} stream data thread(s) not started within {timeout:?}; \
+                     proceeding degraded (#178)",
+                    self.expected as usize - self.sem.available_permits()
+                );
+                false
+            }
+        }
+    }
 }
 
 /// Sets `done` when dropped, so every exit path of a test handler — including
@@ -1637,33 +1677,36 @@ pub fn run_udp_receiver_blocking(
 mod tests {
     use super::*;
 
-    // #178 readiness barrier: returns true immediately when the threads are
-    // already in, true once they arrive late, false only past the deadline.
+    // #178 readiness barrier: wait() is trivially true with nothing spawned,
+    // true once every gate-spawned thread checks in (even when the threads
+    // start slowly), and false — without hanging — when a thread can't start.
     #[tokio::test]
-    async fn await_stream_threads_entered_counts_and_times_out() {
-        use std::sync::atomic::AtomicU32;
-
-        let entered = Arc::new(AtomicU32::new(2));
+    async fn stream_thread_gate_waits_and_times_out() {
+        let gate = StreamThreadGate::new();
         assert!(
-            await_stream_threads_entered(&entered, 2, Duration::from_millis(50)).await,
-            "already-entered threads must satisfy the barrier instantly"
+            gate.wait(Duration::from_millis(50)).await,
+            "an empty gate must not wait"
         );
 
-        let entered = Arc::new(AtomicU32::new(0));
-        let e = entered.clone();
-        let bumper = tokio::spawn(async move {
-            tokio::time::sleep(Duration::from_millis(30)).await;
-            e.fetch_add(2, Ordering::Release);
-        });
+        let mut gate = StreamThreadGate::new();
+        let h1 = gate.spawn(|| std::thread::sleep(Duration::from_millis(20)));
+        let h2 = gate.spawn(|| ());
         assert!(
-            await_stream_threads_entered(&entered, 2, Duration::from_secs(5)).await,
-            "late arrivals within the deadline must satisfy the barrier"
+            gate.wait(Duration::from_secs(5)).await,
+            "gate-spawned threads must satisfy the barrier once running"
         );
-        bumper.await.unwrap();
+        h1.await.unwrap();
+        h2.await.unwrap();
 
-        let entered = Arc::new(AtomicU32::new(1));
+        // A check-in that never comes (in real life: a spawn whose thread is
+        // queued behind a saturated blocking pool): an expectation with no
+        // permit ever released.
+        let starved = StreamThreadGate {
+            sem: Arc::new(tokio::sync::Semaphore::new(0)),
+            expected: 1,
+        };
         assert!(
-            !await_stream_threads_entered(&entered, 2, Duration::from_millis(40)).await,
+            !starved.wait(Duration::from_millis(40)).await,
             "missing threads must time out, not hang"
         );
     }

--- a/riperf3/src/stream.rs
+++ b/riperf3/src/stream.rs
@@ -1077,10 +1077,13 @@ impl StreamThreadGate {
         match tokio::time::timeout(timeout, self.sem.acquire_many(self.expected)).await {
             Ok(Ok(_permits)) => true,
             _ => {
+                // No late/total breakdown: a thread can check in between the
+                // timeout firing and any count we'd read, making a precise
+                // number a lie exactly when it matters (review r2).
                 log::warn!(
-                    "{} stream data thread(s) not started within {timeout:?}; \
+                    "not all of {} stream data thread(s) started within {timeout:?}; \
                      proceeding degraded (#178)",
-                    self.expected as usize - self.sem.available_permits()
+                    self.expected
                 );
                 false
             }

--- a/riperf3/src/stream.rs
+++ b/riperf3/src/stream.rs
@@ -1011,6 +1011,43 @@ fn await_start(start: &AtomicBool, done: &AtomicBool) -> bool {
     true
 }
 
+/// How long the control plane waits for spawned stream data threads to check
+/// in before opening the test window anyway (#178). Generous: the worst stall
+/// observed on loaded windows-latest runners was ~3.5 s; a barrier timeout
+/// only recreates the pre-fix behavior, so erring long costs nothing in the
+/// normal case (the wait ends the moment the threads are up).
+pub(crate) const STREAM_THREAD_START_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Wait (bounded) until `expected` stream data threads have checked in (#178).
+///
+/// The UDP data plane runs on `spawn_blocking` OS threads while the `-t` test
+/// clock is driven by the async control plane. On a loaded host (2-core CI
+/// runners), OS-thread creation can stall for seconds — the whole test window
+/// can elapse before a single data thread runs, completing a run "normally"
+/// with zero bytes (the late receiver goes straight to its post-test drain and
+/// discards everything the peer sent). Each blocking task bumps `entered` as
+/// its first action; the control plane calls this before letting the test
+/// window open, so the duration clock cannot start ahead of the data plane.
+///
+/// Returns whether all threads checked in. On timeout the caller proceeds
+/// anyway — a degraded run (today's behavior) beats failing a test that would
+/// have moved most of its bytes.
+pub(crate) async fn await_stream_threads_entered(
+    entered: &std::sync::atomic::AtomicU32,
+    expected: u32,
+    timeout: Duration,
+) -> bool {
+    let deadline = tokio::time::Instant::now() + timeout;
+    while entered.load(Ordering::Acquire) < expected {
+        if tokio::time::Instant::now() >= deadline {
+            log::debug!("stream data threads not all started within {timeout:?} (#178)");
+            return false;
+        }
+        tokio::time::sleep(Duration::from_millis(2)).await;
+    }
+    true
+}
+
 /// Sets `done` when dropped, so every exit path of a test handler — including
 /// early `?` error returns before the normal `done.store(true)` — signals the
 /// data tasks to stop. Without this, a UDP sender parked in `await_start`
@@ -1599,6 +1636,37 @@ pub fn run_udp_receiver_blocking(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // #178 readiness barrier: returns true immediately when the threads are
+    // already in, true once they arrive late, false only past the deadline.
+    #[tokio::test]
+    async fn await_stream_threads_entered_counts_and_times_out() {
+        use std::sync::atomic::AtomicU32;
+
+        let entered = Arc::new(AtomicU32::new(2));
+        assert!(
+            await_stream_threads_entered(&entered, 2, Duration::from_millis(50)).await,
+            "already-entered threads must satisfy the barrier instantly"
+        );
+
+        let entered = Arc::new(AtomicU32::new(0));
+        let e = entered.clone();
+        let bumper = tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(30)).await;
+            e.fetch_add(2, Ordering::Release);
+        });
+        assert!(
+            await_stream_threads_entered(&entered, 2, Duration::from_secs(5)).await,
+            "late arrivals within the deadline must satisfy the barrier"
+        );
+        bumper.await.unwrap();
+
+        let entered = Arc::new(AtomicU32::new(1));
+        assert!(
+            !await_stream_threads_entered(&entered, 2, Duration::from_millis(40)).await,
+            "missing threads must time out, not hang"
+        );
+    }
 
     // #178: a connection-reset-class error on a UDP socket is ICMP
     // port-unreachable noise from something WE sent — Windows surfaces it as

--- a/riperf3/tests/common/mod.rs
+++ b/riperf3/tests/common/mod.rs
@@ -1,0 +1,29 @@
+//! Shared lib-test helpers (`mod common;` per test binary).
+
+#![allow(dead_code)] // each test binary uses a subset
+
+use std::sync::atomic::{AtomicU16, Ordering};
+
+/// Sub-ephemeral, PID-windowed port allocation — same scheme as the CLI test
+/// harness (`riperf3-cli/tests/common`, #176): ephemeral-range picks collide
+/// with concurrent test binaries' connect() source ports under the parallel
+/// harness. Windows are PID-offset so concurrently-running test binaries don't
+/// share one; an atomic counter serializes callers within a binary; a
+/// bind-check skips anything still occupied.
+pub fn free_port() -> u16 {
+    use std::net::{Ipv4Addr, Ipv6Addr, TcpListener};
+
+    static NEXT: AtomicU16 = AtomicU16::new(0);
+    let window = 7000 + (std::process::id() % 250) as u16 * 100;
+    for _ in 0..100 {
+        let port = window + NEXT.fetch_add(1, Ordering::Relaxed) % 100;
+        // Sequential probes — a held `::` listener (v6only=0 on Linux) claims
+        // the v4 side too; `.is_ok()` drops each listener before the next bind.
+        if TcpListener::bind((Ipv6Addr::UNSPECIFIED, port)).is_ok()
+            && TcpListener::bind((Ipv4Addr::UNSPECIFIED, port)).is_ok()
+        {
+            return port;
+        }
+    }
+    panic!("no free port in test window {window}-{}", window + 99);
+}

--- a/riperf3/tests/stream_thread_readiness.rs
+++ b/riperf3/tests/stream_thread_readiness.rs
@@ -1,0 +1,108 @@
+//! #178 regression: the test window must not open before the stream data
+//! threads exist.
+//!
+//! On loaded windows-latest runners, OS-thread creation for the
+//! `spawn_blocking` UDP data threads stalled 1.2-3.5 s past TestStart while
+//! the async control plane kept the `-t` clock advancing — the whole test
+//! window elapsed before a single data thread ran, and a `-u --bidir` run
+//! completed "normally" with zero bytes both ways (the late receiver went
+//! straight to its post-test drain and *discarded* everything the peer had
+//! sent). DBG178-instrumented CI runs on the issue pin the timeline.
+//!
+//! This reproduces that deterministically on any platform: cap the runtime's
+//! blocking pool and saturate it with hogs that outlive the test duration, so
+//! the stream threads queue behind them exactly like the loaded runner. The
+//! readiness barrier must hold the test window open until the data threads
+//! have checked in; without it both directions report zero bytes.
+
+use std::sync::atomic::{AtomicU16, Ordering};
+use std::time::Duration;
+
+use riperf3::{ClientBuilder, RiperfError, ServerBuilder, TransportProtocol};
+
+/// Sub-ephemeral, PID-windowed port allocation — same scheme as the CLI test
+/// harness (`riperf3-cli/tests/common`): ephemeral-range picks collide with
+/// concurrent test binaries' connect() source ports under the parallel
+/// harness (#176).
+fn free_port() -> u16 {
+    use std::net::{Ipv4Addr, Ipv6Addr, TcpListener};
+
+    static NEXT: AtomicU16 = AtomicU16::new(0);
+    let window = 7000 + (std::process::id() % 250) as u16 * 100;
+    for _ in 0..100 {
+        let port = window + NEXT.fetch_add(1, Ordering::Relaxed) % 100;
+        if TcpListener::bind((Ipv6Addr::UNSPECIFIED, port)).is_ok()
+            && TcpListener::bind((Ipv4Addr::UNSPECIFIED, port)).is_ok()
+        {
+            return port;
+        }
+    }
+    panic!("no free port in test window {window}-{}", window + 99);
+}
+
+#[test]
+fn udp_bidir_window_waits_for_stream_threads() {
+    // Hogs == max_blocking_threads, so every spawn_blocking'd stream thread
+    // queues until the hogs exit (1.5 s — past the whole 1 s test duration).
+    const HOGS: usize = 4;
+    const HOG_LIFETIME: Duration = Duration::from_millis(1500);
+
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(2)
+        .max_blocking_threads(HOGS)
+        .enable_all()
+        .build()
+        .unwrap();
+
+    rt.block_on(async {
+        let port = free_port();
+        let server = ServerBuilder::new()
+            .port(Some(port))
+            .one_off(true)
+            .build()
+            .unwrap();
+        let srv = tokio::spawn(async move { server.run().await });
+
+        // The server binds inside run(); retry the control connect briefly.
+        // IMPORTANT: spawn the hogs only once the server is accepting, so
+        // they stall stream-thread creation, not the control-plane setup.
+        let client = ClientBuilder::new("127.0.0.1")
+            .port(Some(port))
+            .protocol(TransportProtocol::Udp)
+            .bidir(true)
+            .duration(1)
+            .build()
+            .unwrap();
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
+        let results = loop {
+            for _ in 0..HOGS {
+                tokio::task::spawn_blocking(move || std::thread::sleep(HOG_LIFETIME));
+            }
+            match client.run().await {
+                Ok(r) => break r,
+                Err(RiperfError::Io(e))
+                    if e.kind() == std::io::ErrorKind::ConnectionRefused
+                        && tokio::time::Instant::now() < deadline =>
+                {
+                    tokio::time::sleep(Duration::from_millis(100)).await;
+                }
+                Err(e) => panic!("client run failed: {e}"),
+            }
+        };
+        srv.await.unwrap().expect("server run");
+
+        // The server's exchanged results carry both streams: its receiving
+        // stream (forward bytes received) and its sending stream (reverse
+        // bytes sent). Pre-fix, the hogged pool keeps every data thread off
+        // the CPU until the window has already closed, and both are zero.
+        assert_eq!(results.streams.len(), 2, "bidir run has two streams");
+        for s in &results.streams {
+            assert!(
+                s.bytes > 0,
+                "stream {} moved no bytes — test window opened before the \
+                 data threads started (#178): {results:?}",
+                s.id
+            );
+        }
+    });
+}

--- a/riperf3/tests/stream_thread_readiness.rs
+++ b/riperf3/tests/stream_thread_readiness.rs
@@ -24,9 +24,13 @@ mod common;
 #[test]
 fn udp_bidir_window_waits_for_stream_threads() {
     // Hogs == max_blocking_threads, so every spawn_blocking'd stream thread
-    // queues until the hogs exit (1.5 s — past the whole 1 s test duration).
+    // queues until the hogs exit — 2.5 s, past the whole 1 s test duration
+    // with margin: the wave starts at attempt start, so the control handshake
+    // would have to outlive it for the test to pass without exercising the
+    // gate (review r2 — vacuous-pass, not false-fail, is the failure mode of
+    // a too-short wave).
     const HOGS: usize = 4;
-    const HOG_LIFETIME: Duration = Duration::from_millis(1500);
+    const HOG_LIFETIME: Duration = Duration::from_millis(2500);
 
     let rt = tokio::runtime::Builder::new_multi_thread()
         .worker_threads(2)

--- a/riperf3/tests/stream_thread_readiness.rs
+++ b/riperf3/tests/stream_thread_readiness.rs
@@ -12,33 +12,14 @@
 //! This reproduces that deterministically on any platform: cap the runtime's
 //! blocking pool and saturate it with hogs that outlive the test duration, so
 //! the stream threads queue behind them exactly like the loaded runner. The
-//! readiness barrier must hold the test window open until the data threads
-//! have checked in; without it both directions report zero bytes.
+//! readiness gate must hold the test window open until the data threads have
+//! checked in; without it both directions report zero bytes.
 
-use std::sync::atomic::{AtomicU16, Ordering};
 use std::time::Duration;
 
 use riperf3::{ClientBuilder, RiperfError, ServerBuilder, TransportProtocol};
 
-/// Sub-ephemeral, PID-windowed port allocation — same scheme as the CLI test
-/// harness (`riperf3-cli/tests/common`): ephemeral-range picks collide with
-/// concurrent test binaries' connect() source ports under the parallel
-/// harness (#176).
-fn free_port() -> u16 {
-    use std::net::{Ipv4Addr, Ipv6Addr, TcpListener};
-
-    static NEXT: AtomicU16 = AtomicU16::new(0);
-    let window = 7000 + (std::process::id() % 250) as u16 * 100;
-    for _ in 0..100 {
-        let port = window + NEXT.fetch_add(1, Ordering::Relaxed) % 100;
-        if TcpListener::bind((Ipv6Addr::UNSPECIFIED, port)).is_ok()
-            && TcpListener::bind((Ipv4Addr::UNSPECIFIED, port)).is_ok()
-        {
-            return port;
-        }
-    }
-    panic!("no free port in test window {window}-{}", window + 99);
-}
+mod common;
 
 #[test]
 fn udp_bidir_window_waits_for_stream_threads() {
@@ -55,7 +36,7 @@ fn udp_bidir_window_waits_for_stream_threads() {
         .unwrap();
 
     rt.block_on(async {
-        let port = free_port();
+        let port = common::free_port();
         let server = ServerBuilder::new()
             .port(Some(port))
             .one_off(true)
@@ -63,16 +44,26 @@ fn udp_bidir_window_waits_for_stream_threads() {
             .unwrap();
         let srv = tokio::spawn(async move { server.run().await });
 
-        // The server binds inside run(); retry the control connect briefly.
-        // IMPORTANT: spawn the hogs only once the server is accepting, so
-        // they stall stream-thread creation, not the control-plane setup.
+        // 100 Mbit/s keeps the run light but shrinks the sender's pacing
+        // batch interval from ~8 s (loopback blksize at the 1 Mbit/s default)
+        // to ~80 ms, so teardown joins promptly instead of parking in the
+        // pacing sleep for most of 10 s of wall time.
         let client = ClientBuilder::new("127.0.0.1")
             .port(Some(port))
             .protocol(TransportProtocol::Udp)
             .bidir(true)
             .duration(1)
+            .bandwidth(100_000_000)
             .build()
             .unwrap();
+
+        // The server binds inside run(), so the control connect can race it;
+        // retry on refusal. Each attempt saturates the pool with a FRESH hog
+        // wave so the stall covers the successful attempt's CreateStreams —
+        // and a refused attempt first waits out the previous wave, so waves
+        // never stack up FIFO-ahead of the stream threads (stacked waves
+        // would serialize at 1.5 s each and could blow the 10 s gate budget,
+        // failing the test in exactly the loaded environment it targets).
         let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
         let results = loop {
             for _ in 0..HOGS {
@@ -84,7 +75,7 @@ fn udp_bidir_window_waits_for_stream_threads() {
                     if e.kind() == std::io::ErrorKind::ConnectionRefused
                         && tokio::time::Instant::now() < deadline =>
                 {
-                    tokio::time::sleep(Duration::from_millis(100)).await;
+                    tokio::time::sleep(HOG_LIFETIME).await;
                 }
                 Err(e) => panic!("client run failed: {e}"),
             }


### PR DESCRIPTION
## Root cause (instrumented, not theorized)

A DBG178-instrumented hammer (`debug/178-instrument`: stderr tracing on every UDP socket path + 8 windows-latest shards replaying the failing job's exact `cargo test --workspace` profile) reproduced the failure on **5/8 shards** and pinned the timeline:

```
+67ms    client got TestStart, releasing senders     <- test clock starts
+1762ms  sender enter                                <- spawn_blocking thread runs 1.7s late
+2231ms  receiver enter                              <- 2.2s late
+2270ms  receiver exit ok=0 ... drain=true           <- done already set; drain DISCARDS peer bytes
+2270ms  sender exit   ok=0
```

On a loaded 2-core runner, OS-thread creation for the `spawn_blocking` UDP data threads stalls for seconds while the async control plane keeps the protocol and the `-t` clock advancing — the whole test window elapses before the data plane exists. The late receiver sees `done`, goes straight to the post-test drain (#48), and discards everything the peer sent. This explains every observed #178 signature (zero-zero runs, the one-batch-forward run, "interval 1 dead both directions", reverse never recovering, no repro on idle mithrandir). Dead suspects, definitively: dual-stack source-address selection, WSAECONNRESET (zero reset-class events in instrumented failures; #179 remains good hardening), handshake role-swap.

## Fix

`StreamThreadGate` (stream.rs): UDP stream tasks are spawned through a gate that counts expected threads and has each release a semaphore permit as its first action; the control plane awaits the full count (10 s bound, proceed-on-timeout with a warn — degraded = pre-fix behavior) before the test window can open:

- **client** — end of `create_streams`' UDP arm: TestStart isn't read (clock not started, senders not released) until the data plane exists;
- **server** — end of both UDP setup paths (recycling + demux): TestStart isn't sent until its senders/receivers run.

No wire changes; iperf3 interop unaffected (the gate only delays existing transitions). TCP tasks are `tokio::spawn` async (no OS-thread creation) and kernel-buffered — deliberately out of scope, rationale on the gate docs. Scope note: the gate covers each side's own clock/threads; a *cross-host* stall confined to the client can still cost the start of the window (no post-handshake wire signal exists to hold the server; iperf3 has the identical exposure) — documented at the client call site.

## Validation

- **Deterministic regression test** (`riperf3/tests/stream_thread_readiness.rs`): saturates a capped blocking pool with hogs that outlive the test duration — the loaded-runner stall, on any platform. **Red on main** (both streams 0 bytes, the exact CI signature), green with the gate.
- **Hammer A/B on windows-latest**: un-fixed baseline 5/8 shards failing (run 27297893183); with the fix, **24/24 full-suite iterations green** (run 27298958387; the one red job is a cache-save infra step, hammer loop green).
- Two cold review rounds applied (r1: gate refactor, comment accuracy, test anti-flake + speed; r2: nits).

Fixes #178
