### PR TITLE
fix(#184): text end-block parity — sender/receiver pairs, role tags, Retr column

### DIFF
--- a/riperf3-cli/tests/end_block_text.rs
+++ b/riperf3-cli/tests/end_block_text.rs
@@ -1,0 +1,164 @@
+//! #184: the client's text end block must print iperf3's per-stream
+//! sender/receiver line PAIRS in every mode, with iperf3's sender-line
+//! datagram stats (`0.000 ms  0/<sent>`), role tags in bidir, and no
+//! cross-direction `[SUM]`. Ground truth: iperf3 3.20 on the sandbox fleet
+//! (captured on #184) — the client end block pairs both halves of every
+//! stream (local + peer-reported), while the server prints one line per
+//! stream in its own role only.
+
+use std::process::{Command, Stdio};
+use std::time::Duration;
+
+mod common;
+
+/// Kills the wrapped child on drop so a spawned server is reaped on panic.
+struct ChildGuard(std::process::Child);
+impl Drop for ChildGuard {
+    fn drop(&mut self) {
+        let _ = self.0.kill();
+        let _ = self.0.wait();
+    }
+}
+
+fn spawn_server(port_str: &str) -> ChildGuard {
+    let bin = env!("CARGO_BIN_EXE_riperf3");
+    ChildGuard(
+        Command::new(bin)
+            .args(["-s", "-1", "-p", port_str])
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("spawn server"),
+    )
+}
+
+/// The end block: every line after the `- - -` separator.
+fn end_block(out: &str) -> Vec<&str> {
+    let sep = out
+        .lines()
+        .position(|l| l.starts_with("- - -"))
+        .unwrap_or_else(|| panic!("no end-block separator in: {out}"));
+    out.lines()
+        .skip(sep + 1)
+        .filter(|l| !l.trim().is_empty())
+        .collect()
+}
+
+fn run(port: &str, args: &[&str]) -> String {
+    let mut full = vec!["-c", "127.0.0.1", "-p", port];
+    full.extend_from_slice(args);
+    common::run_client_ok(&full, Duration::from_secs(20), "client").stdout
+}
+
+/// UDP bidir: per stream a sender AND a receiver line (4 stream lines), the
+/// sender lines carrying `0/<sent>` datagram totals — not blank columns — and
+/// no `[SUM]` rows at P=1 (iperf3 prints none in the bidir end block).
+#[test]
+fn udp_bidir_end_block_pairs_each_stream() {
+    let port = common::free_port().to_string();
+    let mut server = spawn_server(&port);
+    let out = run(&port, &["-u", "--bidir", "-t", "1"]);
+    let _ = server.0.wait();
+
+    let end = end_block(&out);
+    let senders: Vec<&&str> = end.iter().filter(|l| l.ends_with("sender")).collect();
+    let receivers: Vec<&&str> = end.iter().filter(|l| l.ends_with("receiver")).collect();
+    assert_eq!(
+        (senders.len(), receivers.len()),
+        (2, 2),
+        "bidir end block must pair both streams (2 sender + 2 receiver lines): {out}"
+    );
+    assert!(
+        !end.iter().any(|l| l.contains("SUM")),
+        "iperf3 prints no [SUM] in a P=1 bidir end block: {out}"
+    );
+    for s in senders {
+        assert!(
+            s.contains("ms") && s.contains('/') && !s.contains("0/0 "),
+            "sender lines carry `0.000 ms 0/<sent>` datagram stats with a real \
+             sent total, not blank columns or 0/0: {s}"
+        );
+    }
+    // Bidir lines are role-tagged like iperf3 ([TX-C]/[RX-C]).
+    assert!(
+        end.iter().any(|l| l.contains("TX-C")) && end.iter().any(|l| l.contains("RX-C")),
+        "bidir end-block lines carry role tags: {out}"
+    );
+}
+
+/// UDP reverse: the client's lone receiving stream still yields a PAIR — the
+/// sender line comes from the server's results (its sent bytes/datagrams).
+#[test]
+fn udp_reverse_end_block_has_sender_line() {
+    let port = common::free_port().to_string();
+    let mut server = spawn_server(&port);
+    let out = run(&port, &["-u", "-R", "-t", "1"]);
+    let _ = server.0.wait();
+
+    let end = end_block(&out);
+    let sender = end
+        .iter()
+        .find(|l| l.ends_with("sender"))
+        .unwrap_or_else(|| {
+            panic!("reverse end block must include the server's sender line: {out}")
+        });
+    assert!(
+        sender.contains("ms") && sender.contains('/') && !sender.contains("0/0 "),
+        "the sender line carries the peer's REAL sent datagram total — a 0/0 \
+         means the exchange did not fill sender packets (#184): {sender}"
+    );
+    assert!(
+        end.iter().any(|l| l.ends_with("receiver")),
+        "and the local receiver line stays: {out}"
+    );
+}
+
+/// UDP forward keeps its existing pair, and the sender line gains the
+/// `0/<sent>` total instead of blank columns.
+#[test]
+fn udp_forward_sender_line_carries_sent_total() {
+    let port = common::free_port().to_string();
+    let mut server = spawn_server(&port);
+    let out = run(&port, &["-u", "-t", "1"]);
+    let _ = server.0.wait();
+
+    let end = end_block(&out);
+    let sender = end
+        .iter()
+        .find(|l| l.ends_with("sender"))
+        .unwrap_or_else(|| panic!("forward end block must include the sender line: {out}"));
+    assert!(
+        sender.contains("ms") && sender.contains('/'),
+        "sender line shows `0.000 ms 0/<sent>` like iperf3: {sender}"
+    );
+    assert!(
+        end.iter().any(|l| l.ends_with("receiver")),
+        "pair intact: {out}"
+    );
+}
+
+/// TCP bidir: pairs too — Retr on sender lines only, no [SUM] at P=1, role tags.
+#[test]
+fn tcp_bidir_end_block_pairs_each_stream() {
+    let port = common::free_port().to_string();
+    let mut server = spawn_server(&port);
+    let out = run(&port, &["--bidir", "-t", "1"]);
+    let _ = server.0.wait();
+
+    let end = end_block(&out);
+    let senders = end.iter().filter(|l| l.ends_with("sender")).count();
+    let receivers = end.iter().filter(|l| l.ends_with("receiver")).count();
+    assert_eq!(
+        (senders, receivers),
+        (2, 2),
+        "TCP bidir end block must pair both streams: {out}"
+    );
+    assert!(
+        !end.iter().any(|l| l.contains("SUM")),
+        "no [SUM] in a P=1 bidir end block: {out}"
+    );
+    assert!(
+        end.iter().any(|l| l.contains("TX-C")) && end.iter().any(|l| l.contains("RX-C")),
+        "bidir end-block lines carry role tags: {out}"
+    );
+}

--- a/riperf3-cli/tests/end_block_text.rs
+++ b/riperf3-cli/tests/end_block_text.rs
@@ -137,6 +137,52 @@ fn udp_forward_sender_line_carries_sent_total() {
     );
 }
 
+/// TCP reverse: the client's lone receiving stream pairs with the server's
+/// sender line (its bytes + Retr from the exchange), exercising the `!is_udp`
+/// peer-sender branch that UDP reverse does not.
+#[test]
+fn tcp_reverse_end_block_pairs_with_server_sender() {
+    let port = common::free_port().to_string();
+    let mut server = spawn_server(&port);
+    let out = run(&port, &["-R", "-t", "1"]);
+    let _ = server.0.wait();
+
+    let end = end_block(&out);
+    assert!(
+        end.iter().any(|l| l.ends_with("sender")),
+        "TCP reverse end block must include the server's sender line: {out}"
+    );
+    assert!(
+        end.iter().any(|l| l.ends_with("receiver")),
+        "and the local receiver line: {out}"
+    );
+}
+
+/// `-P 2 -u --bidir`: four streams, four pairs, and exactly four direction-pure
+/// `[SUM]` rows — one per (role, line-direction) group — never a SUM mixing the
+/// two directions (the sum_summaries role grouping, #184).
+#[test]
+fn udp_parallel_bidir_sums_are_direction_pure() {
+    let port = common::free_port().to_string();
+    let mut server = spawn_server(&port);
+    let out = run(&port, &["-u", "--bidir", "-P", "2", "-t", "1"]);
+    let _ = server.0.wait();
+
+    let end = end_block(&out);
+    let sums: Vec<&&str> = end.iter().filter(|l| l.contains("SUM")).collect();
+    assert_eq!(
+        sums.len(),
+        4,
+        "P=2 bidir yields 4 SUM rows (TX-C sender+receiver, RX-C sender+receiver): {out}"
+    );
+    for s in &sums {
+        assert!(
+            s.contains("TX-C") || s.contains("RX-C"),
+            "every bidir SUM carries one direction's role tag: {s}"
+        );
+    }
+}
+
 /// TCP bidir: pairs too — Retr on sender lines only, no [SUM] at P=1, role tags.
 #[test]
 fn tcp_bidir_end_block_pairs_each_stream() {

--- a/riperf3/src/client.rs
+++ b/riperf3/src/client.rs
@@ -986,16 +986,9 @@ impl Client {
                         (0.0, 0, 0, 0, 0)
                     };
                 let is_udp_stream = self.protocol == TransportProtocol::Udp;
-
-                // #156: when sender_has_retransmits=1, the peer prints this
-                // value (iperf3 get_results stores it into stream_retrans and
-                // the summary renders it) — it must be the REAL end-of-test
-                // total. The sender task snapshots it into the counters while
-                // its socket is still open; by exchange time the socket is
-                // closed, so a live fd read here only serves as a fallback
-                // for paths that never reached the snapshot. With -O the
-                // boundary baseline is subtracted (#171), like iperf3's
-                // stream_retrans after iperf_reset_stats.
+                // #156 sentinel: -1 = "no retransmit total" (receiver/UDP/no
+                // TCP_INFO); the wire carries it, the peer renders it (#171
+                // omit-adjustment and the fd fallback live in the method).
                 let retransmits = s.sender_retransmits(is_udp_stream).unwrap_or(-1);
 
                 protocol::StreamResultJson {

--- a/riperf3/src/client.rs
+++ b/riperf3/src/client.rs
@@ -89,29 +89,34 @@ fn peer_half_summary(
     x: &protocol::StreamResultJson,
     local_is_sender: bool,
     is_udp: bool,
+    peer_has_retransmits: bool,
     end: f64,
     role_tag: Option<&'static str>,
 ) -> crate::reporter::StreamSummary {
+    let peer_is_sender = !local_is_sender;
     let (jitter, lost, total) = if !is_udp {
         (None, None, None)
-    } else if local_is_sender {
+    } else if peer_is_sender {
+        // Peer sent: zero jitter/loss over its sent count.
+        (Some(0.0), Some(0), Some(x.packets - x.omitted_packets))
+    } else {
         // Peer received: its measured stats.
         (
             Some(x.jitter),
             Some(x.errors - x.omitted_errors),
             Some(x.packets - x.omitted_packets),
         )
-    } else {
-        // Peer sent: zero jitter/loss over its sent count.
-        (Some(0.0), Some(0), Some(x.packets - x.omitted_packets))
     };
+    // A TCP peer sender renders the retransmit total it exchanged (#156/#184),
+    // when it reported having one; receivers and UDP carry none.
+    let retransmits = (!is_udp && peer_is_sender && peer_has_retransmits).then_some(x.retransmits);
     crate::reporter::StreamSummary {
         stream_id: x.id,
         start: 0.0,
         end,
         bytes: x.bytes,
-        is_sender: !local_is_sender,
-        retransmits: None,
+        is_sender: peer_is_sender,
+        retransmits,
         jitter,
         lost,
         total_packets: total,
@@ -973,8 +978,9 @@ impl Client {
                         // that count unconditionally (iperf_api.c
                         // `"packets"`). Fill the equivalent from sent bytes,
                         // keeping the gross+baseline convention (#184).
-                        let gross = (s.counters.bytes_sent() / blksize as u64) as i64;
-                        let net = (bytes / blksize as u64) as i64;
+                        let blk = blksize.max(1) as u64;
+                        let gross = (s.counters.bytes_sent() / blk) as i64;
+                        let net = (bytes / blk) as i64;
                         (0.0, 0, gross, 0, gross - net)
                     } else {
                         (0.0, 0, 0, 0, 0)
@@ -990,21 +996,7 @@ impl Client {
                 // for paths that never reached the snapshot. With -O the
                 // boundary baseline is subtracted (#171), like iperf3's
                 // stream_retrans after iperf_reset_stats.
-                let retransmits =
-                    if s.is_sender && crate::tcp_info::has_retransmit_info() && !is_udp_stream {
-                        let lifetime = match s.counters.final_retransmits() {
-                            n if n >= 0 => Some(n),
-                            _ => s
-                                .raw_fd
-                                .and_then(crate::tcp_info::get_tcp_info)
-                                .map(|i| i.total_retransmits as i64),
-                        };
-                        lifetime
-                            .map(|t| s.counters.omit_adjusted_retransmits(t))
-                            .unwrap_or(-1)
-                    } else {
-                        -1
-                    };
+                let retransmits = s.sender_retransmits(is_udp_stream).unwrap_or(-1);
 
                 protocol::StreamResultJson {
                     id: s.id,
@@ -1151,7 +1143,11 @@ impl Client {
             } else if is_udp {
                 // Local sending stream: iperf3's sender line shows zero
                 // jitter/loss over the sent datagram count.
-                (Some(0.0), Some(0), Some((bytes / blksize as u64) as i64))
+                (
+                    Some(0.0),
+                    Some(0),
+                    Some((bytes / blksize.max(1) as u64) as i64),
+                )
             } else {
                 (None, None, None)
             };
@@ -1162,7 +1158,9 @@ impl Client {
                 end: test_duration,
                 bytes,
                 is_sender: s.is_sender,
-                retransmits: None,
+                // TCP sender lines carry the omit-adjusted retransmit total
+                // iperf3 prints (#184); receivers/UDP carry none.
+                retransmits: s.sender_retransmits(is_udp),
                 jitter,
                 lost,
                 total_packets: total,
@@ -1170,10 +1168,22 @@ impl Client {
             };
             // The peer half — the opposite role of the same stream — from the
             // server's per-stream results entry. Tolerant of a missing entry
-            // (an odd peer): the pair just collapses to the local line.
+            // (an odd peer): the pair just collapses to the local line. The
+            // peer's sender line shows its retransmits only when the peer
+            // reported having them (#156 sender_has_retransmits).
+            let peer_has_retr = server_results.is_some_and(|r| r.sender_has_retransmits == 1);
             let peer = server_results
                 .and_then(|r| r.streams.iter().find(|x| x.id == s.id))
-                .map(|x| peer_half_summary(x, s.is_sender, is_udp, test_duration, role_tag));
+                .map(|x| {
+                    peer_half_summary(
+                        x,
+                        s.is_sender,
+                        is_udp,
+                        peer_has_retr,
+                        test_duration,
+                        role_tag,
+                    )
+                });
 
             // iperf3 orders each pair sender-first.
             match peer {
@@ -1183,8 +1193,10 @@ impl Client {
             }
         }
 
-        // iperf3 reprints the column header above the final summaries.
-        crate::reporter::print_final_header(self.protocol, self.bidir);
+        // iperf3 reprints the column header above the final summaries, with
+        // the Retr column only when a line actually carries a retransmit total.
+        let with_retr = summaries.iter().any(|s| s.retransmits.is_some());
+        crate::reporter::print_final_header(self.protocol, self.bidir, with_retr);
         // Per-stream lines plus aggregate [SUM] row(s) for parallel streams
         // (issue #4), via the shared path the server also uses.
         crate::reporter::print_final_summaries(&summaries, self.format_char);
@@ -2769,7 +2781,7 @@ mod tests {
                 end_time: 5.0,
             };
 
-            let recv = peer_half_summary(&x, true, true, 5.0, None);
+            let recv = peer_half_summary(&x, true, true, false, 5.0, None);
             assert!(!recv.is_sender, "server is the receiver in forward mode");
             assert_eq!(recv.lost, Some(4258));
             assert_eq!(recv.total_packets, Some(267_190));
@@ -2781,7 +2793,7 @@ mod tests {
             assert!(line.contains("4258/267190"), "{line}");
 
             // TCP forward: no datagram-loss columns, just a receiver byte line.
-            let tcp = peer_half_summary(&x, true, false, 5.0, None);
+            let tcp = peer_half_summary(&x, true, false, false, 5.0, None);
             assert_eq!(tcp.lost, None);
             assert_eq!(tcp.total_packets, None);
             assert_eq!(tcp.jitter, None);
@@ -2804,7 +2816,7 @@ mod tests {
                 start_time: 0.0,
                 end_time: 5.0,
             };
-            let snd = peer_half_summary(&x, false, true, 5.0, Some("RX-C"));
+            let snd = peer_half_summary(&x, false, true, false, 5.0, Some("RX-C"));
             assert!(snd.is_sender, "peer half of a local receiver is the sender");
             assert_eq!(snd.jitter, Some(0.0), "sender line shows zero jitter");
             assert_eq!(snd.lost, Some(0), "sender line shows zero loss");

--- a/riperf3/src/client.rs
+++ b/riperf3/src/client.rs
@@ -75,35 +75,48 @@ pub struct Client {
     pub(crate) use_pkcs1_padding: bool,
 }
 
-/// Build receiver-perspective summaries from the server's results. In a forward
-/// test the local streams are senders, so the receiver's view — most importantly
-/// UDP loss — lives only in the results the server returned. Surfacing it as a
-/// `receiver` line matches iperf3; without it, forward UDP looks loss-free even
-/// when the link is dropping packets (issue #25). `is_udp` gates the datagram
-/// loss/jitter columns so a forward TCP run shows a plain receiver byte line.
-fn server_receiver_summaries(
-    server: &TestResultsJson,
-    end: f64,
+/// Build the peer half of a stream's end-block pair from the server's
+/// per-stream results entry (#184, generalizing #25): the opposite role of
+/// the local stream. When the peer RECEIVED (local sender), its measured
+/// loss/jitter is the only receiver view that exists — without it, forward
+/// UDP looks loss-free even when the link drops packets (#25). When the peer
+/// SENT, iperf3's sender line shows zero jitter/loss over the sent datagram
+/// count. The exchange carries GROSS packets/errors plus omitted_* baselines;
+/// subtract for the post-omit summary (#31) — this also reads a real iperf3
+/// server's omit results correctly. `is_udp` gates the datagram columns so a
+/// TCP pair line stays a plain byte line.
+fn peer_half_summary(
+    x: &protocol::StreamResultJson,
+    local_is_sender: bool,
     is_udp: bool,
-) -> Vec<crate::reporter::StreamSummary> {
-    server
-        .streams
-        .iter()
-        .map(|s| crate::reporter::StreamSummary {
-            stream_id: s.id,
-            start: 0.0,
-            end,
-            bytes: s.bytes,
-            is_sender: false,
-            retransmits: None,
-            jitter: is_udp.then_some(s.jitter),
-            // The exchange carries GROSS packets/errors plus omitted_*
-            // baselines; subtract for the post-omit summary (#31). This also
-            // reads a real iperf3 server's omit results correctly.
-            lost: is_udp.then_some(s.errors - s.omitted_errors),
-            total_packets: is_udp.then_some(s.packets - s.omitted_packets),
-        })
-        .collect()
+    end: f64,
+    role_tag: Option<&'static str>,
+) -> crate::reporter::StreamSummary {
+    let (jitter, lost, total) = if !is_udp {
+        (None, None, None)
+    } else if local_is_sender {
+        // Peer received: its measured stats.
+        (
+            Some(x.jitter),
+            Some(x.errors - x.omitted_errors),
+            Some(x.packets - x.omitted_packets),
+        )
+    } else {
+        // Peer sent: zero jitter/loss over its sent count.
+        (Some(0.0), Some(0), Some(x.packets - x.omitted_packets))
+    };
+    crate::reporter::StreamSummary {
+        stream_id: x.id,
+        start: 0.0,
+        end,
+        bytes: x.bytes,
+        is_sender: !local_is_sender,
+        retransmits: None,
+        jitter,
+        lost,
+        total_packets: total,
+        role_tag,
+    }
 }
 
 /// Bytes transferred so far against an `-n`/`-k` limit. Faithful to iperf3's
@@ -267,7 +280,8 @@ impl Client {
                 }
 
                 TestState::ExchangeResults => {
-                    let results = self.build_results(&streams, cpu_start.as_ref(), measured_secs);
+                    let results =
+                        self.build_results(&streams, cpu_start.as_ref(), blksize, measured_secs);
                     protocol::send_results(&mut ctrl, &results).await?;
                     server_results = Some(protocol::recv_results(&mut ctrl).await?);
                 }
@@ -919,6 +933,7 @@ impl Client {
         &self,
         streams: &[DataStream],
         cpu_start: Option<&CpuSnapshot>,
+        blksize: usize,
         test_duration: f64,
     ) -> TestResultsJson {
         let cpu_end = CpuSnapshot::now();
@@ -952,6 +967,15 @@ impl Client {
                                 )
                             })
                             .unwrap_or((0.0, 0, 0, 0, 0))
+                    } else if s.is_sender && self.protocol == TransportProtocol::Udp {
+                        // iperf3's UDP sender counts every datagram it sends
+                        // (iperf_udp.c `++sp->packet_count`) and exchanges
+                        // that count unconditionally (iperf_api.c
+                        // `"packets"`). Fill the equivalent from sent bytes,
+                        // keeping the gross+baseline convention (#184).
+                        let gross = (s.counters.bytes_sent() / blksize as u64) as i64;
+                        let net = (bytes / blksize as u64) as i64;
+                        (0.0, 0, gross, 0, gross - net)
                     } else {
                         (0.0, 0, 0, 0, 0)
                     };
@@ -1057,7 +1081,7 @@ impl Client {
                 test_duration,
             );
         } else {
-            self.print_results_text(streams, remote_cpu, test_duration);
+            self.print_results_text(streams, remote_cpu, blksize, test_duration);
         }
     }
 
@@ -1087,61 +1111,80 @@ impl Client {
         &self,
         streams: &[DataStream],
         server_results: Option<&TestResultsJson>,
+        blksize: usize,
         test_duration: f64,
     ) {
         crate::reporter::print_separator();
 
-        let mut summaries: Vec<crate::reporter::StreamSummary> = streams
-            .iter()
-            .map(|s| {
-                let bytes = if s.is_sender {
-                    s.counters.bytes_sent_net()
-                } else {
-                    s.counters.bytes_received_net()
-                };
+        let is_udp = matches!(self.protocol, TransportProtocol::Udp);
+        // iperf3's end block pairs BOTH halves of every stream — a `sender`
+        // line and a `receiver` line — in every mode (#184): the local half
+        // from our counters/stats, the peer half from the results the server
+        // returned (#25 generalized; pre-#184 only forward runs got the peer
+        // line, so reverse lacked its sender line and bidir paired nothing).
+        // Sender lines carry `0.000 ms 0/<sent>` like iperf3 — the sent count
+        // is bytes/blksize locally, or the peer's reported packets.
+        let mut summaries: Vec<crate::reporter::StreamSummary> = Vec::new();
+        for s in streams {
+            // Bidir tags every line with the STREAM's direction (#184).
+            let role_tag = self
+                .bidir
+                .then_some(if s.is_sender { "TX-C" } else { "RX-C" });
+            let bytes = if s.is_sender {
+                s.counters.bytes_sent_net()
+            } else {
+                s.counters.bytes_received_net()
+            };
 
-                let (jitter, lost, total) = if let Some(ref udp_stats) = s.udp_recv_stats {
-                    udp_stats
-                        .lock()
-                        .map(|st| {
-                            // Post-omit stats (#31): gross minus baselines.
-                            (
-                                Some(st.jitter),
-                                Some(st.cnt_error - st.omitted_cnt_error),
-                                Some(st.packet_count - st.omitted_packet_count),
-                            )
-                        })
-                        .unwrap_or((None, None, None))
-                } else {
-                    (None, None, None)
-                };
+            let (jitter, lost, total) = if let Some(ref udp_stats) = s.udp_recv_stats {
+                udp_stats
+                    .lock()
+                    .map(|st| {
+                        // Post-omit stats (#31): gross minus baselines.
+                        (
+                            Some(st.jitter),
+                            Some(st.cnt_error - st.omitted_cnt_error),
+                            Some(st.packet_count - st.omitted_packet_count),
+                        )
+                    })
+                    .unwrap_or((None, None, None))
+            } else if is_udp {
+                // Local sending stream: iperf3's sender line shows zero
+                // jitter/loss over the sent datagram count.
+                (Some(0.0), Some(0), Some((bytes / blksize as u64) as i64))
+            } else {
+                (None, None, None)
+            };
 
-                crate::reporter::StreamSummary {
-                    stream_id: s.id,
-                    start: 0.0,
-                    end: test_duration,
-                    bytes,
-                    is_sender: s.is_sender,
-                    retransmits: None,
-                    jitter,
-                    lost,
-                    total_packets: total,
-                }
-            })
-            .collect();
+            let local = crate::reporter::StreamSummary {
+                stream_id: s.id,
+                start: 0.0,
+                end: test_duration,
+                bytes,
+                is_sender: s.is_sender,
+                retransmits: None,
+                jitter,
+                lost,
+                total_packets: total,
+                role_tag,
+            };
+            // The peer half — the opposite role of the same stream — from the
+            // server's per-stream results entry. Tolerant of a missing entry
+            // (an odd peer): the pair just collapses to the local line.
+            let peer = server_results
+                .and_then(|r| r.streams.iter().find(|x| x.id == s.id))
+                .map(|x| peer_half_summary(x, s.is_sender, is_udp, test_duration, role_tag));
 
-        // Forward: the server is the receiver, so its loss/throughput lives only
-        // in the results it returned — surface it as the receiver line iperf3
-        // prints, otherwise forward UDP looks loss-free even when the link drops
-        // packets (issue #25). Reverse already reports the receiver locally;
-        // bidir's server-receive half isn't split out of the aggregate results.
-        if !self.reverse && !self.bidir {
-            if let Some(server) = server_results {
-                let is_udp = matches!(self.protocol, TransportProtocol::Udp);
-                summaries.extend(server_receiver_summaries(server, test_duration, is_udp));
+            // iperf3 orders each pair sender-first.
+            match peer {
+                Some(peer) if s.is_sender => summaries.extend([local, peer]),
+                Some(peer) => summaries.extend([peer, local]),
+                None => summaries.push(local),
             }
         }
 
+        // iperf3 reprints the column header above the final summaries.
+        crate::reporter::print_final_header(self.protocol, self.bidir);
         // Per-stream lines plus aggregate [SUM] row(s) for parallel streams
         // (issue #4), via the shared path the server also uses.
         crate::reporter::print_final_summaries(&summaries, self.format_char);
@@ -2267,7 +2310,7 @@ mod tests {
             rcvbuf_actual: None,
             congestion_used: None,
         };
-        let results = client.build_results(std::slice::from_ref(&ds), None, 1.0);
+        let results = client.build_results(std::slice::from_ref(&ds), None, 1460, 1.0);
         assert_eq!(results.sender_has_retransmits, 1);
         assert!(
             results.streams[0].retransmits >= 0,
@@ -2353,7 +2396,7 @@ mod tests {
             congestion_used: None,
         };
         let client = crate::ClientBuilder::new("127.0.0.1").build().unwrap();
-        let results = client.build_results(std::slice::from_ref(&ds), None, 1.0);
+        let results = client.build_results(std::slice::from_ref(&ds), None, 1460, 1.0);
         assert_eq!(
             results.streams[0].retransmits, 3,
             "#171: warm-up retransmits (5) must be subtracted from the \
@@ -2705,7 +2748,7 @@ mod tests {
             assert_eq!(c.build_params(1460).pacing_timer, Some(500));
         }
 
-        // -- forward UDP receiver-loss reporting (issue #25) --
+        // -- end-block peer halves (issue #25 generalized by #184) --
 
         #[test]
         fn forward_udp_surfaces_server_receiver_loss() {
@@ -2713,45 +2756,61 @@ mod tests {
             // only in the server's results. riperf3 must surface it as a receiver
             // line, like iperf3 — otherwise forward looks artificially loss-free
             // even when the link drops packets (issue #25).
-            let server = TestResultsJson {
-                cpu_util_total: 0.0,
-                cpu_util_user: 0.0,
-                cpu_util_system: 0.0,
-                sender_has_retransmits: -1,
-                congestion_used: None,
-                server_output_text: None,
-                server_output_json: None,
-                streams: vec![protocol::StreamResultJson {
-                    id: 1,
-                    bytes: 2_000_000,
-                    retransmits: -1,
-                    jitter: 0.000_03,
-                    errors: 4258,
-                    omitted_errors: 0,
-                    packets: 267_190,
-                    omitted_packets: 0,
-                    start_time: 0.0,
-                    end_time: 5.0,
-                }],
+            let x = protocol::StreamResultJson {
+                id: 1,
+                bytes: 2_000_000,
+                retransmits: -1,
+                jitter: 0.000_03,
+                errors: 4258,
+                omitted_errors: 0,
+                packets: 267_190,
+                omitted_packets: 0,
+                start_time: 0.0,
+                end_time: 5.0,
             };
 
-            let recv = server_receiver_summaries(&server, 5.0, true);
-            assert_eq!(recv.len(), 1);
-            assert!(!recv[0].is_sender, "server is the receiver in forward mode");
-            assert_eq!(recv[0].lost, Some(4258));
-            assert_eq!(recv[0].total_packets, Some(267_190));
-            assert_eq!(recv[0].jitter, Some(0.000_03));
+            let recv = peer_half_summary(&x, true, true, 5.0, None);
+            assert!(!recv.is_sender, "server is the receiver in forward mode");
+            assert_eq!(recv.lost, Some(4258));
+            assert_eq!(recv.total_packets, Some(267_190));
+            assert_eq!(recv.jitter, Some(0.000_03));
 
             // Renders as a receiver line carrying the loss iperf3 would print.
-            let line = crate::reporter::format_summary_line(&recv[0], 'a');
+            let line = crate::reporter::format_summary_line(&recv, 'a');
             assert!(line.contains("receiver"), "{line}");
             assert!(line.contains("4258/267190"), "{line}");
 
             // TCP forward: no datagram-loss columns, just a receiver byte line.
-            let tcp = server_receiver_summaries(&server, 5.0, false);
-            assert_eq!(tcp[0].lost, None);
-            assert_eq!(tcp[0].total_packets, None);
-            assert_eq!(tcp[0].jitter, None);
+            let tcp = peer_half_summary(&x, true, false, 5.0, None);
+            assert_eq!(tcp.lost, None);
+            assert_eq!(tcp.total_packets, None);
+            assert_eq!(tcp.jitter, None);
+        }
+
+        #[test]
+        fn peer_sender_half_carries_sent_total_not_measured_stats() {
+            // Reverse/bidir: the peer SENT this stream — its pair line is a
+            // sender line with zero jitter/loss over the sent count (#184),
+            // exactly iperf3's sender-line convention.
+            let x = protocol::StreamResultJson {
+                id: 3,
+                bytes: 250_000,
+                retransmits: -1,
+                jitter: 0.5, // a peer sender reports no meaningful jitter
+                errors: 0,
+                omitted_errors: 0,
+                packets: 30,
+                omitted_packets: 5,
+                start_time: 0.0,
+                end_time: 5.0,
+            };
+            let snd = peer_half_summary(&x, false, true, 5.0, Some("RX-C"));
+            assert!(snd.is_sender, "peer half of a local receiver is the sender");
+            assert_eq!(snd.jitter, Some(0.0), "sender line shows zero jitter");
+            assert_eq!(snd.lost, Some(0), "sender line shows zero loss");
+            assert_eq!(snd.total_packets, Some(25), "post-omit sent count (#31)");
+            let line = crate::reporter::format_summary_line(&snd, 'a');
+            assert!(line.contains("sender") && line.contains("RX-C"), "{line}");
         }
 
         // -- client -B vs -4/-6 build-time validation (issue #15) --

--- a/riperf3/src/reporter.rs
+++ b/riperf3/src/reporter.rs
@@ -38,6 +38,11 @@ pub struct StreamSummary {
     pub jitter: Option<f64>,
     pub lost: Option<i64>,
     pub total_packets: Option<i64>,
+    /// Bidir role tag (`TX-C`/`RX-C`/`TX-S`/`RX-S`), rendered as iperf3's
+    /// `[ ID][Role]` column (#184). `None` outside bidir. Tags the STREAM's
+    /// direction, so both halves of a pair carry the same tag, and `[SUM]`
+    /// grouping never mixes directions.
+    pub role_tag: Option<&'static str>,
 }
 
 // ---------------------------------------------------------------------------
@@ -50,6 +55,15 @@ fn fmt_id(id: i32) -> String {
         "SUM".to_string()
     } else {
         format!("{id:3}")
+    }
+}
+
+/// The line prefix: `[ ID]`, or `[ ID][Role]` when the summary carries a bidir
+/// role tag (#184) — matching iperf3's bidir column.
+fn fmt_id_role(id: i32, role_tag: Option<&'static str>) -> String {
+    match role_tag {
+        Some(tag) => format!("{}][{tag}", fmt_id(id)),
+        None => fmt_id(id),
     }
 }
 
@@ -161,7 +175,7 @@ pub fn lost_percent(lost: i64, total: i64) -> f64 {
 /// Format a single final-summary line (no trailing newline). Pure, so the
 /// rendered output can be unit-tested without capturing stdout.
 pub fn format_summary_line(summary: &StreamSummary, format_char: char) -> String {
-    let id = fmt_id(summary.stream_id);
+    let id = fmt_id_role(summary.stream_id, summary.role_tag);
     let transfer = units::format_bytes(summary.bytes as f64, format_char.to_ascii_uppercase());
     let seconds = summary.end - summary.start;
     let bits_per_sec = if seconds > 0.0 {
@@ -240,17 +254,28 @@ pub fn print_final_summaries(per_stream: &[StreamSummary], format_char: char) {
 }
 
 /// Derive the aggregate `[SUM]` rows for the final report from the per-stream
-/// summaries. Returns one SUM per direction (sender / receiver) that has more
+/// summaries. Returns one SUM per (role, line-direction) group that has more
 /// than one stream — matching iperf3, which prints a `[SUM]` for parallel
-/// streams and omits it for a single stream. Bidir runs yield up to two SUM
-/// rows (one per direction). UDP SUM rows aggregate lost/total datagrams and
-/// carry the worst-case (max) jitter across the grouped streams.
+/// streams and omits it for a single stream. Grouping by the bidir role tag
+/// keeps a `[SUM]` from ever mixing the two directions of a bidir run (#184):
+/// a `P=1` bidir end block (one stream per direction, two lines each) gets no
+/// SUM at all, exactly like iperf3. UDP SUM rows aggregate lost/total
+/// datagrams and carry the worst-case (max) jitter across the grouped streams.
 pub fn sum_summaries(streams: &[StreamSummary]) -> Vec<StreamSummary> {
+    // Distinct (role_tag, is_sender) keys in first-seen order, so SUM rows
+    // come out in the same order iperf3 lists the groups.
+    let mut keys: Vec<(Option<&'static str>, bool)> = Vec::new();
+    for s in streams {
+        let key = (s.role_tag, s.is_sender);
+        if !keys.contains(&key) {
+            keys.push(key);
+        }
+    }
     let mut out = Vec::new();
-    for is_sender in [true, false] {
+    for (role_tag, is_sender) in keys {
         let group: Vec<&StreamSummary> = streams
             .iter()
-            .filter(|s| s.is_sender == is_sender)
+            .filter(|s| s.is_sender == is_sender && s.role_tag == role_tag)
             .collect();
         if group.len() <= 1 {
             continue;
@@ -288,9 +313,30 @@ pub fn sum_summaries(streams: &[StreamSummary]) -> Vec<StreamSummary> {
             jitter,
             lost,
             total_packets,
+            role_tag,
         });
     }
     out
+}
+
+/// Print the column header iperf3 reprints above the final (end-block)
+/// summaries (#184) — like the interval header, but TCP drops the `Cwnd`
+/// column (per-stream cwnd is an interval-only figure) and bidir adds the
+/// `[Role]` column.
+pub fn print_final_header(protocol: TransportProtocol, with_role: bool) {
+    let role = if with_role { "[Role]" } else { "" };
+    match protocol {
+        TransportProtocol::Tcp => {
+            titled(format_args!(
+                "[ ID]{role} Interval           Transfer     Bitrate         Retr"
+            ));
+        }
+        TransportProtocol::Udp => {
+            titled(format_args!(
+                "[ ID]{role} Interval           Transfer     Bitrate         Jitter    Lost/Total Datagrams"
+            ));
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -1117,6 +1163,7 @@ mod tests {
             jitter: Some(0.012),
             lost: Some(5),
             total_packets: Some(100),
+            role_tag: None,
         };
         print_summary(&summary, 'm');
     }
@@ -1152,6 +1199,7 @@ mod tests {
             jitter: None,
             lost: None,
             total_packets: None,
+            role_tag: None,
         }
     }
 
@@ -1308,6 +1356,7 @@ mod tests {
                 jitter: Some(0.010),
                 lost: Some(2),
                 total_packets: Some(1000),
+                role_tag: None,
             },
             StreamSummary {
                 stream_id: 3,
@@ -1319,6 +1368,7 @@ mod tests {
                 jitter: Some(0.025),
                 lost: Some(5),
                 total_packets: Some(2000),
+                role_tag: None,
             },
         ];
         let sums = sum_summaries(&streams);

--- a/riperf3/src/reporter.rs
+++ b/riperf3/src/reporter.rs
@@ -294,10 +294,9 @@ pub fn sum_summaries(streams: &[StreamSummary]) -> Vec<StreamSummary> {
         } else {
             (None, None, None)
         };
-        // Aggregate per-stream retransmits when present. The final per-stream
-        // summaries don't yet carry retransmits (the producers pass `None`, so
-        // this is dormant today), but the math is kept correct and tested so
-        // the SUM stays right if/when end-of-test TCP_INFO is plumbed in.
+        // Aggregate per-stream retransmits when present — live since #184 wired
+        // the TCP sender lines' omit-adjusted totals into the producers; a SUM
+        // over a TCP sender group carries the summed Retr iperf3 prints.
         let retransmits = if group.iter().any(|s| s.retransmits.is_some()) {
             Some(group.iter().filter_map(|s| s.retransmits).sum())
         } else {

--- a/riperf3/src/reporter.rs
+++ b/riperf3/src/reporter.rs
@@ -322,13 +322,16 @@ pub fn sum_summaries(streams: &[StreamSummary]) -> Vec<StreamSummary> {
 /// Print the column header iperf3 reprints above the final (end-block)
 /// summaries (#184) — like the interval header, but TCP drops the `Cwnd`
 /// column (per-stream cwnd is an interval-only figure) and bidir adds the
-/// `[Role]` column.
-pub fn print_final_header(protocol: TransportProtocol, with_role: bool) {
+/// `[Role]` column. `with_retr` gates the TCP `Retr` column on retransmit info
+/// actually being available (iperf3 omits it on Windows / for a peer without
+/// it), mirroring the interval header's `has_retransmits`.
+pub fn print_final_header(protocol: TransportProtocol, with_role: bool, with_retr: bool) {
     let role = if with_role { "[Role]" } else { "" };
     match protocol {
         TransportProtocol::Tcp => {
+            let retr = if with_retr { "         Retr" } else { "" };
             titled(format_args!(
-                "[ ID]{role} Interval           Transfer     Bitrate         Retr"
+                "[ ID]{role} Interval           Transfer     Bitrate{retr}"
             ));
         }
         TransportProtocol::Udp => {

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -648,6 +648,17 @@ impl Server {
                     } else {
                         (0.0, 0, 0, 0, 0)
                     }
+                } else if s.is_sender && matches!(cfg.protocol, TransportProtocol::Udp) {
+                    // iperf3's UDP sender counts every datagram it sends
+                    // (iperf_udp.c `++sp->packet_count`) and exchanges that
+                    // count unconditionally (iperf_api.c `"packets"`); the
+                    // peer's sender line renders it. Fill the equivalent from
+                    // sent bytes, keeping the gross+baseline convention (#184
+                    // — a zero here made an iperf3 client print `0/0` for a
+                    // riperf3 server's reverse stream).
+                    let gross = (s.counters.bytes_sent() / cfg.blksize as u64) as i64;
+                    let net = (bytes / cfg.blksize as u64) as i64;
+                    (0.0, 0, gross, 0, gross - net)
                 } else {
                     (0.0, 0, 0, 0, 0)
                 };
@@ -700,7 +711,9 @@ impl Server {
         // report), or attach the full -J report for a JSON-mode server.
         let mut prebuilt_report: Option<crate::json_report::Report> = None;
         let (server_output_text, server_output_json) = if let Some(capture) = capture {
-            let summaries = Self::text_summaries(&streams, test_duration);
+            let summaries = Self::text_summaries(&streams, test_duration, &cfg);
+            crate::reporter::print_separator();
+            crate::reporter::print_final_header(cfg.protocol, cfg.bidir);
             crate::reporter::print_final_summaries(&summaries, 'a');
             (Some(capture.take()), None)
         } else if want_server_output && self.json_output {
@@ -804,7 +817,9 @@ impl Server {
             // the pre-exchange render TEE'd to console + capture (iperf3 also
             // prints at TEST_END, before its exchange), so printing here again
             // would duplicate the lines.
-            let summaries = Self::text_summaries(&streams, test_duration);
+            let summaries = Self::text_summaries(&streams, test_duration, &cfg);
+            crate::reporter::print_separator();
+            crate::reporter::print_final_header(cfg.protocol, cfg.bidir);
             crate::reporter::print_final_summaries(&summaries, 'a');
         }
 
@@ -1198,7 +1213,9 @@ impl Server {
     fn text_summaries(
         streams: &[DataStream],
         test_duration: f64,
+        cfg: &TestConfig,
     ) -> Vec<crate::reporter::StreamSummary> {
+        let is_udp = matches!(cfg.protocol, TransportProtocol::Udp);
         streams
             .iter()
             .map(|s| {
@@ -1222,6 +1239,14 @@ impl Server {
                             )
                         })
                         .unwrap_or((None, None, None))
+                } else if is_udp && s.is_sender {
+                    // iperf3's sender line shows zero jitter/loss over the
+                    // sent datagram count, not blank columns (#184).
+                    (
+                        Some(0.0),
+                        Some(0),
+                        Some((bytes / cfg.blksize as u64) as i64),
+                    )
                 } else {
                     (None, None, None)
                 };
@@ -1236,6 +1261,10 @@ impl Server {
                     jitter,
                     lost,
                     total_packets: total,
+                    // Bidir tags every line with the stream's direction (#184).
+                    role_tag: cfg
+                        .bidir
+                        .then_some(if s.is_sender { "TX-S" } else { "RX-S" }),
                 }
             })
             .collect()

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -656,39 +656,16 @@ impl Server {
                     // sent bytes, keeping the gross+baseline convention (#184
                     // — a zero here made an iperf3 client print `0/0` for a
                     // riperf3 server's reverse stream).
-                    let gross = (s.counters.bytes_sent() / cfg.blksize as u64) as i64;
-                    let net = (bytes / cfg.blksize as u64) as i64;
+                    let blk = cfg.blksize.max(1) as u64;
+                    let gross = (s.counters.bytes_sent() / blk) as i64;
+                    let net = (bytes / blk) as i64;
                     (0.0, 0, gross, 0, gross - net)
                 } else {
                     (0.0, 0, 0, 0, 0)
                 };
 
             let is_udp_stream = matches!(cfg.protocol, TransportProtocol::Udp);
-
-            // #156: when sender_has_retransmits=1, the peer prints this
-            // value (iperf3 get_results stores it into stream_retrans and
-            // the summary renders it) — it must be the REAL end-of-test
-            // total. The sender task snapshots it into the counters while
-            // its socket is still open; by exchange time the socket is
-            // closed, so a live fd read here only serves as a fallback for
-            // paths that never reached the snapshot. With -O the boundary
-            // baseline is subtracted (#171), like iperf3's stream_retrans
-            // after iperf_reset_stats.
-            let retransmits =
-                if s.is_sender && crate::tcp_info::has_retransmit_info() && !is_udp_stream {
-                    let lifetime = match s.counters.final_retransmits() {
-                        n if n >= 0 => Some(n),
-                        _ => s
-                            .raw_fd
-                            .and_then(crate::tcp_info::get_tcp_info)
-                            .map(|i| i.total_retransmits as i64),
-                    };
-                    lifetime
-                        .map(|t| s.counters.omit_adjusted_retransmits(t))
-                        .unwrap_or(-1)
-                } else {
-                    -1
-                };
+            let retransmits = s.sender_retransmits(is_udp_stream).unwrap_or(-1);
 
             result_streams.push(protocol::StreamResultJson {
                 id: s.id,
@@ -712,8 +689,9 @@ impl Server {
         let mut prebuilt_report: Option<crate::json_report::Report> = None;
         let (server_output_text, server_output_json) = if let Some(capture) = capture {
             let summaries = Self::text_summaries(&streams, test_duration, &cfg);
+            let with_retr = summaries.iter().any(|s| s.retransmits.is_some());
             crate::reporter::print_separator();
-            crate::reporter::print_final_header(cfg.protocol, cfg.bidir);
+            crate::reporter::print_final_header(cfg.protocol, cfg.bidir, with_retr);
             crate::reporter::print_final_summaries(&summaries, 'a');
             (Some(capture.take()), None)
         } else if want_server_output && self.json_output {
@@ -818,8 +796,9 @@ impl Server {
             // prints at TEST_END, before its exchange), so printing here again
             // would duplicate the lines.
             let summaries = Self::text_summaries(&streams, test_duration, &cfg);
+            let with_retr = summaries.iter().any(|s| s.retransmits.is_some());
             crate::reporter::print_separator();
-            crate::reporter::print_final_header(cfg.protocol, cfg.bidir);
+            crate::reporter::print_final_header(cfg.protocol, cfg.bidir, with_retr);
             crate::reporter::print_final_summaries(&summaries, 'a');
         }
 
@@ -1245,7 +1224,7 @@ impl Server {
                     (
                         Some(0.0),
                         Some(0),
-                        Some((bytes / cfg.blksize as u64) as i64),
+                        Some((bytes / cfg.blksize.max(1) as u64) as i64),
                     )
                 } else {
                     (None, None, None)
@@ -1257,7 +1236,8 @@ impl Server {
                     end: test_duration,
                     bytes,
                     is_sender: s.is_sender,
-                    retransmits: None,
+                    // TCP sender lines carry the retransmit total (#184).
+                    retransmits: s.sender_retransmits(is_udp),
                     jitter,
                     lost,
                     total_packets: total,

--- a/riperf3/src/stream.rs
+++ b/riperf3/src/stream.rs
@@ -408,6 +408,34 @@ pub struct DataStream {
     pub congestion_used: Option<String>,
 }
 
+impl DataStream {
+    /// The omit-adjusted lifetime retransmit total to render/exchange for a TCP
+    /// sending stream, or `None` for a receiver, a UDP stream, or a platform
+    /// without TCP_INFO retransmits (Windows) — where iperf3 omits the `Retr`
+    /// column entirely. The sender task snapshots the count while the socket is
+    /// open (#156); a live fd read is only a fallback. With `-O` the boundary
+    /// baseline is subtracted (#171), like iperf3's `stream_retrans` after
+    /// `iperf_reset_stats`. `Some(-1)` means info exists but the value was
+    /// unavailable (iperf3's sentinel, rendered literally).
+    pub(crate) fn sender_retransmits(&self, is_udp: bool) -> Option<i64> {
+        if !self.is_sender || is_udp || !crate::tcp_info::has_retransmit_info() {
+            return None;
+        }
+        let lifetime = match self.counters.final_retransmits() {
+            n if n >= 0 => Some(n),
+            _ => self
+                .raw_fd
+                .and_then(crate::tcp_info::get_tcp_info)
+                .map(|i| i.total_retransmits as i64),
+        };
+        Some(
+            lifetime
+                .map(|t| self.counters.omit_adjusted_retransmits(t))
+                .unwrap_or(-1),
+        )
+    }
+}
+
 /// Build the shared `-n`/`-k` byte budget the sending streams decrement, or
 /// `None` when there is no limit. A `0` limit means **unlimited** — iperf3 sends
 /// `num`/`blocks` = 0 for a plain `-t` run, so it must be filtered out or a


### PR DESCRIPTION
## Gap

riperf3's text end block diverged from iperf3 3.20 in several ways (all ground-truthed against a real iperf3 build on the sandbox fleet, client + server, TCP + UDP, fwd/rev/bidir):
- the client printed only a **lone** line per stream (forward had a grafted receiver line via #25; reverse had no sender line; bidir paired nothing),
- no column header was reprinted after the separator,
- bidir lines had no role tags and the `[SUM]` **mixed both directions**,
- UDP sender lines showed blank datagram columns instead of iperf3's `0.000 ms 0/<sent>`,
- TCP runs never showed the `Retr` column at all.

## Fix

iperf3 pairs **both halves** of every stream — a `sender` line and a `receiver` line — in every mode: the local half from our counters/stats, the peer half from the results the server returned. This generalizes the #25 forward-only graft to all modes.

- **reporter**: `StreamSummary.role_tag` renders iperf3's `[ ID][Role]` column; `sum_summaries` groups by `(role, line-direction)` so a bidir `[SUM]` can never mix directions (and a P=1 bidir gets no SUM, like iperf3); `print_final_header` reprints the column header (TCP drops the interval-only `Cwnd`, and gates the `Retr` column on retransmit info being available — so Windows/no-info peers omit it like iperf3).
- **client/server**: pair every stream (sender-first), UDP sender lines carry `0.000 ms 0/<sent>` (local `bytes/blksize`, peer's reported packets), TCP sender lines carry the omit-adjusted retransmit total.
- **exchange**: UDP **sending** streams now carry their sent packet count (`bytes/blksize`, gross+omitted baseline), matching iperf3 (`iperf_udp.c ++sp->packet_count`, `iperf_api.c "packets"`) — a zero here made an iperf3 client render `0/0` against a riperf3 server in reverse/bidir.
- **dedup**: `DataStream::sender_retransmits` is the single source for the retransmit total used by both the wire exchange and the displayed `Retr` column.

## Review (two cold rounds)

- **r1, CRITICAL**: the new `bytes/blksize` fills divided by a wire-supplied blksize with no guard — a peer negotiating `len=0` (or local `-u -l 0`) panicked the client and could abort a persistent server mid-exchange (remote DoS). Guarded with `blksize.max(1)` at all four sites (the codebase's `json_report.rs` convention).
- **r1, MAJOR**: the new header advertised a `Retr` column that was never filled. Populated it (local + peer halves) and gated the header on a value actually being present.
- **r2**: comment accuracy only; no behavioral findings. The `-l 0` config-validation gap the `.max(1)` papers over (iperf3 rejects at config) is filed as **#188**. The post-omit UDP `0/0` a reviewer noted is the pre-existing pacing bug **#185**.

Red/green CLI tests (`end_block_text.rs`): pairs + tags + no-SUM in P=1 bidir, reverse gains its sender line, UDP sender totals must be real (not `0/0`), TCP-reverse pairing, and P=2 bidir SUM direction-purity (exactly 4 role-tagged SUMs).

Patch-scope (no public lib API change; `reporter`/`StreamSummary` are `pub(crate)`). Fixes #184
