### PR TITLE
fix: reset-class ICMP noise no longer aborts UDP demux setup or the shared drain (#180)

### DIFF
--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -1108,7 +1108,13 @@ impl Server {
             }
             let (n, src) =
                 match tokio::time::timeout(remaining, udp_sock.recv_from(&mut magic_buf)).await {
-                    Ok(r) => r?,
+                    Ok(Ok(r)) => r,
+                    // Reset-class noise: our own UDP_CONNECT_REPLY to a client
+                    // port that just closed (e.g. a retry on a fresh socket)
+                    // queues WSAECONNRESET on Windows — it must not abort setup
+                    // for EVERY stream; skip like the data-phase receivers (#180).
+                    Ok(Err(e)) if crate::stream::is_reset_class(&e) => continue,
+                    Ok(Err(e)) => return Err(e.into()),
                     Err(_) => {
                         return Err(RiperfError::Aborted(
                             "timed out waiting for UDP stream connect".into(),

--- a/riperf3/src/stream.rs
+++ b/riperf3/src/stream.rs
@@ -1711,6 +1711,18 @@ pub(crate) fn run_udp_server_demux_receiver(
 /// after the test ends, keep the shared socket open and discard late datagrams
 /// (from any source) until one read-timeout of silence, bounded by
 /// [`UDP_RECEIVER_DRAIN_TIMEOUT`]. See [`drain_udp_after_done`] for the why.
+/// Reset-class noise on a UDP socket (#178/#180): ICMP port-unreachable
+/// blowback from something WE sent to a port that just closed. Windows
+/// latches WSAECONNRESET per send_to target even on an unconnected socket;
+/// Linux surfaces ECONNREFUSED only on connected sockets. Neither is an EOF
+/// — receivers skip and keep going.
+pub(crate) fn is_reset_class(e: &std::io::Error) -> bool {
+    matches!(
+        e.kind(),
+        std::io::ErrorKind::ConnectionReset | std::io::ErrorKind::ConnectionRefused
+    )
+}
+
 fn drain_udp_demux_after_done(socket: &std::net::UdpSocket, buf: &mut [u8]) {
     let deadline = Instant::now() + UDP_RECEIVER_DRAIN_TIMEOUT;
     while Instant::now() < deadline {
@@ -1722,6 +1734,11 @@ fn drain_udp_demux_after_done(socket: &std::net::UdpSocket, buf: &mut [u8]) {
             {
                 break
             }
+            // One client's reset-class noise must not end the SHARED drain
+            // for every client — that reopens the #48 reset against a
+            // still-sending iperf3 <=3.12 peer. The deadline above bounds
+            // the loop, so continuing is safe (#180).
+            Err(e) if is_reset_class(&e) => continue,
             Err(_) => break,
         }
     }
@@ -2270,6 +2287,18 @@ mod tests {
     // floor (max(rate*0.1, 4*blksize) = 512 KiB, granted instantly) overshoots
     // a low -b by ~2x at 1 Mbit/s. iperf3's cumulative-average throttle bounds
     // total sent to elapsed*rate + one in-flight block at any rate/blksize.
+    #[test]
+    fn reset_class_covers_both_platform_shapes() {
+        // #180: WSAECONNRESET (Windows, unconnected send_to blowback) and
+        // ECONNREFUSED (Linux, connected sockets) — neither is an EOF.
+        use std::io::{Error, ErrorKind};
+        assert!(is_reset_class(&Error::from(ErrorKind::ConnectionReset)));
+        assert!(is_reset_class(&Error::from(ErrorKind::ConnectionRefused)));
+        assert!(!is_reset_class(&Error::from(ErrorKind::WouldBlock)));
+        assert!(!is_reset_class(&Error::from(ErrorKind::TimedOut)));
+        assert!(!is_reset_class(&Error::from(ErrorKind::BrokenPipe)));
+    }
+
     /// A `done` flag that never fires, for limiter tests.
     fn never_done() -> AtomicBool {
         AtomicBool::new(false)

--- a/riperf3/src/stream.rs
+++ b/riperf3/src/stream.rs
@@ -1690,14 +1690,7 @@ pub(crate) fn run_udp_server_demux_receiver(
             // (that needs IP_RECVERR); the arm is live on Windows, where
             // winsock latches WSAECONNRESET per send_to target. A break here
             // would silently end reception for EVERY stream at once.
-            Err(e)
-                if matches!(
-                    e.kind(),
-                    std::io::ErrorKind::ConnectionReset | std::io::ErrorKind::ConnectionRefused
-                ) =>
-            {
-                continue
-            }
+            Err(e) if is_reset_class(&e) => continue,
             Err(_) => break,
         }
     }
@@ -1707,10 +1700,6 @@ pub(crate) fn run_udp_server_demux_receiver(
     Ok(())
 }
 
-/// `recv_from` analogue of [`drain_udp_after_done`] for the single-socket demux:
-/// after the test ends, keep the shared socket open and discard late datagrams
-/// (from any source) until one read-timeout of silence, bounded by
-/// [`UDP_RECEIVER_DRAIN_TIMEOUT`]. See [`drain_udp_after_done`] for the why.
 /// Reset-class noise on a UDP socket (#178/#180): ICMP port-unreachable
 /// blowback from something WE sent to a port that just closed. Windows
 /// latches WSAECONNRESET per send_to target even on an unconnected socket;
@@ -1723,6 +1712,10 @@ pub(crate) fn is_reset_class(e: &std::io::Error) -> bool {
     )
 }
 
+/// `recv_from` analogue of [`drain_udp_after_done`] for the single-socket demux:
+/// after the test ends, keep the shared socket open and discard late datagrams
+/// (from any source) until one read-timeout of silence, bounded by
+/// [`UDP_RECEIVER_DRAIN_TIMEOUT`]. See [`drain_udp_after_done`] for the why.
 fn drain_udp_demux_after_done(socket: &std::net::UdpSocket, buf: &mut [u8]) {
     let deadline = Instant::now() + UDP_RECEIVER_DRAIN_TIMEOUT;
     while Instant::now() < deadline {
@@ -1837,14 +1830,7 @@ pub fn run_udp_receiver_blocking(
             // here silently ended the reverse flow: a bidir run completed
             // "normally" with sum_bidir_reverse 0 throughout (windows-latest
             // CI signature).
-            Err(e)
-                if matches!(
-                    e.kind(),
-                    std::io::ErrorKind::ConnectionReset | std::io::ErrorKind::ConnectionRefused
-                ) =>
-            {
-                continue
-            }
+            Err(e) if is_reset_class(&e) => continue,
             Err(_) => break,
         }
     }
@@ -2280,13 +2266,6 @@ mod tests {
         // Effective (post-omit) packet count: 6 - 3 = 3
         assert_eq!(stats.packet_count - stats.omitted_packet_count, 3);
     }
-
-    // -- RateLimiter --
-
-    // #116: with TCP's 128 KiB default block, the old token bucket's burst
-    // floor (max(rate*0.1, 4*blksize) = 512 KiB, granted instantly) overshoots
-    // a low -b by ~2x at 1 Mbit/s. iperf3's cumulative-average throttle bounds
-    // total sent to elapsed*rate + one in-flight block at any rate/blksize.
     #[test]
     fn reset_class_covers_both_platform_shapes() {
         // #180: WSAECONNRESET (Windows, unconnected send_to blowback) and
@@ -2299,6 +2278,12 @@ mod tests {
         assert!(!is_reset_class(&Error::from(ErrorKind::BrokenPipe)));
     }
 
+    // -- RateLimiter --
+
+    // #116: with TCP's 128 KiB default block, the old token bucket's burst
+    // floor (max(rate*0.1, 4*blksize) = 512 KiB, granted instantly) overshoots
+    // a low -b by ~2x at 1 Mbit/s. iperf3's cumulative-average throttle bounds
+    // total sent to elapsed*rate + one in-flight block at any rate/blksize.
     /// A `done` flag that never fires, for limiter tests.
     fn never_done() -> AtomicBool {
         AtomicBool::new(false)


### PR DESCRIPTION
## #180 — reset-class noise resilience (setup + teardown)

Both follow-ups from PR #179's review, the #178 WSAECONNRESET class in two other phases:

1. **Setup**: the demux connect-magic accept loop propagated `recv_from` errors — the server's own `UDP_CONNECT_REPLY` to a client port that just closed (client retrying on a fresh socket) queues WSAECONNRESET on Windows and aborted setup for **every** stream. Now skipped, like the data-phase receivers handle the same class post-#178.
2. **Teardown**: `drain_udp_demux_after_done` broke on any error — one client's reset noise ended the **shared** drain for all clients, reopening the #48 reset against a still-sending iperf3 ≤3.12 peer. The drain is deadline-bounded, so `continue` is safe.

Shared `is_reset_class()` (WSAECONNRESET + ECONNREFUSED) used by both new sites; classification unit-pinned.

### Verification
- **mithrandir (native MSVC)**: all 75 UDP-matching tests green; a real `-u --bidir -P 4` demux run completes cleanly (8 streams, no error). The reset-injection scenario itself is timing-dependent ICMP, deliberately not made a CI test (the #159/#195 flake lesson).
- xcheck 7/7; full workspace green; clippy/fmt clean.

Fixes #180.

🤖 Generated with [Claude Code](https://claude.com/claude-code)