### PR TITLE
test(#184): de-flake end_block_text UDP tests under 2-core CI contention

### DIFF
--- a/riperf3-cli/tests/end_block_text.rs
+++ b/riperf3-cli/tests/end_block_text.rs
@@ -11,6 +11,21 @@ use std::time::Duration;
 
 mod common;
 
+/// Serializes the UDP tests in this binary. Several concurrent UDP runs on a
+/// 2-core CI runner starve the async UDP-connect handshake (the #178
+/// thread-contention family): loopback handshake datagrams sit undrained, the
+/// retry budget approaches the 30 s `UDP_CONNECT_TOTAL_TIMEOUT`, and the
+/// control connection resets (`ECONNRESET`). The data plane is fine once it
+/// runs — this is a setup-phase scheduling artifact under pathological test
+/// concurrency, not a production defect — so the cheapest robust fix is to run
+/// the UDP cases one at a time (cargo runs test *binaries* sequentially, so a
+/// per-binary lock suffices; TCP cases still parallelize). `into_inner`
+/// tolerates a poisoned lock so one failing UDP test doesn't cascade.
+static UDP_SERIAL: std::sync::Mutex<()> = std::sync::Mutex::new(());
+fn udp_serial() -> std::sync::MutexGuard<'static, ()> {
+    UDP_SERIAL.lock().unwrap_or_else(|e| e.into_inner())
+}
+
 /// Kills the wrapped child on drop so a spawned server is reaped on panic.
 struct ChildGuard(std::process::Child);
 impl Drop for ChildGuard {
@@ -55,6 +70,7 @@ fn run(port: &str, args: &[&str]) -> String {
 /// no `[SUM]` rows at P=1 (iperf3 prints none in the bidir end block).
 #[test]
 fn udp_bidir_end_block_pairs_each_stream() {
+    let _serial = udp_serial();
     let port = common::free_port().to_string();
     let mut server = spawn_server(&port);
     let out = run(&port, &["-u", "--bidir", "-t", "1"]);
@@ -90,6 +106,7 @@ fn udp_bidir_end_block_pairs_each_stream() {
 /// sender line comes from the server's results (its sent bytes/datagrams).
 #[test]
 fn udp_reverse_end_block_has_sender_line() {
+    let _serial = udp_serial();
     let port = common::free_port().to_string();
     let mut server = spawn_server(&port);
     let out = run(&port, &["-u", "-R", "-t", "1"]);
@@ -117,6 +134,7 @@ fn udp_reverse_end_block_has_sender_line() {
 /// `0/<sent>` total instead of blank columns.
 #[test]
 fn udp_forward_sender_line_carries_sent_total() {
+    let _serial = udp_serial();
     let port = common::free_port().to_string();
     let mut server = spawn_server(&port);
     let out = run(&port, &["-u", "-t", "1"]);
@@ -158,14 +176,18 @@ fn tcp_reverse_end_block_pairs_with_server_sender() {
     );
 }
 
-/// `-P 2 -u --bidir`: four streams, four pairs, and exactly four direction-pure
+/// `-P 2 --bidir`: four streams, four pairs, and exactly four direction-pure
 /// `[SUM]` rows — one per (role, line-direction) group — never a SUM mixing the
-/// two directions (the sum_summaries role grouping, #184).
+/// two directions (the sum_summaries role grouping, #184). TCP, deliberately:
+/// the role grouping is protocol-agnostic, and a 4-stream UDP run here starves
+/// the async connect handshake under the parallel harness on a 2-core runner
+/// (the #178 thread-contention family), hitting the 30 s UDP-connect budget and
+/// resetting the control connection. TCP's kernel handshake has no such load.
 #[test]
-fn udp_parallel_bidir_sums_are_direction_pure() {
+fn parallel_bidir_sums_are_direction_pure() {
     let port = common::free_port().to_string();
     let mut server = spawn_server(&port);
-    let out = run(&port, &["-u", "--bidir", "-P", "2", "-t", "1"]);
+    let out = run(&port, &["--bidir", "-P", "2", "-t", "1"]);
     let _ = server.0.wait();
 
     let end = end_block(&out);


### PR DESCRIPTION
## Problem

`main` is red: `udp_bidir_end_block_pairs_each_stream` (one of the UDP end-block tests added in #184) intermittently times out — a 20 s zero-output hang on the `Native/Test (Linux)` job. It passed on #189's PR CI but failed on the post-merge main run and again on #190's CI (the flake lottery).

## Root cause

Not a hang — the client **errors out** with `ECONNRESET` after ~30 s. The new tests put **four concurrent UDP runs** in one binary (forward, reverse, P=1 bidir, P=2 bidir). On a 2-core runner the parallel harness starves the **async UDP-connect handshake** (the #178 thread-contention family): loopback handshake datagrams sit undrained while other tests hold the cores, the retry budget approaches the 30 s `UDP_CONNECT_TOTAL_TIMEOUT`, and the server tears down the control connection → the client sees `ECONNRESET`. The data plane is correct once it runs; this is a setup-phase scheduling artifact under pathological **test** concurrency, not a production defect (the pre-existing `bidir_intervals` binary, with fewer concurrent UDP tests, doesn't trip it).

Reproduced reliably at `--test-threads=2` on two pinned cores (`taskset -c 0,1`): **fails on round 1** before the fix.

## Fix (setup-phase only, no product change)

- The P=2 SUM direction-purity test moves to **TCP** — `sum_summaries`' role grouping is protocol-agnostic, so coverage is identical without the 4-stream UDP handshake load.
- The remaining UDP tests **serialize on a per-binary lock** (cargo runs test *binaries* sequentially, so this suffices; TCP cases still parallelize).

**0/20** failures after the fix under the same CI-exact condition (2 threads, 2 cores) that failed on round 1 before.

Hotfix for the #184 tests now on main; independent of the in-flight #185 (PR #190), which will additionally cut these serialized UDP tests' runtime (its pacing fix makes the senders exit at ~1 s instead of ~8 s).
