### PR TITLE
fix: grow-only UDP SO_SNDBUF; paced-UDP compat coverage (#163)

### DIFF
--- a/riperf3/src/client.rs
+++ b/riperf3/src/client.rs
@@ -725,6 +725,7 @@ impl Client {
                         // so a low -b over a large datagram paces smoothly.
                         let pt = self.pacing_timer;
                         let bu = self.burst;
+                        let uw = self.window.is_some();
                         let u64bit = self.udp_counters_64bit;
                         let use_sendmmsg = self.sendmmsg;
                         let st = start.clone();
@@ -732,11 +733,11 @@ impl Client {
                         thread_gate.spawn(move || {
                             if use_sendmmsg {
                                 stream::run_udp_sender_sendmmsg(
-                                    std_sock, c, bs, d, rate, pt, bu, u64bit, st, md,
+                                    std_sock, c, bs, d, rate, pt, bu, uw, u64bit, st, md,
                                 )
                             } else {
                                 stream::run_udp_sender_blocking(
-                                    std_sock, c, bs, d, rate, pt, bu, u64bit, st, md,
+                                    std_sock, c, bs, d, rate, pt, bu, uw, u64bit, st, md,
                                 )
                             }
                         })

--- a/riperf3/src/net.rs
+++ b/riperf3/src/net.rs
@@ -533,7 +533,7 @@ const UDP_SEND_TIMEOUT_MS: u64 = 1000;
 /// send buffer fills, redundantly re-staging the whole batch and starving the
 /// async runtime. Switching to blocking lets the kernel backpressure the
 /// sender thread instead. The `SO_SNDBUF` bump is best-effort (clamped by
-/// `net.core.wmem_max`); `SO_SNDTIMEO` bounds a wedged link (see
+/// `net.core.wmem_max`) and GROW-ONLY (#163); `SO_SNDTIMEO` bounds a wedged link (see
 /// [`UDP_SEND_TIMEOUT_MS`]). Note: this is `SO_SNDTIMEO`, *not* the
 /// `TCP_USER_TIMEOUT` of [`set_snd_timeout`] (which is a no-op on UDP).
 #[cfg(unix)]
@@ -542,7 +542,18 @@ pub fn configure_udp_sender(socket: &std::net::UdpSocket, sndbuf_target: usize) 
     use nix::sys::time::TimeVal;
     socket.set_nonblocking(false)?;
     let sock = socket2::SockRef::from(socket);
-    let _ = sock.set_send_buffer_size(sndbuf_target);
+    // GROW-ONLY (#163): iperf3 never sets UDP SO_SNDBUF except for -w. The
+    // old unconditional set shrank the buffer ~9-90x below the OS default
+    // whenever batch x blksize was small (a quantum batch at moderate -b, or
+    // -b rate/1's single datagram) and clobbered an earlier -w bump — on a
+    // completion-latency-bound path (real NIC/qdisc; virtio under light
+    // load) that serializes the blocking sender well below target. The
+    // readback compare only ever grows (Linux doubles the requested value;
+    // BSDs don't — comparing against the readback is correct on both).
+    let current = sock.send_buffer_size().unwrap_or(0);
+    if sndbuf_target > current {
+        let _ = sock.set_send_buffer_size(sndbuf_target);
+    }
     let tv = TimeVal::new(
         (UDP_SEND_TIMEOUT_MS / 1000) as libc::time_t,
         ((UDP_SEND_TIMEOUT_MS % 1000) * 1000) as libc::suseconds_t,
@@ -932,6 +943,39 @@ pub async fn udp_bind_reusable(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// #163: configure_udp_sender must be GROW-ONLY. The old unconditional
+    /// set_send_buffer_size shrank SO_SNDBUF ~9-90x below the OS default at
+    /// moderate batch×blksize products (worst at -b rate/1: one datagram!) —
+    /// iperf3 never sets UDP SO_SNDBUF except for an explicit -w.
+    #[cfg(unix)]
+    #[test]
+    fn configure_udp_sender_never_shrinks_sndbuf() {
+        let s = std::net::UdpSocket::bind("127.0.0.1:0").unwrap();
+        let sock = socket2::SockRef::from(&s);
+        let default_buf = sock.send_buffer_size().unwrap();
+        configure_udp_sender(&s, 4096).unwrap();
+        assert!(
+            sock.send_buffer_size().unwrap() >= default_buf,
+            "a small batch target must not shrink the send buffer below the default"
+        );
+    }
+
+    /// #163: an explicit -w bump applied earlier (apply_socket_window runs
+    /// before the data thread) must survive configure_udp_sender.
+    #[cfg(unix)]
+    #[test]
+    fn configure_udp_sender_preserves_window_bump() {
+        let s = std::net::UdpSocket::bind("127.0.0.1:0").unwrap();
+        let sock = socket2::SockRef::from(&s);
+        let _ = sock.set_send_buffer_size(1024 * 1024);
+        let bumped = sock.send_buffer_size().unwrap();
+        configure_udp_sender(&s, 11_584).unwrap();
+        assert!(
+            sock.send_buffer_size().unwrap() >= bumped,
+            "-w's bump must not be clobbered down to batch x blksize"
+        );
+    }
 
     // #59: -w/--window must be applied to UDP sockets, not just TCP. Requesting a
     // size *below* the default and asserting the read-back drops is robust across

--- a/riperf3/src/net.rs
+++ b/riperf3/src/net.rs
@@ -530,12 +530,16 @@ const UDP_SEND_TIMEOUT_MS: u64 = 1000;
 /// [`UDP_SEND_TIMEOUT_MS`]). Note: this is `SO_SNDTIMEO`, *not* the
 /// `TCP_USER_TIMEOUT` of [`set_snd_timeout`] (which is a no-op on UDP).
 #[cfg(unix)]
-pub fn configure_udp_sender(socket: &std::net::UdpSocket, sndbuf_target: usize) -> Result<()> {
+pub fn configure_udp_sender(
+    socket: &std::net::UdpSocket,
+    sndbuf_target: Option<usize>,
+) -> Result<()> {
     use nix::sys::socket::{self, sockopt};
     use nix::sys::time::TimeVal;
     socket.set_nonblocking(false)?;
     let sock = socket2::SockRef::from(socket);
-    // GROW-ONLY (#163): iperf3 never sets UDP SO_SNDBUF except for -w. The
+    // GROW-ONLY, and not at all under an explicit -w (#163; callers pass
+    // None then): iperf3 never sets UDP SO_SNDBUF except for -w. The
     // old unconditional set shrank the buffer ~9-90x below the OS default
     // whenever batch x blksize was small (a quantum batch at moderate -b, or
     // -b rate/1's single datagram) and clobbered an earlier -w bump — on a
@@ -543,9 +547,16 @@ pub fn configure_udp_sender(socket: &std::net::UdpSocket, sndbuf_target: usize) 
     // load) that serializes the blocking sender well below target. The
     // readback compare only ever grows (Linux doubles the requested value;
     // BSDs don't — comparing against the readback is correct on both).
-    let current = sock.send_buffer_size().unwrap_or(0);
-    if sndbuf_target > current {
-        let _ = sock.set_send_buffer_size(sndbuf_target);
+    if let Some(target) = sndbuf_target {
+        // A readback failure degrades to SKIP (the faithful direction), not
+        // to an unconditional set. Linux readback is doubled (BSDs aren't):
+        // a target inside (current/2, current] is a deliberate forgone grow
+        // — blocking-socket kernel backpressure is iperf3's own behavior, so
+        // don't "fix" this comparison to a pre-doubled value.
+        let current = sock.send_buffer_size().unwrap_or(usize::MAX);
+        if target > current {
+            let _ = sock.set_send_buffer_size(target);
+        }
     }
     let tv = TimeVal::new(
         (UDP_SEND_TIMEOUT_MS / 1000) as libc::time_t,
@@ -559,7 +570,10 @@ pub fn configure_udp_sender(socket: &std::net::UdpSocket, sndbuf_target: usize) 
 // wedged send can block until the link recovers; the per-batch deadline can't
 // fire mid-block. Acceptable given the sendmmsg fast path is Unix-only anyway.
 #[cfg(not(unix))]
-pub fn configure_udp_sender(socket: &std::net::UdpSocket, _sndbuf_target: usize) -> Result<()> {
+pub fn configure_udp_sender(
+    socket: &std::net::UdpSocket,
+    _sndbuf_target: Option<usize>,
+) -> Result<()> {
     socket.set_nonblocking(false)?;
     Ok(())
 }
@@ -934,7 +948,7 @@ mod tests {
         let s = std::net::UdpSocket::bind("127.0.0.1:0").unwrap();
         let sock = socket2::SockRef::from(&s);
         let default_buf = sock.send_buffer_size().unwrap();
-        configure_udp_sender(&s, 4096).unwrap();
+        configure_udp_sender(&s, Some(4096)).unwrap();
         assert!(
             sock.send_buffer_size().unwrap() >= default_buf,
             "a small batch target must not shrink the send buffer below the default"
@@ -950,7 +964,7 @@ mod tests {
         let sock = socket2::SockRef::from(&s);
         let _ = sock.set_send_buffer_size(1024 * 1024);
         let bumped = sock.send_buffer_size().unwrap();
-        configure_udp_sender(&s, 11_584).unwrap();
+        configure_udp_sender(&s, Some(11_584)).unwrap();
         assert!(
             sock.send_buffer_size().unwrap() >= bumped,
             "-w's bump must not be clobbered down to batch x blksize"
@@ -1488,7 +1502,7 @@ mod tests {
             "precondition: socket starts non-blocking"
         );
 
-        configure_udp_sender(&socket, 128 * 1460).unwrap();
+        configure_udp_sender(&socket, Some(128 * 1460)).unwrap();
         assert!(
             !is_nonblocking(socket.as_raw_fd()),
             "sender socket must be switched to blocking"
@@ -1503,7 +1517,7 @@ mod tests {
         // is a no-op on UDP and would leave the timeout unset (#6 review).
         use nix::sys::socket::{getsockopt, sockopt};
         let socket = std::net::UdpSocket::bind("127.0.0.1:0").unwrap();
-        configure_udp_sender(&socket, 128 * 1460).unwrap();
+        configure_udp_sender(&socket, Some(128 * 1460)).unwrap();
         let tv = getsockopt(&socket, sockopt::SendTimeout).unwrap();
         assert!(
             tv.tv_sec() > 0 || tv.tv_usec() > 0,

--- a/riperf3/src/net.rs
+++ b/riperf3/src/net.rs
@@ -977,6 +977,38 @@ mod tests {
 
     /// #163: an explicit -w bump applied earlier (apply_socket_window runs
     /// before the data thread) must survive configure_udp_sender.
+    /// #163 review r2 nit: the None path (explicit -w given) must leave
+    /// SO_SNDBUF exactly untouched while still switching to blocking — the
+    /// regression guard against the buffer setup migrating inside the
+    /// Some-arm.
+    #[cfg(unix)]
+    #[test]
+    fn configure_udp_sender_none_leaves_buffer_untouched() {
+        let s = std::net::UdpSocket::bind("127.0.0.1:0").unwrap();
+        let sock = socket2::SockRef::from(&s);
+        let _ = sock.set_send_buffer_size(64 * 1024);
+        let before = sock.send_buffer_size().unwrap();
+        configure_udp_sender(&s, None).unwrap();
+        assert_eq!(
+            sock.send_buffer_size().unwrap(),
+            before,
+            "None must not touch SO_SNDBUF"
+        );
+        // Blocking mode still applied: a recv on an empty socket with the
+        // SO_SNDTIMEO-class timeout... cheapest observable: nonblocking off
+        // means recv_from with a read timeout blocks ~that long, while a
+        // nonblocking socket returns WouldBlock instantly.
+        s.set_read_timeout(Some(std::time::Duration::from_millis(50)))
+            .unwrap();
+        let t0 = std::time::Instant::now();
+        let mut buf = [0u8; 8];
+        let _ = s.recv_from(&mut buf);
+        assert!(
+            t0.elapsed() >= std::time::Duration::from_millis(30),
+            "socket must be in blocking mode after configure_udp_sender(None)"
+        );
+    }
+
     #[cfg(unix)]
     #[test]
     fn configure_udp_sender_preserves_window_bump() {

--- a/riperf3/src/net.rs
+++ b/riperf3/src/net.rs
@@ -957,6 +957,38 @@ mod tests {
 
     /// #163: an explicit -w bump applied earlier (apply_socket_window runs
     /// before the data thread) must survive configure_udp_sender.
+    /// #163 review r2 nit: the None path (explicit -w given) must leave
+    /// SO_SNDBUF exactly untouched while still switching to blocking — the
+    /// regression guard against the buffer setup migrating inside the
+    /// Some-arm.
+    #[cfg(unix)]
+    #[test]
+    fn configure_udp_sender_none_leaves_buffer_untouched() {
+        let s = std::net::UdpSocket::bind("127.0.0.1:0").unwrap();
+        let sock = socket2::SockRef::from(&s);
+        let _ = sock.set_send_buffer_size(64 * 1024);
+        let before = sock.send_buffer_size().unwrap();
+        configure_udp_sender(&s, None).unwrap();
+        assert_eq!(
+            sock.send_buffer_size().unwrap(),
+            before,
+            "None must not touch SO_SNDBUF"
+        );
+        // Blocking mode still applied: a recv on an empty socket with the
+        // SO_SNDTIMEO-class timeout... cheapest observable: nonblocking off
+        // means recv_from with a read timeout blocks ~that long, while a
+        // nonblocking socket returns WouldBlock instantly.
+        s.set_read_timeout(Some(std::time::Duration::from_millis(50)))
+            .unwrap();
+        let t0 = std::time::Instant::now();
+        let mut buf = [0u8; 8];
+        let _ = s.recv_from(&mut buf);
+        assert!(
+            t0.elapsed() >= std::time::Duration::from_millis(30),
+            "socket must be in blocking mode after configure_udp_sender(None)"
+        );
+    }
+
     #[cfg(unix)]
     #[test]
     fn configure_udp_sender_preserves_window_bump() {

--- a/riperf3/src/net.rs
+++ b/riperf3/src/net.rs
@@ -526,7 +526,7 @@ const UDP_SEND_TIMEOUT_MS: u64 = 1000;
 /// send buffer fills, redundantly re-staging the whole batch and starving the
 /// async runtime. Switching to blocking lets the kernel backpressure the
 /// sender thread instead. The `SO_SNDBUF` bump is best-effort (clamped by
-/// `net.core.wmem_max`); `SO_SNDTIMEO` bounds a wedged link (see
+/// `net.core.wmem_max`) and GROW-ONLY (#163); `SO_SNDTIMEO` bounds a wedged link (see
 /// [`UDP_SEND_TIMEOUT_MS`]). Note: this is `SO_SNDTIMEO`, *not* the
 /// `TCP_USER_TIMEOUT` of [`set_snd_timeout`] (which is a no-op on UDP).
 #[cfg(unix)]
@@ -535,7 +535,18 @@ pub fn configure_udp_sender(socket: &std::net::UdpSocket, sndbuf_target: usize) 
     use nix::sys::time::TimeVal;
     socket.set_nonblocking(false)?;
     let sock = socket2::SockRef::from(socket);
-    let _ = sock.set_send_buffer_size(sndbuf_target);
+    // GROW-ONLY (#163): iperf3 never sets UDP SO_SNDBUF except for -w. The
+    // old unconditional set shrank the buffer ~9-90x below the OS default
+    // whenever batch x blksize was small (a quantum batch at moderate -b, or
+    // -b rate/1's single datagram) and clobbered an earlier -w bump — on a
+    // completion-latency-bound path (real NIC/qdisc; virtio under light
+    // load) that serializes the blocking sender well below target. The
+    // readback compare only ever grows (Linux doubles the requested value;
+    // BSDs don't — comparing against the readback is correct on both).
+    let current = sock.send_buffer_size().unwrap_or(0);
+    if sndbuf_target > current {
+        let _ = sock.set_send_buffer_size(sndbuf_target);
+    }
     let tv = TimeVal::new(
         (UDP_SEND_TIMEOUT_MS / 1000) as libc::time_t,
         ((UDP_SEND_TIMEOUT_MS % 1000) * 1000) as libc::suseconds_t,
@@ -912,6 +923,39 @@ pub async fn udp_bind_reusable(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// #163: configure_udp_sender must be GROW-ONLY. The old unconditional
+    /// set_send_buffer_size shrank SO_SNDBUF ~9-90x below the OS default at
+    /// moderate batch×blksize products (worst at -b rate/1: one datagram!) —
+    /// iperf3 never sets UDP SO_SNDBUF except for an explicit -w.
+    #[cfg(unix)]
+    #[test]
+    fn configure_udp_sender_never_shrinks_sndbuf() {
+        let s = std::net::UdpSocket::bind("127.0.0.1:0").unwrap();
+        let sock = socket2::SockRef::from(&s);
+        let default_buf = sock.send_buffer_size().unwrap();
+        configure_udp_sender(&s, 4096).unwrap();
+        assert!(
+            sock.send_buffer_size().unwrap() >= default_buf,
+            "a small batch target must not shrink the send buffer below the default"
+        );
+    }
+
+    /// #163: an explicit -w bump applied earlier (apply_socket_window runs
+    /// before the data thread) must survive configure_udp_sender.
+    #[cfg(unix)]
+    #[test]
+    fn configure_udp_sender_preserves_window_bump() {
+        let s = std::net::UdpSocket::bind("127.0.0.1:0").unwrap();
+        let sock = socket2::SockRef::from(&s);
+        let _ = sock.set_send_buffer_size(1024 * 1024);
+        let bumped = sock.send_buffer_size().unwrap();
+        configure_udp_sender(&s, 11_584).unwrap();
+        assert!(
+            sock.send_buffer_size().unwrap() >= bumped,
+            "-w's bump must not be clobbered down to batch x blksize"
+        );
+    }
 
     // #59: -w/--window must be applied to UDP sockets, not just TCP. Requesting a
     // size *below* the default and asserting the read-back drops is robust across

--- a/riperf3/src/net.rs
+++ b/riperf3/src/net.rs
@@ -537,12 +537,16 @@ const UDP_SEND_TIMEOUT_MS: u64 = 1000;
 /// [`UDP_SEND_TIMEOUT_MS`]). Note: this is `SO_SNDTIMEO`, *not* the
 /// `TCP_USER_TIMEOUT` of [`set_snd_timeout`] (which is a no-op on UDP).
 #[cfg(unix)]
-pub fn configure_udp_sender(socket: &std::net::UdpSocket, sndbuf_target: usize) -> Result<()> {
+pub fn configure_udp_sender(
+    socket: &std::net::UdpSocket,
+    sndbuf_target: Option<usize>,
+) -> Result<()> {
     use nix::sys::socket::{self, sockopt};
     use nix::sys::time::TimeVal;
     socket.set_nonblocking(false)?;
     let sock = socket2::SockRef::from(socket);
-    // GROW-ONLY (#163): iperf3 never sets UDP SO_SNDBUF except for -w. The
+    // GROW-ONLY, and not at all under an explicit -w (#163; callers pass
+    // None then): iperf3 never sets UDP SO_SNDBUF except for -w. The
     // old unconditional set shrank the buffer ~9-90x below the OS default
     // whenever batch x blksize was small (a quantum batch at moderate -b, or
     // -b rate/1's single datagram) and clobbered an earlier -w bump — on a
@@ -550,9 +554,16 @@ pub fn configure_udp_sender(socket: &std::net::UdpSocket, sndbuf_target: usize) 
     // load) that serializes the blocking sender well below target. The
     // readback compare only ever grows (Linux doubles the requested value;
     // BSDs don't — comparing against the readback is correct on both).
-    let current = sock.send_buffer_size().unwrap_or(0);
-    if sndbuf_target > current {
-        let _ = sock.set_send_buffer_size(sndbuf_target);
+    if let Some(target) = sndbuf_target {
+        // A readback failure degrades to SKIP (the faithful direction), not
+        // to an unconditional set. Linux readback is doubled (BSDs aren't):
+        // a target inside (current/2, current] is a deliberate forgone grow
+        // — blocking-socket kernel backpressure is iperf3's own behavior, so
+        // don't "fix" this comparison to a pre-doubled value.
+        let current = sock.send_buffer_size().unwrap_or(usize::MAX);
+        if target > current {
+            let _ = sock.set_send_buffer_size(target);
+        }
     }
     let tv = TimeVal::new(
         (UDP_SEND_TIMEOUT_MS / 1000) as libc::time_t,
@@ -566,7 +577,10 @@ pub fn configure_udp_sender(socket: &std::net::UdpSocket, sndbuf_target: usize) 
 // wedged send can block until the link recovers; the per-batch deadline can't
 // fire mid-block. Acceptable given the sendmmsg fast path is Unix-only anyway.
 #[cfg(not(unix))]
-pub fn configure_udp_sender(socket: &std::net::UdpSocket, _sndbuf_target: usize) -> Result<()> {
+pub fn configure_udp_sender(
+    socket: &std::net::UdpSocket,
+    _sndbuf_target: Option<usize>,
+) -> Result<()> {
     socket.set_nonblocking(false)?;
     Ok(())
 }
@@ -954,7 +968,7 @@ mod tests {
         let s = std::net::UdpSocket::bind("127.0.0.1:0").unwrap();
         let sock = socket2::SockRef::from(&s);
         let default_buf = sock.send_buffer_size().unwrap();
-        configure_udp_sender(&s, 4096).unwrap();
+        configure_udp_sender(&s, Some(4096)).unwrap();
         assert!(
             sock.send_buffer_size().unwrap() >= default_buf,
             "a small batch target must not shrink the send buffer below the default"
@@ -970,7 +984,7 @@ mod tests {
         let sock = socket2::SockRef::from(&s);
         let _ = sock.set_send_buffer_size(1024 * 1024);
         let bumped = sock.send_buffer_size().unwrap();
-        configure_udp_sender(&s, 11_584).unwrap();
+        configure_udp_sender(&s, Some(11_584)).unwrap();
         assert!(
             sock.send_buffer_size().unwrap() >= bumped,
             "-w's bump must not be clobbered down to batch x blksize"
@@ -1534,7 +1548,7 @@ mod tests {
             "precondition: socket starts non-blocking"
         );
 
-        configure_udp_sender(&socket, 128 * 1460).unwrap();
+        configure_udp_sender(&socket, Some(128 * 1460)).unwrap();
         assert!(
             !is_nonblocking(socket.as_raw_fd()),
             "sender socket must be switched to blocking"
@@ -1549,7 +1563,7 @@ mod tests {
         // is a no-op on UDP and would leave the timeout unset (#6 review).
         use nix::sys::socket::{getsockopt, sockopt};
         let socket = std::net::UdpSocket::bind("127.0.0.1:0").unwrap();
-        configure_udp_sender(&socket, 128 * 1460).unwrap();
+        configure_udp_sender(&socket, Some(128 * 1460)).unwrap();
         let tv = getsockopt(&socket, sockopt::SendTimeout).unwrap();
         assert!(
             tv.tv_sec() > 0 || tv.tv_usec() > 0,

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -987,11 +987,12 @@ impl Server {
                 let pt = cfg.pacing_timer; // #185: pace the UDP batch too
                 let u64bit = cfg.udp_counters_64bit;
                 let bu = cfg.burst;
+                let uw = cfg.window.is_some();
                 let st = start.clone();
                 let md = max_duration;
                 let task = thread_gate.spawn(move || {
                     stream::run_udp_sender_blocking(
-                        std_sock, c, bs, d, rate, pt, bu, u64bit, st, md,
+                        std_sock, c, bs, d, rate, pt, bu, uw, u64bit, st, md,
                     )
                 });
                 streams.push(DataStream {
@@ -1212,6 +1213,7 @@ impl Server {
                 let c = counters.clone();
                 let d = done.clone();
                 let bu = cfg.burst;
+                let uw = cfg.window.is_some();
                 let st = start.clone();
                 let md = max_duration;
                 let task = thread_gate.spawn(move || {
@@ -1224,6 +1226,7 @@ impl Server {
                         rate,
                         pt,
                         bu,
+                        uw,
                         u64bit,
                         st,
                         md,

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -965,11 +965,12 @@ impl Server {
                 let pt = cfg.pacing_timer; // #185: pace the UDP batch too
                 let u64bit = cfg.udp_counters_64bit;
                 let bu = cfg.burst;
+                let uw = cfg.window.is_some();
                 let st = start.clone();
                 let md = max_duration;
                 let task = thread_gate.spawn(move || {
                     stream::run_udp_sender_blocking(
-                        std_sock, c, bs, d, rate, pt, bu, u64bit, st, md,
+                        std_sock, c, bs, d, rate, pt, bu, uw, u64bit, st, md,
                     )
                 });
                 streams.push(DataStream {
@@ -1180,6 +1181,7 @@ impl Server {
                 let c = counters.clone();
                 let d = done.clone();
                 let bu = cfg.burst;
+                let uw = cfg.window.is_some();
                 let st = start.clone();
                 let md = max_duration;
                 let task = thread_gate.spawn(move || {
@@ -1192,6 +1194,7 @@ impl Server {
                         rate,
                         pt,
                         bu,
+                        uw,
                         u64bit,
                         st,
                         md,

--- a/riperf3/src/stream.rs
+++ b/riperf3/src/stream.rs
@@ -1191,6 +1191,7 @@ pub fn run_udp_sender_sendmmsg(
     rate_bits_per_sec: u64,
     pacing_timer_us: u32,
     burst: u32,
+    user_window: bool,
     use_64bit: bool,
     start: Arc<AtomicBool>,
     max_duration: Option<Duration>,
@@ -1225,7 +1226,9 @@ pub fn run_udp_sender_sendmmsg(
     // whole batch and starving the async runtime. Blocking lets the kernel
     // backpressure this thread instead; best-effort enlarge the buffer to a
     // batch and bound a wedged link with SO_SNDTIMEO (issue #6).
-    crate::net::configure_udp_sender(&socket, batch_size * blksize)?;
+    // None under an explicit -w: iperf3 applies the user's window and never
+    // a batch-derived size (#163 review r1 n1).
+    crate::net::configure_udp_sender(&socket, (!user_window).then_some(batch_size * blksize))?;
 
     let fd = socket.as_raw_fd();
 
@@ -1322,6 +1325,7 @@ pub fn run_udp_sender_sendmmsg(
     rate_bits_per_sec: u64,
     pacing_timer_us: u32,
     burst: u32,
+    user_window: bool,
     use_64bit: bool,
     start: Arc<AtomicBool>,
     max_duration: Option<Duration>,
@@ -1334,6 +1338,7 @@ pub fn run_udp_sender_sendmmsg(
         rate_bits_per_sec,
         pacing_timer_us,
         burst,
+        user_window,
         use_64bit,
         start,
         max_duration,
@@ -1438,6 +1443,7 @@ fn udp_send_loop(
     rate_bits_per_sec: u64,
     pacing_timer_us: u32,
     burst: u32,
+    user_window: bool,
     use_64bit: bool,
     start: Arc<AtomicBool>,
     max_duration: Option<Duration>,
@@ -1460,7 +1466,10 @@ fn udp_send_loop(
 
     // Blocking I/O so send() backpressures in-kernel instead of returning
     // WouldBlock and truncating the batch once SO_SNDBUF fills (issue #6).
-    crate::net::configure_udp_sender(socket, batch_size as usize * blksize)?;
+    crate::net::configure_udp_sender(
+        socket,
+        (!user_window).then_some(batch_size as usize * blksize),
+    )?;
 
     let pacing = if rate_bits_per_sec > 0 {
         let rate_bytes = rate_bits_per_sec as f64 / 8.0;
@@ -1544,6 +1553,7 @@ pub fn run_udp_sender_blocking(
     rate_bits_per_sec: u64,
     pacing_timer_us: u32,
     burst: u32,
+    user_window: bool,
     use_64bit: bool,
     start: Arc<AtomicBool>,
     max_duration: Option<Duration>,
@@ -1557,6 +1567,7 @@ pub fn run_udp_sender_blocking(
         rate_bits_per_sec,
         pacing_timer_us,
         burst,
+        user_window,
         use_64bit,
         start,
         max_duration,
@@ -1578,6 +1589,7 @@ pub(crate) fn run_udp_server_demux_sender(
     rate_bits_per_sec: u64,
     pacing_timer_us: u32,
     burst: u32,
+    user_window: bool,
     use_64bit: bool,
     start: Arc<AtomicBool>,
     max_duration: Option<Duration>,
@@ -1591,6 +1603,7 @@ pub(crate) fn run_udp_server_demux_sender(
         rate_bits_per_sec,
         pacing_timer_us,
         burst,
+        user_window,
         use_64bit,
         start,
         max_duration,
@@ -2448,6 +2461,7 @@ mod tests {
                 0,
                 1000,
                 false,
+                false,
                 started(),
                 None,
             )
@@ -2605,6 +2619,7 @@ mod tests {
             1000,
             0,
             false,
+            false,
             started(),
             Some(Duration::from_millis(200)),
         )
@@ -2645,6 +2660,7 @@ mod tests {
             1000,
             0,
             false,
+            false,
             started(),
             Some(Duration::from_millis(200)),
         )
@@ -2675,6 +2691,7 @@ mod tests {
             0,
             1000,
             0,
+            false,
             false,
             started(),
             Some(Duration::from_millis(200)),
@@ -2713,6 +2730,7 @@ mod tests {
             1000,
             0,
             false,
+            false,
             started(),
             None,
         )
@@ -2744,6 +2762,7 @@ mod tests {
                 0,
                 1000,
                 0,
+                false,
                 false,
                 s2,
                 Some(Duration::from_secs(10)),
@@ -2787,6 +2806,7 @@ mod tests {
             1000,
             0,
             false,
+            false,
             start,
             Some(Duration::from_secs(10)),
         )
@@ -2817,6 +2837,7 @@ mod tests {
                 0,
                 1000,
                 0,
+                false,
                 false,
                 s,
                 Some(Duration::from_secs(10)),

--- a/scripts/interop.sh
+++ b/scripts/interop.sh
@@ -241,6 +241,7 @@ order=(
     tcp_fwd tcp_rev tcp_bidir tcp_p4 tcp_len128k tcp_win256k tcp_mss1400
     tcp_omit tcp_zerocopy tcp_get_output
     udp_fwd udp_rev udp_bidir udp_p4 udp_len8192 udp_64bit
+    udp_b100m udp_b100m_rev
 )
 declare -A opts=(
     [tcp_fwd]="-t $DUR"
@@ -259,6 +260,10 @@ declare -A opts=(
     [udp_p4]="-u -P 4 -b 0 -t $DUR"
     [udp_len8192]="-u -l 8192 -b 0 -t $DUR"
     [udp_64bit]="-u --udp-counters-64bit -b 0 -t $DUR"
+    # Paced UDP at a moderate rate (#163): the matrices only ran -b 0, so the
+    # rate-limited send path had no cross-tool coverage at all.
+    [udp_b100m]="-u -b 100M -t $DUR"
+    [udp_b100m_rev]="-u -b 100M -R -t $DUR"
 )
 
 for name in "${order[@]}"; do


### PR DESCRIPTION
## #163 — investigation + the residual fix

**Fleet diagnosis first** (per the issue's ask for an iperf3 same-cell comparison): the filed symptom (`-b 100M` → ~16 Mbit effective, 30-40% loss) **no longer reproduces** on main. Full sweep on the sandbox fleet, VM-to-VM:

| cell | result |
|---|---|
| iperf3 `-b 100M` baseline | 100.0 Mbit/s, 0.0% loss |
| riperf3 `-b 10M` / `-b 100M` / `-b 1G` | on target, 0.0% loss |
| riperf3 `-b 100M -w 416K` | 100.0 Mbit/s, 0.0% loss |
| riperf3 `-b 100M/1`, `-b 1G/1` (burst=1, worst sndbuf case) | on target, 0.0% loss |
| riperf3 `-b 0` (regression check) | 38.1 Gbit/s, 1.0% loss (normal) |

#190's pacing-quantum batch sizing (merged the day after #163 was filed) fixed the live mechanism.

**What lands here:**
- `configure_udp_sender` is **grow-only**: the unconditional `set_send_buffer_size` shrank SO_SNDBUF ~9-90× below the OS default whenever batch×blksize was small (quantum batch at moderate `-b`; `-b rate/1` floors it at one datagram) and clobbered an earlier `-w` bump. iperf3 never sets UDP SO_SNDBUF except for `-w`. Asymptomatic on virtio (fast TX completions) but the exact serialization hazard on completion-latency-bound paths — flagged independently by #193's round-2 review (n3). Red→green unit tests pin both properties.
- **Coverage**: the matrices only ran `-b 0` — why #163 had no signal. `scripts/interop.sh` gains `udp_b100m`/`udp_b100m_rev`; the fleet compat skill gained the same pair, so every future drift gate exercises the paced path.
- Side-find filed as #205 (clap rejects repeated flags where getopt is last-wins).

Fixes #163.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
