### PR TITLE
fix: --get-server-output x --json-stream parity on both roles; timestamps ride the capture (#168)

### DIFF
--- a/riperf3-cli/tests/get_server_output.rs
+++ b/riperf3-cli/tests/get_server_output.rs
@@ -187,3 +187,140 @@ fn no_flag_no_server_output() {
     assert!(v.get("server_output_text").is_none());
     assert!(v.get("server_output_json").is_none());
 }
+
+// ---------------------------------------------------------------------------
+// #168: --get-server-output x --json-stream divergences (both roles) + the
+// timestamps-in-capture gap. Ground truth iperf3 3.20 (iperf_api.c:3900,
+// 5310-5323): a --json-stream SERVER keeps its JSON alive when the client
+// requests output and attaches server_output_json; a --json-stream CLIENT
+// emits server_output_text/_json NDJSON events BEFORE `end`; a capturing
+// --timestamps server's returned text carries the prefixes.
+// ---------------------------------------------------------------------------
+
+/// A `--json-stream` server attaches its JSON report for a requesting client.
+#[test]
+fn json_stream_server_attaches_json_output() {
+    let port = free_port();
+    let ps = port.to_string();
+    let server = spawn_server_capturing(&["--json-stream"], &ps);
+    let out = run_capturing(
+        &[
+            "-c",
+            "127.0.0.1",
+            "-p",
+            &ps,
+            "-t",
+            "1",
+            "-J",
+            "--get-server-output",
+        ],
+        Duration::from_secs(20),
+        "json client vs json-stream server",
+    );
+    drop(server);
+    let v: serde_json::Value = serde_json::from_str(&out).expect("client -J output");
+    assert!(
+        v.get("server_output_json").is_some(),
+        "a --json-stream server must attach server_output_json (iperf3 keeps \
+         json_top alive for get_server_output): {out}"
+    );
+}
+
+/// A `--json-stream` client emits the returned server output as an NDJSON
+/// event before `end` (iperf3 event order: start, interval*, server_output_*,
+/// end).
+#[test]
+fn json_stream_client_emits_server_output_event_before_end() {
+    let port = free_port();
+    let ps = port.to_string();
+    let server = spawn_server_capturing(&[], &ps);
+    let out = run_capturing(
+        &[
+            "-c",
+            "127.0.0.1",
+            "-p",
+            &ps,
+            "-t",
+            "1",
+            "--json-stream",
+            "--get-server-output",
+        ],
+        Duration::from_secs(20),
+        "json-stream client",
+    );
+    drop(server);
+    let mut saw_server_output_at = None;
+    let mut saw_end_at = None;
+    for (i, line) in out.lines().enumerate() {
+        let v: serde_json::Value = serde_json::from_str(line)
+            .unwrap_or_else(|e| panic!("non-JSON NDJSON line ({e}): {line}"));
+        match v.get("event").and_then(|e| e.as_str()) {
+            Some("server_output_text") | Some("server_output_json") => {
+                saw_server_output_at.get_or_insert(i);
+            }
+            Some("end") => {
+                saw_end_at.get_or_insert(i);
+            }
+            _ => {}
+        }
+    }
+    let so = saw_server_output_at
+        .unwrap_or_else(|| panic!("no server_output_* event in the NDJSON: {out}"));
+    let end = saw_end_at.unwrap_or_else(|| panic!("no end event: {out}"));
+    assert!(
+        so < end,
+        "server_output_* must precede end (iperf3 order): {out}"
+    );
+}
+
+/// `--timestamps` on a capturing server: the returned text carries the
+/// prefixes (iperf3 buffers the PREFIXED linebuffer).
+#[test]
+fn timestamped_server_capture_carries_prefixes() {
+    let port = free_port();
+    let ps = port.to_string();
+    let server = spawn_server_capturing(&["--timestamps"], &ps);
+    let out = run_capturing(
+        &[
+            "-c",
+            "127.0.0.1",
+            "-p",
+            &ps,
+            "-t",
+            "1",
+            "--get-server-output",
+        ],
+        Duration::from_secs(20),
+        "client vs timestamped server",
+    );
+    drop(server);
+    let server_block: Vec<&str> = out
+        .lines()
+        .skip_while(|l| !l.contains("Server output:"))
+        .skip(1)
+        .filter(|l| l.contains("Mbits/sec") || l.contains("bits/sec"))
+        .collect();
+    assert!(
+        !server_block.is_empty(),
+        "no server report lines in the capture: {out}"
+    );
+    let ts = regex_lite_timestamp(server_block[0]);
+    assert!(
+        ts,
+        "captured server report lines must carry the --timestamps prefix \
+         (iperf3 tees the prefixed line): {:?}",
+        server_block[0]
+    );
+}
+
+/// HH:MM:SS-ish prefix check without a regex dependency.
+fn regex_lite_timestamp(line: &str) -> bool {
+    let b = line.as_bytes();
+    b.len() > 9
+        && b[0].is_ascii_digit()
+        && b[1].is_ascii_digit()
+        && b[2] == b':'
+        && b[3].is_ascii_digit()
+        && b[4].is_ascii_digit()
+        && b[5] == b':'
+}

--- a/riperf3-cli/tests/get_server_output.rs
+++ b/riperf3-cli/tests/get_server_output.rs
@@ -224,6 +224,15 @@ fn json_stream_server_attaches_json_output() {
         "a --json-stream server must attach server_output_json (iperf3 keeps \
          json_top alive for get_server_output): {out}"
     );
+    let n_intervals = v["server_output_json"]["intervals"]
+        .as_array()
+        .map(|a| a.len())
+        .unwrap_or(0);
+    assert!(
+        n_intervals >= 1,
+        "the attached report carries populated intervals — discard_json's \
+         whole purpose (review r1 n2): {out}"
+    );
 }
 
 /// A `--json-stream` client emits the returned server output as an NDJSON

--- a/riperf3-cli/tests/get_server_output.rs
+++ b/riperf3-cli/tests/get_server_output.rs
@@ -229,6 +229,15 @@ fn json_stream_server_attaches_json_output() {
         "a --json-stream server must attach server_output_json (iperf3 keeps \
          json_top alive for get_server_output): {out}"
     );
+    let n_intervals = v["server_output_json"]["intervals"]
+        .as_array()
+        .map(|a| a.len())
+        .unwrap_or(0);
+    assert!(
+        n_intervals >= 1,
+        "the attached report carries populated intervals — discard_json's \
+         whole purpose (review r1 n2): {out}"
+    );
 }
 
 /// A `--json-stream` client emits the returned server output as an NDJSON

--- a/riperf3-cli/tests/get_server_output.rs
+++ b/riperf3-cli/tests/get_server_output.rs
@@ -192,3 +192,140 @@ fn no_flag_no_server_output() {
     assert!(v.get("server_output_text").is_none());
     assert!(v.get("server_output_json").is_none());
 }
+
+// ---------------------------------------------------------------------------
+// #168: --get-server-output x --json-stream divergences (both roles) + the
+// timestamps-in-capture gap. Ground truth iperf3 3.20 (iperf_api.c:3900,
+// 5310-5323): a --json-stream SERVER keeps its JSON alive when the client
+// requests output and attaches server_output_json; a --json-stream CLIENT
+// emits server_output_text/_json NDJSON events BEFORE `end`; a capturing
+// --timestamps server's returned text carries the prefixes.
+// ---------------------------------------------------------------------------
+
+/// A `--json-stream` server attaches its JSON report for a requesting client.
+#[test]
+fn json_stream_server_attaches_json_output() {
+    let port = free_port();
+    let ps = port.to_string();
+    let server = spawn_server_capturing(&["--json-stream"], &ps);
+    let out = run_capturing(
+        &[
+            "-c",
+            "127.0.0.1",
+            "-p",
+            &ps,
+            "-t",
+            "1",
+            "-J",
+            "--get-server-output",
+        ],
+        Duration::from_secs(20),
+        "json client vs json-stream server",
+    );
+    drop(server);
+    let v: serde_json::Value = serde_json::from_str(&out).expect("client -J output");
+    assert!(
+        v.get("server_output_json").is_some(),
+        "a --json-stream server must attach server_output_json (iperf3 keeps \
+         json_top alive for get_server_output): {out}"
+    );
+}
+
+/// A `--json-stream` client emits the returned server output as an NDJSON
+/// event before `end` (iperf3 event order: start, interval*, server_output_*,
+/// end).
+#[test]
+fn json_stream_client_emits_server_output_event_before_end() {
+    let port = free_port();
+    let ps = port.to_string();
+    let server = spawn_server_capturing(&[], &ps);
+    let out = run_capturing(
+        &[
+            "-c",
+            "127.0.0.1",
+            "-p",
+            &ps,
+            "-t",
+            "1",
+            "--json-stream",
+            "--get-server-output",
+        ],
+        Duration::from_secs(20),
+        "json-stream client",
+    );
+    drop(server);
+    let mut saw_server_output_at = None;
+    let mut saw_end_at = None;
+    for (i, line) in out.lines().enumerate() {
+        let v: serde_json::Value = serde_json::from_str(line)
+            .unwrap_or_else(|e| panic!("non-JSON NDJSON line ({e}): {line}"));
+        match v.get("event").and_then(|e| e.as_str()) {
+            Some("server_output_text") | Some("server_output_json") => {
+                saw_server_output_at.get_or_insert(i);
+            }
+            Some("end") => {
+                saw_end_at.get_or_insert(i);
+            }
+            _ => {}
+        }
+    }
+    let so = saw_server_output_at
+        .unwrap_or_else(|| panic!("no server_output_* event in the NDJSON: {out}"));
+    let end = saw_end_at.unwrap_or_else(|| panic!("no end event: {out}"));
+    assert!(
+        so < end,
+        "server_output_* must precede end (iperf3 order): {out}"
+    );
+}
+
+/// `--timestamps` on a capturing server: the returned text carries the
+/// prefixes (iperf3 buffers the PREFIXED linebuffer).
+#[test]
+fn timestamped_server_capture_carries_prefixes() {
+    let port = free_port();
+    let ps = port.to_string();
+    let server = spawn_server_capturing(&["--timestamps"], &ps);
+    let out = run_capturing(
+        &[
+            "-c",
+            "127.0.0.1",
+            "-p",
+            &ps,
+            "-t",
+            "1",
+            "--get-server-output",
+        ],
+        Duration::from_secs(20),
+        "client vs timestamped server",
+    );
+    drop(server);
+    let server_block: Vec<&str> = out
+        .lines()
+        .skip_while(|l| !l.contains("Server output:"))
+        .skip(1)
+        .filter(|l| l.contains("Mbits/sec") || l.contains("bits/sec"))
+        .collect();
+    assert!(
+        !server_block.is_empty(),
+        "no server report lines in the capture: {out}"
+    );
+    let ts = regex_lite_timestamp(server_block[0]);
+    assert!(
+        ts,
+        "captured server report lines must carry the --timestamps prefix \
+         (iperf3 tees the prefixed line): {:?}",
+        server_block[0]
+    );
+}
+
+/// HH:MM:SS-ish prefix check without a regex dependency.
+fn regex_lite_timestamp(line: &str) -> bool {
+    let b = line.as_bytes();
+    b.len() > 9
+        && b[0].is_ascii_digit()
+        && b[1].is_ascii_digit()
+        && b[2] == b':'
+        && b[3].is_ascii_digit()
+        && b[4].is_ascii_digit()
+        && b[5] == b':'
+}

--- a/riperf3/src/client.rs
+++ b/riperf3/src/client.rs
@@ -163,6 +163,11 @@ impl Client {
         // both see it.
         let _title_guard = (!self.json_output && !self.json_stream)
             .then(|| crate::macros::OutputTitleGuard::set(self.title.clone()));
+        // --timestamps prefixes every text report line, run-scoped like the
+        // title; never in the machine-JSON modes (#168).
+        let _ts_guard = crate::macros::OutputTimestampGuard::set(
+            self.timestamps.is_some() && !self.json_output && !self.json_stream,
+        );
 
         // ---- Generate cookie and connect ----
         let cookie = protocol::make_cookie();
@@ -887,7 +892,6 @@ impl Client {
                     omit_secs: self.omit,
                     num_streams: streams.len(),
                     forceflush: self.forceflush,
-                    timestamp_format: self.timestamps.clone(),
                     json_stream: self.json_stream,
                     print: print_intervals,
                     blksize,
@@ -1110,6 +1114,31 @@ impl Client {
                 test_duration,
             );
         } else if self.json_stream {
+            // iperf3's NDJSON order is start, interval*, server_output_*, end
+            // (iperf_api.c:5310-5323): the returned server output is emitted
+            // as its own event(s) BEFORE `end`; riperf3 used to drop it (#168).
+            if self.get_server_output {
+                if let Some(server) = remote_cpu {
+                    if let Some(json) = &server.server_output_json {
+                        crate::reporter::emit_json_stream_line(
+                            &serde_json::json!({
+                                "event": "server_output_json",
+                                "data": json,
+                            })
+                            .to_string(),
+                        );
+                    }
+                    if let Some(text) = &server.server_output_text {
+                        crate::reporter::emit_json_stream_line(
+                            &serde_json::json!({
+                                "event": "server_output_text",
+                                "data": text,
+                            })
+                            .to_string(),
+                        );
+                    }
+                }
+            }
             // --json-stream: emit the `end` event. (Previously this fell through
             // to print_results_text, printing text banners into the NDJSON — #62.)
             self.emit_json_stream_end(

--- a/riperf3/src/client.rs
+++ b/riperf3/src/client.rs
@@ -165,9 +165,8 @@ impl Client {
             .then(|| crate::macros::OutputTitleGuard::set(self.title.clone()));
         // --timestamps prefixes every text report line, run-scoped like the
         // title; never in the machine-JSON modes (#168).
-        let _ts_guard = crate::macros::OutputTimestampGuard::set(
-            self.timestamps.is_some() && !self.json_output && !self.json_stream,
-        );
+        let _ts_guard = (self.timestamps.is_some() && !self.json_output && !self.json_stream)
+            .then(crate::macros::OutputTimestampGuard::set);
 
         // ---- Generate cookie and connect ----
         let cookie = protocol::make_cookie();
@@ -895,6 +894,7 @@ impl Client {
                     json_stream: self.json_stream,
                     print: print_intervals,
                     blksize,
+                    keep_intervals: false,
                 },
                 stream_refs,
                 done.clone(),
@@ -1119,22 +1119,18 @@ impl Client {
             // as its own event(s) BEFORE `end`; riperf3 used to drop it (#168).
             if self.get_server_output {
                 if let Some(server) = remote_cpu {
+                    // Through the shared envelope helper — a hand-built
+                    // serde_json::json! map serializes alphabetically
+                    // ("data" before "event"), breaking the {"event":..,
+                    // "data":..} contract every other event keeps (r1 n1).
                     if let Some(json) = &server.server_output_json {
                         crate::reporter::emit_json_stream_line(
-                            &serde_json::json!({
-                                "event": "server_output_json",
-                                "data": json,
-                            })
-                            .to_string(),
+                            &crate::json_report::json_stream_event("server_output_json", json),
                         );
                     }
                     if let Some(text) = &server.server_output_text {
                         crate::reporter::emit_json_stream_line(
-                            &serde_json::json!({
-                                "event": "server_output_text",
-                                "data": text,
-                            })
-                            .to_string(),
+                            &crate::json_report::json_stream_event("server_output_text", text),
                         );
                     }
                 }

--- a/riperf3/src/client.rs
+++ b/riperf3/src/client.rs
@@ -163,6 +163,11 @@ impl Client {
         // both see it.
         let _title_guard = (!self.json_output && !self.json_stream)
             .then(|| crate::macros::OutputTitleGuard::set(self.title.clone()));
+        // --timestamps prefixes every text report line, run-scoped like the
+        // title; never in the machine-JSON modes (#168).
+        let _ts_guard = crate::macros::OutputTimestampGuard::set(
+            self.timestamps.is_some() && !self.json_output && !self.json_stream,
+        );
 
         // ---- Generate cookie and connect ----
         let cookie = protocol::make_cookie();
@@ -851,7 +856,6 @@ impl Client {
                     omit_secs: self.omit,
                     num_streams: streams.len(),
                     forceflush: self.forceflush,
-                    timestamp_format: self.timestamps.clone(),
                     json_stream: self.json_stream,
                     print: print_intervals,
                     blksize,
@@ -1074,6 +1078,31 @@ impl Client {
                 test_duration,
             );
         } else if self.json_stream {
+            // iperf3's NDJSON order is start, interval*, server_output_*, end
+            // (iperf_api.c:5310-5323): the returned server output is emitted
+            // as its own event(s) BEFORE `end`; riperf3 used to drop it (#168).
+            if self.get_server_output {
+                if let Some(server) = remote_cpu {
+                    if let Some(json) = &server.server_output_json {
+                        crate::reporter::emit_json_stream_line(
+                            &serde_json::json!({
+                                "event": "server_output_json",
+                                "data": json,
+                            })
+                            .to_string(),
+                        );
+                    }
+                    if let Some(text) = &server.server_output_text {
+                        crate::reporter::emit_json_stream_line(
+                            &serde_json::json!({
+                                "event": "server_output_text",
+                                "data": text,
+                            })
+                            .to_string(),
+                        );
+                    }
+                }
+            }
             // --json-stream: emit the `end` event. (Previously this fell through
             // to print_results_text, printing text banners into the NDJSON — #62.)
             self.emit_json_stream_end(

--- a/riperf3/src/client.rs
+++ b/riperf3/src/client.rs
@@ -165,9 +165,8 @@ impl Client {
             .then(|| crate::macros::OutputTitleGuard::set(self.title.clone()));
         // --timestamps prefixes every text report line, run-scoped like the
         // title; never in the machine-JSON modes (#168).
-        let _ts_guard = crate::macros::OutputTimestampGuard::set(
-            self.timestamps.is_some() && !self.json_output && !self.json_stream,
-        );
+        let _ts_guard = (self.timestamps.is_some() && !self.json_output && !self.json_stream)
+            .then(crate::macros::OutputTimestampGuard::set);
 
         // ---- Generate cookie and connect ----
         let cookie = protocol::make_cookie();
@@ -859,6 +858,7 @@ impl Client {
                     json_stream: self.json_stream,
                     print: print_intervals,
                     blksize,
+                    keep_intervals: false,
                 },
                 stream_refs,
                 done.clone(),
@@ -1083,22 +1083,18 @@ impl Client {
             // as its own event(s) BEFORE `end`; riperf3 used to drop it (#168).
             if self.get_server_output {
                 if let Some(server) = remote_cpu {
+                    // Through the shared envelope helper — a hand-built
+                    // serde_json::json! map serializes alphabetically
+                    // ("data" before "event"), breaking the {"event":..,
+                    // "data":..} contract every other event keeps (r1 n1).
                     if let Some(json) = &server.server_output_json {
                         crate::reporter::emit_json_stream_line(
-                            &serde_json::json!({
-                                "event": "server_output_json",
-                                "data": json,
-                            })
-                            .to_string(),
+                            &crate::json_report::json_stream_event("server_output_json", json),
                         );
                     }
                     if let Some(text) = &server.server_output_text {
                         crate::reporter::emit_json_stream_line(
-                            &serde_json::json!({
-                                "event": "server_output_text",
-                                "data": text,
-                            })
-                            .to_string(),
+                            &crate::json_report::json_stream_event("server_output_text", text),
                         );
                     }
                 }

--- a/riperf3/src/macros.rs
+++ b/riperf3/src/macros.rs
@@ -72,9 +72,15 @@ static OUTPUT_TIMESTAMPS: RwLock<bool> = RwLock::new(false);
 pub(crate) struct OutputTimestampGuard;
 
 impl OutputTimestampGuard {
-    pub(crate) fn set(active: bool) -> Self {
+    /// Construct ONLY when timestamps are active (callers use
+    /// `cond.then(OutputTimestampGuard::set)`): an unconditional `set(false)`
+    /// from a concurrent in-process run would clobber another run's `true` —
+    /// the exact server-clobbers-client topology of the lib's
+    /// `timestamps_runs` test (#168 review r1 n3). Mirrors OutputTitleGuard,
+    /// whose construct-only-when-titled shape has no such mode.
+    pub(crate) fn set() -> Self {
         if let Ok(mut g) = OUTPUT_TIMESTAMPS.write() {
-            *g = active;
+            *g = true;
         }
         OutputTimestampGuard
     }

--- a/riperf3/src/macros.rs
+++ b/riperf3/src/macros.rs
@@ -63,6 +63,51 @@ impl Drop for OutputCaptureGuard {
     }
 }
 
+/// `--timestamps` prefix state (#168): set run-scoped like OUTPUT_TITLE; when
+/// active, `titled` prepends the rendered prefix to EVERY report line, so the
+/// console and the --get-server-output capture both carry it — iperf3 buffers
+/// the PREFIXED linebuffer. (Same one-run-at-a-time process-global caveat.)
+static OUTPUT_TIMESTAMPS: RwLock<bool> = RwLock::new(false);
+
+pub(crate) struct OutputTimestampGuard;
+
+impl OutputTimestampGuard {
+    pub(crate) fn set(active: bool) -> Self {
+        if let Ok(mut g) = OUTPUT_TIMESTAMPS.write() {
+            *g = active;
+        }
+        OutputTimestampGuard
+    }
+}
+
+impl Drop for OutputTimestampGuard {
+    fn drop(&mut self) {
+        if let Ok(mut g) = OUTPUT_TIMESTAMPS.write() {
+            *g = false;
+        }
+    }
+}
+
+/// The rendered `--timestamps` prefix for the current line, or "" when off.
+/// HH:MM:SS (UTC) — the custom strftime FORMAT argument is a recorded
+/// fidelity gap, tracked separately from #168.
+pub(crate) fn output_timestamp_prefix() -> String {
+    let on = OUTPUT_TIMESTAMPS.read().map(|g| *g).unwrap_or(false);
+    if !on {
+        return String::new();
+    }
+    let secs = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+    format!(
+        "{:02}:{:02}:{:02} ",
+        (secs % 86400) / 3600,
+        (secs % 3600) / 60,
+        secs % 60
+    )
+}
+
 pub(crate) fn set_output_title(title: Option<String>) {
     if let Ok(mut g) = OUTPUT_TITLE.write() {
         *g = title;

--- a/riperf3/src/reporter.rs
+++ b/riperf3/src/reporter.rs
@@ -379,6 +379,11 @@ pub struct IntervalReporterConfig {
     /// Datagram size, used to derive the UDP *sender's* per-interval packet count
     /// (the sender doesn't measure loss/jitter, so iperf3 reports only `packets`).
     pub blksize: usize,
+    /// json-stream normally streams intervals without collecting; a SERVER
+    /// whose client requested --get-server-output keeps them too, so the
+    /// attached server_output_json carries populated intervals like iperf3's
+    /// json_top under discard_json (#168).
+    pub keep_intervals: bool,
 }
 
 /// A single TCP_INFO sample reused for the final interval (#55) when the socket
@@ -966,6 +971,14 @@ pub fn spawn_interval_reporter(
                             "{}",
                             crate::json_report::json_stream_event("interval", &interval)
                         );
+                        // A json-stream SERVER additionally keeps them when
+                        // the client requested --get-server-output: iperf3's
+                        // discard_json exists precisely to retain the
+                        // interval objects for the attached
+                        // server_output_json (#168 r1 n2).
+                        if config.keep_intervals {
+                            collected.push(interval);
+                        }
                     } else {
                         collected.push(interval);
                     }
@@ -1499,6 +1512,7 @@ mod interval_reporter_tests {
             json_stream: false,
             print: true,
             blksize: 128 * 1024,
+            keep_intervals: false,
         };
         assert!(spawn_interval_reporter(
             config,
@@ -1525,6 +1539,7 @@ mod interval_reporter_tests {
             json_stream: false,
             print: true,
             blksize: 128 * 1024,
+            keep_intervals: false,
         };
         assert!(spawn_interval_reporter(
             config,
@@ -1551,6 +1566,7 @@ mod interval_reporter_tests {
             json_stream: false,
             print: true,
             blksize: 128 * 1024,
+            keep_intervals: false,
         };
         let handle = spawn_interval_reporter(
             config,
@@ -1604,6 +1620,7 @@ mod interval_reporter_tests {
             json_stream: false,
             print: false, // collect-only; assert on the collector
             blksize: 128 * 1024,
+            keep_intervals: false,
         };
         let reporter_end = Arc::new(ReporterEnd::new());
         let report_start = std::time::Instant::now();
@@ -1686,6 +1703,7 @@ mod interval_reporter_tests {
             json_stream: false,
             print: false, // collect-only; assert on the collector
             blksize: 128 * 1024,
+            keep_intervals: false,
         };
         let reporter_end = Arc::new(ReporterEnd::new());
         let report_start = std::time::Instant::now();
@@ -1763,6 +1781,7 @@ mod interval_reporter_tests {
             json_stream: false,
             print: false,
             blksize: 128 * 1024,
+            keep_intervals: false,
         };
         let reporter_end = Arc::new(ReporterEnd::new());
         let handle = spawn_interval_reporter(
@@ -1836,6 +1855,7 @@ mod interval_reporter_tests {
             json_stream: false,
             print: false,
             blksize: 128 * 1024,
+            keep_intervals: false,
         };
         let reporter_end = Arc::new(ReporterEnd::new());
         let handle = spawn_interval_reporter(

--- a/riperf3/src/reporter.rs
+++ b/riperf3/src/reporter.rs
@@ -71,7 +71,12 @@ fn fmt_id_role(id: i32, role_tag: Option<&'static str>) -> String {
 /// when a title is active (#34). Every report line routes through this so the
 /// prefix matches iperf3 without changing the public printer signatures.
 fn titled(line: std::fmt::Arguments) {
-    let rendered = format!("{}{}", crate::macros::output_title_prefix(), line);
+    let rendered = format!(
+        "{}{}{}",
+        crate::macros::output_timestamp_prefix(),
+        crate::macros::output_title_prefix(),
+        line
+    );
     // --get-server-output (#33): a capturing server TEES its report lines
     // into the exchange buffer while still printing — iperf3's iperf_printf
     // dual-writes (console + server_output_list).
@@ -367,7 +372,6 @@ pub struct IntervalReporterConfig {
     pub omit_secs: u32,
     pub num_streams: usize,
     pub forceflush: bool,
-    pub timestamp_format: Option<String>,
     pub json_stream: bool,
     /// Print interval lines live (text or json-stream). When false the reporter
     /// runs purely to collect intervals for the final `-J` blob (issue #36 PR2).
@@ -684,19 +688,9 @@ pub fn spawn_interval_reporter(
             if do_emit {
                 let seconds = end - start;
 
-                // Timestamp prefix for this tick (text decoration; never on --json-stream)
-                if config.print && !config.json_stream && config.timestamp_format.is_some() {
-                    // Use libc strftime for iperf3-compatible timestamp formatting
-                    let now = std::time::SystemTime::now()
-                        .duration_since(std::time::UNIX_EPOCH)
-                        .unwrap_or_default();
-                    let secs = now.as_secs();
-                    // Simple ISO-ish format without pulling in chrono
-                    let hours = (secs % 86400) / 3600;
-                    let mins = (secs % 3600) / 60;
-                    let s = secs % 60;
-                    print!("{hours:02}:{mins:02}:{s:02} ");
-                }
+                // The --timestamps prefix rides every titled() line now —
+                // per line AND into the capture, like iperf3's prefixed
+                // linebuffer (#168).
 
                 // The text header banner is suppressed under --json-stream (pure NDJSON).
                 if config.print && !config.json_stream && !header_printed {
@@ -1495,7 +1489,6 @@ mod interval_reporter_tests {
             omit_secs: 0,
             num_streams: 1,
             forceflush: false,
-            timestamp_format: None,
             json_stream: false,
             print: true,
             blksize: 128 * 1024,
@@ -1522,7 +1515,6 @@ mod interval_reporter_tests {
             omit_secs: 0,
             num_streams: 1,
             forceflush: false,
-            timestamp_format: None,
             json_stream: false,
             print: true,
             blksize: 128 * 1024,
@@ -1549,7 +1541,6 @@ mod interval_reporter_tests {
             omit_secs: 0,
             num_streams: 0,
             forceflush: false,
-            timestamp_format: None,
             json_stream: false,
             print: true,
             blksize: 128 * 1024,
@@ -1603,7 +1594,6 @@ mod interval_reporter_tests {
             omit_secs: 0,
             num_streams: 1,
             forceflush: false,
-            timestamp_format: None,
             json_stream: false,
             print: false, // collect-only; assert on the collector
             blksize: 128 * 1024,
@@ -1686,7 +1676,6 @@ mod interval_reporter_tests {
             omit_secs: 0,
             num_streams: 1,
             forceflush: false,
-            timestamp_format: None,
             json_stream: false,
             print: false, // collect-only; assert on the collector
             blksize: 128 * 1024,
@@ -1764,7 +1753,6 @@ mod interval_reporter_tests {
             omit_secs: 0,
             num_streams: 1,
             forceflush: false,
-            timestamp_format: None,
             json_stream: false,
             print: false,
             blksize: 128 * 1024,
@@ -1838,7 +1826,6 @@ mod interval_reporter_tests {
             omit_secs: 0,
             num_streams: 1,
             forceflush: false,
-            timestamp_format: None,
             json_stream: false,
             print: false,
             blksize: 128 * 1024,

--- a/riperf3/src/reporter.rs
+++ b/riperf3/src/reporter.rs
@@ -379,6 +379,11 @@ pub struct IntervalReporterConfig {
     /// Datagram size, used to derive the UDP *sender's* per-interval packet count
     /// (the sender doesn't measure loss/jitter, so iperf3 reports only `packets`).
     pub blksize: usize,
+    /// json-stream normally streams intervals without collecting; a SERVER
+    /// whose client requested --get-server-output keeps them too, so the
+    /// attached server_output_json carries populated intervals like iperf3's
+    /// json_top under discard_json (#168).
+    pub keep_intervals: bool,
 }
 
 /// A single TCP_INFO sample reused for the final interval (#55) when the socket
@@ -959,6 +964,14 @@ pub fn spawn_interval_reporter(
                             "{}",
                             crate::json_report::json_stream_event("interval", &interval)
                         );
+                        // A json-stream SERVER additionally keeps them when
+                        // the client requested --get-server-output: iperf3's
+                        // discard_json exists precisely to retain the
+                        // interval objects for the attached
+                        // server_output_json (#168 r1 n2).
+                        if config.keep_intervals {
+                            collected.push(interval);
+                        }
                     } else {
                         collected.push(interval);
                     }
@@ -1492,6 +1505,7 @@ mod interval_reporter_tests {
             json_stream: false,
             print: true,
             blksize: 128 * 1024,
+            keep_intervals: false,
         };
         assert!(spawn_interval_reporter(
             config,
@@ -1518,6 +1532,7 @@ mod interval_reporter_tests {
             json_stream: false,
             print: true,
             blksize: 128 * 1024,
+            keep_intervals: false,
         };
         assert!(spawn_interval_reporter(
             config,
@@ -1544,6 +1559,7 @@ mod interval_reporter_tests {
             json_stream: false,
             print: true,
             blksize: 128 * 1024,
+            keep_intervals: false,
         };
         let handle = spawn_interval_reporter(
             config,
@@ -1597,6 +1613,7 @@ mod interval_reporter_tests {
             json_stream: false,
             print: false, // collect-only; assert on the collector
             blksize: 128 * 1024,
+            keep_intervals: false,
         };
         let reporter_end = Arc::new(ReporterEnd::new());
         let report_start = std::time::Instant::now();
@@ -1679,6 +1696,7 @@ mod interval_reporter_tests {
             json_stream: false,
             print: false, // collect-only; assert on the collector
             blksize: 128 * 1024,
+            keep_intervals: false,
         };
         let reporter_end = Arc::new(ReporterEnd::new());
         let report_start = std::time::Instant::now();
@@ -1756,6 +1774,7 @@ mod interval_reporter_tests {
             json_stream: false,
             print: false,
             blksize: 128 * 1024,
+            keep_intervals: false,
         };
         let reporter_end = Arc::new(ReporterEnd::new());
         let handle = spawn_interval_reporter(
@@ -1829,6 +1848,7 @@ mod interval_reporter_tests {
             json_stream: false,
             print: false,
             blksize: 128 * 1024,
+            keep_intervals: false,
         };
         let reporter_end = Arc::new(ReporterEnd::new());
         let handle = spawn_interval_reporter(

--- a/riperf3/src/reporter.rs
+++ b/riperf3/src/reporter.rs
@@ -71,7 +71,12 @@ fn fmt_id_role(id: i32, role_tag: Option<&'static str>) -> String {
 /// when a title is active (#34). Every report line routes through this so the
 /// prefix matches iperf3 without changing the public printer signatures.
 fn titled(line: std::fmt::Arguments) {
-    let rendered = format!("{}{}", crate::macros::output_title_prefix(), line);
+    let rendered = format!(
+        "{}{}{}",
+        crate::macros::output_timestamp_prefix(),
+        crate::macros::output_title_prefix(),
+        line
+    );
     // --get-server-output (#33): a capturing server TEES its report lines
     // into the exchange buffer while still printing — iperf3's iperf_printf
     // dual-writes (console + server_output_list).
@@ -367,7 +372,6 @@ pub struct IntervalReporterConfig {
     pub omit_secs: u32,
     pub num_streams: usize,
     pub forceflush: bool,
-    pub timestamp_format: Option<String>,
     pub json_stream: bool,
     /// Print interval lines live (text or json-stream). When false the reporter
     /// runs purely to collect intervals for the final `-J` blob (issue #36 PR2).
@@ -686,19 +690,9 @@ pub fn spawn_interval_reporter(
             if do_emit {
                 let seconds = end - start;
 
-                // Timestamp prefix for this tick (text decoration; never on --json-stream)
-                if config.print && !config.json_stream && config.timestamp_format.is_some() {
-                    // Use libc strftime for iperf3-compatible timestamp formatting
-                    let now = std::time::SystemTime::now()
-                        .duration_since(std::time::UNIX_EPOCH)
-                        .unwrap_or_default();
-                    let secs = now.as_secs();
-                    // Simple ISO-ish format without pulling in chrono
-                    let hours = (secs % 86400) / 3600;
-                    let mins = (secs % 3600) / 60;
-                    let s = secs % 60;
-                    print!("{hours:02}:{mins:02}:{s:02} ");
-                }
+                // The --timestamps prefix rides every titled() line now —
+                // per line AND into the capture, like iperf3's prefixed
+                // linebuffer (#168).
 
                 // The text header banner is suppressed under --json-stream (pure NDJSON).
                 if config.print && !config.json_stream && !header_printed {
@@ -1502,7 +1496,6 @@ mod interval_reporter_tests {
             omit_secs: 0,
             num_streams: 1,
             forceflush: false,
-            timestamp_format: None,
             json_stream: false,
             print: true,
             blksize: 128 * 1024,
@@ -1529,7 +1522,6 @@ mod interval_reporter_tests {
             omit_secs: 0,
             num_streams: 1,
             forceflush: false,
-            timestamp_format: None,
             json_stream: false,
             print: true,
             blksize: 128 * 1024,
@@ -1556,7 +1548,6 @@ mod interval_reporter_tests {
             omit_secs: 0,
             num_streams: 0,
             forceflush: false,
-            timestamp_format: None,
             json_stream: false,
             print: true,
             blksize: 128 * 1024,
@@ -1610,7 +1601,6 @@ mod interval_reporter_tests {
             omit_secs: 0,
             num_streams: 1,
             forceflush: false,
-            timestamp_format: None,
             json_stream: false,
             print: false, // collect-only; assert on the collector
             blksize: 128 * 1024,
@@ -1693,7 +1683,6 @@ mod interval_reporter_tests {
             omit_secs: 0,
             num_streams: 1,
             forceflush: false,
-            timestamp_format: None,
             json_stream: false,
             print: false, // collect-only; assert on the collector
             blksize: 128 * 1024,
@@ -1771,7 +1760,6 @@ mod interval_reporter_tests {
             omit_secs: 0,
             num_streams: 1,
             forceflush: false,
-            timestamp_format: None,
             json_stream: false,
             print: false,
             blksize: 128 * 1024,
@@ -1845,7 +1833,6 @@ mod interval_reporter_tests {
             omit_secs: 0,
             num_streams: 1,
             forceflush: false,
-            timestamp_format: None,
             json_stream: false,
             print: false,
             blksize: 128 * 1024,

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -302,9 +302,8 @@ impl Server {
         // --timestamps prefixes every text report line — through titled(), so
         // the capture above tees the PREFIXED line like iperf3's linebuffer
         // (#168). Run-scoped; never in the machine-JSON modes.
-        let _ts_guard = crate::macros::OutputTimestampGuard::set(
-            self.timestamps.is_some() && !self.json_output && !self.json_stream,
-        );
+        let _ts_guard = (self.timestamps.is_some() && !self.json_output && !self.json_stream)
+            .then(crate::macros::OutputTimestampGuard::set);
 
         // ---- Auth validation (after params, before streams) ----
         if let (Some(ref privkey_path), Some(ref users_path)) =
@@ -610,6 +609,9 @@ impl Server {
                     json_stream: self.json_stream,
                     print: print_intervals,
                     blksize: cfg.blksize,
+                    // iperf3's discard_json: a json-stream server RETAINS the
+                    // interval objects when the client asked for output (#168).
+                    keep_intervals: want_server_output && self.json_stream,
                 },
                 stream_refs,
                 done.clone(),

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -291,6 +291,12 @@ impl Server {
         // server_output event).
         let capture = (want_server_output && !self.json_output && !self.json_stream)
             .then(crate::macros::OutputCaptureGuard::start);
+        // --timestamps prefixes every text report line — through titled(), so
+        // the capture above tees the PREFIXED line like iperf3's linebuffer
+        // (#168). Run-scoped; never in the machine-JSON modes.
+        let _ts_guard = crate::macros::OutputTimestampGuard::set(
+            self.timestamps.is_some() && !self.json_output && !self.json_stream,
+        );
 
         // ---- Auth validation (after params, before streams) ----
         if let (Some(ref privkey_path), Some(ref users_path)) =
@@ -593,7 +599,6 @@ impl Server {
                     omit_secs: cfg.omit,
                     num_streams: streams.len(),
                     forceflush: self.forceflush,
-                    timestamp_format: self.timestamps.clone(),
                     json_stream: self.json_stream,
                     print: print_intervals,
                     blksize: cfg.blksize,
@@ -756,7 +761,12 @@ impl Server {
             crate::reporter::print_final_header(cfg.protocol, cfg.bidir, with_retr);
             crate::reporter::print_final_summaries(&summaries, 'a');
             (Some(capture.take()), None)
-        } else if want_server_output && self.json_output {
+        } else if want_server_output && (self.json_output || self.json_stream) {
+            // A --json-stream server attaches its JSON report too: iperf3
+            // keeps json_top alive specifically for this flag
+            // (discard_json = json_stream && ... && !(server && get_server_output),
+            // iperf_api.c:3900) — without this a real iperf3 client
+            // requesting output silently got none (#168).
             let report = self.build_report(
                 &streams,
                 &cfg,

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -299,6 +299,12 @@ impl Server {
         // server_output event).
         let capture = (want_server_output && !self.json_output && !self.json_stream)
             .then(crate::macros::OutputCaptureGuard::start);
+        // --timestamps prefixes every text report line — through titled(), so
+        // the capture above tees the PREFIXED line like iperf3's linebuffer
+        // (#168). Run-scoped; never in the machine-JSON modes.
+        let _ts_guard = crate::macros::OutputTimestampGuard::set(
+            self.timestamps.is_some() && !self.json_output && !self.json_stream,
+        );
 
         // ---- Auth validation (after params, before streams) ----
         if let (Some(ref privkey_path), Some(ref users_path)) =
@@ -601,7 +607,6 @@ impl Server {
                     omit_secs: cfg.omit,
                     num_streams: streams.len(),
                     forceflush: self.forceflush,
-                    timestamp_format: self.timestamps.clone(),
                     json_stream: self.json_stream,
                     print: print_intervals,
                     blksize: cfg.blksize,
@@ -764,7 +769,12 @@ impl Server {
             crate::reporter::print_final_header(cfg.protocol, cfg.bidir, with_retr);
             crate::reporter::print_final_summaries(&summaries, 'a');
             (Some(capture.take()), None)
-        } else if want_server_output && self.json_output {
+        } else if want_server_output && (self.json_output || self.json_stream) {
+            // A --json-stream server attaches its JSON report too: iperf3
+            // keeps json_top alive specifically for this flag
+            // (discard_json = json_stream && ... && !(server && get_server_output),
+            // iperf_api.c:3900) — without this a real iperf3 client
+            // requesting output silently got none (#168).
             let report = self.build_report(
                 &streams,
                 &cfg,

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -294,9 +294,8 @@ impl Server {
         // --timestamps prefixes every text report line — through titled(), so
         // the capture above tees the PREFIXED line like iperf3's linebuffer
         // (#168). Run-scoped; never in the machine-JSON modes.
-        let _ts_guard = crate::macros::OutputTimestampGuard::set(
-            self.timestamps.is_some() && !self.json_output && !self.json_stream,
-        );
+        let _ts_guard = (self.timestamps.is_some() && !self.json_output && !self.json_stream)
+            .then(crate::macros::OutputTimestampGuard::set);
 
         // ---- Auth validation (after params, before streams) ----
         if let (Some(ref privkey_path), Some(ref users_path)) =
@@ -602,6 +601,9 @@ impl Server {
                     json_stream: self.json_stream,
                     print: print_intervals,
                     blksize: cfg.blksize,
+                    // iperf3's discard_json: a json-stream server RETAINS the
+                    // interval objects when the client asked for output (#168).
+                    keep_intervals: want_server_output && self.json_stream,
                 },
                 stream_refs,
                 done.clone(),


### PR DESCRIPTION
## #168 — `--get-server-output` × `--json-stream` (both roles) + timestamps-in-capture

Three live-confirmed divergences vs iperf3 3.20:

1. **`--json-stream` server attaches nothing.** iperf3 keeps `json_top` alive specifically for a requesting client (`discard_json` gates on `!(server && get_server_output)`, iperf_api.c:3900) and attaches `server_output_json`. The attach gate now includes `json_stream` — a real iperf3 client requesting output gets it.
2. **`--json-stream` client drops the returned output.** It now emits `server_output_json`/`server_output_text` NDJSON events **before** `end`, matching iperf3's event order (`start, interval*, server_output_*, end` — iperf_api.c:5310-5323).
3. **`--timestamps` on a capturing server**: the prefix printed outside the tee'd line path, so the `--get-server-output` capture lacked timestamps. The prefix now renders inside `titled()` (per **line**, like iperf3's prefixed linebuffer) via a run-scoped `OutputTimestampGuard` mirroring the title guard; the reporter's per-tick `print!` and its config field are gone. The strftime FORMAT fidelity gap is split to #202.

### Verification
TDD: three CLI tests observed red first; full workspace green; clippy/fmt clean.

Fixes #168.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
