### PR TITLE
fix(#182): bidir sender end-block carries the peer-measured UDP stats

### DIFF
--- a/riperf3-cli/tests/bidir_intervals.rs
+++ b/riperf3-cli/tests/bidir_intervals.rs
@@ -224,6 +224,63 @@ fn udp_bidir_interval_sums_split_udp_stats() {
     }
 }
 
+/// #182: the client's end-block entry for its UDP *sending* stream must carry
+/// the peer-measured datagram stats — iperf3 attaches the server's
+/// receiver-side packets/jitter/loss to the sender entry in bidir exactly as
+/// it does in forward mode (verified against iperf3 3.20 ground truth).
+/// Pre-fix, a bidir sender matched neither stats source and reported a
+/// zero-filled udp block: `packets: 0` despite real bytes.
+#[test]
+fn udp_bidir_sender_end_stream_carries_peer_measured_stats() {
+    let port = free_port();
+    let ps = port.to_string();
+    let mut server = spawn_server(&ps);
+
+    let out = run_capturing(
+        &[
+            "-c",
+            "127.0.0.1",
+            "-p",
+            &ps,
+            "-u",
+            "--bidir",
+            "-t",
+            "1",
+            "-J",
+        ],
+        Duration::from_secs(20),
+        "client",
+    );
+    let _ = server.0.wait();
+
+    let v: Value = serde_json::from_str(&out)
+        .unwrap_or_else(|e| panic!("client -u --bidir -J is not valid JSON ({e}): {out}"));
+    let streams = v["end"]["streams"]
+        .as_array()
+        .unwrap_or_else(|| panic!("missing end.streams: {v}"));
+    assert_eq!(streams.len(), 2, "bidir run has two streams: {v}");
+
+    for st in streams {
+        let u = &st["udp"];
+        let sender = u["sender"].as_bool().expect("udp.sender");
+        let bytes = u["bytes"].as_u64().expect("udp.bytes");
+        let packets = u["packets"].as_i64().expect("udp.packets");
+        assert!(bytes > 0, "stream moved no bytes: {st}");
+        assert!(
+            packets > 0,
+            "end-block {} stream reports packets=0 despite bytes={bytes} (#182): {st}",
+            if sender { "sender" } else { "receiver" },
+        );
+        // Like iperf3, both entries carry measured datagram stats (the
+        // sender's are the peer's receiver-side measurements).
+        assert!(
+            u.get("jitter_ms").is_some_and(Value::is_number)
+                && u.get("lost_packets").is_some_and(Value::is_number),
+            "end-block udp entry must carry measured stats: {st}"
+        );
+    }
+}
+
 /// A plain forward run must not grow a `sum_bidir_reverse` key.
 #[test]
 fn tcp_forward_intervals_have_no_bidir_reverse() {

--- a/riperf3-cli/tests/bidir_intervals.rs
+++ b/riperf3-cli/tests/bidir_intervals.rs
@@ -266,17 +266,15 @@ fn udp_bidir_sender_end_stream_carries_peer_measured_stats() {
         let bytes = u["bytes"].as_u64().expect("udp.bytes");
         let packets = u["packets"].as_i64().expect("udp.packets");
         assert!(bytes > 0, "stream moved no bytes: {st}");
+        // packets > 0 is the discriminator: pre-fix the sender entry was a
+        // zero-filled block (jitter_ms/lost_packets keys are serialized
+        // unconditionally, so key presence can't tell measured from filled).
+        // The sender's values are the peer's receiver-side measurements,
+        // matching iperf3's JSON.
         assert!(
             packets > 0,
             "end-block {} stream reports packets=0 despite bytes={bytes} (#182): {st}",
             if sender { "sender" } else { "receiver" },
-        );
-        // Like iperf3, both entries carry measured datagram stats (the
-        // sender's are the peer's receiver-side measurements).
-        assert!(
-            u.get("jitter_ms").is_some_and(Value::is_number)
-                && u.get("lost_packets").is_some_and(Value::is_number),
-            "end-block udp entry must carry measured stats: {st}"
         );
     }
 }

--- a/riperf3/src/client.rs
+++ b/riperf3/src/client.rs
@@ -1186,9 +1186,6 @@ impl Client {
             .unwrap_or((0.0, 0.0, 0.0));
 
         let is_udp = matches!(self.protocol, TransportProtocol::Udp);
-        // Forward UDP: the server is the receiver, so its loss lives only in the
-        // results it returned — attach it to the (sender) streams (#25).
-        let is_forward_udp = is_udp && !self.reverse && !self.bidir;
 
         let stream_reports: Vec<StreamReport> = streams
             .iter()
@@ -1213,7 +1210,11 @@ impl Client {
                         packets: st.packet_count - st.omitted_packet_count,
                         out_of_order: st.outoforder_packets - st.omitted_outoforder_packets,
                     })
-                } else if is_forward_udp && s.is_sender {
+                } else if is_udp && s.is_sender {
+                    // A sending stream's datagram stats are measured at the
+                    // peer's receiver and live only in the results it returned
+                    // — attach them to the sender entry, in bidir exactly as
+                    // in forward mode (#25, #182; iperf3 does the same).
                     // Peer's gross counts minus its omitted_* baselines (#31).
                     server_stream.map(|x| UdpStreamStats {
                         jitter_secs: x.jitter,

--- a/riperf3/src/client.rs
+++ b/riperf3/src/client.rs
@@ -1199,8 +1199,9 @@ impl Client {
                 let server_stream =
                     remote_cpu.and_then(|r| r.streams.iter().find(|x| x.id == s.id));
 
-                // UDP datagram stats: from our local receiver if we measured them,
-                // else (forward UDP) from the server's results for this stream (#25).
+                // UDP datagram stats: from our local receiver if we measured
+                // them, else (any UDP sending stream) from the server's
+                // results for this stream (#25, #182).
                 let udp = if let Some(ref lock) = s.udp_recv_stats {
                     // Local receiver: post-omit stats (#31) — gross counters
                     // minus the boundary baselines.


### PR DESCRIPTION
## Bug

In a UDP `--bidir` run, the client's JSON end-block entry for its **sending** stream was a zero-filled udp block — `packets: 0` (and zero jitter/loss) despite real bytes. First spotted in #178's failing-run evidence; reproduces deterministically on loopback.

## Fix

A sending stream's datagram stats are measured at the peer's receiver and arrive only in the exchanged results. The end-block assembly attached them to sender entries in **forward mode only** (`is_forward_udp && s.is_sender`, #25) — a bidir sender matched neither stats source. Widened to `is_udp && s.is_sender`.

Faithfulness verified against **iperf3 3.20 ground truth** (sandbox fleet): its JSON bidir sender entry carries the server-measured `packets`/`jitter_ms`/`lost_packets` — exactly what riperf3 now emits (`packets: 32`, real jitter/loss on loopback). Mode safety: reverse-mode clients have no sending streams (the arm is unreachable), forward is semantically unchanged, TCP is excluded by `is_udp`; per-stream id matching, `-O` omitted-baseline subtraction (#31), and 3.12-class tolerant decode (#24) all ride the existing forward-mode machinery — verified in review (including an empirical `-O 1 -b 10M` check: 64 post-omit vs 128 gross).

Red/green CLI test: `udp_bidir_sender_end_stream_carries_peer_measured_stats` (red on main, `packets > 0` is the discriminator — key presence can't distinguish measured from zero-filled since the fields serialize unconditionally).

## Adjacent gaps found in review (pre-existing, filed separately)

- #183 — server-role sibling: server `-J` zero-fills its sending streams' udp stats (discards the client's exchanged results).
- #184 — bidir **text** end block lacks iperf3's per-stream sender/receiver line pairs (text sender row semantics differ from JSON: `0.000 ms 0/<sent>` + a paired receiver line).
- #185 — UDP sender bursts a full 32-packet batch then starves at low rate × large blksize, which makes default-rate `--bidir -O 1` runs report zero post-omit traffic (mimics this bug via a different mechanism).

Two cold review rounds applied. Fixes #182
