### PR TITLE
fix: small faithfulness batch — -S strtol base 0, -b rate/burst, pacing nits, blksize bounds, SUM jitter mean (#167, #160, #188, #169)

### DIFF
--- a/riperf3-cli/src/cli.rs
+++ b/riperf3-cli/src/cli.rs
@@ -161,9 +161,11 @@ pub struct Cli {
     #[arg(short = 'b', long, value_name = "rate[/burst]")]
     pub bitrate: Option<String>,
 
-    /// Set the IP type of service (0-255)
+    /// Set the IP type of service (0-255; decimal, 0x hex, or 0 octal)
+    // String, parsed by the builder's `tos_str` with iperf3's strtol-base-0
+    // semantics + IEBADTOS range check (#167).
     #[arg(short = 'S', long, value_name = "tos")]
-    pub tos: Option<i32>,
+    pub tos: Option<String>,
 
     /// Omit the first N seconds of the test
     #[arg(short = 'O', long, value_name = "secs")]
@@ -202,10 +204,11 @@ pub struct Cli {
     pub cport: Option<u16>,
 
     /// Set the server timing for pacing in microseconds (deprecated)
-    // Capped at i32::MAX: the wire TestParams field is i32 (a larger u32
-    // would wrap negative on the wire — review r1).
-    #[arg(long, value_name = "usec", value_parser = clap::value_parser!(u32).range(..=i32::MAX as i64))]
-    pub pacing_timer: Option<u32>,
+    // String, parsed by the builder's `pacing_timer_str`: iperf3 reads it
+    // with unit_atoi, so KMG suffixes (1024-based) work; the i32::MAX wire
+    // cap (review r1) is enforced there too (#160).
+    #[arg(long, value_name = "usec")]
+    pub pacing_timer: Option<String>,
 
     /// Only use IPv4
     #[arg(short = '4', long, conflicts_with = "version6")]
@@ -487,8 +490,8 @@ impl Cli {
         if let Some(t) = self.time {
             builder = builder.duration(t);
         }
-        if let Some(us) = self.pacing_timer {
-            builder = builder.pacing_timer(us);
+        if let Some(ref s) = self.pacing_timer {
+            builder = builder.pacing_timer_str(s)?;
         }
         if let Some(ref s) = self.bytes {
             builder = builder.bytes_str(s)?;
@@ -523,8 +526,8 @@ impl Cli {
         if let Some(ref s) = self.bitrate {
             builder = builder.bandwidth_str(s)?;
         }
-        if let Some(tos) = self.tos {
-            builder = builder.tos(tos);
+        if let Some(ref s) = self.tos {
+            builder = builder.tos_str(s)?;
         }
         if let Some(o) = self.omit {
             builder = builder.omit(o);
@@ -1155,6 +1158,25 @@ mod cli_tests {
             assert_eq!(c, expected_client("host").tos(16).build().unwrap());
         }
 
+        // #167: -S takes iperf3's strtol-base-0 forms (hex/octal), and bad
+        // values fail the build with IEBADTOS wording instead of parsing.
+        #[test]
+        fn tos_flag_accepts_hex_and_octal() {
+            let cli = Cli::parse_from(["riperf3", "-c", "host", "-S", "0x20"]);
+            let c = build_client_from_cli(&cli);
+            assert_eq!(c, expected_client("host").tos(0x20).build().unwrap());
+            let cli = Cli::parse_from(["riperf3", "-c", "host", "-S", "020"]);
+            let c = build_client_from_cli(&cli);
+            assert_eq!(c, expected_client("host").tos(16).build().unwrap());
+        }
+
+        #[test]
+        fn tos_flag_rejects_out_of_range() {
+            let cli = Cli::parse_from(["riperf3", "-c", "host", "-S", "256"]);
+            let err = cli.build_client().unwrap_err().to_string();
+            assert!(err.contains("bad TOS value"), "got: {err}");
+        }
+
         #[test]
         fn omit_flag_wired() {
             let cli = Cli::parse_from(["riperf3", "-c", "host", "-O", "3"]);
@@ -1636,6 +1658,14 @@ mod cli_tests {
         }
 
         // #32: --pacing-timer was parsed but never wired — a silent no-op.
+        #[test]
+        fn pacing_timer_accepts_kmg_suffix() {
+            // #160: iperf3 parses --pacing-timer with unit_atoi (1024-based).
+            let cli = Cli::parse_from(["riperf3", "-c", "h", "--pacing-timer", "1K"]);
+            let c = build_client_from_cli(&cli);
+            assert_eq!(c, expected_client("h").pacing_timer(1024).build().unwrap());
+        }
+
         #[test]
         fn pacing_timer_wired() {
             let cli = Cli::parse_from(["riperf3", "-c", "h", "--pacing-timer", "500"]);

--- a/riperf3/src/client.rs
+++ b/riperf3/src/client.rs
@@ -688,6 +688,7 @@ impl Client {
                         // #185: honor --pacing-timer on the UDP send batch too,
                         // so a low -b over a large datagram paces smoothly.
                         let pt = self.pacing_timer;
+                        let bu = self.burst;
                         let u64bit = self.udp_counters_64bit;
                         let use_sendmmsg = self.sendmmsg;
                         let st = start.clone();
@@ -695,11 +696,11 @@ impl Client {
                         thread_gate.spawn(move || {
                             if use_sendmmsg {
                                 stream::run_udp_sender_sendmmsg(
-                                    std_sock, c, bs, d, rate, pt, u64bit, st, md,
+                                    std_sock, c, bs, d, rate, pt, bu, u64bit, st, md,
                                 )
                             } else {
                                 stream::run_udp_sender_blocking(
-                                    std_sock, c, bs, d, rate, pt, u64bit, st, md,
+                                    std_sock, c, bs, d, rate, pt, bu, u64bit, st, md,
                                 )
                             }
                         })
@@ -2694,6 +2695,19 @@ mod tests {
             assert_eq!(c.burst, 10);
             // IEBURST parity on the setter path too.
             assert!(ClientBuilder::new("h").burst(1001).build().is_err());
+        }
+
+        #[test]
+        fn pacing_timer_str_enforces_i32_wire_cap() {
+            // The wire TestParams field is i32; larger would wrap negative
+            // (review r1 of #32; coverage restored per #193 review r1 n2).
+            assert!(ClientBuilder::new("h").pacing_timer_str("3G").is_err());
+            assert!(ClientBuilder::new("h")
+                .pacing_timer_str("2147483647")
+                .is_ok());
+            assert!(ClientBuilder::new("h")
+                .pacing_timer_str("2147483648")
+                .is_err());
         }
 
         #[test]

--- a/riperf3/src/client.rs
+++ b/riperf3/src/client.rs
@@ -2943,6 +2943,21 @@ mod tests {
         // 1000 µs), so the server's reverse/bidir sender paces on the same
         // quantum. riperf3 left it unset.
         #[test]
+        fn build_params_sends_burst_only_when_set() {
+            // iperf3 gates the param on nonzero (`if (test->settings->burst)`,
+            // iperf_api.c:2461) — absent otherwise, so the wire JSON is
+            // byte-identical for every burst-less invocation (#160 review r2 n4).
+            let c = ClientBuilder::new("h")
+                .bandwidth_str("100M/10")
+                .unwrap()
+                .build()
+                .unwrap();
+            assert_eq!(c.build_params(1460).burst, Some(10));
+            let c = ClientBuilder::new("h").build().unwrap();
+            assert_eq!(c.build_params(1460).burst, None);
+        }
+
+        #[test]
         fn build_params_always_sends_pacing_timer() {
             let c = ClientBuilder::new("h").build().unwrap();
             assert_eq!(c.build_params(1460).pacing_timer, Some(1000));

--- a/riperf3/src/client.rs
+++ b/riperf3/src/client.rs
@@ -35,6 +35,8 @@ pub struct Client {
     pub(crate) mss: Option<i32>,
     pub(crate) window: Option<i32>,
     pub(crate) bandwidth: u64,
+    /// `-b rate/burst` block count (0 = unset) — iperf3's multisend batch (#160).
+    pub(crate) burst: u32,
     pub(crate) pacing_timer: u32,
     pub(crate) tos: i32,
     pub(crate) congestion: Option<String>,
@@ -365,6 +367,9 @@ impl Client {
         // it. `bandwidth` is the effective rate after the build-time default
         // (UDP unset → 1 Mbit/s), so 0 here unambiguously means unlimited (#17).
         p.bandwidth = Some(self.bandwidth);
+        // Sent only when set, like iperf3 (`if (test->settings->burst)`): the
+        // server's reverse/bidir sender batches on the client's burst (#160).
+        p.burst = (self.burst > 0).then_some(self.burst as i32);
         // Always sent, like iperf3 (default 1000 µs): the server's
         // reverse/bidir sender paces on the client's quantum (#32).
         p.pacing_timer = Some(self.pacing_timer as i32);
@@ -536,6 +541,7 @@ impl Client {
                         let zc = self.zerocopy;
                         let rate = self.bandwidth;
                         let pt = self.pacing_timer;
+                        let bu = self.burst;
                         let bb = byte_budget.clone();
                         tokio::spawn(async move {
                             // Zerocopy (sendfile) is used only for an unlimited,
@@ -565,11 +571,21 @@ impl Client {
                                     target_os = "freebsd"
                                 )))]
                                 {
-                                    stream::run_tcp_sender(data_stream, c, buf, d, fp, rate, pt, bb)
-                                        .await
+                                    stream::run_tcp_sender(
+                                        data_stream,
+                                        c,
+                                        buf,
+                                        d,
+                                        fp,
+                                        rate,
+                                        pt,
+                                        bu,
+                                        bb,
+                                    )
+                                    .await
                                 }
                             } else {
-                                stream::run_tcp_sender(data_stream, c, buf, d, fp, rate, pt, bb)
+                                stream::run_tcp_sender(data_stream, c, buf, d, fp, rate, pt, bu, bb)
                                     .await
                             }
                         })
@@ -1517,6 +1533,7 @@ pub struct ClientBuilder {
     mss: Option<i32>,
     window: Option<i32>,
     bandwidth: Option<u64>,
+    burst: u32,
     pacing_timer: u32,
     tos: i32,
     congestion: Option<String>,
@@ -1574,6 +1591,7 @@ impl Default for ClientBuilder {
             mss: None,
             window: None,
             bandwidth: None,
+            burst: 0,
             pacing_timer: 0,
             tos: 0,
             congestion: None,
@@ -1705,6 +1723,14 @@ impl ClientBuilder {
         // `Some` even for 0: an explicit `-b 0` means unlimited and must be
         // distinguishable from "unset" (which resolves to the UDP default) (#17).
         self.bandwidth = Some(bps);
+        self
+    }
+
+    /// `-b rate/burst` burst count: blocks sent per throttle green light
+    /// (iperf3's multisend batch, 1..=1000; 0 = unset) (#160). Range-checked
+    /// at `build()`.
+    pub fn burst(mut self, blocks: u32) -> Self {
+        self.burst = blocks;
         self
     }
 
@@ -2017,11 +2043,29 @@ impl ClientBuilder {
         Ok(self.window(parse_kmg(s)? as i32))
     }
 
-    /// Like [`Self::bandwidth`], accepting an iperf3 rate string (`-b 10M`;
-    /// decimal, 1000-based). A `/burst` suffix is parsed but not applied.
+    /// Like [`Self::bandwidth`], accepting an iperf3 rate string
+    /// (`-b 10M[/burst]`; decimal, 1000-based). A `/burst` count is applied
+    /// per [`Self::burst`] (#160).
     pub fn bandwidth_str(self, s: &str) -> std::result::Result<Self, ConfigError> {
-        let (rate, _burst) = parse_bitrate(s)?;
-        Ok(self.bandwidth(rate))
+        let (rate, burst) = parse_bitrate(s)?;
+        Ok(self.bandwidth(rate).burst(burst))
+    }
+
+    /// Like [`Self::tos`], accepting iperf3's `-S` string forms: decimal,
+    /// `0x` hex, or leading-`0` octal (strtol base 0), range 0-255 (#167).
+    pub fn tos_str(self, s: &str) -> std::result::Result<Self, ConfigError> {
+        Ok(self.tos(crate::utils::parse_tos(s)?))
+    }
+
+    /// Like [`Self::pacing_timer`], accepting a KMG-suffixed string
+    /// (`--pacing-timer 1K`; binary, 1024-based, like iperf3's `unit_atoi`) (#160).
+    pub fn pacing_timer_str(self, s: &str) -> std::result::Result<Self, ConfigError> {
+        let us = parse_kmg(s)?;
+        // The wire TestParams field is i32; larger would wrap negative.
+        if us > i32::MAX as u64 {
+            return Err(ConfigError::InvalidValue("pacing_timer", s.to_string()));
+        }
+        Ok(self.pacing_timer(us as u32))
     }
 
     /// Like [`Self::fq_rate`], accepting an iperf3 rate string
@@ -2122,6 +2166,59 @@ impl ClientBuilder {
         } else {
             self.tos
         };
+        // IEBADTOS parity for the i32 setter path (the string path validates
+        // in parse_tos; --dscp resolves to 0-252 by construction) (#167).
+        if !(0..=255).contains(&tos) {
+            return Err(ConfigError::InvalidValue(
+                "tos",
+                format!("bad TOS value (must be between 0 and 255 inclusive): {tos}"),
+            ));
+        }
+
+        // IEBURST parity for the u32 setter path (#160).
+        if self.burst > crate::utils::MAX_BURST {
+            return Err(ConfigError::InvalidValue(
+                "burst count",
+                format!(
+                    "invalid burst count (maximum = {}): {}",
+                    crate::utils::MAX_BURST,
+                    self.burst
+                ),
+            ));
+        }
+
+        // -l 0 means "unset", like iperf3 (blksize 0 picks up the protocol
+        // default before validation; for UDP the dynamic-MSS resolution
+        // applies). A nonzero value is bounds-checked per protocol: TCP
+        // 1..=MAX_BLOCKSIZE (IEBLOCKSIZE), UDP MIN..=MAX_UDP_BLKSIZE
+        // (IEUDPBLOCKSIZE) (#188).
+        let blksize_req = self.blksize.filter(|&b| b != 0);
+        if let Some(b) = blksize_req {
+            match self.protocol {
+                TransportProtocol::Tcp if b > crate::utils::MAX_BLOCKSIZE => {
+                    return Err(ConfigError::InvalidValue(
+                        "len",
+                        format!(
+                            "block size too large (maximum = {} bytes): {b}",
+                            crate::utils::MAX_BLOCKSIZE
+                        ),
+                    ));
+                }
+                TransportProtocol::Udp
+                    if !(crate::utils::MIN_UDP_BLKSIZE..=MAX_UDP_BLKSIZE).contains(&b) =>
+                {
+                    return Err(ConfigError::InvalidValue(
+                        "len",
+                        format!(
+                            "block size invalid (minimum = {} bytes, maximum = {} bytes): {b}",
+                            crate::utils::MIN_UDP_BLKSIZE,
+                            MAX_UDP_BLKSIZE
+                        ),
+                    ));
+                }
+                _ => {}
+            }
+        }
 
         Ok(Client {
             host,
@@ -2129,8 +2226,8 @@ impl ClientBuilder {
             protocol: self.protocol,
             duration: self.duration,
             num_streams: self.num_streams,
-            blksize: self.blksize.unwrap_or(default_blksize),
-            blksize_explicit: self.blksize.is_some(),
+            blksize: blksize_req.unwrap_or(default_blksize),
+            blksize_explicit: blksize_req.is_some(),
             reverse: self.reverse,
             bidir: self.bidir,
             omit: self.omit,
@@ -2144,6 +2241,7 @@ impl ClientBuilder {
                 TransportProtocol::Udp => DEFAULT_UDP_RATE,
                 TransportProtocol::Tcp => 0,
             }),
+            burst: self.burst,
             // 0 = unset → iperf3's default quantum, like its pacing_timer
             // option parsing (it never sends 0).
             pacing_timer: if self.pacing_timer == 0 {
@@ -2295,6 +2393,7 @@ mod tests {
             None,
             0,
             1000,
+            0,
             Some(budget.clone()),
         ));
         while budget.load(std::sync::atomic::Ordering::Relaxed) > 0 {
@@ -2525,6 +2624,87 @@ mod tests {
         fn client_builder_window() {
             let c = ClientBuilder::new("h").window(524288).build().unwrap();
             assert_eq!(c.window, Some(524288));
+        }
+
+        #[test]
+        fn build_blksize_zero_is_default() {
+            // -l 0 means "unset", like iperf3: blksize 0 resolves to the
+            // protocol default pre-validation; for UDP the dynamic-MSS path
+            // stays live (blksize_explicit = false) (#188).
+            let c = ClientBuilder::new("h").blksize(0).build().unwrap();
+            assert_eq!(c.blksize, DEFAULT_TCP_BLKSIZE);
+            assert!(!c.blksize_explicit);
+            let c = ClientBuilder::new("h")
+                .protocol(TransportProtocol::Udp)
+                .blksize(0)
+                .build()
+                .unwrap();
+            assert_eq!(c.blksize, DEFAULT_UDP_BLKSIZE);
+            assert!(!c.blksize_explicit);
+        }
+
+        #[test]
+        fn build_blksize_bounds_match_iperf3() {
+            // TCP: 1..=MAX_BLOCKSIZE (IEBLOCKSIZE); UDP: MIN..=MAX_UDP_BLKSIZE
+            // (IEUDPBLOCKSIZE) (#188).
+            let tcp = |b| ClientBuilder::new("h").blksize(b).build();
+            let udp = |b| {
+                ClientBuilder::new("h")
+                    .protocol(TransportProtocol::Udp)
+                    .blksize(b)
+                    .build()
+            };
+            assert!(tcp(MAX_BLOCKSIZE).is_ok());
+            assert!(tcp(MAX_BLOCKSIZE + 1).is_err());
+            assert!(udp(MIN_UDP_BLKSIZE).is_ok());
+            assert!(udp(MIN_UDP_BLKSIZE - 1).is_err());
+            assert!(udp(MAX_UDP_BLKSIZE).is_ok());
+            assert!(udp(MAX_UDP_BLKSIZE + 1).is_err());
+        }
+
+        #[test]
+        fn build_tos_range_checked() {
+            // IEBADTOS parity for the i32 setter path (#167).
+            assert!(ClientBuilder::new("h").tos(255).build().is_ok());
+            assert!(ClientBuilder::new("h").tos(256).build().is_err());
+            assert!(ClientBuilder::new("h").tos(-1).build().is_err());
+        }
+
+        #[test]
+        fn tos_str_parses_strtol_base0() {
+            // -S accepts decimal/hex/octal like iperf3's strtol base 0 (#167).
+            let c = ClientBuilder::new("h")
+                .tos_str("0x20")
+                .unwrap()
+                .build()
+                .unwrap();
+            assert_eq!(c.tos, 0x20);
+            assert!(ClientBuilder::new("h").tos_str("256").is_err());
+        }
+
+        #[test]
+        fn bandwidth_str_applies_burst() {
+            // The /burst count is no longer discarded (#160).
+            let c = ClientBuilder::new("h")
+                .bandwidth_str("100M/10")
+                .unwrap()
+                .build()
+                .unwrap();
+            assert_eq!(c.bandwidth, 100_000_000);
+            assert_eq!(c.burst, 10);
+            // IEBURST parity on the setter path too.
+            assert!(ClientBuilder::new("h").burst(1001).build().is_err());
+        }
+
+        #[test]
+        fn pacing_timer_str_accepts_kmg() {
+            // iperf3 parses --pacing-timer with unit_atoi (1024-based) (#160).
+            let c = ClientBuilder::new("h")
+                .pacing_timer_str("1K")
+                .unwrap()
+                .build()
+                .unwrap();
+            assert_eq!(c.pacing_timer, 1024);
         }
 
         #[test]

--- a/riperf3/src/protocol.rs
+++ b/riperf3/src/protocol.rs
@@ -236,6 +236,10 @@ pub struct TestParams {
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub bandwidth: Option<u64>,
 
+    /// `-b rate/burst` block count; iperf3 sends it only when nonzero (#160).
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub burst: Option<i32>,
+
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub fqrate: Option<u64>,
 

--- a/riperf3/src/reporter.rs
+++ b/riperf3/src/reporter.rs
@@ -260,7 +260,9 @@ pub fn print_final_summaries(per_stream: &[StreamSummary], format_char: char) {
 /// keeps a `[SUM]` from ever mixing the two directions of a bidir run (#184):
 /// a `P=1` bidir end block (one stream per direction, two lines each) gets no
 /// SUM at all, exactly like iperf3. UDP SUM rows aggregate lost/total
-/// datagrams and carry the worst-case (max) jitter across the grouped streams.
+/// datagrams and carry the MEAN jitter across the grouped streams, matching
+/// iperf3's END block (`avg_jitter += sp->jitter` per stream of the
+/// direction, then `avg_jitter /= test->num_streams` — #169).
 pub fn sum_summaries(streams: &[StreamSummary]) -> Vec<StreamSummary> {
     // Distinct (role_tag, is_sender) keys in first-seen order, so SUM rows
     // come out in the same order iperf3 lists the groups.
@@ -285,11 +287,13 @@ pub fn sum_summaries(streams: &[StreamSummary]) -> Vec<StreamSummary> {
         let (jitter, lost, total_packets) = if is_udp {
             let lost = group.iter().filter_map(|s| s.lost).sum();
             let total = group.iter().filter_map(|s| s.total_packets).sum();
-            // Jitter doesn't sum; report the worst stream's jitter on the SUM.
+            // iperf3 averages jitter across the direction's streams in the
+            // END block (it divides by num_streams, the group size — #169).
+            let jitter_sum: f64 = group.iter().filter_map(|s| s.jitter).sum();
             let jitter = group
                 .iter()
-                .filter_map(|s| s.jitter)
-                .fold(None, |acc, j| Some(acc.map_or(j, |a: f64| a.max(j))));
+                .any(|s| s.jitter.is_some())
+                .then(|| jitter_sum / group.len() as f64);
             (jitter, Some(lost), Some(total))
         } else {
             (None, None, None)
@@ -1346,7 +1350,7 @@ mod tests {
     }
 
     #[test]
-    fn sum_summaries_udp_aggregates_loss_and_max_jitter() {
+    fn sum_summaries_udp_aggregates_loss_and_mean_jitter() {
         let streams = vec![
             StreamSummary {
                 stream_id: 1,
@@ -1379,7 +1383,14 @@ mod tests {
         assert_eq!(s.bytes, 300_000);
         assert_eq!(s.lost, Some(7), "lost datagrams summed");
         assert_eq!(s.total_packets, Some(3000), "total datagrams summed");
-        assert_eq!(s.jitter, Some(0.025), "SUM carries worst-case jitter");
+        // iperf3's END-block SUM jitter is the MEAN across the direction's
+        // streams (iperf_api.c: avg_jitter += sp->jitter per stream, then
+        // avg_jitter /= test->num_streams), not the worst case (#169).
+        assert_eq!(
+            s.jitter,
+            Some((0.010f64 + 0.025) / 2.0),
+            "SUM jitter is the mean across streams"
+        );
     }
 
     #[test]

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -953,10 +953,13 @@ impl Server {
                 let rate = cfg.bandwidth;
                 let pt = cfg.pacing_timer; // #185: pace the UDP batch too
                 let u64bit = cfg.udp_counters_64bit;
+                let bu = cfg.burst;
                 let st = start.clone();
                 let md = max_duration;
                 let task = thread_gate.spawn(move || {
-                    stream::run_udp_sender_blocking(std_sock, c, bs, d, rate, pt, u64bit, st, md)
+                    stream::run_udp_sender_blocking(
+                        std_sock, c, bs, d, rate, pt, bu, u64bit, st, md,
+                    )
                 });
                 streams.push(DataStream {
                     id: stream_id,
@@ -1165,6 +1168,7 @@ impl Server {
                 let s = shared.clone();
                 let c = counters.clone();
                 let d = done.clone();
+                let bu = cfg.burst;
                 let st = start.clone();
                 let md = max_duration;
                 let task = thread_gate.spawn(move || {
@@ -1176,6 +1180,7 @@ impl Server {
                         d,
                         rate,
                         pt,
+                        bu,
                         u64bit,
                         st,
                         md,

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -23,6 +23,8 @@ pub(crate) struct TestConfig {
     pub mss: Option<i32>,
     pub window: Option<i32>,
     pub bandwidth: u64,
+    /// `-b rate/burst` block count from the client (0 = unset) (#160).
+    pub burst: u32,
     pub pacing_timer: u32,
     pub tos: i32,
     pub congestion: Option<String>,
@@ -32,7 +34,7 @@ pub(crate) struct TestConfig {
 impl TestConfig {
     // Crate-internal: takes the wire `TestParams` (now `pub(crate)` per #67),
     // so it cannot be part of the public API.
-    pub(crate) fn from_params(params: &TestParams) -> Self {
+    pub(crate) fn from_params(params: &TestParams) -> std::result::Result<Self, ConfigError> {
         let is_udp = params.udp.unwrap_or(false);
         let protocol = if is_udp {
             TransportProtocol::Udp
@@ -46,11 +48,46 @@ impl TestConfig {
             DEFAULT_TCP_BLKSIZE
         };
 
-        Self {
+        // Bounds-check a negotiated `len` like the client builder (#188):
+        // 0/absent → protocol default (iperf3 clients omit len 0); negative
+        // would wrap `as usize` into a multi-EiB allocation; UDP below
+        // MIN_UDP_BLKSIZE panicked the datagram-header write; oversized is an
+        // allocation DoS. iperf3's server never sees these from real clients
+        // (they validate locally), so rejection only fires for broken or
+        // hostile peers — drop the test rather than run degenerate.
+        let blksize = match params.len {
+            None | Some(0) => default_blksize,
+            Some(l) if l < 0 => {
+                return Err(ConfigError::InvalidValue(
+                    "len",
+                    format!("negative block size: {l}"),
+                ));
+            }
+            Some(l) => {
+                let l = l as usize;
+                if is_udp && !(MIN_UDP_BLKSIZE..=MAX_UDP_BLKSIZE).contains(&l) {
+                    return Err(ConfigError::InvalidValue(
+                        "len",
+                        format!(
+                            "block size invalid (minimum = {MIN_UDP_BLKSIZE} bytes, maximum = {MAX_UDP_BLKSIZE} bytes): {l}"
+                        ),
+                    ));
+                }
+                if !is_udp && l > MAX_BLOCKSIZE {
+                    return Err(ConfigError::InvalidValue(
+                        "len",
+                        format!("block size too large (maximum = {MAX_BLOCKSIZE} bytes): {l}"),
+                    ));
+                }
+                l
+            }
+        };
+
+        Ok(Self {
             protocol,
             duration: params.time.unwrap_or(DEFAULT_DURATION as i32) as u32,
             num_streams: params.parallel.unwrap_or(1) as u32,
-            blksize: params.len.unwrap_or(default_blksize as i32) as usize,
+            blksize,
             reverse: params.reverse.unwrap_or(false),
             bidir: params.bidirectional.unwrap_or(false),
             omit: params.omit.unwrap_or(0) as u32,
@@ -64,6 +101,13 @@ impl TestConfig {
             // 1 Mbit/s throttled an iperf3 -b 0 reverse/bidir sender (#21). The
             // 1 Mbit/s UDP default is a client-side concern, resolved at build.
             bandwidth: params.bandwidth.unwrap_or(0),
+            // Present only when the client set `-b rate/burst`, like iperf3
+            // (it gates on nonzero before sending) (#160).
+            burst: params
+                .burst
+                .filter(|&b| b > 0)
+                .map(|b| b as u32)
+                .unwrap_or(0),
             // The client's --pacing-timer quantum (#32); iperf3 always sends
             // it. Absent/non-positive (older peers) → iperf3's 1000 µs default.
             pacing_timer: params
@@ -74,7 +118,7 @@ impl TestConfig {
             tos: params.tos.unwrap_or(0),
             congestion: params.congestion.clone(),
             udp_counters_64bit: params.udp_counters_64bit.unwrap_or(0) != 0,
-        }
+        })
     }
 }
 
@@ -219,7 +263,12 @@ impl Server {
         // unlimited so the byte-limit checks below don't misread a duration test
         // as byte-limited (#119).
         params.normalize_unlimited();
-        let cfg = TestConfig::from_params(&params);
+        // Malformed negotiated params (e.g. len 0 < l < 16 on UDP, negative,
+        // or oversized) refuse the test outright (#188). No SERVER_ERROR
+        // state: iperf3's client follows that with an errno exchange we don't
+        // speak, and real iperf3 clients never send these values — dropping
+        // the control connection is the safe shape for a hostile peer.
+        let cfg = TestConfig::from_params(&params)?;
         // --get-server-output (#33): when the client asks and this server is
         // in text mode, TEE the console report into the exchange buffer
         // (iperf3's iperf_printf dual-write — the console stays live).
@@ -384,9 +433,11 @@ impl Server {
                         // quantum. #102/#32
                         let rate = cfg.bandwidth;
                         let pt = cfg.pacing_timer;
+                        let bu = cfg.burst;
                         let bb = byte_budget.clone();
                         tokio::spawn(async move {
-                            stream::run_tcp_sender(data_stream, c, buf, d, fp, rate, pt, bb).await
+                            stream::run_tcp_sender(data_stream, c, buf, d, fp, rate, pt, bu, bb)
+                                .await
                         })
                     } else {
                         let c = counters.clone();
@@ -1879,7 +1930,7 @@ mod test_config_tests {
             tcp: Some(true),
             ..Default::default()
         };
-        let cfg = TestConfig::from_params(&p);
+        let cfg = TestConfig::from_params(&p).unwrap();
         assert_eq!(cfg.protocol, TransportProtocol::Tcp);
         assert_eq!(cfg.duration, 10);
         assert_eq!(cfg.num_streams, 1);
@@ -1894,7 +1945,7 @@ mod test_config_tests {
             udp: Some(true),
             ..Default::default()
         };
-        let cfg = TestConfig::from_params(&p);
+        let cfg = TestConfig::from_params(&p).unwrap();
         assert_eq!(cfg.protocol, TransportProtocol::Udp);
         assert_eq!(cfg.blksize, 1460);
     }
@@ -1918,7 +1969,7 @@ mod test_config_tests {
             udp_counters_64bit: Some(1),
             ..Default::default()
         };
-        let cfg = TestConfig::from_params(&p);
+        let cfg = TestConfig::from_params(&p).unwrap();
         assert_eq!(cfg.duration, 30);
         assert_eq!(cfg.num_streams, 4);
         assert_eq!(cfg.blksize, 65536);
@@ -1943,17 +1994,77 @@ mod test_config_tests {
             pacing_timer: Some(250),
             ..Default::default()
         };
-        assert_eq!(TestConfig::from_params(&p).pacing_timer, 250);
+        assert_eq!(TestConfig::from_params(&p).unwrap().pacing_timer, 250);
         let p = TestParams::default();
-        assert_eq!(TestConfig::from_params(&p).pacing_timer, 1000);
+        assert_eq!(TestConfig::from_params(&p).unwrap().pacing_timer, 1000);
         let p = TestParams {
             pacing_timer: Some(0),
             ..Default::default()
         };
-        assert_eq!(TestConfig::from_params(&p).pacing_timer, 1000);
+        assert_eq!(TestConfig::from_params(&p).unwrap().pacing_timer, 1000);
     }
 
     // -- server mirrors the client's rate resolution (#17) --
+
+    #[test]
+    fn from_params_validates_len_bounds() {
+        // A negotiated `len` is bounds-checked like the client builder (#188):
+        // 0/absent → protocol default; negative would wrap `as usize` into a
+        // multi-EiB buffer; UDP below MIN_UDP_BLKSIZE panicked the header
+        // write; oversized is an allocation DoS. iperf3 clients never send
+        // these (they validate locally and omit len 0), so rejection only
+        // fires for broken/hostile peers.
+        let udp = |len| TestParams {
+            udp: Some(true),
+            len,
+            ..Default::default()
+        };
+        let tcp = |len| TestParams {
+            tcp: Some(true),
+            len,
+            ..Default::default()
+        };
+
+        assert_eq!(
+            TestConfig::from_params(&udp(None)).unwrap().blksize,
+            crate::utils::DEFAULT_UDP_BLKSIZE
+        );
+        assert_eq!(
+            TestConfig::from_params(&udp(Some(0))).unwrap().blksize,
+            crate::utils::DEFAULT_UDP_BLKSIZE
+        );
+        assert_eq!(
+            TestConfig::from_params(&tcp(Some(0))).unwrap().blksize,
+            crate::utils::DEFAULT_TCP_BLKSIZE
+        );
+        assert_eq!(
+            TestConfig::from_params(&udp(Some(1460))).unwrap().blksize,
+            1460
+        );
+
+        assert!(TestConfig::from_params(&udp(Some(-1))).is_err());
+        assert!(TestConfig::from_params(&tcp(Some(-1))).is_err());
+        assert!(TestConfig::from_params(&udp(Some(8))).is_err());
+        assert!(TestConfig::from_params(&udp(Some(70_000))).is_err());
+        assert!(TestConfig::from_params(&tcp(Some(2 * 1024 * 1024))).is_err());
+        assert!(TestConfig::from_params(&tcp(Some(1024 * 1024))).is_ok());
+    }
+
+    #[test]
+    fn from_params_honors_burst() {
+        // `-b rate/burst` arrives on the wire only when set (#160).
+        let p = TestParams {
+            tcp: Some(true),
+            burst: Some(10),
+            ..Default::default()
+        };
+        assert_eq!(TestConfig::from_params(&p).unwrap().burst, 10);
+        let p = TestParams {
+            tcp: Some(true),
+            ..Default::default()
+        };
+        assert_eq!(TestConfig::from_params(&p).unwrap().burst, 0);
+    }
 
     #[test]
     fn udp_absent_bandwidth_is_unlimited() {
@@ -1966,7 +2077,7 @@ mod test_config_tests {
             udp: Some(true),
             ..Default::default()
         };
-        let cfg = TestConfig::from_params(&p);
+        let cfg = TestConfig::from_params(&p).unwrap();
         assert_eq!(cfg.bandwidth, 0);
     }
 
@@ -1979,7 +2090,7 @@ mod test_config_tests {
             bandwidth: Some(0),
             ..Default::default()
         };
-        let cfg = TestConfig::from_params(&p);
+        let cfg = TestConfig::from_params(&p).unwrap();
         assert_eq!(cfg.bandwidth, 0);
     }
 
@@ -1989,7 +2100,7 @@ mod test_config_tests {
             tcp: Some(true),
             ..Default::default()
         };
-        let cfg = TestConfig::from_params(&p);
+        let cfg = TestConfig::from_params(&p).unwrap();
         assert_eq!(cfg.bandwidth, 0);
     }
 }

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -48,6 +48,23 @@ impl TestConfig {
             DEFAULT_TCP_BLKSIZE
         };
 
+        // Bound a negotiated `burst` like the client parse (IEBURST,
+        // 1..=MAX_BURST): no real iperf3 client can send more (its own parse
+        // enforces the cap), and an unbounded value drives the sender's
+        // per-batch loop and green-light debt for hours — the same
+        // hostile-peer posture as `len` below (#160 review r2). Absent or
+        // non-positive (iperf3 gates on nonzero before sending) = unset.
+        let burst = match params.burst {
+            Some(b) if b > MAX_BURST as i32 => {
+                return Err(ConfigError::InvalidValue(
+                    "burst count",
+                    format!("invalid burst count (maximum = {MAX_BURST}): {b}"),
+                ));
+            }
+            Some(b) if b > 0 => b as u32,
+            _ => 0,
+        };
+
         // Bounds-check a negotiated `len` like the client builder (#188):
         // 0/absent → protocol default (iperf3 clients omit len 0); negative
         // would wrap `as usize` into a multi-EiB allocation; UDP below
@@ -101,13 +118,7 @@ impl TestConfig {
             // 1 Mbit/s throttled an iperf3 -b 0 reverse/bidir sender (#21). The
             // 1 Mbit/s UDP default is a client-side concern, resolved at build.
             bandwidth: params.bandwidth.unwrap_or(0),
-            // Present only when the client set `-b rate/burst`, like iperf3
-            // (it gates on nonzero before sending) (#160).
-            burst: params
-                .burst
-                .filter(|&b| b > 0)
-                .map(|b| b as u32)
-                .unwrap_or(0),
+            burst,
             // The client's --pacing-timer quantum (#32); iperf3 always sends
             // it. Absent/non-positive (older peers) → iperf3's 1000 µs default.
             pacing_timer: params
@@ -2066,6 +2077,20 @@ mod test_config_tests {
         assert_eq!(TestConfig::from_params(&p).unwrap().burst, 10);
         let p = TestParams {
             tcp: Some(true),
+            ..Default::default()
+        };
+        assert_eq!(TestConfig::from_params(&p).unwrap().burst, 0);
+        // Hostile/broken peers: above MAX_BURST is rejected (no real iperf3
+        // client can produce it), non-positive is unset (#160 review r2).
+        let p = TestParams {
+            tcp: Some(true),
+            burst: Some(1001),
+            ..Default::default()
+        };
+        assert!(TestConfig::from_params(&p).is_err());
+        let p = TestParams {
+            tcp: Some(true),
+            burst: Some(-5),
             ..Default::default()
         };
         assert_eq!(TestConfig::from_params(&p).unwrap().burst, 0);

--- a/riperf3/src/stream.rs
+++ b/riperf3/src/stream.rs
@@ -1171,6 +1171,7 @@ pub fn run_udp_sender_sendmmsg(
     done: Arc<AtomicBool>,
     rate_bits_per_sec: u64,
     pacing_timer_us: u32,
+    burst: u32,
     use_64bit: bool,
     start: Arc<AtomicBool>,
     max_duration: Option<Duration>,
@@ -1197,7 +1198,7 @@ pub fn run_udp_sender_sendmmsg(
     // doesn't stage one huge burst then sleep past a short test (#185); an
     // unlimited run (rate 0, -b 0) keeps the full 128.
     let batch_size: usize =
-        udp_pacing_batch(rate_bits_per_sec, blksize, pacing_timer_us, 128) as usize;
+        udp_pacing_batch(rate_bits_per_sec, blksize, pacing_timer_us, 128, burst) as usize;
 
     // Switch to blocking I/O — tokio's into_std() leaves the socket
     // non-blocking, which makes sendmmsg busy-spin on EAGAIN once SO_SNDBUF
@@ -1307,6 +1308,7 @@ pub fn run_udp_sender_sendmmsg(
     done: Arc<AtomicBool>,
     rate_bits_per_sec: u64,
     pacing_timer_us: u32,
+    burst: u32,
     use_64bit: bool,
     start: Arc<AtomicBool>,
     max_duration: Option<Duration>,
@@ -1318,6 +1320,7 @@ pub fn run_udp_sender_sendmmsg(
         done,
         rate_bits_per_sec,
         pacing_timer_us,
+        burst,
         use_64bit,
         start,
         max_duration,
@@ -1345,7 +1348,17 @@ fn udp_pacing_batch(
     blksize: usize,
     pacing_timer_us: u32,
     max_batch: u32,
+    burst: u32,
 ) -> u32 {
+    // `-b rate/burst` (#160): iperf3's multisend loop sends exactly `burst`
+    // blocks per throttle check, taking precedence over every other batch
+    // heuristic (iperf_send_mt: `if (burst) multisend = burst`). The absolute
+    // schedule below then spaces batches at burst-sized intervals — the same
+    // long-run shape as iperf3's burst-then-recheck. Not clamped to
+    // max_batch: iperf3 honors up to MAX_BURST (1000, enforced at parse).
+    if burst > 0 {
+        return burst;
+    }
     if rate_bits_per_sec == 0 {
         return max_batch;
     }
@@ -1379,6 +1392,7 @@ fn udp_send_loop(
     done: Arc<AtomicBool>,
     rate_bits_per_sec: u64,
     pacing_timer_us: u32,
+    burst: u32,
     use_64bit: bool,
     start: Arc<AtomicBool>,
     max_duration: Option<Duration>,
@@ -1397,7 +1411,7 @@ fn udp_send_loop(
     // atomic counters, but bounded so one batch is about a pacing quantum of
     // send budget, not a fixed count that becomes seconds at a low rate (#185).
     // 32 is the high-rate ceiling (the old fixed value).
-    let batch_size: u32 = udp_pacing_batch(rate_bits_per_sec, blksize, pacing_timer_us, 32);
+    let batch_size: u32 = udp_pacing_batch(rate_bits_per_sec, blksize, pacing_timer_us, 32, burst);
 
     // Blocking I/O so send() backpressures in-kernel instead of returning
     // WouldBlock and truncating the batch once SO_SNDBUF fills (issue #6).
@@ -1490,6 +1504,7 @@ pub fn run_udp_sender_blocking(
     done: Arc<AtomicBool>,
     rate_bits_per_sec: u64,
     pacing_timer_us: u32,
+    burst: u32,
     use_64bit: bool,
     start: Arc<AtomicBool>,
     max_duration: Option<Duration>,
@@ -1502,6 +1517,7 @@ pub fn run_udp_sender_blocking(
         done,
         rate_bits_per_sec,
         pacing_timer_us,
+        burst,
         use_64bit,
         start,
         max_duration,
@@ -1522,6 +1538,7 @@ pub(crate) fn run_udp_server_demux_sender(
     done: Arc<AtomicBool>,
     rate_bits_per_sec: u64,
     pacing_timer_us: u32,
+    burst: u32,
     use_64bit: bool,
     start: Arc<AtomicBool>,
     max_duration: Option<Duration>,
@@ -1534,6 +1551,7 @@ pub(crate) fn run_udp_server_demux_sender(
         done,
         rate_bits_per_sec,
         pacing_timer_us,
+        burst,
         use_64bit,
         start,
         max_duration,
@@ -1787,25 +1805,33 @@ mod tests {
         // Default 1 Mbit/s over a loopback-MSS datagram: one packet already
         // exceeds a 1 ms quantum's budget, so the batch floors at 1 (the bug
         // was a fixed 32 → an ~8 s batch interval).
-        assert_eq!(udp_pacing_batch(1_000_000, 32_741, 1000, 32), 1);
+        assert_eq!(udp_pacing_batch(1_000_000, 32_741, 1000, 32, 0), 1);
         // A high rate over a small datagram saturates at the ceiling.
-        assert_eq!(udp_pacing_batch(10_000_000_000, 1448, 1000, 32), 32);
-        assert_eq!(udp_pacing_batch(10_000_000_000, 1448, 1000, 128), 128);
+        assert_eq!(udp_pacing_batch(10_000_000_000, 1448, 1000, 32, 0), 32);
+        assert_eq!(udp_pacing_batch(10_000_000_000, 1448, 1000, 128, 0), 128);
         // Unlimited (-b 0) is unpaced and keeps the full ceiling.
-        assert_eq!(udp_pacing_batch(0, 32_741, 1000, 32), 32);
+        assert_eq!(udp_pacing_batch(0, 32_741, 1000, 32, 0), 32);
         // A larger --pacing-timer admits a larger batch at the same rate.
-        let small_q = udp_pacing_batch(100_000_000, 1448, 1000, 64);
-        let big_q = udp_pacing_batch(100_000_000, 1448, 10_000, 64);
+        let small_q = udp_pacing_batch(100_000_000, 1448, 1000, 64, 0);
+        let big_q = udp_pacing_batch(100_000_000, 1448, 10_000, 64, 0);
         assert!(big_q > small_q, "{big_q} should exceed {small_q}");
         // pacing_timer 0 resolves to iperf3's 1 ms default, not a div-by-zero.
         assert_eq!(
-            udp_pacing_batch(100_000_000, 1448, 0, 64),
-            udp_pacing_batch(100_000_000, 1448, 1000, 64),
+            udp_pacing_batch(100_000_000, 1448, 0, 64, 0),
+            udp_pacing_batch(100_000_000, 1448, 1000, 64, 0),
         );
         // A degenerate blksize cannot divide by zero — it yields a valid
         // clamped batch (here the max, since 1-byte packets are tiny), not a
         // panic or a garbage value.
-        assert_eq!(udp_pacing_batch(1_000_000, 0, 1000, 32), 32);
+        assert_eq!(udp_pacing_batch(1_000_000, 0, 1000, 32, 0), 32);
+
+        // `-b rate/burst` (#160): an explicit burst IS the batch — iperf3's
+        // multisend sends exactly `burst` blocks per green light, overriding
+        // the quantum heuristic and the max_batch ceiling (its own cap is
+        // MAX_BURST=1000, enforced at parse).
+        assert_eq!(udp_pacing_batch(100_000_000, 1448, 1000, 32, 5), 5);
+        assert_eq!(udp_pacing_batch(100_000_000, 1448, 1000, 128, 1000), 1000);
+        assert_eq!(udp_pacing_batch(0, 1448, 1000, 32, 50), 50);
     }
 
     // #178 readiness barrier: wait() is trivially true with nothing spawned,
@@ -2485,6 +2511,7 @@ mod tests {
             done.clone(),
             0,
             1000,
+            0,
             false,
             started(),
             Some(Duration::from_millis(200)),
@@ -2524,6 +2551,7 @@ mod tests {
             done.clone(),
             100_000_000, // 100 Mbps → rate>0 → batched + paced
             1000,
+            0,
             false,
             started(),
             Some(Duration::from_millis(200)),
@@ -2554,6 +2582,7 @@ mod tests {
             done.clone(),
             0,
             1000,
+            0,
             false,
             started(),
             Some(Duration::from_millis(200)),
@@ -2583,8 +2612,19 @@ mod tests {
         });
 
         let t0 = Instant::now();
-        run_udp_sender_blocking(send, counters, 1400, done, 0, 1000, false, started(), None)
-            .unwrap();
+        run_udp_sender_blocking(
+            send,
+            counters,
+            1400,
+            done,
+            0,
+            1000,
+            0,
+            false,
+            started(),
+            None,
+        )
+        .unwrap();
         assert!(
             t0.elapsed() < Duration::from_secs(2),
             "should stop shortly after done is set"
@@ -2611,6 +2651,7 @@ mod tests {
                 d2,
                 0,
                 1000,
+                0,
                 false,
                 s2,
                 Some(Duration::from_secs(10)),
@@ -2652,6 +2693,7 @@ mod tests {
             done,
             0,
             1000,
+            0,
             false,
             start,
             Some(Duration::from_secs(10)),
@@ -2682,6 +2724,7 @@ mod tests {
                 d,
                 0,
                 1000,
+                0,
                 false,
                 s,
                 Some(Duration::from_secs(10)),

--- a/riperf3/src/stream.rs
+++ b/riperf3/src/stream.rs
@@ -391,11 +391,16 @@ impl RateLimiter {
             if done.load(Ordering::Relaxed) {
                 return;
             }
-            // Sleep toward the green-light instant in bounded slices, but
-            // never less than the pacing quantum — the documented
-            // --pacing-timer semantics (iperf3 <= 3.17's minimum wakeup was
-            // one tick; 3.18+ deprecated the quantum). The cumulative math
-            // absorbs any oversleep.
+            // Sleep toward the green-light instant in bounded slices, no
+            // shorter than the pacing quantum (the documented --pacing-timer
+            // wakeup; iperf3 3.18+ deprecated it) but capped at the 100 ms
+            // interruptibility slice — a quantum above the slice only adds
+            // internal wakeups; the loop re-checks `behind` and still sends
+            // no earlier than the green light. The cap is also load-bearing:
+            // from_params accepts any positive wire pacing_timer, and an
+            // uncapped hostile quantum would recreate the uninterruptible
+            // sleep this fixes (#160 r2/r3). The cumulative math absorbs any
+            // oversleep.
             let to_green = Duration::from_secs_f64(behind / self.rate_bytes_per_sec);
             tokio::time::sleep(to_green.max(self.pacing).min(SLICE)).await;
         }
@@ -2457,7 +2462,7 @@ mod tests {
         );
     }
 
-    // -- TCP send/recv integration --    // -- TCP send/recv integration --
+    // -- TCP send/recv integration --
 
     #[tokio::test]
     async fn tcp_send_recv_counts_bytes() {

--- a/riperf3/src/stream.rs
+++ b/riperf3/src/stream.rs
@@ -370,7 +370,13 @@ impl RateLimiter {
     /// 2..=burst of a batch skip the check entirely — iperf3's multisend
     /// loop sends the whole burst per green light and only then re-checks
     /// the throttle (#160).
-    pub async fn acquire(&mut self, bytes: u64) {
+    ///
+    /// The green-light wait is interruptible by `done`: a burst-sized debt
+    /// can exceed the remaining test, and cleanup joins the sender (#160
+    /// review r2). On interruption the bytes are NOT accounted — the caller
+    /// re-checks `done` after acquire and breaks without sending.
+    pub async fn acquire(&mut self, bytes: u64, done: &AtomicBool) {
+        const SLICE: Duration = Duration::from_millis(100);
         if self.in_burst > 0 {
             self.in_burst -= 1;
             self.sent += bytes;
@@ -382,12 +388,16 @@ impl RateLimiter {
             if behind <= 0.0 {
                 break;
             }
-            // Sleep to the green-light instant, but never less than the pacing
-            // quantum — the documented --pacing-timer semantics (iperf3
-            // <= 3.17's minimum wakeup was one tick; 3.18+ deprecated the
-            // quantum). The cumulative math absorbs any oversleep.
+            if done.load(Ordering::Relaxed) {
+                return;
+            }
+            // Sleep toward the green-light instant in bounded slices, but
+            // never less than the pacing quantum — the documented
+            // --pacing-timer semantics (iperf3 <= 3.17's minimum wakeup was
+            // one tick; 3.18+ deprecated the quantum). The cumulative math
+            // absorbs any oversleep.
             let to_green = Duration::from_secs_f64(behind / self.rate_bytes_per_sec);
-            tokio::time::sleep(to_green.max(self.pacing)).await;
+            tokio::time::sleep(to_green.max(self.pacing).min(SLICE)).await;
         }
         self.sent += bytes;
         self.in_burst = self.burst.saturating_sub(1);
@@ -562,8 +572,8 @@ pub async fn run_tcp_sender(
         }
 
         if let Some(rl) = limiter.as_mut() {
-            rl.acquire(buf.len() as u64).await;
-            // The green-light sleep can outlast the test at very low -b:
+            rl.acquire(buf.len() as u64, &done).await;
+            // The green-light wait can end early because the test is over:
             // re-check `done` after waking instead of writing one more block
             // past the end, like modern iperf3's send worker (#160).
             if done.load(Ordering::Relaxed) {
@@ -960,7 +970,11 @@ pub async fn run_udp_sender(
 
     while !done.load(Ordering::Relaxed) {
         if let Some(ref mut limiter) = rate_limiter {
-            limiter.acquire(blksize as u64).await;
+            limiter.acquire(blksize as u64, &done).await;
+            // Test may have ended during the green-light wait (#160 r2).
+            if done.load(Ordering::Relaxed) {
+                break;
+            }
         }
 
         seq += 1;
@@ -1280,18 +1294,12 @@ pub fn run_udp_sender_sendmmsg(
             }
         }
 
-        // Rate pacing: one clock check per batch
+        // Rate pacing: one clock check per batch, interruptible by `done`
+        // and the `-t` deadline (#160 review r2).
         if let Some(batch_interval) = pacing {
             next_send += batch_interval;
-            let now = Instant::now();
-            if next_send > now {
-                let remaining = next_send - now;
-                if remaining > Duration::from_micros(50) {
-                    std::thread::sleep(remaining - Duration::from_micros(20));
-                }
-                while Instant::now() < next_send {
-                    std::hint::spin_loop();
-                }
+            if !pace_until(next_send, &done, deadline) {
+                break;
             }
         }
     }
@@ -1325,6 +1333,38 @@ pub fn run_udp_sender_sendmmsg(
         start,
         max_duration,
     )
+}
+
+/// Sleep until `next_send` in bounded slices, re-checking `done` and the
+/// `-t` deadline each slice. A burst-sized green-light debt
+/// (`burst x blksize x 8 / rate`) can exceed the remaining test (#160 review
+/// r2: measured 11.7 s wall vs iperf3's 3.0 s on `-u -b 1M/1000 -t 3`):
+/// iperf3 sleeps the same debt but escapes it via pthread_cancel at test
+/// end, which Rust threads don't have — so the sleep itself must be
+/// interruptible, or test cleanup joins a sleeping sender for the residue.
+/// Returns false when interrupted (the caller breaks out of its send loop);
+/// keeps the original 20 µs sleep margin + spin to the line for pacing
+/// precision on the final stretch.
+fn pace_until(next_send: Instant, done: &AtomicBool, deadline: Option<Instant>) -> bool {
+    const SLICE: Duration = Duration::from_millis(100);
+    const SPIN_GUARD: Duration = Duration::from_micros(50);
+    loop {
+        let now = Instant::now();
+        if now >= next_send {
+            return true;
+        }
+        if done.load(Ordering::Relaxed) || deadline.is_some_and(|d| now >= d) {
+            return false;
+        }
+        let remaining = next_send - now;
+        if remaining <= SPIN_GUARD {
+            while Instant::now() < next_send {
+                std::hint::spin_loop();
+            }
+            return true;
+        }
+        std::thread::sleep((remaining - Duration::from_micros(20)).min(SLICE));
+    }
 }
 
 /// Datagrams to send between pacing clock-checks (#185). The old fixed batch
@@ -1473,21 +1513,15 @@ fn udp_send_loop(
 
         counters.record_sent(batch_bytes);
 
-        // Rate pacing: one clock check per batch
+        // Rate pacing: one clock check per batch, interruptible by `done`
+        // and the `-t` deadline (#160 review r2). If behind schedule,
+        // next_send stays in the past — sends immediately until caught up
+        // (no accumulating debt).
         if let Some(batch_interval) = pacing {
             next_send += batch_interval;
-            let now = Instant::now();
-            if next_send > now {
-                let remaining = next_send - now;
-                if remaining > Duration::from_micros(50) {
-                    std::thread::sleep(remaining - Duration::from_micros(20));
-                }
-                while Instant::now() < next_send {
-                    std::hint::spin_loop();
-                }
+            if !pace_until(next_send, &done, deadline) {
+                break;
             }
-            // If behind schedule, next_send stays in the past — sends
-            // immediately until caught up (no accumulating debt)
         }
     }
     Ok(())
@@ -2218,6 +2252,11 @@ mod tests {
     // floor (max(rate*0.1, 4*blksize) = 512 KiB, granted instantly) overshoots
     // a low -b by ~2x at 1 Mbit/s. iperf3's cumulative-average throttle bounds
     // total sent to elapsed*rate + one in-flight block at any rate/blksize.
+    /// A `done` flag that never fires, for limiter tests.
+    fn never_done() -> AtomicBool {
+        AtomicBool::new(false)
+    }
+
     #[tokio::test]
     async fn rate_limiter_total_accuracy_low_rate_large_blocks() {
         let rate_bits: u64 = 1_000_000; // 1 Mbit/s
@@ -2226,7 +2265,7 @@ mod tests {
         let start = Instant::now();
         let mut sent: u64 = 0;
         while start.elapsed() < Duration::from_millis(1000) {
-            limiter.acquire(blk).await;
+            limiter.acquire(blk, &never_done()).await;
             sent += blk;
         }
         let budget = (rate_bits as f64 / 8.0) * start.elapsed().as_secs_f64();
@@ -2244,7 +2283,7 @@ mod tests {
         let mut limiter = RateLimiter::new(1_000_000, 0, 0); // 1 Mbit/s
         let start = Instant::now();
         // Cumulative average: nothing sent yet → always green-lit.
-        limiter.acquire(1000).await;
+        limiter.acquire(1000, &never_done()).await;
         assert!(start.elapsed() < Duration::from_millis(10));
     }
 
@@ -2254,9 +2293,9 @@ mod tests {
         // the average is 1000 bytes ahead of schedule, so block 2 waits ~100ms
         // — there is no up-front burst grant (#116).
         let mut limiter = RateLimiter::new(80_000, 0, 0);
-        limiter.acquire(1000).await; // instant
+        limiter.acquire(1000, &never_done()).await; // instant
         let start = Instant::now();
-        limiter.acquire(1000).await; // must wait ~100ms
+        limiter.acquire(1000, &never_done()).await; // must wait ~100ms
         let elapsed = start.elapsed();
         assert!(elapsed >= Duration::from_millis(50)); // generous lower bound
         assert!(elapsed < Duration::from_millis(300)); // generous upper bound
@@ -2274,7 +2313,7 @@ mod tests {
         let start = Instant::now();
         let mut total_bytes: u64 = 0;
         while start.elapsed() < Duration::from_millis(100) {
-            limiter.acquire(blksize).await;
+            limiter.acquire(blksize, &never_done()).await;
             total_bytes += blksize;
         }
 
@@ -2295,7 +2334,7 @@ mod tests {
 
         // 10 × 1000-byte blocks at 125 KB/s ≈ 72ms of pacing after block 1.
         for _ in 0..10 {
-            limiter.acquire(1000).await;
+            limiter.acquire(1000, &never_done()).await;
             total_bytes += 1000;
         }
 
@@ -2314,7 +2353,7 @@ mod tests {
         let mut limiter = RateLimiter::new(8_000, 0, 4);
         let t0 = tokio::time::Instant::now();
         for _ in 0..4 {
-            limiter.acquire(1000).await;
+            limiter.acquire(1000, &never_done()).await;
         }
         assert_eq!(
             t0.elapsed(),
@@ -2323,7 +2362,7 @@ mod tests {
         );
         // Block 5 is the next batch head: 4000 B sent against a 1000 B/s
         // schedule → it must wait to the green-light instant (~4 s).
-        limiter.acquire(1000).await;
+        limiter.acquire(1000, &never_done()).await;
         assert!(
             t0.elapsed() >= Duration::from_secs(4),
             "next batch head waits to green light, got {:?}",
@@ -2358,6 +2397,7 @@ mod tests {
         let (peer, _) = listener.accept().await.unwrap();
 
         // Flip `done` mid-sleep (5 s < the ~10 s green-light instant).
+        let t0 = tokio::time::Instant::now();
         tokio::time::sleep(Duration::from_secs(5)).await;
         done.store(true, Ordering::Relaxed);
 
@@ -2368,9 +2408,56 @@ mod tests {
             blksize,
             "sender wrote a block after `done` despite the post-sleep re-check"
         );
+        // The wait itself must be interruptible (#160 review r2): the sender
+        // exits shortly after `done` (~5 s + one 100 ms slice), not at the
+        // 10 s green-light instant — cleanup joins this task.
+        assert!(
+            t0.elapsed() < Duration::from_secs(6),
+            "sender slept out the full green-light debt past done: {:?}",
+            t0.elapsed()
+        );
     }
 
-    // -- TCP send/recv integration --
+    #[test]
+    fn udp_blocking_sender_pacing_interruptible_by_done() {
+        // #160 review r2: a burst-sized batch debt (here 1000 x 100 B at
+        // 400 kbit/s = 2 s) used to be slept in one uninterruptible chunk;
+        // cleanup joins the sender thread, so the process outlived the test
+        // by the residue (measured 11.7 s vs iperf3's 3.0 s wall). pace_until
+        // re-checks `done` per 100 ms slice.
+        let recv = std::net::UdpSocket::bind("127.0.0.1:0").unwrap();
+        let send = std::net::UdpSocket::bind("127.0.0.1:0").unwrap();
+        send.connect(recv.local_addr().unwrap()).unwrap();
+        let counters = Arc::new(StreamCounters::new());
+        let done = Arc::new(AtomicBool::new(false));
+        let d = done.clone();
+
+        let t0 = Instant::now();
+        let h = std::thread::spawn(move || {
+            run_udp_sender_blocking(
+                send,
+                counters,
+                100,
+                d,
+                400_000,
+                0,
+                1000,
+                false,
+                started(),
+                None,
+            )
+        });
+        std::thread::sleep(Duration::from_millis(300));
+        done.store(true, Ordering::Relaxed);
+        h.join().unwrap().unwrap();
+        assert!(
+            t0.elapsed() < Duration::from_millis(1500),
+            "sender slept out the batch debt past done: {:?}",
+            t0.elapsed()
+        );
+    }
+
+    // -- TCP send/recv integration --    // -- TCP send/recv integration --
 
     #[tokio::test]
     async fn tcp_send_recv_counts_bytes() {

--- a/riperf3/src/stream.rs
+++ b/riperf3/src/stream.rs
@@ -325,6 +325,10 @@ pub struct RateLimiter {
     pacing: Duration,
     start: tokio::time::Instant,
     sent: u64,
+    /// `-b rate/burst` (#160): blocks allowed per green light (0 = per-block).
+    burst: u32,
+    /// Blocks remaining in the current burst window (skip the throttle check).
+    in_burst: u32,
 }
 
 impl RateLimiter {
@@ -343,7 +347,8 @@ impl RateLimiter {
     /// - `rate_bits_per_sec`: target send rate
     /// - `pacing_timer_us`: wakeup quantum when behind (`--pacing-timer`,
     ///   0 → iperf3's 1000 µs default)
-    pub fn new(rate_bits_per_sec: u64, pacing_timer_us: u32) -> Self {
+    /// - `burst`: `-b rate/burst` block count (0 = unset → per-block checks)
+    pub fn new(rate_bits_per_sec: u64, pacing_timer_us: u32, burst: u32) -> Self {
         let pacing_us = if pacing_timer_us == 0 {
             crate::utils::DEFAULT_PACING_TIMER_US
         } else {
@@ -355,12 +360,22 @@ impl RateLimiter {
             // tokio's Instant so the accuracy tests can run under start_paused.
             start: tokio::time::Instant::now(),
             sent: 0,
+            burst,
+            in_burst: 0,
         }
     }
 
     /// Wait until the cumulative average is at or below the target rate, then
-    /// account `bytes` as sent.
+    /// account `bytes` as sent. With a `-b rate/burst` count, blocks
+    /// 2..=burst of a batch skip the check entirely — iperf3's multisend
+    /// loop sends the whole burst per green light and only then re-checks
+    /// the throttle (#160).
     pub async fn acquire(&mut self, bytes: u64) {
+        if self.in_burst > 0 {
+            self.in_burst -= 1;
+            self.sent += bytes;
+            return;
+        }
         loop {
             let allowed = self.start.elapsed().as_secs_f64() * self.rate_bytes_per_sec;
             let behind = self.sent as f64 - allowed;
@@ -375,6 +390,7 @@ impl RateLimiter {
             tokio::time::sleep(to_green.max(self.pacing)).await;
         }
         self.sent += bytes;
+        self.in_burst = self.burst.saturating_sub(1);
     }
 }
 
@@ -490,6 +506,7 @@ pub async fn run_tcp_sender(
     file_path: Option<std::path::PathBuf>,
     rate: u64,
     pacing_timer_us: u32,
+    burst: u32,
     byte_budget: Option<Arc<AtomicI64>>,
 ) -> Result<()> {
     use std::io::Read;
@@ -497,8 +514,9 @@ pub async fn run_tcp_sender(
     // `-b` pacing: iperf3's cumulative-average throttle caps the application
     // send rate, waking on the `--pacing-timer` quantum (#32/#116). 0 =
     // unlimited → no limiter, so the default TCP path is unchanged (#102;
-    // mirrors UDP's `-b 0` per #17).
-    let mut limiter = (rate > 0).then(|| RateLimiter::new(rate, pacing_timer_us));
+    // mirrors UDP's `-b 0` per #17). A `-b rate/burst` count lets `burst`
+    // blocks through per green light (#160).
+    let mut limiter = (rate > 0).then(|| RateLimiter::new(rate, pacing_timer_us, burst));
 
     while !done.load(Ordering::Relaxed) {
         // `-n`/`-k` byte/block limit: claim this block from the shared budget and
@@ -545,6 +563,12 @@ pub async fn run_tcp_sender(
 
         if let Some(rl) = limiter.as_mut() {
             rl.acquire(buf.len() as u64).await;
+            // The green-light sleep can outlast the test at very low -b:
+            // re-check `done` after waking instead of writing one more block
+            // past the end, like modern iperf3's send worker (#160).
+            if done.load(Ordering::Relaxed) {
+                break;
+            }
         }
 
         match stream.write_all(&buf).await {
@@ -2172,7 +2196,7 @@ mod tests {
     async fn rate_limiter_total_accuracy_low_rate_large_blocks() {
         let rate_bits: u64 = 1_000_000; // 1 Mbit/s
         let blk: u64 = 128 * 1024; // TCP default block
-        let mut limiter = RateLimiter::new(rate_bits, 0);
+        let mut limiter = RateLimiter::new(rate_bits, 0, 0);
         let start = Instant::now();
         let mut sent: u64 = 0;
         while start.elapsed() < Duration::from_millis(1000) {
@@ -2191,7 +2215,7 @@ mod tests {
 
     #[tokio::test]
     async fn rate_limiter_first_acquire_is_instant() {
-        let mut limiter = RateLimiter::new(1_000_000, 0); // 1 Mbit/s
+        let mut limiter = RateLimiter::new(1_000_000, 0, 0); // 1 Mbit/s
         let start = Instant::now();
         // Cumulative average: nothing sent yet → always green-lit.
         limiter.acquire(1000).await;
@@ -2203,7 +2227,7 @@ mod tests {
         // 80_000 bits/sec = 10_000 bytes/sec, 1000-byte blocks: after block 1
         // the average is 1000 bytes ahead of schedule, so block 2 waits ~100ms
         // — there is no up-front burst grant (#116).
-        let mut limiter = RateLimiter::new(80_000, 0);
+        let mut limiter = RateLimiter::new(80_000, 0, 0);
         limiter.acquire(1000).await; // instant
         let start = Instant::now();
         limiter.acquire(1000).await; // must wait ~100ms
@@ -2219,7 +2243,7 @@ mod tests {
         // after any oversleep keeps throughput within 50% of target.
         let rate = 10_000_000_000u64; // 10 Gbps
         let blksize = 1460u64;
-        let mut limiter = RateLimiter::new(rate, 0);
+        let mut limiter = RateLimiter::new(rate, 0, 0);
 
         let start = Instant::now();
         let mut total_bytes: u64 = 0;
@@ -2239,7 +2263,7 @@ mod tests {
 
     #[tokio::test]
     async fn rate_limiter_low_rate_still_works() {
-        let mut limiter = RateLimiter::new(1_000_000, 0); // 1 Mbps
+        let mut limiter = RateLimiter::new(1_000_000, 0, 0); // 1 Mbps
         let start = Instant::now();
         let mut total_bytes: u64 = 0;
 
@@ -2253,6 +2277,71 @@ mod tests {
         assert!(total_bytes == 10_000);
         // Should complete in under 1 second (generously)
         assert!(elapsed < Duration::from_secs(1));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn rate_limiter_burst_allows_burst_blocks_per_green_light() {
+        // -b 8K/4 → 1000 bytes/s, bursts of 4 (#160). iperf3's multisend loop
+        // sends `burst` blocks per throttle check: after the batch head is
+        // green-lit, the next 3 blocks pass with NO check even though the
+        // cumulative average is far ahead of schedule.
+        let mut limiter = RateLimiter::new(8_000, 0, 4);
+        let t0 = tokio::time::Instant::now();
+        for _ in 0..4 {
+            limiter.acquire(1000).await;
+        }
+        assert_eq!(
+            t0.elapsed(),
+            Duration::ZERO,
+            "burst window must not sleep: blocks 2..=4 ride block 1's green light"
+        );
+        // Block 5 is the next batch head: 4000 B sent against a 1000 B/s
+        // schedule → it must wait to the green-light instant (~4 s).
+        limiter.acquire(1000).await;
+        assert!(
+            t0.elapsed() >= Duration::from_secs(4),
+            "next batch head waits to green light, got {:?}",
+            t0.elapsed()
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn tcp_sender_rechecks_done_after_pacing_sleep() {
+        // At very low -b the green-light sleep can outlast the test; the
+        // sender must re-check `done` after the throttle wakes instead of
+        // writing one more block past the end (#160; modern iperf3's worker
+        // re-checks before sending).
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+
+        let counters = Arc::new(StreamCounters::new());
+        let done = Arc::new(AtomicBool::new(false));
+        let blksize = 10_000u64;
+
+        let sc = counters.clone();
+        let d = done.clone();
+        let sender = tokio::spawn(async move {
+            let stream = TcpStream::connect(format!("127.0.0.1:{port}"))
+                .await
+                .unwrap();
+            let buf = vec![0u8; blksize as usize];
+            // 8000 bits/s = 1000 bytes/s: block 1 is green-lit immediately,
+            // block 2's acquire sleeps ~10 virtual seconds.
+            run_tcp_sender(stream, sc, buf, d, None, 8_000, 0, 0, None).await
+        });
+        let (peer, _) = listener.accept().await.unwrap();
+
+        // Flip `done` mid-sleep (5 s < the ~10 s green-light instant).
+        tokio::time::sleep(Duration::from_secs(5)).await;
+        done.store(true, Ordering::Relaxed);
+
+        sender.await.unwrap().unwrap();
+        drop(peer);
+        assert_eq!(
+            counters.bytes_sent(),
+            blksize,
+            "sender wrote a block after `done` despite the post-sleep re-check"
+        );
     }
 
     // -- TCP send/recv integration --
@@ -2273,7 +2362,7 @@ mod tests {
                 .await
                 .unwrap();
             let buf = vec![0u8; 1024];
-            run_tcp_sender(stream, sc, buf, d, None, 0, 1000, None).await
+            run_tcp_sender(stream, sc, buf, d, None, 0, 1000, 0, None).await
         });
 
         let rc = recv_counters.clone();

--- a/riperf3/src/utils.rs
+++ b/riperf3/src/utils.rs
@@ -76,14 +76,21 @@ fn parse_int_base0(s: &str) -> std::result::Result<i32, std::num::ParseIntError>
 /// Parse a `-S/--tos` value like iperf3: `strtol(optarg, &endptr, 0)` (decimal,
 /// `0x` hex, or leading-`0` octal) with the IEBADTOS range check (#167).
 pub fn parse_tos(s: &str) -> std::result::Result<i32, ConfigError> {
-    let val =
-        parse_int_base0(s.trim()).map_err(|_| ConfigError::InvalidValue("tos", s.to_string()))?;
-    if !(0..=255).contains(&val) {
-        // iperf3's IEBADTOS wording.
-        return Err(ConfigError::InvalidValue(
+    // Stricter than C strtol on purpose: iperf3 only checks endptr == optarg,
+    // so it ACCEPTS partial parses like `32abc` (→32), `08` (→0), `0x` (→0).
+    // Full-string parsing rejects those; recorded as a deliberate divergence
+    // (#167 review r1 n4).
+    let bad = || {
+        ConfigError::InvalidValue(
             "tos",
+            // iperf3's IEBADTOS wording, for the unparsable and the
+            // out-of-range case alike (iperf3 raises IEBADTOS for both).
             format!("bad TOS value (must be between 0 and 255 inclusive): {s}"),
-        ));
+        )
+    };
+    let val = parse_int_base0(s.trim()).map_err(|_| bad())?;
+    if !(0..=255).contains(&val) {
+        return Err(bad());
     }
     Ok(val)
 }

--- a/riperf3/src/utils.rs
+++ b/riperf3/src/utils.rs
@@ -46,17 +46,7 @@ pub fn parse_dscp(s: &str) -> std::result::Result<i32, ConfigError> {
         "ef" => 46,
         "voice-admit" => 44,
         "le" => 1,
-        _ => {
-            // Numeric: supports decimal, 0x hex, 0 octal
-            let val = if s.starts_with("0x") || s.starts_with("0X") {
-                i32::from_str_radix(&s[2..], 16)
-            } else if s.starts_with('0') && s.len() > 1 {
-                i32::from_str_radix(&s[1..], 8)
-            } else {
-                s.parse::<i32>()
-            };
-            val.map_err(|_| ConfigError::InvalidValue("dscp", s.to_string()))?
-        }
+        _ => parse_int_base0(s).map_err(|_| ConfigError::InvalidValue("dscp", s.to_string()))?,
     };
 
     if !(0..=63).contains(&dscp_val) {
@@ -68,6 +58,34 @@ pub fn parse_dscp(s: &str) -> std::result::Result<i32, ConfigError> {
 
     // DSCP occupies the top 6 bits of the TOS byte
     Ok(dscp_val << 2)
+}
+
+/// Parse an integer with C `strtol(s, _, 0)` base selection: `0x`/`0X` hex,
+/// leading-`0` octal, decimal otherwise. Shared by the `--dscp` and `-S/--tos`
+/// numeric arms (#167).
+fn parse_int_base0(s: &str) -> std::result::Result<i32, std::num::ParseIntError> {
+    if s.starts_with("0x") || s.starts_with("0X") {
+        i32::from_str_radix(&s[2..], 16)
+    } else if s.starts_with('0') && s.len() > 1 {
+        i32::from_str_radix(&s[1..], 8)
+    } else {
+        s.parse::<i32>()
+    }
+}
+
+/// Parse a `-S/--tos` value like iperf3: `strtol(optarg, &endptr, 0)` (decimal,
+/// `0x` hex, or leading-`0` octal) with the IEBADTOS range check (#167).
+pub fn parse_tos(s: &str) -> std::result::Result<i32, ConfigError> {
+    let val =
+        parse_int_base0(s.trim()).map_err(|_| ConfigError::InvalidValue("tos", s.to_string()))?;
+    if !(0..=255).contains(&val) {
+        // iperf3's IEBADTOS wording.
+        return Err(ConfigError::InvalidValue(
+            "tos",
+            format!("bad TOS value (must be between 0 and 255 inclusive): {s}"),
+        ));
+    }
+    Ok(val)
 }
 
 /// Parse a `--cntl-ka` keepalive spec: `idle/interval/count`.
@@ -134,6 +152,12 @@ pub fn system_info() -> String {
 
 /// Maximum UDP payload: 65535 - 8 (UDP header) - 20 (IP header)
 pub const MAX_UDP_BLKSIZE: usize = 65507;
+
+/// iperf3's `MAX_BLOCKSIZE` (1 MiB): the `-l` upper bound for TCP (IEBLOCKSIZE).
+pub const MAX_BLOCKSIZE: usize = 1024 * 1024;
+
+/// iperf3's `MAX_BURST`: the `-b rate/burst` upper bound (IEBURST).
+pub const MAX_BURST: u32 = 1000;
 
 /// Resolve the effective UDP datagram size.
 ///
@@ -228,6 +252,15 @@ pub fn parse_bitrate(s: &str) -> std::result::Result<(u64, u32), ConfigError> {
         let burst: u32 = burst_str
             .parse()
             .map_err(|_| ConfigError::InvalidValue("burst count", burst_str.to_string()))?;
+        // A present burst must be 1..=MAX_BURST, like iperf3's IEBURST check
+        // (`burst <= 0 || burst > MAX_BURST`) — "/0" is an error, distinct
+        // from no slash at all (#160).
+        if burst == 0 || burst > MAX_BURST {
+            return Err(ConfigError::InvalidValue(
+                "burst count",
+                format!("invalid burst count (maximum = {MAX_BURST}): {burst_str}"),
+            ));
+        }
         Ok((rate, burst))
     } else {
         let rate = parse_rate(s)?;
@@ -293,6 +326,41 @@ mod tests {
     #[test]
     fn parse_bitrate_with_burst() {
         assert_eq!(parse_bitrate("100M/10").unwrap(), (100 * 1_000_000, 10));
+    }
+
+    #[test]
+    fn parse_bitrate_burst_range_matches_ieburst() {
+        // iperf3 rejects a present burst outside 1..=MAX_BURST (IEBURST,
+        // iperf_api.c case 'b': burst <= 0 || burst > MAX_BURST). Note a
+        // PRESENT "/0" is an error there, distinct from no slash at all
+        // (burst stays 0 = unset). #160.
+        assert_eq!(parse_bitrate("100M/1").unwrap(), (100 * 1_000_000, 1));
+        assert_eq!(parse_bitrate("100M/1000").unwrap(), (100 * 1_000_000, 1000));
+        assert!(parse_bitrate("100M/0").is_err());
+        assert!(parse_bitrate("100M/1001").is_err());
+        assert!(parse_bitrate("100M/-1").is_err());
+    }
+
+    #[test]
+    fn parse_tos_strtol_base0() {
+        // iperf3 parses -S with strtol(optarg, &endptr, 0): decimal, 0x hex,
+        // leading-0 octal all accepted (#167).
+        assert_eq!(parse_tos("32").unwrap(), 32);
+        assert_eq!(parse_tos("0x20").unwrap(), 0x20);
+        assert_eq!(parse_tos("0X20").unwrap(), 0x20);
+        assert_eq!(parse_tos("020").unwrap(), 16);
+        assert_eq!(parse_tos("0").unwrap(), 0);
+        assert_eq!(parse_tos("255").unwrap(), 255);
+    }
+
+    #[test]
+    fn parse_tos_rejects_out_of_range_and_garbage() {
+        // IEBADTOS: "bad TOS value (must be between 0 and 255 inclusive)".
+        assert!(parse_tos("256").is_err());
+        assert!(parse_tos("-1").is_err());
+        assert!(parse_tos("zzz").is_err());
+        assert!(parse_tos("0x").is_err());
+        assert!(parse_tos("").is_err());
     }
 
     #[test]


### PR DESCRIPTION
## Small faithfulness batch (0.7.3, batch 1 of the campaign)

Four small parity fixes, bundled per the PR #166 precedent. Every behavioral claim was audited against the iperf3 source (`iperf_api.c` @ 8701e52) before implementation.

### #169 — END-block SUM jitter is the mean, not the max
iperf3: `avg_jitter += sp->jitter` per stream of the direction, then `avg_jitter /= test->num_streams` (iperf_api.c:4249, 4490). `sum_summaries` used worst-case; identical at `-P 1`, divergent at `-P ≥ 2` UDP (text `[SUM]` + `-J end.sum.jitter_ms`). Same fix the interval layer got in #166 (#142).

### #167 — `-S/--tos` accepts strtol-base-0 forms
`-S 0x20` / `-S 020` now parse (shared numeric arm with `--dscp`), with iperf3's IEBADTOS 0-255 range check (iperf_api.c:1504-1511) at string parse and at `build()` for the lib setter path. CLI carries the raw string through `ClientBuilder::tos_str` (lib stays clap-free).

### #160 — pacing follow-ups from the #157 review
- **`-b rate/burst` honored**: the limiter green-lights `burst` blocks per throttle check (iperf3's multisend loop, iperf_api.c:2193-2213); the count rides the param exchange (`"burst"`, sent only when nonzero, iperf_api.c:2461) so reverse/bidir servers batch too; present-burst range is 1..=1000 per IEBURST — `/0` is an error, distinct from no slash.
- **`--pacing-timer 1K` works**: iperf3 parses it with `unit_atoi` (1024-based, iperf_api.c:1780); the old plain-u32 clap parser rejected suffixes. The i32::MAX wire cap moved into `pacing_timer_str`.
- **`done` re-checked after the throttle sleep**: at very low `-b` the green-light sleep can outlast the test; the sender wrote one extra block past `done` (red test observed 2 blocks where 1 was correct).

### #188 — block size bounds at config, like iperf3
iperf3's semantics (iperf_api.c:1926-1942) are subtler than the issue stated: `blksize == 0` maps to the **default** (UDP: dynamic-from-MSS), then TCP validates `1..=MAX_BLOCKSIZE` (IEBLOCKSIZE) and UDP `MIN_UDP_BLOCKSIZE..=MAX_UDP_BLOCKSIZE` (IEUDPBLOCKSIZE). Implemented exactly that at `ClientBuilder::build()`, and the same bounds on a **negotiated** `len` in the server's `from_params` — closing the `-l 0` UDP header-write panic, a negative-len `as usize` wrap (multi-EiB alloc), and the oversized-alloc DoS from hostile peers. No SERVER_ERROR state on rejection: iperf3 clients follow that with an errno exchange we don't speak, and real clients never send these values — the server drops the test instead. The #184 `.max(1)` guards stay as defense.

### Wire note
`TestParams` gains an optional `"burst"` field, serialized only when nonzero — exactly iperf3's `if (test->settings->burst) cJSON_AddNumber(...)`, so the param JSON stays byte-compatible for every flag combination that exists today.

### Verification
- TDD: red observed for the limiter burst window, the done re-check, `parse_bitrate` burst range, `from_params` bounds, and the jitter mean; all green after.
- Full workspace suite green; clippy/fmt clean; xcheck green on all 7 targets.
- Smoke compat-matrix drift gate to run post-merge per campaign process.

Fixes #167. Fixes #169. Fixes #188. Closes #160.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
