### PR TITLE
fix: --bind-dev rejects where unhonorable; server applies it like netannounce (#149)

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ riperf3 builds on Linux, macOS, FreeBSD, and Windows. Linux is the reference pla
 | `-Z` zerocopy (sendfile) | yes | yes | yes | |
 | `-C` congestion control | yes | | yes | |
 | `-D` daemon | yes | | yes | |
-| `--bind-dev` | yes | yes | | |
+| `--bind-dev` | yes | yes (client) | | |
 | `--rcv-timeout` | yes | yes | yes | |
 | `--cntl-ka` keepalive | yes | yes | yes | |
 | TCP_INFO stats | yes | yes | yes | |

--- a/riperf3-cli/src/cli.rs
+++ b/riperf3-cli/src/cli.rs
@@ -1419,8 +1419,10 @@ mod cli_tests {
             assert_eq!(c, expected_client("h").bind_dev("eth0").build().unwrap());
         }
 
-        // #149: the server applies --bind-dev too (iperf3's netannounce).
-        #[cfg(any(target_os = "linux", target_os = "macos"))]
+        // #149: the server applies --bind-dev too (iperf3's netannounce —
+        // SO_BINDTODEVICE-only, so the server side is Linux-only; iperf3's
+        // macOS IP_BOUND_IF covers only the client path).
+        #[cfg(target_os = "linux")]
         #[test]
         fn bind_dev_wired_server() {
             let cli = Cli::parse_from(["riperf3", "-s", "--bind-dev", "eth0"]);
@@ -1435,15 +1437,24 @@ mod cli_tests {
         }
 
         // #149: where it cannot be honored, --bind-dev is a config-time error
-        // on BOTH roles (iperf3 without CAN_BIND_TO_DEVICE doesn't recognize
-        // the option at all; the old behavior on FreeBSD/NetBSD was a silent
-        // no-op). Exercised by the FreeBSD/NetBSD/Windows CI jobs.
+        // (iperf3 without CAN_BIND_TO_DEVICE doesn't recognize the option at
+        // all; the old behavior on FreeBSD/NetBSD was a silent no-op).
+        // Exercised by the FreeBSD and Windows CI jobs (NetBSD is xcheck
+        // compile-only).
         #[cfg(not(any(target_os = "linux", target_os = "macos")))]
         #[test]
         fn bind_dev_rejected_on_unsupported_platforms() {
             let cli = Cli::parse_from(["riperf3", "-c", "h", "--bind-dev", "eth0"]);
             let err = cli.build_client().unwrap_err().to_string();
             assert!(err.contains("--bind-dev"), "got: {err}");
+        }
+
+        // #149 review r1: the SERVER rejects --bind-dev everywhere but Linux
+        // — including macOS, where real iperf3's netannounce (SO_BINDTODEVICE
+        // -only) fails the listen. The macOS native CI job exercises this.
+        #[cfg(not(target_os = "linux"))]
+        #[test]
+        fn bind_dev_rejected_on_server_off_linux() {
             let cli = Cli::parse_from(["riperf3", "-s", "--bind-dev", "eth0"]);
             let err = cli.build_server().unwrap_err().to_string();
             assert!(err.contains("--bind-dev"), "got: {err}");

--- a/riperf3-cli/src/cli.rs
+++ b/riperf3-cli/src/cli.rs
@@ -675,6 +675,10 @@ impl Cli {
         if let Some(ref addr) = self.bind {
             builder = builder.bind_address(addr);
         }
+        if let Some(ref dev) = self.bind_dev {
+            // iperf3's server applies --bind-dev in netannounce (#149).
+            builder = builder.bind_dev(dev);
+        }
         if self.version4 {
             builder = builder.ip_version(4);
         } else if self.version6 {
@@ -1404,14 +1408,45 @@ mod cli_tests {
             );
         }
 
-        // build() rejects --bind-dev (SO_BINDTODEVICE/IP_BOUND_IF) on non-Unix,
-        // so gate the wiring test to match.
-        #[cfg(unix)]
+        // build() rejects --bind-dev where there is no SO_BINDTODEVICE (Linux)
+        // or IP_BOUND_IF (macOS) — including FreeBSD/NetBSD since #149 closed
+        // the silent-no-op fallback — so gate the wiring tests to match.
+        #[cfg(any(target_os = "linux", target_os = "macos"))]
         #[test]
         fn bind_dev_wired() {
             let cli = Cli::parse_from(["riperf3", "-c", "h", "--bind-dev", "eth0"]);
             let c = build_client_from_cli(&cli);
             assert_eq!(c, expected_client("h").bind_dev("eth0").build().unwrap());
+        }
+
+        // #149: the server applies --bind-dev too (iperf3's netannounce).
+        #[cfg(any(target_os = "linux", target_os = "macos"))]
+        #[test]
+        fn bind_dev_wired_server() {
+            let cli = Cli::parse_from(["riperf3", "-s", "--bind-dev", "eth0"]);
+            let s = build_server_from_cli(&cli);
+            assert_eq!(
+                s,
+                riperf3::ServerBuilder::new()
+                    .bind_dev("eth0")
+                    .build()
+                    .unwrap()
+            );
+        }
+
+        // #149: where it cannot be honored, --bind-dev is a config-time error
+        // on BOTH roles (iperf3 without CAN_BIND_TO_DEVICE doesn't recognize
+        // the option at all; the old behavior on FreeBSD/NetBSD was a silent
+        // no-op). Exercised by the FreeBSD/NetBSD/Windows CI jobs.
+        #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+        #[test]
+        fn bind_dev_rejected_on_unsupported_platforms() {
+            let cli = Cli::parse_from(["riperf3", "-c", "h", "--bind-dev", "eth0"]);
+            let err = cli.build_client().unwrap_err().to_string();
+            assert!(err.contains("--bind-dev"), "got: {err}");
+            let cli = Cli::parse_from(["riperf3", "-s", "--bind-dev", "eth0"]);
+            let err = cli.build_server().unwrap_err().to_string();
+            assert!(err.contains("--bind-dev"), "got: {err}");
         }
 
         #[test]

--- a/riperf3/src/client.rs
+++ b/riperf3/src/client.rs
@@ -1930,9 +1930,10 @@ impl ClientBuilder {
         self
     }
 
-    /// `--bind-dev`: bind to a network interface — `SO_BINDTODEVICE` on Linux,
-    /// `IP_BOUND_IF`/`IPV6_BOUND_IF` on macOS; a silent no-op elsewhere on
-    /// unix, rejected at `build()` on non-unix.
+    /// `--bind-dev`: bind data sockets to a network device. Linux
+    /// (`SO_BINDTODEVICE`) and macOS (`IP_BOUND_IF`/`IPV6_BOUND_IF`) only;
+    /// rejected at `build()` everywhere else (#149) — matching iperf3, whose
+    /// client-side IP_BOUND_IF fallback covers exactly these two.
     pub fn bind_dev(mut self, dev: &str) -> Self {
         self.bind_dev = Some(dev.to_string());
         self

--- a/riperf3/src/client.rs
+++ b/riperf3/src/client.rs
@@ -2166,11 +2166,6 @@ impl ClientBuilder {
                     "this OS does not support sendfile".into(),
                 ));
             }
-            if self.bind_dev.is_some() {
-                return Err(ConfigError::Unsupported(
-                    "SO_BINDTODEVICE is not supported on this platform".into(),
-                ));
-            }
             if self.congestion.is_some() {
                 return Err(ConfigError::Unsupported(
                     "TCP congestion control is not supported on this platform".into(),
@@ -2181,6 +2176,17 @@ impl ClientBuilder {
                     "UDP GSO/GRO is not supported on this platform".into(),
                 ));
             }
+        }
+
+        // --bind-dev needs SO_BINDTODEVICE (Linux) or IP_BOUND_IF (macOS). The
+        // old gate only covered not(unix), so FreeBSD/NetBSD silently
+        // no-opped through net.rs's fallback — no binding, no error (#149).
+        // iperf3 without CAN_BIND_TO_DEVICE doesn't recognize the option.
+        #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+        if self.bind_dev.is_some() {
+            return Err(ConfigError::Unsupported(
+                "--bind-dev is not supported on this platform".into(),
+            ));
         }
 
         // sendmmsg's real implementation is Linux/FreeBSD/NetBSD only; elsewhere

--- a/riperf3/src/net.rs
+++ b/riperf3/src/net.rs
@@ -345,7 +345,8 @@ pub async fn tcp_listen(
         socket.set_only_v6(ip_version == Some(6))?;
     }
     // --bind-dev on the LISTENING socket, pre-bind, like iperf3's
-    // netannounce (#149); inherited by accepted data sockets on Linux.
+    // netannounce (#149) — which is SO_BINDTODEVICE-only, hence the server
+    // builder's Linux-only gate; inherited by accepted data sockets.
     if let Some(dev) = bind_dev {
         set_bind_dev(&socket, dev, addr.is_ipv6())?;
     }

--- a/riperf3/src/net.rs
+++ b/riperf3/src/net.rs
@@ -322,6 +322,7 @@ pub async fn tcp_listen(
     bind_addr: Option<&str>,
     port: u16,
     ip_version: Option<u8>,
+    bind_dev: Option<&str>,
 ) -> Result<TcpListener> {
     let host = bind_addr.unwrap_or(default_bind_addr(ip_version));
     let addr: SocketAddr = format_addr(host, port)
@@ -342,6 +343,11 @@ pub async fn tcp_listen(
         // can't rely on the platform default. For a non-wildcard IPv6 address
         // (e.g. `::1`) the flag is moot but harmless.
         socket.set_only_v6(ip_version == Some(6))?;
+    }
+    // --bind-dev on the LISTENING socket, pre-bind, like iperf3's
+    // netannounce (#149); inherited by accepted data sockets on Linux.
+    if let Some(dev) = bind_dev {
+        set_bind_dev(&socket, dev, addr.is_ipv6())?;
     }
     socket.set_nonblocking(true)?;
     socket.bind(&addr.into())?;
@@ -714,9 +720,16 @@ pub fn set_bind_dev(fd: &impl std::os::unix::io::AsFd, dev: &str, is_ipv6: bool)
     Ok(())
 }
 
+// No SO_BINDTODEVICE / IP_BOUND_IF equivalent: error instead of silently
+// no-opping (#149) — iperf3 compiles --bind-dev out entirely on these
+// platforms (no CAN_BIND_TO_DEVICE), so a silent accept-and-ignore is the
+// worst of both. The builders reject at config time; this is defense in
+// depth for internal callers.
 #[cfg(not(any(target_os = "linux", target_os = "macos")))]
 pub fn set_bind_dev<F>(_fd: &F, _dev: &str, _is_ipv6: bool) -> Result<()> {
-    Ok(())
+    Err(RiperfError::Config(crate::error::ConfigError::Unsupported(
+        "--bind-dev is not supported on this platform".into(),
+    )))
 }
 
 /// Set TCP keepalive options on a socket.
@@ -881,6 +894,7 @@ pub async fn udp_bind_reusable(
     bind_addr: Option<&str>,
     port: u16,
     ip_version: Option<u8>,
+    bind_dev: Option<&str>,
 ) -> Result<UdpSocket> {
     let host = bind_addr.unwrap_or(default_bind_addr(ip_version));
     let addr: SocketAddr = format_addr(host, port)
@@ -897,6 +911,11 @@ pub async fn udp_bind_reusable(
     if addr.is_ipv6() {
         // Set V6ONLY on every IPv6 bind, explicit `-B` included — see tcp_listen.
         socket.set_only_v6(ip_version == Some(6))?;
+    }
+    // --bind-dev pre-bind, like the TCP listener (#149); iperf3's UDP server
+    // socket goes through the same netannounce path.
+    if let Some(dev) = bind_dev {
+        set_bind_dev(&socket, dev, addr.is_ipv6())?;
     }
     socket.set_nonblocking(true)?;
     socket.bind(&addr.into())?;
@@ -945,9 +964,35 @@ mod tests {
         assert_eq!(s2.send_buffer_size().unwrap(), before);
     }
 
+    // #149: the server's listener and UDP socket honor --bind-dev pre-bind
+    // (iperf3's netannounce). Loopback is always present, so bind to it and
+    // read SO_BINDTODEVICE back.
+    #[cfg(target_os = "linux")]
+    #[tokio::test]
+    async fn tcp_listen_binds_device() {
+        use nix::sys::socket::{self, sockopt};
+        let listener = tcp_listen(Some("127.0.0.1"), 0, None, Some("lo"))
+            .await
+            .unwrap();
+        let dev = socket::getsockopt(&listener, sockopt::BindToDevice).unwrap();
+        // The kernel readback is NUL-padded.
+        assert_eq!(dev.to_string_lossy().trim_end_matches('\0'), "lo");
+    }
+
+    #[cfg(target_os = "linux")]
+    #[tokio::test]
+    async fn udp_bind_reusable_binds_device() {
+        use nix::sys::socket::{self, sockopt};
+        let sock = udp_bind_reusable(Some("127.0.0.1"), 0, None, Some("lo"))
+            .await
+            .unwrap();
+        let dev = socket::getsockopt(&sock, sockopt::BindToDevice).unwrap();
+        assert_eq!(dev.to_string_lossy().trim_end_matches('\0'), "lo");
+    }
+
     #[tokio::test]
     async fn tcp_listen_and_connect() {
-        let listener = tcp_listen(Some("127.0.0.1"), 0, None).await.unwrap();
+        let listener = tcp_listen(Some("127.0.0.1"), 0, None, None).await.unwrap();
         let port = listener.local_addr().unwrap().port();
 
         let client_task = tokio::spawn(async move {
@@ -988,7 +1033,7 @@ mod tests {
         // Bind the client source to 127.0.0.2 (loopback /8 on Linux). The OS
         // would otherwise pick 127.0.0.1, so observing 127.0.0.2 proves -B
         // actually took effect rather than being silently ignored (#15).
-        let listener = tcp_listen(Some("127.0.0.1"), 0, None).await.unwrap();
+        let listener = tcp_listen(Some("127.0.0.1"), 0, None, None).await.unwrap();
         let port = listener.local_addr().unwrap().port();
         let client_task = tokio::spawn(async move {
             tcp_connect(
@@ -1017,7 +1062,7 @@ mod tests {
     async fn tcp_connect_rejects_bind_family_mismatch() {
         // A -B with a v6 literal while connecting to a v4 target must error,
         // not silently ignore it (#15 family validation, mirroring #12).
-        let listener = tcp_listen(Some("127.0.0.1"), 0, None).await.unwrap();
+        let listener = tcp_listen(Some("127.0.0.1"), 0, None, None).await.unwrap();
         let port = listener.local_addr().unwrap().port();
         let result = tcp_connect(
             "127.0.0.1",
@@ -1095,7 +1140,7 @@ mod tests {
     async fn tcp_connect_binds_local_address_and_port() {
         // -B and --cport together: the source IP is applied through the same
         // socket2 bind path that also handles the local port (#15).
-        let listener = tcp_listen(Some("127.0.0.1"), 0, None).await.unwrap();
+        let listener = tcp_listen(Some("127.0.0.1"), 0, None, None).await.unwrap();
         let port = listener.local_addr().unwrap().port();
         let client_task = tokio::spawn(async move {
             // local_port Some(0) = ephemeral, exercised alongside the -B bind.
@@ -1128,7 +1173,7 @@ mod tests {
         // was treated as fatal, so the connect failed on Windows (#79). Use an
         // OS-assigned source port (Some(0)) so this is portable and collision-
         // free while still exercising the explicit-local-port path on every OS.
-        let listener = tcp_listen(Some("127.0.0.1"), 0, None).await.unwrap();
+        let listener = tcp_listen(Some("127.0.0.1"), 0, None, None).await.unwrap();
         let port = listener.local_addr().unwrap().port();
         let client_task = tokio::spawn(async move {
             tcp_connect("127.0.0.1", port, None, Some(0), None, None, false, None).await
@@ -1252,7 +1297,7 @@ mod tests {
     /// clients on the same port — matches iperf3's dual-stack default.
     #[tokio::test]
     async fn tcp_listen_dual_stack_default() {
-        let listener = tcp_listen(None, 0, None).await.unwrap();
+        let listener = tcp_listen(None, 0, None, None).await.unwrap();
         let port = listener.local_addr().unwrap().port();
 
         // IPv4 connect must succeed.
@@ -1281,7 +1326,7 @@ mod tests {
     /// `ip_version=Some(4)` restricts the listener to IPv4 only.
     #[tokio::test]
     async fn tcp_listen_ipv4_only() {
-        let listener = tcp_listen(None, 0, Some(4)).await.unwrap();
+        let listener = tcp_listen(None, 0, Some(4), None).await.unwrap();
         let local = listener.local_addr().unwrap();
         assert!(local.is_ipv4(), "expected IPv4 local_addr, got {local}");
         let port = local.port();
@@ -1308,7 +1353,7 @@ mod tests {
     /// addresses; the test guards against that regression.
     #[tokio::test]
     async fn tcp_listen_ipv6_only() {
-        let listener = tcp_listen(None, 0, Some(6)).await.unwrap();
+        let listener = tcp_listen(None, 0, Some(6), None).await.unwrap();
         let local = listener.local_addr().unwrap();
         assert!(local.is_ipv6(), "expected IPv6 local_addr, got {local}");
         let port = local.port();
@@ -1333,7 +1378,7 @@ mod tests {
     #[tokio::test]
     async fn tcp_listen_explicit_bind_respects_ip_version() {
         // `-B :: -6`  → IPv6-only: an IPv4 client must be refused.
-        let v6only = tcp_listen(Some("::"), 0, Some(6)).await.unwrap();
+        let v6only = tcp_listen(Some("::"), 0, Some(6), None).await.unwrap();
         let port = v6only.local_addr().unwrap().port();
         let v4 = tcp_connect("127.0.0.1", port, None, None, None, None, false, None).await;
         assert!(
@@ -1343,7 +1388,7 @@ mod tests {
         drop(v6only);
 
         // `-B ::` alone → dual-stack: an IPv4 client connects via v4-mapped.
-        let dual = tcp_listen(Some("::"), 0, None).await.unwrap();
+        let dual = tcp_listen(Some("::"), 0, None, None).await.unwrap();
         let port = dual.local_addr().unwrap().port();
         let v4 = tcp_connect("127.0.0.1", port, None, None, None, None, false, None).await;
         match v4 {
@@ -1364,7 +1409,7 @@ mod tests {
     async fn tcp_maxseg_reports_mss_for_connected_stream() {
         // A connected TCP stream exposes a positive MSS via TCP_MAXSEG — this
         // is what the UDP datagram-size default is derived from (iperf3 parity).
-        let listener = tcp_listen(Some("127.0.0.1"), 0, None).await.unwrap();
+        let listener = tcp_listen(Some("127.0.0.1"), 0, None, None).await.unwrap();
         let port = listener.local_addr().unwrap().port();
         let client_task = tokio::spawn(async move {
             tcp_connect("127.0.0.1", port, None, None, None, None, false, None)
@@ -1388,7 +1433,7 @@ mod tests {
         // #37: a connected TCP stream reports its in-effect congestion algorithm,
         // trimmed to a clean C-string (no nul padding / trailing whitespace) like
         // iperf3 — getsockopt(TCP_CONGESTION) returns a fixed-size padded buffer.
-        let listener = tcp_listen(Some("127.0.0.1"), 0, None).await.unwrap();
+        let listener = tcp_listen(Some("127.0.0.1"), 0, None, None).await.unwrap();
         let port = listener.local_addr().unwrap().port();
         let client_task = tokio::spawn(async move {
             tcp_connect("127.0.0.1", port, None, None, None, None, false, None)

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -152,7 +152,7 @@ pub struct Server {
     pub(crate) forceflush: bool,
     pub(crate) bind_address: Option<String>,
     /// `--bind-dev`: bind the listener (and UDP server sockets) to a device,
-    /// like iperf3's netannounce (#149).
+    /// like iperf3's netannounce — Linux/SO_BINDTODEVICE only (#149).
     pub(crate) bind_dev: Option<String>,
     pub(crate) ip_version: Option<u8>,
     pub(crate) timestamps: Option<String>,
@@ -1737,17 +1737,17 @@ impl ServerBuilder {
         self
     }
 
-    /// `-B/--bind`: bind the listener to a specific local address.
     /// `--bind-dev`: bind the listening socket (and the UDP server sockets)
-    /// to a network device, like iperf3's netannounce (#149). Linux
-    /// (SO_BINDTODEVICE) and macOS (IP_BOUND_IF) only; rejected at `build()`
-    /// elsewhere, mirroring iperf3 (which compiles the option out without
-    /// CAN_BIND_TO_DEVICE).
+    /// to a network device, like iperf3's netannounce (#149). Linux only:
+    /// netannounce applies SO_BINDTODEVICE exclusively (iperf3's macOS
+    /// IP_BOUND_IF covers only the CLIENT path, so its macOS server fails
+    /// the listen); rejected at `build()` elsewhere.
     pub fn bind_dev(mut self, dev: &str) -> Self {
         self.bind_dev = Some(dev.to_string());
         self
     }
 
+    /// `-B/--bind`: bind the listener to a specific local address.
     pub fn bind_address(mut self, addr: &str) -> Self {
         self.bind_address = Some(addr.to_string());
         self
@@ -1816,14 +1816,18 @@ impl ServerBuilder {
     }
 
     pub fn build(self) -> std::result::Result<Server, ConfigError> {
-        // --bind-dev needs SO_BINDTODEVICE (Linux) or IP_BOUND_IF (macOS);
-        // everywhere else reject at config time like the client builder —
-        // iperf3 without CAN_BIND_TO_DEVICE doesn't recognize the option at
-        // all, so a silent no-op bind would be the worst behavior (#149).
-        #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+        // The SERVER honors --bind-dev only on Linux: iperf3's netannounce
+        // applies SO_BINDTODEVICE exclusively (its macOS IP_BOUND_IF support
+        // covers only the client's bind_to_device/create_socket path, so a
+        // macOS `iperf3 -s --bind-dev` FAILS at listener creation — review
+        // r1 ground truth). Rejecting at config time everywhere else matches
+        // both that and the no-CAN_BIND_TO_DEVICE unrecognized-option case;
+        // a silent no-op bind would be the worst behavior (#149).
+        #[cfg(not(target_os = "linux"))]
         if self.bind_dev.is_some() {
             return Err(ConfigError::Unsupported(
-                "--bind-dev is not supported on this platform".into(),
+                "--bind-dev on the server requires SO_BINDTODEVICE, which this platform lacks"
+                    .into(),
             ));
         }
 

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -151,6 +151,9 @@ pub struct Server {
     pub(crate) server_max_duration: Option<u32>,
     pub(crate) forceflush: bool,
     pub(crate) bind_address: Option<String>,
+    /// `--bind-dev`: bind the listener (and UDP server sockets) to a device,
+    /// like iperf3's netannounce (#149).
+    pub(crate) bind_dev: Option<String>,
     pub(crate) ip_version: Option<u8>,
     pub(crate) timestamps: Option<String>,
     pub(crate) file: Option<String>,
@@ -194,8 +197,13 @@ impl Server {
         // *before* the tokio runtime is built — `daemon()` forks, and a fork from
         // inside a multi-threaded runtime would leave the child with no worker
         // threads (#81). The library must not fork here.
-        let listener =
-            net::tcp_listen(self.bind_address.as_deref(), self.port, self.ip_version).await?;
+        let listener = net::tcp_listen(
+            self.bind_address.as_deref(),
+            self.port,
+            self.ip_version,
+            self.bind_dev.as_deref(),
+        )
+        .await?;
         // Under -J / --json-stream iperf3's server stdout is pure JSON (the
         // "Server listening" banners are suppressed) so the document parses
         // cleanly; match that.
@@ -897,9 +905,13 @@ impl Server {
         start: &Arc<AtomicBool>,
         streams: &mut Vec<DataStream>,
     ) -> Result<()> {
-        let mut udp_listener =
-            net::udp_bind_reusable(self.bind_address.as_deref(), self.port, self.ip_version)
-                .await?;
+        let mut udp_listener = net::udp_bind_reusable(
+            self.bind_address.as_deref(),
+            self.port,
+            self.ip_version,
+            self.bind_dev.as_deref(),
+        )
+        .await?;
 
         protocol::send_state(ctrl, TestState::CreateStreams).await?;
 
@@ -925,6 +937,7 @@ impl Server {
                     self.bind_address.as_deref(),
                     self.port,
                     self.ip_version,
+                    self.bind_dev.as_deref(),
                 )
                 .await?;
             } else {
@@ -1050,9 +1063,13 @@ impl Server {
         // One unconnected dual-stack socket for the whole test. Never connect()'d
         // and never sharing its port with a second socket, so there is no
         // connected+wildcard pair for winsock to drop a new source against (#80).
-        let udp_sock =
-            net::udp_bind_reusable(self.bind_address.as_deref(), self.port, self.ip_version)
-                .await?;
+        let udp_sock = net::udp_bind_reusable(
+            self.bind_address.as_deref(),
+            self.port,
+            self.ip_version,
+            self.bind_dev.as_deref(),
+        )
+        .await?;
 
         protocol::send_state(ctrl, TestState::CreateStreams).await?;
 
@@ -1620,6 +1637,7 @@ pub struct ServerBuilder {
     server_max_duration: Option<u32>,
     forceflush: bool,
     bind_address: Option<String>,
+    bind_dev: Option<String>,
     ip_version: Option<u8>,
     timestamps: Option<String>,
     file: Option<String>,
@@ -1642,6 +1660,7 @@ impl Default for ServerBuilder {
             server_max_duration: None,
             forceflush: false,
             bind_address: None,
+            bind_dev: None,
             ip_version: None,
             timestamps: None,
             file: None,
@@ -1719,6 +1738,16 @@ impl ServerBuilder {
     }
 
     /// `-B/--bind`: bind the listener to a specific local address.
+    /// `--bind-dev`: bind the listening socket (and the UDP server sockets)
+    /// to a network device, like iperf3's netannounce (#149). Linux
+    /// (SO_BINDTODEVICE) and macOS (IP_BOUND_IF) only; rejected at `build()`
+    /// elsewhere, mirroring iperf3 (which compiles the option out without
+    /// CAN_BIND_TO_DEVICE).
+    pub fn bind_dev(mut self, dev: &str) -> Self {
+        self.bind_dev = Some(dev.to_string());
+        self
+    }
+
     pub fn bind_address(mut self, addr: &str) -> Self {
         self.bind_address = Some(addr.to_string());
         self
@@ -1787,6 +1816,17 @@ impl ServerBuilder {
     }
 
     pub fn build(self) -> std::result::Result<Server, ConfigError> {
+        // --bind-dev needs SO_BINDTODEVICE (Linux) or IP_BOUND_IF (macOS);
+        // everywhere else reject at config time like the client builder —
+        // iperf3 without CAN_BIND_TO_DEVICE doesn't recognize the option at
+        // all, so a silent no-op bind would be the worst behavior (#149).
+        #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+        if self.bind_dev.is_some() {
+            return Err(ConfigError::Unsupported(
+                "--bind-dev is not supported on this platform".into(),
+            ));
+        }
+
         // Reject -4/-6 contradicting an explicit -B of the opposite family,
         // instead of silently letting the bind address win (issue #12).
         if let (Some(v), Some(addr)) = (self.ip_version, self.bind_address.as_deref()) {
@@ -1813,6 +1853,7 @@ impl ServerBuilder {
             server_max_duration: self.server_max_duration,
             forceflush: self.forceflush,
             bind_address: self.bind_address,
+            bind_dev: self.bind_dev,
             ip_version: self.ip_version,
             timestamps: self.timestamps,
             file: self.file,

--- a/riperf3/tests/integration.rs
+++ b/riperf3/tests/integration.rs
@@ -1555,8 +1555,8 @@ mod unimplemented_flags {
 
     // --bind-dev is implemented on Linux (SO_BINDTODEVICE) and macOS (IP_BOUND_IF),
     // each with its own loopback interface name (`lo` vs `lo0`). The test runs on
-    // both; other platforms (Windows/BSD) don't implement it (set_bind_dev is a
-    // no-op there) so there's nothing to exercise (#72).
+    // both; other platforms reject --bind-dev at build() since #149 (the old
+    // fallback silently no-opped), so the cli rejection tests cover them (#72).
     #[cfg(any(target_os = "linux", target_os = "macos"))]
     const LOOPBACK_DEV: &str = if cfg!(target_os = "macos") {
         "lo0"


### PR DESCRIPTION
## #149 — `--bind-dev`: reject where unhonorable; server-side application

### Silent no-op closed
`ClientBuilder::build()` rejected `bind_dev` only on `not(unix)`, while `net.rs`'s non-Linux/non-macOS unix fallback silently returned `Ok(())` — a FreeBSD/NetBSD `--bind-dev` produced no binding and no error. iperf3 without `CAN_BIND_TO_DEVICE` doesn't recognize the option at all (configure gates it on SO_BINDTODEVICE / IP_BOUND_IF), so the faithful shape is config-time rejection (the #100/#128 pattern). Both builders now reject everywhere except Linux (SO_BINDTODEVICE) and macOS (IP_BOUND_IF), and the fallback `set_bind_dev` errors instead of lying.

### Server-side application (iperf3's netannounce)
`ServerBuilder::bind_dev` + CLI wiring in `build_server`; `tcp_listen` and `udp_bind_reusable` take `bind_dev` and apply it **pre-bind** (consistent with #88's pre-connect ordering) on the TCP listener and every UDP server socket, including the recycling path's rebinds and the demux socket.

### Verification
- Linux readback tests: `SO_BINDTODEVICE` on the listener and the UDP socket (`lo`).
- Both-roles rejection test runs on the FreeBSD/NetBSD/Windows CI jobs (cfg-gated to the unsupported set).
- The existing client wiring test's gate tightened `unix` → `linux|macos` to match (it would otherwise fail on FreeBSD CI now).
- Full workspace green; clippy/fmt clean; xcheck green on all 7 targets.

Fixes #149.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
