### PR TITLE
fix: watch the control socket during the data phase, like iperf3's select (#170)

### DIFF
--- a/riperf3/src/client.rs
+++ b/riperf3/src/client.rs
@@ -176,6 +176,10 @@ async fn watch_control(ctrl: &mut tokio::net::TcpStream) -> ControlEvent {
             Ok(other) => {
                 log::debug!("ignoring control state {other:?} during the data phase");
             }
+            // Recorded deviation (r1 n3): iperf3 splits EOF (IECTRLCLOSE) /
+            // read error (IERECVMESSAGE) / unknown state byte (IEMESSAGE);
+            // riperf3 folds all three into the closed class — the headline
+            // kill case (FIN→EOF) matches byte-for-byte.
             Err(_) => return ControlEvent::Closed,
         }
     }
@@ -980,6 +984,18 @@ impl Client {
         // -n/-k modes had no watch at all, control death in duration mode
         // "completed" the test, and any stray state byte truncated the wait.
         let mut control_event: Option<ControlEvent> = None;
+        // Watch-arm end time (#170 review r1 n2): the reporter timeline is
+        // post-omit-rebased (iperf3 restamps start_time at the boundary), so
+        // an event past the warm-up reports `elapsed - omit`; during the
+        // warm-up the raw elapsed matches iperf3's un-restamped clock.
+        let omit_secs = self.omit as f64;
+        let watch_end_secs = move |raw: f64| {
+            if raw > omit_secs {
+                raw - omit_secs
+            } else {
+                raw
+            }
+        };
         let end_secs = match end_condition {
             EndCondition::Duration(dur) => {
                 // The UDP senders also enforce this deadline themselves inside
@@ -997,7 +1013,7 @@ impl Client {
                     _ = tokio::time::sleep(wall) => dur.as_secs_f64(),
                     ev = watch_control(ctrl) => {
                         control_event = Some(ev);
-                        report_start.elapsed().as_secs_f64()
+                        watch_end_secs(report_start.elapsed().as_secs_f64())
                     }
                 }
             }
@@ -1006,7 +1022,7 @@ impl Client {
                     secs = self.wait_byte_limit(streams, target, &report_start, omit_boundary.as_ref()) => secs,
                     ev = watch_control(ctrl) => {
                         control_event = Some(ev);
-                        report_start.elapsed().as_secs_f64()
+                        watch_end_secs(report_start.elapsed().as_secs_f64())
                     }
                 }
             }
@@ -1021,7 +1037,7 @@ impl Client {
                     ) => secs,
                     ev = watch_control(ctrl) => {
                         control_event = Some(ev);
-                        report_start.elapsed().as_secs_f64()
+                        watch_end_secs(report_start.elapsed().as_secs_f64())
                     }
                 }
             }
@@ -1313,6 +1329,29 @@ impl Client {
                     )
                 });
 
+            // Terminated mid-test (#170): the peer half never arrived.
+            // iperf3 still prints BOTH halves with the missing one ZEROED
+            // (live-captured: `0.00 Bytes 0.00 bits/sec receiver`), so
+            // synthesize a zeroed opposite-role half rather than collapsing
+            // the pair — a lone entry only remains for an odd peer that
+            // exchanged results but skipped this stream id.
+            let peer = peer.or_else(|| {
+                server_results
+                    .is_none()
+                    .then(|| crate::reporter::StreamSummary {
+                        stream_id: s.id,
+                        start: 0.0,
+                        end: test_duration,
+                        bytes: 0,
+                        is_sender: !s.is_sender,
+                        retransmits: None,
+                        jitter: is_udp.then_some(0.0),
+                        lost: is_udp.then_some(0),
+                        total_packets: is_udp.then_some(0),
+                        role_tag,
+                    })
+            });
+
             // iperf3 orders each pair sender-first.
             match peer {
                 Some(peer) if s.is_sender => summaries.extend([local, peer]),
@@ -1538,7 +1577,6 @@ impl Client {
     }
 
     /// `-J`: build and pretty-print the single batched report blob.
-    #[allow(clippy::too_many_arguments)]
     #[allow(clippy::too_many_arguments)]
     fn print_results_json(
         &self,
@@ -3395,6 +3433,11 @@ mod client_run_return_value {
             printed.contains("sender"),
             "a partial summary must render from local data (iperf3 flips to \
              DISPLAY_RESULTS); captured: {printed:?}"
+        );
+        assert!(
+            printed.contains("receiver"),
+            "the missing peer half renders ZEROED, like iperf3's client \
+             (review r1 n1) — never collapsed away: {printed:?}"
         );
         let _ = server_task.await;
     }

--- a/riperf3/src/client.rs
+++ b/riperf3/src/client.rs
@@ -154,6 +154,33 @@ fn transferred_bytes(streams: &[DataStream]) -> u64 {
     sent.max(received)
 }
 
+/// What the mid-test control watch observed (#170).
+enum ControlEvent {
+    /// SERVER_TERMINATE arrived: stop, render a partial summary, error with
+    /// iperf3's IESERVERTERM.
+    Terminated,
+    /// The control connection died (EOF or I/O error): iperf3's select sees
+    /// it immediately and errexits with IECTRLCLOSE.
+    Closed,
+}
+
+/// Watch the control socket during the data phase, like iperf3's select over
+/// control + data fds (#170). Cancel-safe (recv_state is a single 1-byte
+/// read). Any state OTHER than ServerTerminate is logged and ignored — iperf3
+/// treats e.g. a re-sent TEST_RUNNING as a no-op, and the old code's
+/// first-byte-ends-the-wait behavior turned stray bytes into a truncated test.
+async fn watch_control(ctrl: &mut tokio::net::TcpStream) -> ControlEvent {
+    loop {
+        match protocol::recv_state(ctrl).await {
+            Ok(TestState::ServerTerminate) => return ControlEvent::Terminated,
+            Ok(other) => {
+                log::debug!("ignoring control state {other:?} during the data phase");
+            }
+            Err(_) => return ControlEvent::Closed,
+        }
+    }
+}
+
 impl Client {
     pub async fn run(&self) -> Result<TestResultsJson> {
         // -T/--title: prefix every client text line with "<title>:  " (#34),
@@ -308,7 +335,7 @@ impl Client {
                 }
 
                 TestState::TestRunning => {
-                    measured_secs = self
+                    let (secs, terminated) = self
                         .run_test(
                             &mut ctrl,
                             &streams,
@@ -318,6 +345,33 @@ impl Client {
                             byte_budget.as_ref(),
                         )
                         .await?;
+                    measured_secs = secs;
+                    if terminated {
+                        // SERVER_TERMINATE mid-test: iperf3 temporarily flips
+                        // to DISPLAY_RESULTS, renders a summary from the
+                        // PARTIAL local data (no peer half), then errexits
+                        // with IESERVERTERM (#170). A -J run carries the
+                        // message in the blob's "error" key, like
+                        // iperf_json_finish.
+                        self.print_results(
+                            &streams,
+                            cpu_start.as_ref(),
+                            None,
+                            blksize,
+                            &interval_data,
+                            &StartMeta {
+                                cookie: String::from_utf8_lossy(
+                                    &cookie[..protocol::COOKIE_SIZE - 1],
+                                )
+                                .into_owned(),
+                                tcp_mss_default: control_mss,
+                                start_time_millis: test_start_millis,
+                            },
+                            measured_secs,
+                            Some("the server has terminated"),
+                        );
+                        return Err(RiperfError::ServerTerminated);
+                    }
                     // Test finished — send TestEnd
                     protocol::send_state(&mut ctrl, TestState::TestEnd).await?;
                 }
@@ -343,6 +397,7 @@ impl Client {
                             start_time_millis: test_start_millis,
                         },
                         measured_secs,
+                        None,
                     );
                     protocol::send_state(&mut ctrl, TestState::IperfDone).await?;
                     break; // test complete — server will close the connection
@@ -837,6 +892,7 @@ impl Client {
     }
 
     #[allow(clippy::too_many_arguments)] // test-drive knobs, 1:1 with run()'s state
+    /// Returns (authoritative end seconds, server_terminated).
     async fn run_test(
         &self,
         ctrl: &mut TcpStream,
@@ -845,7 +901,7 @@ impl Client {
         blksize: usize,
         collector: Arc<Mutex<crate::reporter::CollectedIntervals>>,
         byte_budget: Option<&(Arc<AtomicI64>, i64)>,
-    ) -> Result<f64> {
+    ) -> Result<(f64, bool)> {
         // Run the interval reporter whenever intervals are enabled. It prints
         // live for text / json-stream; for plain -J it runs silently to collect
         // intervals for the final blob (#36 PR2).
@@ -918,10 +974,14 @@ impl Client {
         // would smear a boundary-aligned end into a spurious sliver). A
         // byte/block run ends at an arbitrary instant, so use the measured
         // elapsed.
+        // Every end-condition mode races the control watch (#170): iperf3's
+        // client main loop is one select() over the control AND data fds, so
+        // control-channel events are observed mid-transfer — previously the
+        // -n/-k modes had no watch at all, control death in duration mode
+        // "completed" the test, and any stray state byte truncated the wait.
+        let mut control_event: Option<ControlEvent> = None;
         let end_secs = match end_condition {
             EndCondition::Duration(dur) => {
-                // Use select to handle both timer and control socket.
-                //
                 // The UDP senders also enforce this deadline themselves inside
                 // their loop (see the `deadline` passed at stream creation):
                 // at a high `-b` the CPU-bound senders can saturate every core
@@ -933,43 +993,37 @@ impl Client {
                 // The authoritative end time handed to the reporter stays the
                 // post-omit `-t` (its timeline restarts at the boundary).
                 let wall = dur + Duration::from_secs(self.omit as u64);
-                let mut aborted = false;
                 tokio::select! {
-                    _ = tokio::time::sleep(wall) => {}
-                    state = protocol::recv_state(ctrl) => {
-                        // Server sent something unexpected during the test
-                        if let Ok(TestState::ServerTerminate) = state {
-                            aborted = true;
-                        }
+                    _ = tokio::time::sleep(wall) => dur.as_secs_f64(),
+                    ev = watch_control(ctrl) => {
+                        control_event = Some(ev);
+                        report_start.elapsed().as_secs_f64()
                     }
                 }
-                if aborted {
-                    // #147: stop the senders and the reporter BEFORE
-                    // propagating — the early return leaked a forever-ticking
-                    // reporter task (and running senders) into a library
-                    // consumer's runtime.
-                    reporter_end.finish(report_start.elapsed().as_secs_f64());
-                    done.store(true, Ordering::Relaxed);
-                    if let Some(handle) = interval_handle {
-                        let _ = handle.await;
-                    }
-                    return Err(RiperfError::Aborted("server terminated".into()));
-                }
-                dur.as_secs_f64()
             }
             EndCondition::Bytes(target) => {
-                self.wait_byte_limit(streams, target, &report_start, omit_boundary.as_ref())
-                    .await
+                tokio::select! {
+                    secs = self.wait_byte_limit(streams, target, &report_start, omit_boundary.as_ref()) => secs,
+                    ev = watch_control(ctrl) => {
+                        control_event = Some(ev);
+                        report_start.elapsed().as_secs_f64()
+                    }
+                }
             }
             EndCondition::Blocks(target) => {
                 // Block-based: approximate by dividing transferred bytes by blksize.
-                self.wait_byte_limit(
-                    streams,
-                    target.saturating_mul(blksize as u64),
-                    &report_start,
-                    omit_boundary.as_ref(),
-                )
-                .await
+                tokio::select! {
+                    secs = self.wait_byte_limit(
+                        streams,
+                        target.saturating_mul(blksize as u64),
+                        &report_start,
+                        omit_boundary.as_ref(),
+                    ) => secs,
+                    ev = watch_control(ctrl) => {
+                        control_event = Some(ev);
+                        report_start.elapsed().as_secs_f64()
+                    }
+                }
             }
         };
 
@@ -984,10 +1038,26 @@ impl Client {
             let _ = handle.await;
         }
 
+        // The watch outcomes surface only AFTER the cleanup above — the #147
+        // class (an early return leaked the reporter into a library
+        // consumer's runtime) must not regrow here.
+        match control_event {
+            Some(ControlEvent::Closed) => {
+                // iperf3 prints no summary on IECTRLCLOSE.
+                return Err(RiperfError::ControlSocketClosed);
+            }
+            Some(ControlEvent::Terminated) => {
+                // The caller renders the partial summary, then errors with
+                // IESERVERTERM (iperf3 flips to DISPLAY_RESULTS first).
+                return Ok((end_secs, true));
+            }
+            None => {}
+        }
+
         // The authoritative test duration: exactly `-t` for a duration run, the
         // measured elapsed for a byte/block-limited run. The summary window and
         // its derived bitrate use this, not the default `-t` (#103).
-        Ok(end_secs)
+        Ok((end_secs, false))
     }
 
     fn build_results(
@@ -1098,6 +1168,7 @@ impl Client {
         interval_data: &Arc<Mutex<crate::reporter::CollectedIntervals>>,
         start_meta: &StartMeta,
         test_duration: f64,
+        error: Option<&str>,
     ) {
         if self.json_output {
             self.print_results_json(
@@ -1108,8 +1179,16 @@ impl Client {
                 interval_data,
                 start_meta,
                 test_duration,
+                error,
             );
         } else if self.json_stream {
+            // iperf3 emits an "error" NDJSON event before the end event when
+            // the run carries one (iperf_api.c:5310-5313) (#170).
+            if let Some(e) = error {
+                crate::reporter::emit_json_stream_line(&crate::json_report::json_stream_event(
+                    "error", &e,
+                ));
+            }
             // --json-stream: emit the `end` event. (Previously this fell through
             // to print_results_text, printing text banners into the NDJSON — #62.)
             self.emit_json_stream_end(
@@ -1389,6 +1468,7 @@ impl Client {
             .collect();
 
         let input = ReportInput {
+            error: None,
             protocol: self.protocol,
             reverse: self.reverse,
             bidir: self.bidir,
@@ -1459,6 +1539,7 @@ impl Client {
 
     /// `-J`: build and pretty-print the single batched report blob.
     #[allow(clippy::too_many_arguments)]
+    #[allow(clippy::too_many_arguments)]
     fn print_results_json(
         &self,
         streams: &[DataStream],
@@ -1468,8 +1549,9 @@ impl Client {
         interval_data: &Arc<Mutex<crate::reporter::CollectedIntervals>>,
         start_meta: &StartMeta,
         test_duration: f64,
+        error: Option<&str>,
     ) {
-        let input = self.build_report_input(
+        let mut input = self.build_report_input(
             streams,
             cpu_start,
             remote_cpu,
@@ -1478,6 +1560,8 @@ impl Client {
             start_meta,
             test_duration,
         );
+        // iperf3's iperf_json_finish attaches the run error to the blob (#170).
+        input.error = error.map(str::to_owned);
         println!("{}", serde_json::to_string_pretty(&input.build()).unwrap());
     }
 
@@ -2376,7 +2460,12 @@ mod tests {
         let res = client
             .run_test(&mut ctrl, &[], &done, 131072, collector.clone(), None)
             .await;
-        assert!(res.is_err(), "ServerTerminate must abort the test");
+        // Since #170 run_test reports the termination as an outcome (the
+        // caller renders the partial summary then errors with IESERVERTERM).
+        assert!(
+            matches!(res, Ok((_, true))),
+            "ServerTerminate must surface as the terminated outcome: {res:?}"
+        );
         assert_eq!(
             Arc::strong_count(&collector),
             1,
@@ -3149,6 +3238,167 @@ mod client_run_return_value {
     /// #147 fix — run()'s DoneOnDrop guard stops the senders on any exit; the
     /// real pre-fix leak (a parked reporter task) is pinned by
     /// `abort_path_joins_the_reporter` in the in-module tests.
+    /// #170 T1: the control connection DYING mid-test (duration mode) must
+    /// surface as ControlSocketClosed promptly — iperf3's select observes the
+    /// EOF immediately and errexits with IECTRLCLOSE. Pre-fix the recv_state
+    /// arm swallowed the error, "completed" the test at the full -t, and the
+    /// failure surfaced (late) as a broken-pipe Io from the TestEnd write.
+    #[tokio::test]
+    async fn control_death_mid_test_is_control_socket_closed() {
+        use crate::protocol::{self, TestState};
+        use tokio::io::AsyncReadExt;
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server_task = tokio::spawn(async move {
+            let (mut ctrl, _) = listener.accept().await.unwrap();
+            let mut cookie = [0u8; 37];
+            ctrl.read_exact(&mut cookie).await.unwrap();
+            protocol::send_state(&mut ctrl, TestState::ParamExchange)
+                .await
+                .unwrap();
+            let _params = protocol::recv_params(&mut ctrl).await.unwrap();
+            protocol::send_state(&mut ctrl, TestState::CreateStreams)
+                .await
+                .unwrap();
+            let (data, _) = listener.accept().await.unwrap();
+            protocol::send_state(&mut ctrl, TestState::TestStart)
+                .await
+                .unwrap();
+            protocol::send_state(&mut ctrl, TestState::TestRunning)
+                .await
+                .unwrap();
+            tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+            drop(ctrl); // control socket dies mid-test
+                        // Hold the data socket a beat so the death is unambiguous.
+            tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+            drop(data);
+        });
+
+        let client = ClientBuilder::new("127.0.0.1")
+            .port(Some(addr.port()))
+            .duration(10)
+            .build()
+            .unwrap();
+        let err = tokio::time::timeout(std::time::Duration::from_secs(5), client.run())
+            .await
+            .expect("must fail promptly, not run out the full -t")
+            .expect_err("control death is an error");
+        assert!(
+            matches!(err, RiperfError::ControlSocketClosed),
+            "iperf3's IECTRLCLOSE class, got {err:?}"
+        );
+        let _ = server_task.await;
+    }
+
+    /// #170 T3: -n/--bytes mode had NO control watch at all — a dead server
+    /// stalled the byte-limit poll forever. Pre-fix this test times out.
+    #[tokio::test]
+    async fn bytes_mode_watches_the_control_socket() {
+        use crate::protocol::{self, TestState};
+        use tokio::io::AsyncReadExt;
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server_task = tokio::spawn(async move {
+            let (mut ctrl, _) = listener.accept().await.unwrap();
+            let mut cookie = [0u8; 37];
+            ctrl.read_exact(&mut cookie).await.unwrap();
+            protocol::send_state(&mut ctrl, TestState::ParamExchange)
+                .await
+                .unwrap();
+            let _params = protocol::recv_params(&mut ctrl).await.unwrap();
+            protocol::send_state(&mut ctrl, TestState::CreateStreams)
+                .await
+                .unwrap();
+            let (data, _) = listener.accept().await.unwrap();
+            protocol::send_state(&mut ctrl, TestState::TestStart)
+                .await
+                .unwrap();
+            protocol::send_state(&mut ctrl, TestState::TestRunning)
+                .await
+                .unwrap();
+            tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+            drop(ctrl);
+            tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+            drop(data); // never read: the byte budget can't complete
+        });
+
+        let client = ClientBuilder::new("127.0.0.1")
+            .port(Some(addr.port()))
+            .bytes(1024 * 1024 * 1024) // far beyond what the mock drains
+            .build()
+            .unwrap();
+        let err = tokio::time::timeout(std::time::Duration::from_secs(8), client.run())
+            .await
+            .expect("-n mode must observe control death (pre-fix: hangs)")
+            .expect_err("control death is an error");
+        assert!(
+            matches!(err, RiperfError::ControlSocketClosed),
+            "got {err:?}"
+        );
+        let _ = server_task.await;
+    }
+
+    /// #170 T2: ServerTerminate mid-test still renders a summary from the
+    /// partial local data — iperf3 flips to DISPLAY_RESULTS before erroring
+    /// with IESERVERTERM ("the server has terminated").
+    #[tokio::test]
+    async fn server_terminate_renders_partial_summary() {
+        use crate::protocol::{self, TestState};
+        use tokio::io::AsyncReadExt;
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server_task = tokio::spawn(async move {
+            let (mut ctrl, _) = listener.accept().await.unwrap();
+            let mut cookie = [0u8; 37];
+            ctrl.read_exact(&mut cookie).await.unwrap();
+            protocol::send_state(&mut ctrl, TestState::ParamExchange)
+                .await
+                .unwrap();
+            let _params = protocol::recv_params(&mut ctrl).await.unwrap();
+            protocol::send_state(&mut ctrl, TestState::CreateStreams)
+                .await
+                .unwrap();
+            let (data, _) = listener.accept().await.unwrap();
+            protocol::send_state(&mut ctrl, TestState::TestStart)
+                .await
+                .unwrap();
+            protocol::send_state(&mut ctrl, TestState::TestRunning)
+                .await
+                .unwrap();
+            tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+            protocol::send_state(&mut ctrl, TestState::ServerTerminate)
+                .await
+                .unwrap();
+            // Hold both sockets open; the client returns on its own.
+            tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+            drop((ctrl, data));
+        });
+
+        // The capture guard tees every titled() report line (process-global;
+        // contains()-tolerant assertions below).
+        let capture = crate::macros::OutputCaptureGuard::start();
+        let client = ClientBuilder::new("127.0.0.1")
+            .port(Some(addr.port()))
+            .duration(10)
+            .build()
+            .unwrap();
+        let err = client.run().await.expect_err("expected ServerTerminated");
+        let printed = capture.take();
+        assert!(
+            matches!(err, RiperfError::ServerTerminated),
+            "iperf3's IESERVERTERM class, got {err:?}"
+        );
+        assert!(
+            printed.contains("sender"),
+            "a partial summary must render from local data (iperf3 flips to \
+             DISPLAY_RESULTS); captured: {printed:?}"
+        );
+        let _ = server_task.await;
+    }
+
     #[tokio::test]
     async fn server_terminate_stops_senders_and_reporter() {
         use crate::protocol::{self, TestState};
@@ -3207,10 +3457,10 @@ mod client_run_return_value {
             .duration(10)
             .build()
             .unwrap();
-        let err = client.run().await.expect_err("expected Aborted");
+        let err = client.run().await.expect_err("expected ServerTerminated");
         assert!(
-            matches!(err, RiperfError::Aborted(_)),
-            "expected Aborted, got {err:?}"
+            matches!(err, RiperfError::ServerTerminated),
+            "IESERVERTERM class since #170, got {err:?}"
         );
         // Kernel socket buffers legitimately hold a few MB in flight on
         // loopback; the LEAK signature is continued line-rate production

--- a/riperf3/src/error.rs
+++ b/riperf3/src/error.rs
@@ -45,6 +45,15 @@ pub enum RiperfError {
     #[error("test aborted: {0}")]
     Aborted(String),
 
+    /// iperf3's IECTRLCLOSE: the control connection died mid-test (#170).
+    #[error("control socket has closed unexpectedly")]
+    ControlSocketClosed,
+
+    /// iperf3's IESERVERTERM: the server sent SERVER_TERMINATE mid-test; a
+    /// partial summary is rendered from local data before this surfaces (#170).
+    #[error("the server has terminated")]
+    ServerTerminated,
+
     #[error("peer disconnected")]
     PeerDisconnected,
 }

--- a/riperf3/src/json_report.rs
+++ b/riperf3/src/json_report.rs
@@ -795,8 +795,18 @@ impl ReportInput {
             // (peer → this host) in the *_bidir_reverse pair, matching iperf3 —
             // rather than folding the reverse flow into sum_received (which would
             // make the two aggregates describe different directions).
-            let fwd_recv = if peer_recv > 0 { peer_recv } else { local_sent };
-            let rev_sent = if peer_sent > 0 { peer_sent } else { local_recv };
+            // No cross-graft on a terminated run (#170 review r2 f1): the
+            // peer halves never arrived — iperf3's bidir sums carry 0 there.
+            let fwd_recv = match (peer_recv, self.error.is_some()) {
+                (p, _) if p > 0 => p,
+                (_, true) => 0,
+                _ => local_sent,
+            };
+            let rev_sent = match (peer_sent, self.error.is_some()) {
+                (p, _) if p > 0 => p,
+                (_, true) => 0,
+                _ => local_recv,
+            };
             sum_sent_bidir_reverse = Some(self.tcp_sum(rev_sent, false, None));
             sum_received_bidir_reverse = Some(self.tcp_sum(local_recv, false, None));
             (
@@ -818,7 +828,16 @@ impl ReportInput {
                 peer_recv
             };
             let sent_packets = (sent_bytes / blk) as i64;
-            sum = Some(self.udp_sum(sent_bytes, fwd_sender, sent_packets, udp_lost, udp_jitter));
+            // iperf3's `sum` packet count falls back to the RECEIVER count
+            // when the sender count is absent (iperf_api.c:4242, the
+            // `packet_count = sender ? sender : receiver` running total) —
+            // reachable when a terminated -R run never exchanged (#170 r2 f2).
+            let sum_packets = if sent_packets > 0 {
+                sent_packets
+            } else {
+                udp_packets
+            };
+            sum = Some(self.udp_sum(sent_bytes, fwd_sender, sum_packets, udp_lost, udp_jitter));
             (
                 self.udp_sum(sent_bytes, true, sent_packets, 0, 0.0),
                 self.udp_sum(recv_bytes, false, udp_packets, udp_lost, udp_jitter),
@@ -990,6 +1009,11 @@ impl ReportInput {
                 // stats — iperf3 reports the sender's LOCAL packet count.
                 let blk = self.blksize.max(1) as u64;
                 (s.local_bytes, (s.local_bytes / blk) as i64)
+            } else if !s.is_sender && self.error.is_some() {
+                // Terminated receiver stream (-R): `bytes` is a SENDER-side
+                // count the dead peer never reported — iperf3 emits 0 while
+                // keeping the locally measured packets (#170 r2 f2).
+                (0, u.packets)
             } else {
                 (s.local_bytes, u.packets)
             };

--- a/riperf3/src/json_report.rs
+++ b/riperf3/src/json_report.rs
@@ -828,12 +828,14 @@ impl ReportInput {
             // test's sender flag (!reverse), like iperf3.
             let sent_bytes = match (local_sent, peer_sent) {
                 (0, p) if p > 0 => p,
-                (0, _) => local_recv,
+                // No cross-graft on a terminated run (#170): iperf3's
+                // sum_sent/sum_received carry 0 for the half it never got.
+                (0, _) if self.error.is_none() => local_recv,
                 (s, _) => s,
             };
             let recv_bytes = match (local_recv, peer_recv) {
                 (0, p) if p > 0 => p,
-                (0, _) => local_sent,
+                (0, _) if self.error.is_none() => local_sent,
                 (r, _) => r,
             };
             (
@@ -983,6 +985,11 @@ impl ReportInput {
                 } else {
                     (0, u.packets)
                 }
+            } else if s.is_sender && s.udp.is_none() && self.error.is_some() {
+                // Terminated before the exchange (#170): no peer-measured
+                // stats — iperf3 reports the sender's LOCAL packet count.
+                let blk = self.blksize.max(1) as u64;
+                (s.local_bytes, (s.local_bytes / blk) as i64)
             } else {
                 (s.local_bytes, u.packets)
             };
@@ -1018,10 +1025,12 @@ impl ReportInput {
         // The server never learns the peer's per-stream byte count, so its
         // un-measured side is 0 (iperf3 reports only local counters) — never
         // grafted from `local_bytes` the way the client fills the peer side.
-        let remote_bytes = if self.is_server {
-            0
-        } else {
-            s.remote_bytes.unwrap_or(s.local_bytes)
+        let remote_bytes = match (self.is_server, self.error.is_some()) {
+            (true, _) => 0,
+            // Terminated mid-test (#170): the peer half never arrived —
+            // iperf3 zeroes it (live-verified), never grafts local as peer.
+            (false, true) => s.remote_bytes.unwrap_or(0),
+            (false, false) => s.remote_bytes.unwrap_or(s.local_bytes),
         };
         // The client always emits the sender sub-object's TCP_INFO keys (real on
         // the forward side, 0 on the reverse side it didn't measure). iperf3's

--- a/riperf3/src/json_report.rs
+++ b/riperf3/src/json_report.rs
@@ -1313,6 +1313,69 @@ mod tests {
         }
     }
 
+    /// #170 r3: the terminated-run shapes only existed in live matrices —
+    /// these pins keep a json_report refactor from silently regrowing the
+    /// fabrication family (it escaped two cold rounds for exactly this lack).
+    #[test]
+    fn terminated_bidir_sums_zero_the_absent_peer_halves() {
+        let mut input = base_input();
+        input.bidir = true;
+        input.error = Some("the server has terminated".into());
+        let mut fwd = tcp_stream(1, true, 1_000_000, 0);
+        fwd.remote_bytes = None;
+        fwd.retransmits = None;
+        let mut rev = tcp_stream(3, false, 500_000, 0);
+        rev.remote_bytes = None;
+        rev.retransmits = None;
+        input.streams = vec![fwd, rev];
+        let v = serde_json::to_value(input.build()).unwrap();
+        // iperf3 (live-captured at #170 r2): locals kept, peer halves 0.
+        assert_eq!(v["end"]["sum_sent"]["bytes"], 1_000_000);
+        assert_eq!(v["end"]["sum_received"]["bytes"], 0);
+        assert_eq!(v["end"]["sum_sent_bidir_reverse"]["bytes"], 0);
+        assert_eq!(v["end"]["sum_received_bidir_reverse"]["bytes"], 500_000);
+    }
+
+    #[test]
+    fn terminated_reverse_udp_keeps_measured_packets_with_zero_bytes() {
+        let mut input = base_input();
+        input.protocol = TransportProtocol::Udp;
+        input.reverse = true;
+        input.blksize = 1460;
+        input.error = Some("the server has terminated".into());
+        let mut st = tcp_stream(1, false, 360_151, 0);
+        st.remote_bytes = None;
+        st.retransmits = None;
+        st.udp = Some(UdpStreamStats {
+            jitter_secs: 0.0001,
+            lost_packets: 1,
+            packets: 13,
+            out_of_order: 0,
+        });
+        input.streams = vec![st];
+        let v = serde_json::to_value(input.build()).unwrap();
+        // iperf3 (live-captured at #170 r2/r3): the sender-side bytes the
+        // dead peer never reported are 0; the locally measured packets stay;
+        // sum.packets falls back to the receiver count (iperf_api.c:4242).
+        assert_eq!(v["end"]["streams"][0]["udp"]["bytes"], 0);
+        assert_eq!(v["end"]["streams"][0]["udp"]["packets"], 13);
+        assert_eq!(v["end"]["sum"]["bytes"], 0);
+        assert_eq!(v["end"]["sum"]["packets"], 13);
+    }
+
+    /// The error=None peer-absent graft (legacy-peer tolerance) is unchanged:
+    /// locks the normal-path equivalence r3 verified by inspection.
+    #[test]
+    fn peer_absent_without_error_still_grafts() {
+        let mut input = base_input();
+        let mut st = tcp_stream(1, true, 1_000_000, 0);
+        st.remote_bytes = None;
+        input.streams = vec![st];
+        let v = serde_json::to_value(input.build()).unwrap();
+        assert_eq!(v["end"]["streams"][0]["receiver"]["bytes"], 1_000_000);
+        assert_eq!(v["end"]["sum_received"]["bytes"], 1_000_000);
+    }
+
     #[test]
     fn tcp_forward_end_streams_are_nested_sender_receiver() {
         let mut input = base_input();

--- a/riperf3/src/json_report.rs
+++ b/riperf3/src/json_report.rs
@@ -140,6 +140,10 @@ pub struct Report {
     /// full `-J` report, appended at the end of the top level like iperf3.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub server_output_text: Option<String>,
+    /// Top-level `"error"` key, like iperf_json_finish: a -J run that ends in
+    /// IESERVERTERM still emits the partial blob, error attached (#170).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub server_output_json: Option<serde_json::Value>,
 }
@@ -541,6 +545,8 @@ pub struct UdpStreamStats {
 #[non_exhaustive]
 pub struct ReportInput {
     pub protocol: TransportProtocol,
+    /// iperf3's `"error"` blob key (e.g. "the server has terminated") (#170).
+    pub error: Option<String>,
     pub reverse: bool,
     pub bidir: bool,
     /// The requested `-t` duration parameter, reported under `test_start`. Stays
@@ -947,6 +953,7 @@ impl ReportInput {
             end,
             extra_data: self.extra_data.clone(),
             server_output_text: self.server_output_text.clone(),
+            error: self.error.clone(),
             server_output_json: self.server_output_json.clone(),
         }
     }
@@ -1209,6 +1216,7 @@ mod tests {
 
     fn base_input() -> ReportInput {
         ReportInput {
+            error: None,
             server_output_text: None,
             server_output_json: None,
             protocol: TransportProtocol::Tcp,

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -1436,6 +1436,7 @@ impl Server {
             .collect();
 
         let input = ReportInput {
+            error: None,
             protocol: cfg.protocol,
             reverse: cfg.reverse,
             bidir: cfg.bidir,


### PR DESCRIPTION
## #170 — control-socket watch during the data phase

iperf3's client main loop is a single `select()` over control + data fds; riperf3 checked the control socket only at phase boundaries, and only in duration mode. Three failure-mode gaps closed:

1. **Control death mid-test** → prompt `ControlSocketClosed` (IECTRLCLOSE text) in **every** end-condition mode. Duration mode previously swallowed the error and "completed" at the full `-t` (failing late as broken-pipe Io); `-n`/`-k` had no watch and hung forever. The watch also fixes the latent "any stray state byte ends the wait" bug — non-terminate states log and continue, like iperf3's no-op handling.
2. **SERVER_TERMINATE mid-test** → partial summary from local data (iperf3 flips to DISPLAY_RESULTS), then `ServerTerminated` (IESERVERTERM). `-J` carries the blob `"error"` key per `iperf_json_finish`; `--json-stream` emits the `error` event before `end` (via the existing envelope helper). The stringly `Aborted("server terminated")` migrates to the typed variant (additive, `#[non_exhaustive]`).
3. Outcomes surface only **after** the #147 cleanup — the reporter-leak class can't regrow (pinned by the updated Arc-refcount test).

### Verification
TDD: 3 new mock-server tests red first (wrong variant; the `-n` hang at its 8s timeout; missing summary) → green. The CLI prints `riperf3: error - the server has terminated` / `control socket has closed unexpectedly` via #151's printer. 300 lib tests; full workspace green; clippy/fmt clean.

Fixes #170.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
