### PR TITLE
fix: iperf3 error shape for CLI errors; live tcpi_snd_wnd/reord_seen on Linux+FreeBSD (#151, #161)

### DIFF
--- a/riperf3-cli/src/main.rs
+++ b/riperf3-cli/src/main.rs
@@ -7,7 +7,21 @@ use log4rs::encode::pattern::PatternEncoder;
 mod cli;
 use cli::Cli;
 
-fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
+fn main() -> std::process::ExitCode {
+    match run() {
+        Ok(()) => std::process::ExitCode::SUCCESS,
+        Err(e) => {
+            // iperf3's iperf_errexit shape ("iperf3: error - <text>", exit 1)
+            // instead of Rust's Debug rendering; ours carries the actual
+            // binary name. The Display strings already mirror iperf3's IE*
+            // wording where riperf3 implements the same rejections (#151).
+            eprintln!("riperf3: error - {e}");
+            std::process::ExitCode::FAILURE
+        }
+    }
+}
+
+fn run() -> std::result::Result<(), Box<dyn std::error::Error>> {
     let cli = Cli::parse();
 
     configure_log4rs(cli.debug.unwrap_or(0));

--- a/riperf3-cli/tests/common/mod.rs
+++ b/riperf3-cli/tests/common/mod.rs
@@ -112,7 +112,15 @@ pub fn run_client(args: &[&str], timeout: Duration, who: &str) -> ClientRun {
             .unwrap();
 
         if !status.success()
-            && (stderr.contains("ConnectionRefused") || stderr.contains("Connection refused"))
+            && (stderr.contains("ConnectionRefused")
+                || stderr.contains("Connection refused")
+                // Windows WSAECONNREFUSED renders as "No connection could be
+                // made because the target machine actively refused it.
+                // (os error 10061)" — neither other token matches, and this
+                // retry is the ONLY server-readiness mechanism (the doc
+                // above): dropping it reopens the bind-race flake on the
+                // required windows-latest check (review r2).
+                || stderr.contains("(os error 10061)"))
             && Instant::now() < retry_deadline
         {
             // Server not listening yet — give it a beat and go again.

--- a/riperf3-cli/tests/common/mod.rs
+++ b/riperf3-cli/tests/common/mod.rs
@@ -112,7 +112,7 @@ pub fn run_client(args: &[&str], timeout: Duration, who: &str) -> ClientRun {
             .unwrap();
 
         if !status.success()
-            && stderr.contains("ConnectionRefused")
+            && (stderr.contains("ConnectionRefused") || stderr.contains("Connection refused"))
             && Instant::now() < retry_deadline
         {
             // Server not listening yet — give it a beat and go again.

--- a/riperf3-cli/tests/error_format.rs
+++ b/riperf3-cli/tests/error_format.rs
@@ -1,0 +1,31 @@
+//! #151: top-level CLI errors print in iperf3's `error - ...` shape, not
+//! Rust's Debug rendering. Scripts written against iperf3 grep stderr for
+//! `error - ` (iperf3 prints `iperf3: error - <text>`; ours prefixes the
+//! actual binary name).
+
+mod common;
+
+#[test]
+fn connect_failure_prints_iperf3_error_shape_and_exits_1() {
+    // A TcpListener bound then dropped gives a port that refuses connections.
+    let port = common::free_port();
+    let out = std::process::Command::new(env!("CARGO_BIN_EXE_riperf3"))
+        .args(["-c", "127.0.0.1", "-p", &port.to_string(), "-t", "1"])
+        .output()
+        .expect("spawn riperf3");
+
+    assert_eq!(out.status.code(), Some(1), "iperf3 exits 1 on errors");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.starts_with("riperf3: error - "),
+        "stderr must start with the iperf3 error shape, got: {stderr}"
+    );
+    assert!(
+        stderr.contains("unable to connect to server"),
+        "connect failures carry iperf3's IECONNECT wording, got: {stderr}"
+    );
+    assert!(
+        !stderr.contains("Error:"),
+        "Rust Debug rendering must be gone, got: {stderr}"
+    );
+}

--- a/riperf3-cli/tests/error_format.rs
+++ b/riperf3-cli/tests/error_format.rs
@@ -21,8 +21,12 @@ fn connect_failure_prints_iperf3_error_shape_and_exits_1() {
         "stderr must start with the iperf3 error shape, got: {stderr}"
     );
     assert!(
-        stderr.contains("unable to connect to server"),
-        "connect failures carry iperf3's IECONNECT wording, got: {stderr}"
+        stderr.contains(
+            "unable to connect to server - server may have stopped running \
+             or use a different port, firewall issue, etc."
+        ),
+        "connect failures carry iperf3's FULL canonical IECONNECT sentence \
+         (review r1 found a line-join artifact the prefix check missed), got: {stderr}"
     );
     assert!(
         !stderr.contains("Error:"),

--- a/riperf3/src/client.rs
+++ b/riperf3/src/client.rs
@@ -177,17 +177,39 @@ impl Client {
             self.ip_version,
         )
         .await
-        .map_err(|e| match e {
-            // iperf3's IECONNECT wording for a failed control connect; the
-            // io kind is preserved so callers (and the test harness's
-            // refused-retry) can still classify it (#151).
-            RiperfError::Io(io) => RiperfError::Io(std::io::Error::new(
-                io.kind(),
-                format!(
-                    "unable to connect to server - server may have stopped running                      or use a different port, firewall issue, etc.: {io}"
+        .map_err(|e| {
+            // iperf3 raises IECONNECT for ANY netdial failure
+            // (iperf_client_api.c:441) — refused, timed out (netdial sets
+            // ETIMEDOUT), and bind-local failures alike — so wrap every
+            // error from the control connect. The io kind is preserved so
+            // callers (and the test harness's refused-retry) can still
+            // classify it (#151). The `(os error N)` suffix std's io::Error
+            // appends is a deliberate, recorded deviation from iperf3's bare
+            // strerror text: substring matchers survive, and strerror text
+            // varies by platform/locale anyway (review r1 n4).
+            let (kind, detail) = match e {
+                RiperfError::Io(io) => (io.kind(), io.to_string()),
+                // iperf3's suffix is strerror(ETIMEDOUT).
+                RiperfError::ConnectionTimeout => (
+                    std::io::ErrorKind::TimedOut,
+                    "Connection timed out".to_string(),
                 ),
-            )),
-            other => other,
+                // Not dial failures: the family-conflict validation (#15)
+                // keeps its Protocol classification (pinned by the lib
+                // tests). Recorded deviation: a failed `-B` local bind is
+                // also Protocol here, where iperf3's netdial would fold it
+                // into IECONNECT (review r1 n3) — it shares the variant with
+                // the validations, so reclassifying needs a net.rs error
+                // split; ledgered.
+                other => return other,
+            };
+            RiperfError::Io(std::io::Error::new(
+                kind,
+                format!(
+                    "unable to connect to server - server may have stopped running \
+                     or use a different port, firewall issue, etc.: {detail}"
+                ),
+            ))
         })?;
         net::configure_tcp_stream(&ctrl, true)?;
 

--- a/riperf3/src/client.rs
+++ b/riperf3/src/client.rs
@@ -189,18 +189,20 @@ impl Client {
             // varies by platform/locale anyway (review r1 n4).
             let (kind, detail) = match e {
                 RiperfError::Io(io) => (io.kind(), io.to_string()),
-                // iperf3's suffix is strerror(ETIMEDOUT).
+                // iperf3's suffix is strerror(ETIMEDOUT) — glibc's text;
+                // macOS/BSD say "Operation timed out" (recorded, like the
+                // os-error suffix above).
                 RiperfError::ConnectionTimeout => (
                     std::io::ErrorKind::TimedOut,
                     "Connection timed out".to_string(),
                 ),
                 // Not dial failures: the family-conflict validation (#15)
                 // keeps its Protocol classification (pinned by the lib
-                // tests). Recorded deviation: a failed `-B` local bind is
-                // also Protocol here, where iperf3's netdial would fold it
-                // into IECONNECT (review r1 n3) — it shares the variant with
-                // the validations, so reclassifying needs a net.rs error
-                // split; ledgered.
+                // tests). Recorded deviations sharing that variant (a
+                // net.rs error split would be needed to reclassify): a
+                // failed `-B` local bind (review r1 n3) and resolve_host's
+                // "no IPvX address found" (r2 n2) — both fold into
+                // IECONNECT in iperf3's netdial.
                 other => return other,
             };
             RiperfError::Io(std::io::Error::new(

--- a/riperf3/src/client.rs
+++ b/riperf3/src/client.rs
@@ -176,7 +176,19 @@ impl Client {
             self.mptcp,
             self.ip_version,
         )
-        .await?;
+        .await
+        .map_err(|e| match e {
+            // iperf3's IECONNECT wording for a failed control connect; the
+            // io kind is preserved so callers (and the test harness's
+            // refused-retry) can still classify it (#151).
+            RiperfError::Io(io) => RiperfError::Io(std::io::Error::new(
+                io.kind(),
+                format!(
+                    "unable to connect to server - server may have stopped running                      or use a different port, firewall issue, etc.: {io}"
+                ),
+            )),
+            other => other,
+        })?;
         net::configure_tcp_stream(&ctrl, true)?;
 
         // The control connection's MSS sizes UDP datagrams (issue #6) and feeds
@@ -1314,6 +1326,7 @@ impl Client {
                     .find(|e| e.stream_id == s.id && e.has_samples());
                 let tcp_end = ext.map(|e| TcpEndExtras {
                     max_snd_cwnd: e.max_snd_cwnd,
+                    max_snd_wnd: e.max_snd_wnd,
                     max_rtt: e.max_rtt,
                     min_rtt: e.min_rtt,
                     mean_rtt: e.mean_rtt(),

--- a/riperf3/src/json_report.rs
+++ b/riperf3/src/json_report.rs
@@ -273,7 +273,8 @@ pub struct IntervalStream {
     #[serde(serialize_with = "ser_f64")]
     pub bits_per_second: f64,
     // TCP per-interval detail (sender side); omitted where TCP_INFO is
-    // unavailable. `snd_wnd` is absent — see TcpStreamSide.
+    // unavailable. `snd_wnd` carries the live tcpi_snd_wnd where the
+    // platform reader has it (#161).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub retransmits: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1992,8 +1993,8 @@ mod tests {
         assert_eq!(snd["mean_rtt"], 15);
         assert_eq!(snd["reorder"], 0);
 
-        // snd_wnd / max_snd_wnd are emitted as 0 — libc can't read tcpi_snd_wnd,
-        // and iperf3 likewise emits 0 when the field is unavailable.
+        // This fixture feeds snd_wnd / max_snd_wnd as 0 — live runs carry the
+        // platform reader's real value since #161.
         assert_eq!(i0["snd_wnd"], 0);
         assert_eq!(snd["max_snd_wnd"], 0);
     }

--- a/riperf3/src/json_report.rs
+++ b/riperf3/src/json_report.rs
@@ -396,8 +396,8 @@ pub struct TcpStreamSide {
     // Sender-side TCP_INFO fields. iperf3 ALWAYS emits these on the sender
     // sub-object (0 when it couldn't measure them), so riperf3 does too for
     // drop-in schema parity; they're omitted on the receiver sub-object.
-    // `max_snd_wnd` and `reorder` are always 0 on Linux — libc's `tcp_info`
-    // exposes neither `tcpi_snd_wnd` nor `tcpi_reord_seen` — matching what iperf3
+    // `max_snd_wnd` and `reorder` carry the live tcpi_snd_wnd/tcpi_reord_seen
+    // on Linux via the UAPI tcp_info mirror (#161), matching what iperf3
     // emits when those are unavailable.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub max_snd_cwnd: Option<u64>,
@@ -519,6 +519,9 @@ pub struct StreamReport {
 #[non_exhaustive]
 pub struct TcpEndExtras {
     pub max_snd_cwnd: u64,
+    /// Peak peer-advertised send window, where the platform reader captures
+    /// it (Linux UAPI mirror / FreeBSD) — iperf3's stream_max_snd_wnd (#161).
+    pub max_snd_wnd: u64,
     pub max_rtt: u32,
     pub min_rtt: u32,
     pub mean_rtt: u32,
@@ -1029,7 +1032,7 @@ impl ReportInput {
             bits_per_second: bps(bytes, dur),
             retransmits: if emit_extras { retransmits } else { None },
             max_snd_cwnd: emit_extras.then_some(e.max_snd_cwnd),
-            max_snd_wnd: emit_extras.then_some(0), // tcpi_snd_wnd unavailable via libc; 0 like iperf3
+            max_snd_wnd: emit_extras.then_some(e.max_snd_wnd),
             max_rtt: emit_extras.then_some(e.max_rtt),
             min_rtt: emit_extras.then_some(e.min_rtt),
             mean_rtt: emit_extras.then_some(e.mean_rtt),
@@ -1653,13 +1656,14 @@ mod tests {
     #[test]
     fn server_reverse_sender_emits_tcp_info_keys() {
         // On a reverse test the server sends, so its sender block carries the
-        // TCP_INFO extras (real cwnd/rtt, snd_wnd 0 like iperf3).
+        // TCP_INFO extras (real cwnd/rtt/snd_wnd, like iperf3 — #161).
         let mut input = base_input();
         input.is_server = true;
         input.reverse = true;
         input.streams = vec![StreamReport {
             tcp_end: Some(TcpEndExtras {
                 max_snd_cwnd: 65535,
+                max_snd_wnd: 1_500_000,
                 max_rtt: 200,
                 min_rtt: 90,
                 mean_rtt: 120,
@@ -1671,7 +1675,7 @@ mod tests {
         let sender = &v["end"]["streams"][0]["sender"];
         assert_eq!(sender["max_snd_cwnd"], 65535);
         assert_eq!(sender["max_rtt"], 200);
-        assert_eq!(sender["max_snd_wnd"], 0); // libc has no tcpi_snd_wnd
+        assert_eq!(sender["max_snd_wnd"], 1_500_000); // real value forwarded (#161)
         assert!(sender["retransmits"].is_number());
     }
 
@@ -1963,6 +1967,7 @@ mod tests {
         s.retransmits = Some(2);
         s.tcp_end = Some(TcpEndExtras {
             max_snd_cwnd: 64000,
+            max_snd_wnd: 0,
             max_rtt: 17,
             min_rtt: 14,
             mean_rtt: 15,

--- a/riperf3/src/reporter.rs
+++ b/riperf3/src/reporter.rs
@@ -382,6 +382,7 @@ pub struct IntervalReporterConfig {
 #[derive(Clone, Copy)]
 struct TcpSample {
     snd_cwnd: u64,
+    snd_wnd: u64,
     rtt: u32,
     rttvar: u32,
     pmtu: u32,
@@ -394,6 +395,7 @@ struct TcpSample {
 pub struct StreamExtremes {
     pub stream_id: i32,
     pub max_snd_cwnd: u64,
+    pub max_snd_wnd: u64,
     pub max_rtt: u32,
     pub min_rtt: u32,
     pub reorder: u32,
@@ -722,7 +724,7 @@ pub fn spawn_interval_reporter(
                     };
 
                     // TCP_INFO for the interval detail and the end extremes.
-                    let (retransmits, snd_cwnd, rtt, rttvar, pmtu, reorder_iv) =
+                    let (retransmits, snd_cwnd, snd_wnd, rtt, rttvar, pmtu, reorder_iv) =
                         if has_retransmits && stream.is_sender {
                             if let Some(fd) = stream.raw_fd {
                                 if let Some(info) = tcp_info::get_tcp_info(fd) {
@@ -732,6 +734,7 @@ pub fn spawn_interval_reporter(
                                     // Accumulate sender-side extremes for the end report.
                                     let e = &mut acc_extremes[i];
                                     e.max_snd_cwnd = e.max_snd_cwnd.max(info.snd_cwnd);
+                                    e.max_snd_wnd = e.max_snd_wnd.max(info.snd_wnd);
                                     e.reorder = e.reorder.max(info.reorder);
                                     if info.rtt > 0 {
                                         e.max_rtt = e.max_rtt.max(info.rtt);
@@ -742,6 +745,7 @@ pub fn spawn_interval_reporter(
                                     e.total_retransmits = Some(info.total_retransmits);
                                     last_tcp[i] = Some(TcpSample {
                                         snd_cwnd: info.snd_cwnd,
+                                        snd_wnd: info.snd_wnd,
                                         rtt: info.rtt,
                                         rttvar: info.rttvar,
                                         pmtu: info.pmtu,
@@ -750,6 +754,7 @@ pub fn spawn_interval_reporter(
                                     (
                                         Some(delta as i64),
                                         Some(info.snd_cwnd),
+                                        Some(info.snd_wnd),
                                         Some(info.rtt),
                                         Some(info.rttvar),
                                         Some(info.pmtu),
@@ -763,19 +768,20 @@ pub fn spawn_interval_reporter(
                                     (
                                         Some(0),
                                         Some(s.snd_cwnd),
+                                        Some(s.snd_wnd),
                                         Some(s.rtt),
                                         Some(s.rttvar),
                                         Some(s.pmtu),
                                         Some(s.reorder),
                                     )
                                 } else {
-                                    (None, None, None, None, None, None)
+                                    (None, None, None, None, None, None, None)
                                 }
                             } else {
-                                (None, None, None, None, None, None)
+                                (None, None, None, None, None, None, None)
                             }
                         } else {
-                            (None, None, None, None, None, None)
+                            (None, None, None, None, None, None, None)
                         };
 
                     // UDP stats (compute deltas for loss/packets)
@@ -847,9 +853,10 @@ pub fn spawn_interval_reporter(
                             bits_per_second: bps_val,
                             retransmits,
                             snd_cwnd,
-                            // snd_wnd is unavailable via libc (see TcpStreamSide); emit
-                            // 0 alongside the other TCP detail, like iperf3.
-                            snd_wnd: snd_cwnd.map(|_| 0u64),
+                            // The live tcpi_snd_wnd where the platform reader
+                            // captures it (Linux UAPI mirror / FreeBSD), like
+                            // iperf3's get_snd_wnd (#161).
+                            snd_wnd,
                             rtt,
                             rttvar,
                             pmtu,

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -1395,6 +1395,7 @@ impl Server {
                     .find(|e| e.stream_id == s.id && e.has_samples());
                 let tcp_end = ext.map(|e| TcpEndExtras {
                     max_snd_cwnd: e.max_snd_cwnd,
+                    max_snd_wnd: e.max_snd_wnd,
                     max_rtt: e.max_rtt,
                     min_rtt: e.min_rtt,
                     mean_rtt: e.mean_rtt(),

--- a/riperf3/src/tcp_info.rs
+++ b/riperf3/src/tcp_info.rs
@@ -365,7 +365,11 @@ mod tests {
     // HAVE_TCP_INFO_SND_WND probe prefers that header) and emits the REAL
     // peer-advertised window; libc's glibc-shaped tcp_info truncates before
     // the field, so the old reader pinned 0. Right after the handshake the
-    // peer's advertised window on loopback is always nonzero.
+    // peer's advertised window on loopback is always nonzero (a zero window
+    // needs a FULL receive buffer). Test prerequisite: kernel >= 5.4
+    // (tcpi_snd_wnd's introduction; older kernels return a short TCP_INFO
+    // and the gated read correctly yields 0, failing this test) — every CI
+    // runner and the fleet are 5.15+.
     #[cfg(target_os = "linux")]
     #[tokio::test]
     async fn linux_snapshot_reads_real_snd_wnd() {

--- a/riperf3/src/tcp_info.rs
+++ b/riperf3/src/tcp_info.rs
@@ -26,6 +26,93 @@ pub struct TcpInfoSnapshot {
     pub reorder: u32,
 }
 
+/// Linux UAPI `struct tcp_info` (`linux/tcp.h`), hand-rolled through
+/// `tcpi_rcv_wnd` because libc 0.2.x mirrors glibc's `netinet/tcp.h`, which
+/// truncates after `tcpi_total_retrans` — losing `tcpi_reord_seen` and
+/// `tcpi_snd_wnd`, both of which iperf3 reads on Linux (its configure probes
+/// prefer `linux/tcp.h`): `get_reorder` → `tcpi_reord_seen` (4.19+),
+/// `get_snd_wnd` → `tcpi_snd_wnd` (5.4+) (#161). The kernel copies
+/// `min(optlen, sizeof(kernel struct))` and returns the copied length, so a
+/// larger-than-kernel buffer is safe and old kernels simply leave the tail
+/// fields unfilled — gate every tail read on the returned length. Layout
+/// pinned by the offset asserts below (the UAPI struct is append-only).
+#[cfg(target_os = "linux")]
+#[repr(C)]
+#[allow(dead_code)] // kernel ABI mirror — every field is required for layout
+#[derive(Clone, Copy)]
+struct LinuxTcpInfo {
+    tcpi_state: u8,
+    tcpi_ca_state: u8,
+    tcpi_retransmits: u8,
+    tcpi_probes: u8,
+    tcpi_backoff: u8,
+    tcpi_options: u8,
+    /// `tcpi_snd_wscale:4, tcpi_rcv_wscale:4`, packed in one byte.
+    tcpi_wscale_bits: u8,
+    /// `tcpi_delivery_rate_app_limited:1, tcpi_fastopen_client_fail:2` + pad.
+    tcpi_rate_limit_bits: u8,
+    tcpi_rto: u32,
+    tcpi_ato: u32,
+    tcpi_snd_mss: u32,
+    tcpi_rcv_mss: u32,
+    tcpi_unacked: u32,
+    tcpi_sacked: u32,
+    tcpi_lost: u32,
+    tcpi_retrans: u32,
+    tcpi_fackets: u32,
+    tcpi_last_data_sent: u32,
+    tcpi_last_ack_sent: u32,
+    tcpi_last_data_recv: u32,
+    tcpi_last_ack_recv: u32,
+    tcpi_pmtu: u32,
+    tcpi_rcv_ssthresh: u32,
+    tcpi_rtt: u32,
+    tcpi_rttvar: u32,
+    tcpi_snd_ssthresh: u32,
+    tcpi_snd_cwnd: u32,
+    tcpi_advmss: u32,
+    tcpi_reordering: u32,
+    tcpi_rcv_rtt: u32,
+    tcpi_rcv_space: u32,
+    tcpi_total_retrans: u32,
+    tcpi_pacing_rate: u64,
+    tcpi_max_pacing_rate: u64,
+    tcpi_bytes_acked: u64,
+    tcpi_bytes_received: u64,
+    tcpi_segs_out: u32,
+    tcpi_segs_in: u32,
+    tcpi_notsent_bytes: u32,
+    tcpi_min_rtt: u32,
+    tcpi_data_segs_in: u32,
+    tcpi_data_segs_out: u32,
+    tcpi_delivery_rate: u64,
+    tcpi_busy_time: u64,
+    tcpi_rwnd_limited: u64,
+    tcpi_sndbuf_limited: u64,
+    tcpi_delivered: u32,
+    tcpi_delivered_ce: u32,
+    tcpi_bytes_sent: u64,
+    tcpi_bytes_retrans: u64,
+    tcpi_dsack_dups: u32,
+    tcpi_reord_seen: u32,
+    tcpi_rcv_ooopack: u32,
+    tcpi_snd_wnd: u32,
+    tcpi_rcv_wnd: u32,
+}
+
+// Pin the ABI-critical offsets against the kernel header. The shared prefix
+// must also agree with libc's glibc-shaped struct (same kernel layout).
+#[cfg(target_os = "linux")]
+const _: () = {
+    assert!(std::mem::offset_of!(LinuxTcpInfo, tcpi_rto) == 8);
+    assert!(std::mem::offset_of!(LinuxTcpInfo, tcpi_pmtu) == 60);
+    assert!(std::mem::offset_of!(LinuxTcpInfo, tcpi_total_retrans) == 100);
+    assert!(std::mem::offset_of!(LinuxTcpInfo, tcpi_pacing_rate) == 104);
+    assert!(std::mem::offset_of!(LinuxTcpInfo, tcpi_reord_seen) == 220);
+    assert!(std::mem::offset_of!(LinuxTcpInfo, tcpi_snd_wnd) == 228);
+    assert!(std::mem::size_of::<LinuxTcpInfo>() == 240); // 236 rounded to the u64 align
+};
+
 /// Query TCP_INFO for a connected TCP socket.
 ///
 /// Returns `None` if the query fails or the platform does not support TCP_INFO.
@@ -34,11 +121,12 @@ pub fn get_tcp_info(fd: i32) -> Option<TcpInfoSnapshot> {
     use std::mem::{self, MaybeUninit};
 
     // SAFETY: getsockopt(TCP_INFO) is a read-only kernel query on a valid fd.
-    // MaybeUninit is fully initialized by getsockopt on success (ret >= 0).
+    // The kernel fills min(len, its struct size) bytes and writes that length
+    // back; zero-init so tail fields an older kernel doesn't fill read as 0.
     // No nix wrapper exists for TCP_INFO — this is the minimal unsafe surface.
-    let info = unsafe {
-        let mut info = MaybeUninit::<libc::tcp_info>::uninit();
-        let mut len = mem::size_of::<libc::tcp_info>() as libc::socklen_t;
+    let (info, filled) = unsafe {
+        let mut info = MaybeUninit::<LinuxTcpInfo>::zeroed();
+        let mut len = mem::size_of::<LinuxTcpInfo>() as libc::socklen_t;
         let ret = libc::getsockopt(
             fd,
             libc::IPPROTO_TCP,
@@ -49,22 +137,36 @@ pub fn get_tcp_info(fd: i32) -> Option<TcpInfoSnapshot> {
         if ret < 0 {
             return None;
         }
-        info.assume_init()
+        (info.assume_init(), len as usize)
     };
 
+    // Tail fields exist only on newer kernels: tcpi_reord_seen 4.19+,
+    // tcpi_snd_wnd 5.4+. The zeroed init already leaves them 0 on short
+    // copies; the explicit length gates make the contract visible.
+    let field_filled = |offset: usize| filled >= offset + std::mem::size_of::<u32>();
     Some(TcpInfoSnapshot {
         total_retransmits: info.tcpi_total_retrans,
         snd_cwnd: info.tcpi_snd_cwnd as u64 * info.tcpi_snd_mss as u64,
-        snd_wnd: 0, // tcpi_snd_wnd is not exposed by libc's tcp_info on Linux
+        // The REAL peer-advertised send window, like iperf3 (its
+        // HAVE_TCP_INFO_SND_WND probe prefers linux/tcp.h, so Linux builds
+        // emit the live value) (#161).
+        snd_wnd: if field_filled(std::mem::offset_of!(LinuxTcpInfo, tcpi_snd_wnd)) {
+            info.tcpi_snd_wnd as u64
+        } else {
+            0
+        },
         rtt: info.tcpi_rtt,
         rttvar: info.tcpi_rttvar,
         snd_mss: info.tcpi_snd_mss,
         pmtu: info.tcpi_pmtu,
-        // iperf3's `reorder` is `tcpi_reord_seen` (count of reordering events),
-        // NOT `tcpi_reordering` (the kernel's reordering-degree estimate). libc's
-        // `tcp_info` truncates before `tcpi_reord_seen`, so it's unreachable here;
-        // report 0, as iperf3 does when the field is unavailable.
-        reorder: 0,
+        // iperf3's `reorder` is `tcpi_reord_seen` (count of reordering events,
+        // 4.19+), NOT `tcpi_reordering` (the kernel's reordering-degree
+        // estimate) — now reachable through the UAPI mirror (#161).
+        reorder: if field_filled(std::mem::offset_of!(LinuxTcpInfo, tcpi_reord_seen)) {
+            info.tcpi_reord_seen
+        } else {
+            0
+        },
     })
 }
 
@@ -153,7 +255,12 @@ pub fn get_tcp_info(fd: i32) -> Option<TcpInfoSnapshot> {
         // iperf3 uses it raw — multiplying by maxseg here would inflate the
         // Cwnd column ~1500x (#96).
         snd_cwnd: info.tcpi_snd_cwnd as u64,
-        snd_wnd: info.tcpi_snd_wnd as u64,
+        // xnu has the live value, but iperf3's HAVE_TCP_INFO_SND_WND probe
+        // checks struct tcp_info — absent on macOS — so its APPLE snd_wnd
+        // branch is dead and get_snd_wnd returns -1. Emitting the real value
+        // here would diverge from every macOS iperf3 build; the faithful -1
+        // needs the 0.8.0 i64 report fields, so pin 0 until then (#161).
+        snd_wnd: 0,
         rtt: info.tcpi_srtt,
         rttvar: info.tcpi_rttvar,
         snd_mss: info.tcpi_maxseg,
@@ -252,6 +359,31 @@ mod tests {
             let info = get_tcp_info(client_stream.as_raw_fd()).unwrap();
             assert!(info.snd_mss > 0);
         }
+    }
+
+    // #161: on Linux iperf3 reads tcpi_snd_wnd through linux/tcp.h (its
+    // HAVE_TCP_INFO_SND_WND probe prefers that header) and emits the REAL
+    // peer-advertised window; libc's glibc-shaped tcp_info truncates before
+    // the field, so the old reader pinned 0. Right after the handshake the
+    // peer's advertised window on loopback is always nonzero.
+    #[cfg(target_os = "linux")]
+    #[tokio::test]
+    async fn linux_snapshot_reads_real_snd_wnd() {
+        use std::os::unix::io::AsRawFd;
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let client =
+            tokio::spawn(async move { tokio::net::TcpStream::connect(addr).await.unwrap() });
+        let (server_stream, _) = listener.accept().await.unwrap();
+        let _client_stream = client.await.unwrap();
+
+        let info = get_tcp_info(server_stream.as_raw_fd()).unwrap();
+        assert!(
+            info.snd_wnd > 0,
+            "tcpi_snd_wnd must be the real advertised window, got {}",
+            info.snd_wnd
+        );
     }
 
     // #40/#96: only platforms with a real sender retransmit *packet* count


### PR DESCRIPTION
## Small parity batch: top-level error shape + live snd_wnd/reorder

### #151 — CLI errors print in iperf3's `error - ...` shape
`main()` returned `Result<(), Box<dyn Error>>`, so every propagated error rendered in Rust Debug form (`Error: Io(Os { code: 111, ... })`). iperf3 prints `iperf3: error - <human text>` and exits 1 (`iperf_errexit`); scripts grep for that shape. `main` now catches and prints `riperf3: error - {Display}`, exit code 1. The control-connect failure also carries iperf3's IECONNECT wording (`unable to connect to server - server may have stopped running or use a different port, firewall issue, etc.: ...`), with the `io::ErrorKind` preserved (the CLI test harness's refused-retry keys off it).

### #161 — live `tcpi_snd_wnd` / `tcpi_reord_seen` where iperf3 has them
Audited iperf3's per-OS reality first: its `HAVE_TCP_INFO_SND_WND` configure probe prefers `linux/tcp.h`, so **Linux** iperf3 emits the real peer-advertised window in `-J` interval `snd_wnd` and end `max_snd_wnd`; **FreeBSD**'s `tcp_info` has the field too (raw); **macOS** has no `struct tcp_info`, the probe is dead, and `get_snd_wnd` returns `-1` everywhere. Same shape for `get_reorder`: Linux reads `tcpi_reord_seen` (4.19+), everywhere else `-1`.

- **Linux**: libc's glibc-shaped `tcp_info` truncates after `tcpi_total_retrans`, so riperf3 pinned `snd_wnd`/`reorder` to 0. New hand-rolled UAPI `tcp_info` mirror through `tcpi_rcv_wnd` (the #96 macOS-binding tradition): `offset_of!` const asserts pin the ABI (`tcpi_snd_wnd` @ 228, `tcpi_reord_seen` @ 220), zeroed init + returned-length gates keep pre-5.4/pre-4.19 kernels at 0 exactly like a short kernel copy.
- **FreeBSD**: the already-captured `tcpi_snd_wnd` now flows to the report (was `#[allow(dead_code)]`).
- **macOS**: pinned 0 with rationale — emitting the live xnu value would diverge from every macOS iperf3 build (-1); the faithful `-1` needs `i64` report fields, a semver break deferred to 0.8.0 (comment incoming on #161, which stays open for that).
- `StreamExtremes`/`TcpEndExtras` gain `max_snd_wnd` (both `#[non_exhaustive]`, additive — SemVer-clean).

### Verification
- TDD: `error_format` CLI test red (Debug shape) → green; `linux_snapshot_reads_real_snd_wnd` red (always 0) → green.
- Full workspace green, clippy/fmt clean, xcheck green on all 7 targets.
- Smoke compat-matrix drift gate post-merge per campaign process.

Fixes #151. (#161 stays open, scoped down to the 0.8.0 `-1` sentinel item.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
