### PR TITLE
test: shared riperf3-test-support crate; retire fixed bind sleeps (#192, #177)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -800,6 +800,7 @@ dependencies = [
  "log",
  "nix",
  "rand 0.9.2",
+ "riperf3-test-support",
  "rpassword",
  "rsa",
  "serde",
@@ -822,10 +823,15 @@ dependencies = [
  "log4rs",
  "nix",
  "riperf3",
+ "riperf3-test-support",
  "serde_json",
  "thiserror 2.0.3",
  "tokio",
 ]
+
+[[package]]
+name = "riperf3-test-support"
+version = "0.7.2"
 
 [[package]]
 name = "rpassword"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ resolver = "2"
 members = [
     "riperf3",
     "riperf3-cli",
+    "riperf3-test-support",
 ]
 
 [workspace.package]

--- a/riperf3-cli/Cargo.toml
+++ b/riperf3-cli/Cargo.toml
@@ -29,6 +29,7 @@ nix.workspace = true
 
 [dev-dependencies]
 serde_json.workspace = true
+riperf3-test-support = { path = "../riperf3-test-support" }
 
 [[bin]]
 name = "riperf3"

--- a/riperf3-cli/tests/bidir_intervals.rs
+++ b/riperf3-cli/tests/bidir_intervals.rs
@@ -17,14 +17,8 @@ fn free_port() -> u16 {
     common::free_port()
 }
 
-/// Kills the wrapped child on drop so a spawned server is reaped on panic.
-struct ChildGuard(std::process::Child);
-impl Drop for ChildGuard {
-    fn drop(&mut self) {
-        let _ = self.0.kill();
-        let _ = self.0.wait();
-    }
-}
+// Reaper guard shared via riperf3-test-support (#192).
+use common::ChildGuard;
 
 /// Run the client to completion (with refused-retry) and return its stdout.
 fn run_capturing(args: &[&str], timeout: Duration, who: &str) -> String {

--- a/riperf3-cli/tests/byte_limit_summary.rs
+++ b/riperf3-cli/tests/byte_limit_summary.rs
@@ -17,14 +17,8 @@ fn free_port() -> u16 {
     common::free_port()
 }
 
-/// Kills the wrapped child on drop so a spawned server is reaped on panic.
-struct ChildGuard(std::process::Child);
-impl Drop for ChildGuard {
-    fn drop(&mut self) {
-        let _ = self.0.kill();
-        let _ = self.0.wait();
-    }
-}
+// Reaper guard shared via riperf3-test-support (#192).
+use common::ChildGuard;
 
 /// Run the client to completion (with refused-retry) and return its stdout.
 fn run_capturing(args: &[&str], timeout: Duration, who: &str) -> String {

--- a/riperf3-cli/tests/common/mod.rs
+++ b/riperf3-cli/tests/common/mod.rs
@@ -1,143 +1,25 @@
 //! Shared CLI-test helpers (`mod common;` per test binary).
+//!
+//! The implementations live in the dev-only `riperf3-test-support` crate
+//! (#192) — single source for the #176 port allocator and refused-retry
+//! runner, the #191 UDP serialization lock, and the child reaper guard. The
+//! `run_client*` wrappers exist because `CARGO_BIN_EXE_riperf3` is only set
+//! while compiling THIS crate's tests; the support crate takes the path as an
+//! argument.
 
 #![allow(dead_code)] // each test binary uses a subset
 
-use std::io::Read;
-use std::process::{Command, ExitStatus, Stdio};
-use std::sync::atomic::{AtomicU16, Ordering};
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
-/// Allocate a test server port from a window BELOW every CI platform's
-/// ephemeral range (Linux 32768+, macOS/Windows/FreeBSD 49152+). The old
-/// `bind(127.0.0.1:0)` approach handed out *ephemeral* ports — the same pool
-/// every concurrent test's client draws its connect() SOURCE ports from — so
-/// a foreign socket could already own the port when our server tried to bind
-/// (reproduced at 3/10 under the parallel harness, PR #176 review). Windows
-/// are PID-offset so concurrently-running test *binaries* don't share one,
-/// and an atomic counter serializes callers within a binary; a bind-check
-/// skips anything still occupied (e.g. lingering from an earlier test).
-pub fn free_port() -> u16 {
-    use std::net::{Ipv4Addr, Ipv6Addr, TcpListener};
+#[allow(unused_imports)] // each test binary uses a subset
+pub use riperf3_test_support::{free_port, udp_serial, ChildGuard, ClientRun};
 
-    static NEXT: AtomicU16 = AtomicU16::new(0);
-    let window = 7000 + (std::process::id() % 250) as u16 * 100;
-    for _ in 0..100 {
-        let port = window + NEXT.fetch_add(1, Ordering::Relaxed) % 100;
-        // Availability check on both wildcard families: no server is racing
-        // for this port yet (it hasn't been handed out), so briefly binding
-        // it here is collision-free, unlike the rejected readiness probes.
-        // SEQUENTIALLY — a held `::` listener (v6only=0 on Linux) claims the
-        // v4 side too, so a simultaneous v4 check always fails against our
-        // own probe. `.is_ok()` drops each listener before the next bind.
-        if TcpListener::bind((Ipv6Addr::UNSPECIFIED, port)).is_ok()
-            && TcpListener::bind((Ipv4Addr::UNSPECIFIED, port)).is_ok()
-        {
-            return port;
-        }
-    }
-    panic!("no free port in test window {window}-{}", window + 99);
-}
-
-/// One finished client run.
-pub struct ClientRun {
-    pub stdout: String,
-    pub stderr: String,
-    pub status: ExitStatus,
-    /// Wall time of the FINAL attempt only (earlier refused attempts excluded),
-    /// so elapsed-time assertions stay meaningful.
-    pub elapsed: Duration,
-}
-
-/// Run the riperf3 CLI to completion with a hard timeout, retrying while the
-/// run is REFUSED — i.e. exits unsuccessfully with `ConnectionRefused` in
-/// stderr — for up to a bounded retry window. This replaces the old fixed 2 s
-/// server-bind sleep: on loaded CI runners the (debug, cold) server could
-/// take longer to bind, the client died on ECONNREFUSED, and with stderr
-/// nulled the only symptom was `not valid JSON (EOF at line 1 column 0)`
-/// (the udp_bidir flake). Port-probing alternatives were rejected: a
-/// 127.0.0.1 probe never fires on BSD/Windows (specific-over-wildcard binds
-/// are legal there), a wildcard probe can steal the port from the server's
-/// own bind, and a connect-probe consumes a `-s -1` one-off's single accept.
-/// A refused connect never reaches accept(), so retrying the client is safe
-/// for one-off servers and race-free by construction.
+/// See `riperf3_test_support::run_client_with`.
 pub fn run_client(args: &[&str], timeout: Duration, who: &str) -> ClientRun {
-    let bin = env!("CARGO_BIN_EXE_riperf3");
-    let retry_deadline = Instant::now() + Duration::from_secs(10);
-    loop {
-        let started = Instant::now();
-        let mut child = Command::new(bin)
-            .args(args)
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .spawn()
-            .unwrap_or_else(|e| panic!("{who}: spawn failed: {e}"));
-
-        let deadline = Instant::now() + timeout;
-        let status = loop {
-            match child.try_wait().expect("try_wait") {
-                Some(status) => break status,
-                None if Instant::now() >= deadline => {
-                    let _ = child.kill();
-                    let _ = child.wait();
-                    // Post-kill the pipes are EOF — drain what the child got
-                    // out before dying, for the panic message.
-                    let mut out = String::new();
-                    let mut err = String::new();
-                    if let Some(mut s) = child.stdout.take() {
-                        let _ = s.read_to_string(&mut out);
-                    }
-                    if let Some(mut s) = child.stderr.take() {
-                        let _ = s.read_to_string(&mut err);
-                    }
-                    panic!("{who}: timed out; stdout so far: {out}; stderr so far: {err}");
-                }
-                None => std::thread::sleep(Duration::from_millis(50)),
-            }
-        };
-        let elapsed = started.elapsed();
-
-        let mut stdout = String::new();
-        child
-            .stdout
-            .take()
-            .unwrap()
-            .read_to_string(&mut stdout)
-            .unwrap();
-        let mut stderr = String::new();
-        child
-            .stderr
-            .take()
-            .unwrap()
-            .read_to_string(&mut stderr)
-            .unwrap();
-
-        if !status.success()
-            && stderr.contains("ConnectionRefused")
-            && Instant::now() < retry_deadline
-        {
-            // Server not listening yet — give it a beat and go again.
-            std::thread::sleep(Duration::from_millis(100));
-            continue;
-        }
-        return ClientRun {
-            stdout,
-            stderr,
-            status,
-            elapsed,
-        };
-    }
+    riperf3_test_support::run_client_with(env!("CARGO_BIN_EXE_riperf3"), args, timeout, who)
 }
 
-/// `run_client` + assert success: the common case for tests whose client must
-/// finish cleanly. Panics with status and stderr so harness failures are
-/// diagnosable (not the old stderr-nulled JSON-EOF riddle).
+/// See `riperf3_test_support::run_client_ok_with`.
 pub fn run_client_ok(args: &[&str], timeout: Duration, who: &str) -> ClientRun {
-    let run = run_client(args, timeout, who);
-    assert!(
-        run.status.success(),
-        "{who}: exited unsuccessfully ({status}); stderr: {stderr}",
-        status = run.status,
-        stderr = run.stderr,
-    );
-    run
+    riperf3_test_support::run_client_ok_with(env!("CARGO_BIN_EXE_riperf3"), args, timeout, who)
 }

--- a/riperf3-cli/tests/common/mod.rs
+++ b/riperf3-cli/tests/common/mod.rs
@@ -12,7 +12,9 @@
 use std::time::Duration;
 
 #[allow(unused_imports)] // each test binary uses a subset
-pub use riperf3_test_support::{free_port, udp_serial, ChildGuard, ClientRun};
+pub use riperf3_test_support::{
+    free_port, refused, udp_serial, wait_bounded, ChildGuard, ClientRun,
+};
 
 /// See `riperf3_test_support::run_client_with`.
 pub fn run_client(args: &[&str], timeout: Duration, who: &str) -> ClientRun {

--- a/riperf3-cli/tests/daemon.rs
+++ b/riperf3-cli/tests/daemon.rs
@@ -102,32 +102,21 @@ fn daemon_server_serves_a_client() {
         "daemon pid {pid} is not alive after fork"
     );
 
-    // Give the listener a moment to bind before connecting.
-    std::thread::sleep(Duration::from_millis(300));
-
-    // Run a short byte-limited client against the daemon. Spawn it as a child
-    // and bound the wait: before the fix the daemon never serves and the client
-    // hangs, so a plain blocking call would hang the whole test suite.
-    let mut client = Command::new(bin)
-        .args(["-c", "127.0.0.1", "-p", &port_s, "-n", "1M"])
-        .spawn()
-        .expect("failed to spawn client");
-
-    let deadline = Instant::now() + Duration::from_secs(15);
-    let exit = loop {
-        match client.try_wait().expect("try_wait on client") {
-            Some(status) => break Some(status),
-            None if Instant::now() >= deadline => {
-                let _ = client.kill();
-                let _ = client.wait();
-                break None;
-            }
-            None => std::thread::sleep(Duration::from_millis(100)),
-        }
-    };
-
-    let exit = exit.expect("client hung against the daemon — server never served (#81)");
-    assert!(exit.success(), "client failed against the daemon: {exit:?}");
+    // No fixed bind sleep (#177): run_client retries a REFUSED connect for a
+    // bounded window (the #176 pattern), and its hard timeout bounds the
+    // pre-fix #81 hang (daemon forked but never serves) instead of stalling
+    // the suite.
+    let run = common::run_client(
+        &["-c", "127.0.0.1", "-p", &port_s, "-n", "1M"],
+        Duration::from_secs(15),
+        "client vs daemon (a timeout here = the #81 never-serves hang)",
+    );
+    assert!(
+        run.status.success(),
+        "client failed against the daemon: {status}; stderr: {stderr}",
+        status = run.status,
+        stderr = run.stderr,
+    );
 
     // Disarm the reaper only here, on full success: the one-off daemon has served
     // the test and is exiting on its own, so there's nothing to kill and we avoid

--- a/riperf3-cli/tests/end_block_text.rs
+++ b/riperf3-cli/tests/end_block_text.rs
@@ -11,29 +11,10 @@ use std::time::Duration;
 
 mod common;
 
-/// Serializes the UDP tests in this binary. Several concurrent UDP runs on a
-/// 2-core CI runner starve the async UDP-connect handshake (the #178
-/// thread-contention family): loopback handshake datagrams sit undrained, the
-/// retry budget approaches the 30 s `UDP_CONNECT_TOTAL_TIMEOUT`, and the
-/// control connection resets (`ECONNRESET`). The data plane is fine once it
-/// runs — this is a setup-phase scheduling artifact under pathological test
-/// concurrency, not a production defect — so the cheapest robust fix is to run
-/// the UDP cases one at a time (cargo runs test *binaries* sequentially, so a
-/// per-binary lock suffices; TCP cases still parallelize). `into_inner`
-/// tolerates a poisoned lock so one failing UDP test doesn't cascade.
-static UDP_SERIAL: std::sync::Mutex<()> = std::sync::Mutex::new(());
-fn udp_serial() -> std::sync::MutexGuard<'static, ()> {
-    UDP_SERIAL.lock().unwrap_or_else(|e| e.into_inner())
-}
-
-/// Kills the wrapped child on drop so a spawned server is reaped on panic.
-struct ChildGuard(std::process::Child);
-impl Drop for ChildGuard {
-    fn drop(&mut self) {
-        let _ = self.0.kill();
-        let _ = self.0.wait();
-    }
-}
+// The #191 per-binary UDP serialization lock and the child reaper now live in
+// riperf3-test-support (#192); semantics unchanged (statics are per linked
+// test binary).
+use common::{udp_serial, ChildGuard};
 
 fn spawn_server(port_str: &str) -> ChildGuard {
     let bin = env!("CARGO_BIN_EXE_riperf3");

--- a/riperf3-cli/tests/get_server_output.rs
+++ b/riperf3-cli/tests/get_server_output.rs
@@ -18,13 +18,8 @@ fn free_port() -> u16 {
     common::free_port()
 }
 
-struct ChildGuard(std::process::Child);
-impl Drop for ChildGuard {
-    fn drop(&mut self) {
-        let _ = self.0.kill();
-        let _ = self.0.wait();
-    }
-}
+// Reaper guard shared via riperf3-test-support (#192).
+use common::ChildGuard;
 
 /// Run the client to completion (with refused-retry) and return its stdout.
 fn run_capturing(args: &[&str], timeout: Duration, who: &str) -> String {

--- a/riperf3-cli/tests/json_stream.rs
+++ b/riperf3-cli/tests/json_stream.rs
@@ -14,7 +14,7 @@
 
 use std::io::Read;
 use std::process::{Command, Stdio};
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 use serde_json::Value;
 
@@ -83,36 +83,18 @@ fn assert_valid_ndjson(stdout: &str, who: &str) {
     }
 }
 
-/// Kills the wrapped child on drop, so a spawned server is reaped even if the
-/// test panics before it is waited on.
-struct ChildGuard(std::process::Child);
-
-impl Drop for ChildGuard {
-    fn drop(&mut self) {
-        let _ = self.0.kill();
-        let _ = self.0.wait();
-    }
-}
+// Reaper guard shared via riperf3-test-support (#192).
+use common::ChildGuard;
 
 /// Wait for a child to exit, bounded by `timeout` (kill + panic on timeout), so a
-/// hang fails the test cleanly instead of stalling the whole suite.
+/// hang fails the test cleanly instead of stalling the whole suite. Thin
+/// panicking shim over the shared bounded wait (#192).
 fn wait_bounded(
     child: &mut std::process::Child,
     timeout: Duration,
     who: &str,
 ) -> std::process::ExitStatus {
-    let deadline = Instant::now() + timeout;
-    loop {
-        match child.try_wait().expect("try_wait") {
-            Some(status) => return status,
-            None if Instant::now() >= deadline => {
-                let _ = child.kill();
-                let _ = child.wait();
-                panic!("{who}: timed out");
-            }
-            None => std::thread::sleep(Duration::from_millis(50)),
-        }
-    }
+    common::wait_bounded(child, timeout).unwrap_or_else(|| panic!("{who}: timed out"))
 }
 
 /// Run the client to completion (with refused-retry) and return its stdout.

--- a/riperf3-cli/tests/omit_behavior.rs
+++ b/riperf3-cli/tests/omit_behavior.rs
@@ -18,13 +18,8 @@ fn free_port() -> u16 {
     common::free_port()
 }
 
-struct ChildGuard(std::process::Child);
-impl Drop for ChildGuard {
-    fn drop(&mut self) {
-        let _ = self.0.kill();
-        let _ = self.0.wait();
-    }
-}
+// Reaper guard shared via riperf3-test-support (#192).
+use common::ChildGuard;
 
 /// Run the client to completion (with refused-retry) and return its stdout
 /// plus the wall time of the final attempt (for elapsed-time assertions).

--- a/riperf3-cli/tests/pidfile.rs
+++ b/riperf3-cli/tests/pidfile.rs
@@ -17,14 +17,8 @@ fn free_port() -> u16 {
     common::free_port()
 }
 
-/// Kills the wrapped child on drop so a spawned server is reaped on panic.
-struct ChildGuard(std::process::Child);
-impl Drop for ChildGuard {
-    fn drop(&mut self) {
-        let _ = self.0.kill();
-        let _ = self.0.wait();
-    }
-}
+// Reaper guard shared via riperf3-test-support (#192).
+use common::ChildGuard;
 
 fn wait_for(cond: impl Fn() -> bool, timeout: Duration, what: &str) {
     let deadline = Instant::now() + timeout;

--- a/riperf3-cli/tests/udp_demux.rs
+++ b/riperf3-cli/tests/udp_demux.rs
@@ -35,37 +35,9 @@ fn free_port() -> u16 {
     common::free_port()
 }
 
-/// Kills the wrapped child on drop, so a spawned server is reaped even if the
-/// test panics before it is waited on.
-struct ChildGuard(std::process::Child);
-
-impl Drop for ChildGuard {
-    fn drop(&mut self) {
-        let _ = self.0.kill();
-        let _ = self.0.wait();
-    }
-}
-
-/// Wait for a child to exit, bounded by `timeout`. On timeout, kill it and
-/// return `None` — the caller turns that into the "#80 hang" failure with
-/// context, instead of stalling the whole suite.
-fn wait_bounded(
-    child: &mut std::process::Child,
-    timeout: Duration,
-) -> Option<std::process::ExitStatus> {
-    let deadline = Instant::now() + timeout;
-    loop {
-        match child.try_wait().expect("try_wait") {
-            Some(status) => return Some(status),
-            None if Instant::now() >= deadline => {
-                let _ = child.kill();
-                let _ = child.wait();
-                return None;
-            }
-            None => std::thread::sleep(Duration::from_millis(50)),
-        }
-    }
-}
+// Reaper guard + bounded wait now live in riperf3-test-support (#192).
+use common::ChildGuard;
+use riperf3_test_support::wait_bounded;
 
 /// Run one UDP mode against a demux-forced one-off server and return the client's
 /// parsed `-J` report. `extra` carries the direction flag (`-R`, `--bidir`, or
@@ -86,38 +58,60 @@ fn run_demux_udp(extra: &[&str], who: &str) -> Value {
         .unwrap_or_else(|e| panic!("{who}: spawn server failed: {e}"));
     let mut server = ChildGuard(server);
 
-    // Let the listener bind before connecting.
-    std::thread::sleep(Duration::from_millis(300));
+    // No fixed bind sleep (#177): the client retries on a REFUSED connect for
+    // a bounded window instead (the #176 pattern — a refused connect never
+    // reaches accept(), so retrying is safe for the one-off server). stderr
+    // is captured (was nulled) so refusal is classifiable and failures
+    // aren't semi-blind.
+    let retry_deadline = Instant::now() + Duration::from_secs(10);
+    let (exit, out) = loop {
+        // Short duration-limited UDP run at -P 4: the #80 hang is in
+        // multi-stream setup, so completing at all is the core assertion.
+        // `-J` lets us also check routing produced bytes on every stream.
+        let mut client = Command::new(bin)
+            .args(["-c", "127.0.0.1", "-p", &port_s, "-u", "-t", "2", "-P", "4"])
+            .args(extra)
+            .arg("-J")
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .unwrap_or_else(|e| panic!("{who}: spawn client failed: {e}"));
 
-    // Short duration-limited UDP run at -P 4: the #80 hang is in multi-stream
-    // setup, so completing at all is the core assertion. `-J` lets us also check
-    // routing produced bytes on every stream.
-    let mut client = Command::new(bin)
-        .args(["-c", "127.0.0.1", "-p", &port_s, "-u", "-t", "2", "-P", "4"])
-        .args(extra)
-        .arg("-J")
-        .stdout(Stdio::piped())
-        .stderr(Stdio::null())
-        .spawn()
-        .unwrap_or_else(|e| panic!("{who}: spawn client failed: {e}"));
+        // Capture stdout concurrently, then bound the wait: a #80 regression
+        // hangs the client at multi-stream setup until its 30 s connect
+        // timeout.
+        let stdout = client.stdout.take().expect("client stdout");
+        let reader = std::thread::spawn(move || {
+            use std::io::Read;
+            let mut s = String::new();
+            let _ = std::io::BufReader::new(stdout).read_to_string(&mut s);
+            s
+        });
+        let stderr_pipe = client.stderr.take().expect("client stderr");
+        let err_reader = std::thread::spawn(move || {
+            use std::io::Read;
+            let mut s = String::new();
+            let _ = std::io::BufReader::new(stderr_pipe).read_to_string(&mut s);
+            s
+        });
 
-    // Capture stdout concurrently, then bound the wait: a #80 regression hangs
-    // the client at multi-stream setup until its 30 s connect timeout.
-    let stdout = client.stdout.take().expect("client stdout");
-    let reader = std::thread::spawn(move || {
-        use std::io::Read;
-        let mut s = String::new();
-        let _ = std::io::BufReader::new(stdout).read_to_string(&mut s);
-        s
-    });
+        let exit = wait_bounded(&mut client, Duration::from_secs(20))
+            .unwrap_or_else(|| panic!("{who}: client hung — UDP demux -P 4 setup wedged (#80)"));
+        let out = reader.join().expect("join stdout reader");
+        let err = err_reader.join().expect("join stderr reader");
 
-    let exit = wait_bounded(&mut client, Duration::from_secs(20))
-        .unwrap_or_else(|| panic!("{who}: client hung — UDP demux -P 4 setup wedged (#80)"));
-    let out = reader.join().expect("join stdout reader");
-    assert!(
-        exit.success(),
-        "{who}: client exited non-zero: {exit:?}\n{out}"
-    );
+        if riperf3_test_support::refused(&exit, &err) && Instant::now() < retry_deadline {
+            // Server not listening yet — give it a beat and go again.
+            std::thread::sleep(Duration::from_millis(100));
+            continue;
+        }
+        assert!(
+            exit.success(),
+            "{who}: client exited non-zero: {exit:?}\nstderr: {err}\n{out}"
+        );
+        break (exit, out);
+    };
+    let _ = exit;
 
     // The one-off server should now have served and exited on its own.
     let _ = wait_bounded(&mut server.0, Duration::from_secs(5));

--- a/riperf3-cli/tests/udp_demux.rs
+++ b/riperf3-cli/tests/udp_demux.rs
@@ -36,8 +36,7 @@ fn free_port() -> u16 {
 }
 
 // Reaper guard + bounded wait now live in riperf3-test-support (#192).
-use common::ChildGuard;
-use riperf3_test_support::wait_bounded;
+use common::{wait_bounded, ChildGuard};
 
 /// Run one UDP mode against a demux-forced one-off server and return the client's
 /// parsed `-J` report. `extra` carries the direction flag (`-R`, `--bidir`, or
@@ -64,7 +63,7 @@ fn run_demux_udp(extra: &[&str], who: &str) -> Value {
     // is captured (was nulled) so refusal is classifiable and failures
     // aren't semi-blind.
     let retry_deadline = Instant::now() + Duration::from_secs(10);
-    let (exit, out) = loop {
+    let out = loop {
         // Short duration-limited UDP run at -P 4: the #80 hang is in
         // multi-stream setup, so completing at all is the core assertion.
         // `-J` lets us also check routing produced bytes on every stream.
@@ -100,7 +99,7 @@ fn run_demux_udp(extra: &[&str], who: &str) -> Value {
         let out = reader.join().expect("join stdout reader");
         let err = err_reader.join().expect("join stderr reader");
 
-        if riperf3_test_support::refused(&exit, &err) && Instant::now() < retry_deadline {
+        if common::refused(&exit, &err) && Instant::now() < retry_deadline {
             // Server not listening yet — give it a beat and go again.
             std::thread::sleep(Duration::from_millis(100));
             continue;
@@ -109,9 +108,8 @@ fn run_demux_udp(extra: &[&str], who: &str) -> Value {
             exit.success(),
             "{who}: client exited non-zero: {exit:?}\nstderr: {err}\n{out}"
         );
-        break (exit, out);
+        break out;
     };
-    let _ = exit;
 
     // The one-off server should now have served and exited on its own.
     let _ = wait_bounded(&mut server.0, Duration::from_secs(5));

--- a/riperf3-cli/tests/udp_pacing.rs
+++ b/riperf3-cli/tests/udp_pacing.rs
@@ -15,13 +15,8 @@ use serde_json::Value;
 
 mod common;
 
-struct ChildGuard(std::process::Child);
-impl Drop for ChildGuard {
-    fn drop(&mut self) {
-        let _ = self.0.kill();
-        let _ = self.0.wait();
-    }
-}
+// Reaper guard shared via riperf3-test-support (#192).
+use common::ChildGuard;
 
 fn spawn_server(port: &str) -> ChildGuard {
     let bin = env!("CARGO_BIN_EXE_riperf3");

--- a/riperf3-test-support/Cargo.toml
+++ b/riperf3-test-support/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "riperf3-test-support"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+publish = false
+description = "Dev-only shared test helpers for the riperf3 workspace (#192)"
+
+[dependencies]

--- a/riperf3-test-support/src/lib.rs
+++ b/riperf3-test-support/src/lib.rs
@@ -1,0 +1,198 @@
+//! Dev-only shared test helpers for the riperf3 workspace (#192).
+//!
+//! Single source for the harness pieces that were copy-pasted (and had begun
+//! to drift) across `riperf3-cli/tests/common`, `riperf3/tests/common`, and
+//! ad-hoc per-file variants: the #176 port allocator, the #191 per-binary UDP
+//! serialization lock, the #176 refused-retry CLI runner, and the child
+//! reaper guard. `publish = false`: this crate is a `[dev-dependencies]`
+//! implementation detail, not API.
+//!
+//! Statics here (the port counter, the UDP lock) are still **per test
+//! binary**: each binary links its own copy of the rlib, and cargo's harness
+//! parallelism is within a binary, so the #191 lock semantics are unchanged.
+
+use std::io::Read;
+use std::process::{Child, Command, ExitStatus, Stdio};
+use std::sync::atomic::{AtomicU16, Ordering};
+use std::time::{Duration, Instant};
+
+/// Allocate a test server port from a window BELOW every CI platform's
+/// ephemeral range (Linux 32768+, macOS/Windows/FreeBSD 49152+). The old
+/// `bind(127.0.0.1:0)` approach handed out *ephemeral* ports — the same pool
+/// every concurrent test's client draws its connect() SOURCE ports from — so
+/// a foreign socket could already own the port when our server tried to bind
+/// (reproduced at 3/10 under the parallel harness, PR #176 review). Windows
+/// are PID-offset so concurrently-running test *binaries* don't share one,
+/// and an atomic counter serializes callers within a binary; a bind-check
+/// skips anything still occupied (e.g. lingering from an earlier test).
+pub fn free_port() -> u16 {
+    use std::net::{Ipv4Addr, Ipv6Addr, TcpListener};
+
+    static NEXT: AtomicU16 = AtomicU16::new(0);
+    let window = 7000 + (std::process::id() % 250) as u16 * 100;
+    for _ in 0..100 {
+        let port = window + NEXT.fetch_add(1, Ordering::Relaxed) % 100;
+        // Availability check on both wildcard families: no server is racing
+        // for this port yet (it hasn't been handed out), so briefly binding
+        // it here is collision-free, unlike the rejected readiness probes.
+        // SEQUENTIALLY — a held `::` listener (v6only=0 on Linux) claims the
+        // v4 side too, so a simultaneous v4 check always fails against our
+        // own probe. `.is_ok()` drops each listener before the next bind.
+        if TcpListener::bind((Ipv6Addr::UNSPECIFIED, port)).is_ok()
+            && TcpListener::bind((Ipv4Addr::UNSPECIFIED, port)).is_ok()
+        {
+            return port;
+        }
+    }
+    panic!("no free port in test window {window}-{}", window + 99);
+}
+
+/// Serialize the handshake-heavy UDP tests within a test binary (#191): on a
+/// 2-core CI runner, concurrent UDP-connect handshakes starve each other past
+/// their setup timeouts. A per-binary lock suffices (cargo runs test binaries
+/// sequentially; only in-binary tests parallelize). `into_inner` tolerates a
+/// poisoned lock so one failing UDP test doesn't cascade.
+pub fn udp_serial() -> std::sync::MutexGuard<'static, ()> {
+    static UDP_SERIAL: std::sync::Mutex<()> = std::sync::Mutex::new(());
+    UDP_SERIAL.lock().unwrap_or_else(|e| e.into_inner())
+}
+
+/// One finished client run.
+pub struct ClientRun {
+    pub stdout: String,
+    pub stderr: String,
+    pub status: ExitStatus,
+    /// Wall time of the FINAL attempt only (earlier refused attempts excluded),
+    /// so elapsed-time assertions stay meaningful.
+    pub elapsed: Duration,
+}
+
+/// Is this run a REFUSED connect (server not listening yet)? Matches both the
+/// pre-#151 Debug rendering (`ConnectionRefused`) and the iperf3-shaped
+/// message (`Connection refused`), so the harness is merge-order-proof.
+pub fn refused(status: &ExitStatus, stderr: &str) -> bool {
+    !status.success()
+        && (stderr.contains("ConnectionRefused") || stderr.contains("Connection refused"))
+}
+
+/// Run a riperf3 CLI binary to completion with a hard timeout, retrying while
+/// the run is REFUSED for up to a bounded retry window. This replaces fixed
+/// server-bind sleeps: on loaded CI runners the (debug, cold) server can take
+/// longer to bind, the client dies on ECONNREFUSED, and with stderr nulled the
+/// only symptom was `not valid JSON (EOF at line 1 column 0)` (the udp_bidir
+/// flake, #176). Port-probing alternatives were rejected: a 127.0.0.1 probe
+/// never fires on BSD/Windows (specific-over-wildcard binds are legal there),
+/// a wildcard probe can steal the port from the server's own bind, and a
+/// connect-probe consumes a `-s -1` one-off's single accept. A refused connect
+/// never reaches accept(), so retrying the client is safe for one-off servers
+/// and race-free by construction.
+///
+/// `bin` is the caller's `env!("CARGO_BIN_EXE_riperf3")` — the env var only
+/// exists when the *caller's* crate builds that binary, so it cannot be read
+/// here.
+pub fn run_client_with(bin: &str, args: &[&str], timeout: Duration, who: &str) -> ClientRun {
+    let retry_deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        let started = Instant::now();
+        let mut child = Command::new(bin)
+            .args(args)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .unwrap_or_else(|e| panic!("{who}: spawn failed: {e}"));
+
+        let deadline = Instant::now() + timeout;
+        let status = loop {
+            match child.try_wait().expect("try_wait") {
+                Some(status) => break status,
+                None if Instant::now() >= deadline => {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    // Post-kill the pipes are EOF — drain what the child got
+                    // out before dying, for the panic message.
+                    let mut out = String::new();
+                    let mut err = String::new();
+                    if let Some(mut s) = child.stdout.take() {
+                        let _ = s.read_to_string(&mut out);
+                    }
+                    if let Some(mut s) = child.stderr.take() {
+                        let _ = s.read_to_string(&mut err);
+                    }
+                    panic!("{who}: timed out; stdout so far: {out}; stderr so far: {err}");
+                }
+                None => std::thread::sleep(Duration::from_millis(50)),
+            }
+        };
+        let elapsed = started.elapsed();
+
+        let mut stdout = String::new();
+        child
+            .stdout
+            .take()
+            .unwrap()
+            .read_to_string(&mut stdout)
+            .unwrap();
+        let mut stderr = String::new();
+        child
+            .stderr
+            .take()
+            .unwrap()
+            .read_to_string(&mut stderr)
+            .unwrap();
+
+        if refused(&status, &stderr) && Instant::now() < retry_deadline {
+            // Server not listening yet — give it a beat and go again.
+            std::thread::sleep(Duration::from_millis(100));
+            continue;
+        }
+        return ClientRun {
+            stdout,
+            stderr,
+            status,
+            elapsed,
+        };
+    }
+}
+
+/// `run_client_with` + assert success: the common case for tests whose client
+/// must finish cleanly. Panics with status and stderr so harness failures are
+/// diagnosable (not the old stderr-nulled JSON-EOF riddle).
+pub fn run_client_ok_with(bin: &str, args: &[&str], timeout: Duration, who: &str) -> ClientRun {
+    let run = run_client_with(bin, args, timeout, who);
+    assert!(
+        run.status.success(),
+        "{who}: exited unsuccessfully ({status}); stderr: {stderr}",
+        status = run.status,
+        stderr = run.stderr,
+    );
+    run
+}
+
+/// Kills the wrapped child on drop, so a spawned server is reaped even if the
+/// test panics before it is waited on.
+pub struct ChildGuard(pub Child);
+
+impl Drop for ChildGuard {
+    fn drop(&mut self) {
+        let _ = self.0.kill();
+        let _ = self.0.wait();
+    }
+}
+
+/// Wait for a child to exit, bounded by `timeout`. On timeout, kill it and
+/// return `None` — the caller turns that into a hang failure with context,
+/// instead of stalling the whole suite.
+pub fn wait_bounded(child: &mut Child, timeout: Duration) -> Option<ExitStatus> {
+    let deadline = Instant::now() + timeout;
+    loop {
+        match child.try_wait().expect("try_wait") {
+            Some(status) => return Some(status),
+            None if Instant::now() >= deadline => {
+                let _ = child.kill();
+                let _ = child.wait();
+                return None;
+            }
+            None => std::thread::sleep(Duration::from_millis(50)),
+        }
+    }
+}

--- a/riperf3-test-support/src/lib.rs
+++ b/riperf3-test-support/src/lib.rs
@@ -67,12 +67,19 @@ pub struct ClientRun {
     pub elapsed: Duration,
 }
 
-/// Is this run a REFUSED connect (server not listening yet)? Matches both the
-/// pre-#151 Debug rendering (`ConnectionRefused`) and the iperf3-shaped
-/// message (`Connection refused`), so the harness is merge-order-proof.
+/// Is this run a REFUSED connect (server not listening yet)? Matches the
+/// pre-#151 Debug rendering (`ConnectionRefused`), the POSIX strerror text
+/// (`Connection refused`), and Windows' WSAECONNREFUSED rendering (no
+/// "refused"-with-that-casing substring: "No connection could be made
+/// because the target machine actively refused it. (os error 10061)") —
+/// drop any one and the refused-retry silently dies on that platform,
+/// reopening the #176 bind-race flake class (#194 review r2 found exactly
+/// that on windows-latest).
 pub fn refused(status: &ExitStatus, stderr: &str) -> bool {
     !status.success()
-        && (stderr.contains("ConnectionRefused") || stderr.contains("Connection refused"))
+        && (stderr.contains("ConnectionRefused")
+            || stderr.contains("Connection refused")
+            || stderr.contains("(os error 10061)"))
 }
 
 /// Run a riperf3 CLI binary to completion with a hard timeout, retrying while

--- a/riperf3/Cargo.toml
+++ b/riperf3/Cargo.toml
@@ -42,3 +42,4 @@ windows-sys.workspace = true
 # test-util enables tokio's paused virtual clock (`start_paused`) so
 # timeout-budget tests run instantly instead of waiting real seconds. Test-only.
 tokio = { workspace = true, features = ["test-util"] }
+riperf3-test-support = { path = "../riperf3-test-support" }

--- a/riperf3/tests/common/mod.rs
+++ b/riperf3/tests/common/mod.rs
@@ -1,29 +1,7 @@
 //! Shared lib-test helpers (`mod common;` per test binary).
+//!
+//! Implementations live in the dev-only `riperf3-test-support` crate (#192).
 
 #![allow(dead_code)] // each test binary uses a subset
 
-use std::sync::atomic::{AtomicU16, Ordering};
-
-/// Sub-ephemeral, PID-windowed port allocation — same scheme as the CLI test
-/// harness (`riperf3-cli/tests/common`, #176): ephemeral-range picks collide
-/// with concurrent test binaries' connect() source ports under the parallel
-/// harness. Windows are PID-offset so concurrently-running test binaries don't
-/// share one; an atomic counter serializes callers within a binary; a
-/// bind-check skips anything still occupied.
-pub fn free_port() -> u16 {
-    use std::net::{Ipv4Addr, Ipv6Addr, TcpListener};
-
-    static NEXT: AtomicU16 = AtomicU16::new(0);
-    let window = 7000 + (std::process::id() % 250) as u16 * 100;
-    for _ in 0..100 {
-        let port = window + NEXT.fetch_add(1, Ordering::Relaxed) % 100;
-        // Sequential probes — a held `::` listener (v6only=0 on Linux) claims
-        // the v4 side too; `.is_ok()` drops each listener before the next bind.
-        if TcpListener::bind((Ipv6Addr::UNSPECIFIED, port)).is_ok()
-            && TcpListener::bind((Ipv4Addr::UNSPECIFIED, port)).is_ok()
-        {
-            return port;
-        }
-    }
-    panic!("no free port in test window {window}-{}", window + 99);
-}
+pub use riperf3_test_support::free_port;

--- a/riperf3/tests/integration.rs
+++ b/riperf3/tests/integration.rs
@@ -3,16 +3,18 @@
 //! These tests start a real riperf3 server and client on localhost,
 //! exercise the complete wire protocol, and verify results.
 
-use std::sync::atomic::{AtomicU16, Ordering};
 use std::time::Duration;
 
 use riperf3::TransportProtocol;
 use riperf3::{ClientBuilder, ServerBuilder};
 
-/// Allocate unique ports for parallel test execution.
-static NEXT_PORT: AtomicU16 = AtomicU16::new(15201);
+mod common;
+
+/// Allocate unique ports for parallel test execution — the shared #176
+/// PID-windowed allocator (#192); the old bare 15201+ counter had no
+/// collision probe and could land inside another binary's PID window.
 fn next_port() -> u16 {
-    NEXT_PORT.fetch_add(1, Ordering::Relaxed)
+    common::free_port()
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Test infra: shared `riperf3-test-support` crate (#192) + fixed-sleep retirement (#177)

Dev/test only — no product or public-API change, no SemVer impact.

### #192 — single source for the duplicated harness helpers
New `riperf3-test-support` workspace member (`publish = false`, dev-dependency of both crates):
- `free_port()` — the #176 PID-windowed sub-ephemeral allocator. Was byte-identical in two `common/mod.rs` files and divergently re-derived in `riperf3/tests/integration.rs` as a bare 15201+ counter with no collision probe (the drift instance the #186 review flagged — it could land inside another binary's PID window ~1/250).
- `udp_serial()` — the #191 per-binary UDP serialization lock. Statics in the rlib are per-linked-binary, so the lock semantics are unchanged (documented in the crate).
- `run_client_with`/`run_client_ok_with`/`ClientRun` — the #176 refused-retry runner. `CARGO_BIN_EXE_riperf3` only exists while compiling riperf3-cli's own tests, so the support fns take the bin path and `common/mod.rs` keeps thin same-signature wrappers — **no test call sites change shape**.
- `ChildGuard` + `wait_bounded` — were private copies in `udp_demux.rs`/`end_block_text.rs`.

### #177 — no more fixed bind sleeps
- `udp_demux.rs`: the 300 ms pre-client sleep is replaced by a bounded refused-retry around its bespoke concurrent-drain client; stderr is now captured (was nulled — a refused client failed semi-blind, the old `not valid JSON (EOF...)` riddle class).
- `daemon.rs`: the 300 ms sleep + hand-rolled bounded wait are replaced by `run_client` (hard timeout still bounds the pre-fix #81 never-serves hang, with the #81 context in the `who` string).
- The shared `refused()` classifier matches both the current Debug rendering and #194's iperf3-shaped message, so this is merge-order-proof.

### Verification
Full workspace green; clippy/fmt clean. The touched binaries (`daemon`, `udp_demux`, `end_block_text`) pass under the faithful 2-core condition. Test-only change.

Fixes #192. Fixes #177.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
