### PR TITLE
fix: Windows signal wiring, pidfile RAII guard, second-signal immediate exit (#158)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -448,9 +448,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.164"
+version = "0.2.168"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "433bfe06b8c75da9b2e3fbea6e5329ff87748f0b144ef75306e674c3f6f7c13f"
+checksum = "5aaeb2981e0606ca11d79718f8bb01164f1d6ed75080182d3abf017e6d244b6d"
 
 [[package]]
 name = "libm"
@@ -1110,9 +1110,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.41.1"
+version = "1.44.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cfb5bee7a6a52939ca9224d6ac897bb669134078daa8735560897f69de4d33"
+checksum = "e6b88822cbe49de4185e3a4cbf8321dd487cf5fe0c5c65695fef6346371e9c48"
 dependencies = [
  "backtrace",
  "bytes",
@@ -1128,9 +1128,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
+checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,8 @@ thiserror = "2.0"
 # tokio >= 1.44: its Windows HandlerRoutine parks for close/logoff/shutdown
 # (tokio #7122) — earlier versions returned immediately and lost the clean
 # pidfile-unlink race (#158 review). libc is lockfile-held at 1.44's floor
-# (0.2.168): 0.2.186 breaks nix-0.29/mio-1.0.2 on NetBSD.
+# (0.2.168): 0.2.186 breaks nix-0.29/mio-1.0.2 on NetBSD (untied by a future
+# nix >= 0.30 bump).
 tokio = { version = "1.44", features = ["full"] }
 windows-sys = { version = "0.52", features = ["Win32_Networking_WinSock", "Win32_System_Threading"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,11 @@ sha1 = "0.10"
 sha2 = "0.10"
 socket2 = "0.5"
 thiserror = "2.0"
-tokio = { version = "1.41", features = ["full"] }
+# tokio >= 1.44: its Windows HandlerRoutine parks for close/logoff/shutdown
+# (tokio #7122) — earlier versions returned immediately and lost the clean
+# pidfile-unlink race (#158 review). libc is lockfile-held at 1.44's floor
+# (0.2.168): 0.2.186 breaks nix-0.29/mio-1.0.2 on NetBSD.
+tokio = { version = "1.44", features = ["full"] }
 windows-sys = { version = "0.52", features = ["Win32_Networking_WinSock", "Win32_System_Threading"] }
 
 [profile.release]

--- a/riperf3-cli/src/main.rs
+++ b/riperf3-cli/src/main.rs
@@ -123,7 +123,7 @@ fn run() -> std::result::Result<(), Box<dyn std::error::Error>> {
     // clean unlink path — there is no startup window where it gets default
     // disposition and strands a fresh pidfile (#105 review). Stream creation
     // registers the OS sigactions immediately; it needs the runtime context.
-    #[cfg(unix)]
+    #[cfg(any(unix, windows))]
     let mut sigend = Sigend::install(&rt).map_err(|e| format!("signal handler setup: {e}"))?;
 
     // Write the PID file LAST before entering the runtime: after daemonizing
@@ -135,23 +135,54 @@ fn run() -> std::result::Result<(), Box<dyn std::error::Error>> {
     }
 
     // The pidfile must be unlinked on EVERY exit path — normal completion,
-    // error, or termination signal — like iperf3, which deletes it after the
-    // server/client loop and in its sigend path (#105). One cleanup point,
-    // after the runtime returns.
+    // error, termination signal, or a panic unwinding through run() (#158):
+    // an RAII guard replaces the single post-runtime unlink, so panic=unwind
+    // can no longer strand the file (iperf3 leaks on crash; strictly better).
+    let _pidfile_guard = PidfileGuard(cli.pidfile.clone().map(std::path::PathBuf::from));
     let pidfile = cli.pidfile.clone();
     let is_server = cli.server;
-    #[cfg(unix)]
+    #[cfg(any(unix, windows))]
     let outcome = rt.block_on(async {
         tokio::select! {
             r = async_main(cli) => r,
             sig = sigend.recv() => Ok(Exit::Signal(sig)),
         }
     });
-    #[cfg(not(unix))]
+    #[cfg(not(any(unix, windows)))]
     let outcome = rt.block_on(async_main(cli));
-    if let Some(ref path) = pidfile {
-        let _ = std::fs::remove_file(path);
+
+    // A SECOND signal during teardown exits immediately (#158): the first
+    // one resolved the select, but a still-blasting UDP peer can hold the
+    // shared drain (and thus runtime shutdown) for up to its 10 s timeout —
+    // pre-#150 a second Ctrl-C always killed the process, and most daemons
+    // treat repeat signals as "now means now".
+    //
+    // Unix: re-register the raw libc handlers — a runtime-spawned watcher
+    // would be cancelled at the start of the very rt-drop hang it exists to
+    // escape. The handler is async-signal-safe (write + unlink + _exit
+    // only); Drop doesn't run under _exit, so it unlinks the pidfile itself.
+    #[cfg(unix)]
+    if matches!(outcome, Ok(Exit::Signal(_))) {
+        drop(sigend); // release tokio's handler state before re-registering
+        second_signal_exits_immediately(pidfile.as_deref());
     }
+    // Windows: best-effort runtime watcher (close/shutdown events carry the
+    // OS's own ~5 s force-kill backstop, so a wedged teardown is bounded
+    // there regardless).
+    #[cfg(windows)]
+    if matches!(outcome, Ok(Exit::Signal(_))) {
+        let pf = pidfile.clone();
+        rt.spawn(async move {
+            let _ = sigend.recv().await;
+            if let Some(ref path) = pf {
+                let _ = std::fs::remove_file(path);
+            }
+            eprintln!("riperf3: interrupt - second signal, exiting immediately");
+            std::process::exit(1);
+        });
+    }
+    #[cfg(not(unix))]
+    let _ = &pidfile;
     match outcome {
         // iperf3 treats SIGTERM/SIGINT/SIGHUP as a NORMAL exit
         // (iperf_got_sigend → iperf_signormalexit → exit 0), printing an
@@ -170,8 +201,59 @@ fn run() -> std::result::Result<(), Box<dyn std::error::Error>> {
 /// signal (which iperf3 reports and treats as a clean exit — see `main`).
 enum Exit {
     Normal,
-    #[cfg_attr(not(unix), allow(dead_code))]
+    #[cfg_attr(not(any(unix, windows)), allow(dead_code))]
     Signal(&'static str),
+}
+
+/// Second-signal hard exit (#158): once the orderly shutdown is underway, a
+/// repeat SIGTERM/SIGINT/SIGHUP must not be swallowed by tokio's (now
+/// shutting-down) signal machinery. Registers plain libc handlers whose body
+/// is async-signal-safe only: write(2) a notice, unlink(2) the pidfile,
+/// _exit(1).
+#[cfg(unix)]
+fn second_signal_exits_immediately(pidfile: Option<&str>) {
+    use std::sync::atomic::{AtomicPtr, Ordering};
+    static PIDFILE: AtomicPtr<libc::c_char> = AtomicPtr::new(std::ptr::null_mut());
+
+    extern "C" fn hard_exit(_sig: libc::c_int) {
+        // SAFETY: async-signal-safe calls only (write/unlink/_exit).
+        unsafe {
+            let msg = b"riperf3: interrupt - second signal, exiting immediately\n";
+            let _ = libc::write(2, msg.as_ptr().cast(), msg.len());
+            let p = PIDFILE.load(Ordering::Relaxed);
+            if !p.is_null() {
+                let _ = libc::unlink(p);
+            }
+            libc::_exit(1);
+        }
+    }
+
+    if let Some(path) = pidfile {
+        if let Ok(c) = std::ffi::CString::new(path) {
+            // Leaked deliberately: the process exits via _exit shortly; the
+            // handler needs a stable pointer.
+            PIDFILE.store(c.into_raw(), Ordering::Relaxed);
+        }
+    }
+    // SAFETY: replacing the dispositions with our handler; tokio's streams
+    // were dropped by the caller.
+    let handler = hard_exit as extern "C" fn(libc::c_int) as *const () as libc::sighandler_t;
+    unsafe {
+        libc::signal(libc::SIGTERM, handler);
+        libc::signal(libc::SIGINT, handler);
+        libc::signal(libc::SIGHUP, handler);
+    }
+}
+
+/// Unlinks the pidfile on drop — every exit path, panics included (#158).
+struct PidfileGuard(Option<std::path::PathBuf>);
+
+impl Drop for PidfileGuard {
+    fn drop(&mut self) {
+        if let Some(p) = &self.0 {
+            let _ = std::fs::remove_file(p);
+        }
+    }
 }
 
 /// The termination-signal set iperf3 catches in `iperf_catch_sigend`
@@ -203,6 +285,41 @@ impl Sigend {
             _ = self.term.recv() => "Terminated(15)",
             _ = self.int.recv() => "Interrupt(2)",
             _ = self.hup.recv() => "Hangup(1)",
+        }
+    }
+}
+
+/// Windows console-event analog of the unix set (#158): iperf3 installs its
+/// sigend handler via CRT signal() for SIGINT/SIGTERM on Windows too. Ctrl+C,
+/// Ctrl+Break, console close, and system shutdown all take the clean
+/// pidfile-unlink path; close/shutdown grant ~5 s before the force-kill.
+#[cfg(windows)]
+struct Sigend {
+    ctrl_c: tokio::signal::windows::CtrlC,
+    ctrl_break: tokio::signal::windows::CtrlBreak,
+    ctrl_close: tokio::signal::windows::CtrlClose,
+    ctrl_shutdown: tokio::signal::windows::CtrlShutdown,
+}
+
+#[cfg(windows)]
+impl Sigend {
+    fn install(rt: &tokio::runtime::Runtime) -> std::io::Result<Self> {
+        use tokio::signal::windows;
+        let _guard = rt.enter();
+        Ok(Self {
+            ctrl_c: windows::ctrl_c()?,
+            ctrl_break: windows::ctrl_break()?,
+            ctrl_close: windows::ctrl_close()?,
+            ctrl_shutdown: windows::ctrl_shutdown()?,
+        })
+    }
+
+    async fn recv(&mut self) -> &'static str {
+        tokio::select! {
+            _ = self.ctrl_c.recv() => "Interrupt(2)",
+            _ = self.ctrl_break.recv() => "Break",
+            _ = self.ctrl_close.recv() => "Close",
+            _ = self.ctrl_shutdown.recv() => "Shutdown",
         }
     }
 }

--- a/riperf3-cli/src/main.rs
+++ b/riperf3-cli/src/main.rs
@@ -143,8 +143,13 @@ fn run() -> std::result::Result<(), Box<dyn std::error::Error>> {
     let is_server = cli.server;
     #[cfg(any(unix, windows))]
     let outcome = rt.block_on(async {
+        // Box::pin: select! polls its futures IN PLACE, and async_main's
+        // future is the entire client/server state machine — inline it
+        // overflows Windows' 1 MiB main-thread stack (unix's 8 MiB masked
+        // it). Heap-pin the big one; the signal future is tiny.
+        let mut app = Box::pin(async_main(cli));
         tokio::select! {
-            r = async_main(cli) => r,
+            r = &mut app => r,
             sig = sigend.recv() => Ok(Exit::Signal(sig)),
         }
     });
@@ -312,8 +317,8 @@ impl Sigend {
 /// the extra events are pidfile hygiene on paths where iperf3 dies dirty.
 /// Close/logoff/shutdown's grace window exists only while the handler runs —
 /// tokio < 1.44 returned from its HandlerRoutine immediately (losing the
-/// race to TerminateProcess); the lockfile pins >= 1.44, whose handler parks
-/// for those events (tokio #7122), so the clean unlink path holds.
+/// race to TerminateProcess); the manifest floors >= 1.44, whose handler
+/// parks for those events (tokio #7122), so the clean unlink path holds.
 #[cfg(windows)]
 struct Sigend {
     ctrl_c: tokio::signal::windows::CtrlC,

--- a/riperf3-cli/src/main.rs
+++ b/riperf3-cli/src/main.rs
@@ -222,7 +222,8 @@ fn second_signal_exits_immediately(pidfile: Option<&str>) {
     static PIDFILE: AtomicPtr<libc::c_char> = AtomicPtr::new(std::ptr::null_mut());
 
     extern "C" fn hard_exit(sig: libc::c_int) {
-        // SAFETY: async-signal-safe calls only (write/unlink/signal/raise/_exit).
+        // SAFETY: async-signal-safe calls only (write/unlink/signal/raise/
+        // pthread_sigmask/_exit; sigemptyset/sigaddset are pure memory ops).
         unsafe {
             let msg = b"riperf3: interrupt - second signal, exiting immediately\n";
             let _ = libc::write(2, msg.as_ptr().cast(), msg.len());
@@ -231,10 +232,17 @@ fn second_signal_exits_immediately(pidfile: Option<&str>) {
                 let _ = libc::unlink(p);
             }
             // Die BY the signal (supervisors distinguish signal-death from
-            // exit-1; a pre-#150 second Ctrl-C read as 130 in shells).
+            // exit-1; a pre-#150 second Ctrl-C read as 130 in shells). The
+            // kernel BLOCKS the handled signal for the handler's duration,
+            // so the re-raise goes pending until it is unblocked — without
+            // the sigmask step the _exit fallback always won (r2 finding 2).
             libc::signal(sig, libc::SIG_DFL);
             let _ = libc::raise(sig);
-            libc::_exit(1); // unreachable fallback
+            let mut set: libc::sigset_t = std::mem::zeroed();
+            libc::sigemptyset(&mut set);
+            libc::sigaddset(&mut set, sig);
+            libc::pthread_sigmask(libc::SIG_UNBLOCK, &set, std::ptr::null_mut());
+            libc::_exit(1); // now genuinely a fallback
         }
     }
 

--- a/riperf3-cli/src/main.rs
+++ b/riperf3-cli/src/main.rs
@@ -163,12 +163,18 @@ fn run() -> std::result::Result<(), Box<dyn std::error::Error>> {
     // only); Drop doesn't run under _exit, so it unlinks the pidfile itself.
     #[cfg(unix)]
     if matches!(outcome, Ok(Exit::Signal(_))) {
-        drop(sigend); // release tokio's handler state before re-registering
+        // tokio never unregisters its libc sigaction (dropping the streams
+        // only detaches listeners) — the libc::signal overwrite below is the
+        // operative action and wins regardless; the drop just tidies.
+        drop(sigend);
         second_signal_exits_immediately(pidfile.as_deref());
     }
-    // Windows: best-effort runtime watcher (close/shutdown events carry the
-    // OS's own ~5 s force-kill backstop, so a wedged teardown is bounded
-    // there regardless).
+    // Windows: best-effort runtime watcher. Once rt-drop cancels it, every
+    // listener is gone, tokio's console handler returns 0 ("run the next
+    // handler"), and the DEFAULT handler terminates the process — so a
+    // second Ctrl+C during a drain hang still exits immediately by
+    // fall-through, just without the notice; the pidfile was already
+    // unlinked by the guard (drop order: guard before rt).
     #[cfg(windows)]
     if matches!(outcome, Ok(Exit::Signal(_))) {
         let pf = pidfile.clone();
@@ -181,7 +187,7 @@ fn run() -> std::result::Result<(), Box<dyn std::error::Error>> {
             std::process::exit(1);
         });
     }
-    #[cfg(not(unix))]
+    #[cfg(not(any(unix, windows)))]
     let _ = &pidfile;
     match outcome {
         // iperf3 treats SIGTERM/SIGINT/SIGHUP as a NORMAL exit
@@ -215,16 +221,20 @@ fn second_signal_exits_immediately(pidfile: Option<&str>) {
     use std::sync::atomic::{AtomicPtr, Ordering};
     static PIDFILE: AtomicPtr<libc::c_char> = AtomicPtr::new(std::ptr::null_mut());
 
-    extern "C" fn hard_exit(_sig: libc::c_int) {
-        // SAFETY: async-signal-safe calls only (write/unlink/_exit).
+    extern "C" fn hard_exit(sig: libc::c_int) {
+        // SAFETY: async-signal-safe calls only (write/unlink/signal/raise/_exit).
         unsafe {
             let msg = b"riperf3: interrupt - second signal, exiting immediately\n";
             let _ = libc::write(2, msg.as_ptr().cast(), msg.len());
-            let p = PIDFILE.load(Ordering::Relaxed);
+            let p = PIDFILE.load(Ordering::Acquire);
             if !p.is_null() {
                 let _ = libc::unlink(p);
             }
-            libc::_exit(1);
+            // Die BY the signal (supervisors distinguish signal-death from
+            // exit-1; a pre-#150 second Ctrl-C read as 130 in shells).
+            libc::signal(sig, libc::SIG_DFL);
+            let _ = libc::raise(sig);
+            libc::_exit(1); // unreachable fallback
         }
     }
 
@@ -232,7 +242,7 @@ fn second_signal_exits_immediately(pidfile: Option<&str>) {
         if let Ok(c) = std::ffi::CString::new(path) {
             // Leaked deliberately: the process exits via _exit shortly; the
             // handler needs a stable pointer.
-            PIDFILE.store(c.into_raw(), Ordering::Relaxed);
+            PIDFILE.store(c.into_raw(), Ordering::Release);
         }
     }
     // SAFETY: replacing the dispositions with our handler; tokio's streams
@@ -289,15 +299,19 @@ impl Sigend {
     }
 }
 
-/// Windows console-event analog of the unix set (#158): iperf3 installs its
-/// sigend handler via CRT signal() for SIGINT/SIGTERM on Windows too. Ctrl+C,
-/// Ctrl+Break, console close, and system shutdown all take the clean
-/// pidfile-unlink path; close/shutdown grant ~5 s before the force-kill.
+/// Windows console-event analog of the unix set (#158): iperf3's CRT
+/// signal() only ever yields Ctrl+C there (SIGTERM is never OS-delivered);
+/// the extra events are pidfile hygiene on paths where iperf3 dies dirty.
+/// Close/logoff/shutdown's grace window exists only while the handler runs —
+/// tokio < 1.44 returned from its HandlerRoutine immediately (losing the
+/// race to TerminateProcess); the lockfile pins >= 1.44, whose handler parks
+/// for those events (tokio #7122), so the clean unlink path holds.
 #[cfg(windows)]
 struct Sigend {
     ctrl_c: tokio::signal::windows::CtrlC,
     ctrl_break: tokio::signal::windows::CtrlBreak,
     ctrl_close: tokio::signal::windows::CtrlClose,
+    ctrl_logoff: tokio::signal::windows::CtrlLogoff,
     ctrl_shutdown: tokio::signal::windows::CtrlShutdown,
 }
 
@@ -310,6 +324,7 @@ impl Sigend {
             ctrl_c: windows::ctrl_c()?,
             ctrl_break: windows::ctrl_break()?,
             ctrl_close: windows::ctrl_close()?,
+            ctrl_logoff: windows::ctrl_logoff()?,
             ctrl_shutdown: windows::ctrl_shutdown()?,
         })
     }
@@ -319,6 +334,7 @@ impl Sigend {
             _ = self.ctrl_c.recv() => "Interrupt(2)",
             _ = self.ctrl_break.recv() => "Break",
             _ = self.ctrl_close.recv() => "Close",
+            _ = self.ctrl_logoff.recv() => "Logoff",
             _ = self.ctrl_shutdown.recv() => "Shutdown",
         }
     }

--- a/riperf3-cli/tests/pidfile.rs
+++ b/riperf3-cli/tests/pidfile.rs
@@ -136,12 +136,13 @@ fn pidfile_unlinked_after_one_off_run() {
     );
 }
 
-/// #158: a SECOND signal during teardown exits immediately. A UDP peer
-/// blasting at unlimited rate holds the server's shared receiver drain (up to
-/// 10 s) after the first SIGTERM; the second must escape it via the raw libc
-/// handler. Race guard: if teardown won before the second signal landed
-/// (fast machine), the run exits cleanly on the FIRST signal — the hard
-/// assertions (bounded exit, pidfile gone) hold either way.
+/// #158: a SECOND signal during teardown exits immediately, dying BY the
+/// signal. Teardown after the first SIGTERM has a hard ~500 ms floor here
+/// (the blasting client aborts on the dropped control conn, then the drain
+/// needs one SO_RCVTIMEO silence window), so the second SIGTERM at +300 ms
+/// reliably lands while alive — the death-by-SIGTERM status is the
+/// discriminator (review r2 f1: a bounded-exit-only assertion false-passed
+/// against a reverted handler, since plain teardown also beats the bound).
 #[cfg(unix)]
 #[test]
 fn second_signal_during_teardown_exits_immediately() {
@@ -186,13 +187,20 @@ fn second_signal_during_teardown_exits_immediately() {
         libc::kill(pid, libc::SIGTERM);
     }
 
-    // Bounded exit: well under the 10 s drain either way (second-signal
-    // escape, or the teardown simply won the race).
+    // Bounded exit AND death-by-SIGTERM: the bound alone is satisfied by a
+    // plain teardown; the signal status is what only the hard-exit handler
+    // produces (SIG_DFL + raise + unblock).
     let exited = common::wait_bounded(&mut server.0, Duration::from_secs(4));
-    assert!(
-        exited.is_some(),
-        "server must exit promptly after the second signal, not ride out the drain"
-    );
+    let status =
+        exited.expect("server must exit promptly after the second signal, not ride out the drain");
+    {
+        use std::os::unix::process::ExitStatusExt;
+        assert_eq!(
+            status.signal(),
+            Some(libc::SIGTERM),
+            "the second signal must kill BY the signal (got {status:?})"
+        );
+    }
     wait_for(
         || !pf.exists(),
         Duration::from_secs(2),

--- a/riperf3-cli/tests/pidfile.rs
+++ b/riperf3-cli/tests/pidfile.rs
@@ -135,3 +135,68 @@ fn pidfile_unlinked_after_one_off_run() {
         "pidfile must be unlinked when a one-off server exits normally (#105)"
     );
 }
+
+/// #158: a SECOND signal during teardown exits immediately. A UDP peer
+/// blasting at unlimited rate holds the server's shared receiver drain (up to
+/// 10 s) after the first SIGTERM; the second must escape it via the raw libc
+/// handler. Race guard: if teardown won before the second signal landed
+/// (fast machine), the run exits cleanly on the FIRST signal — the hard
+/// assertions (bounded exit, pidfile gone) hold either way.
+#[cfg(unix)]
+#[test]
+fn second_signal_during_teardown_exits_immediately() {
+    let bin = env!("CARGO_BIN_EXE_riperf3");
+    let dir = std::env::temp_dir();
+    let pf = dir.join(format!("riperf3-2sig-{}.pid", std::process::id()));
+    let _ = std::fs::remove_file(&pf);
+    let port = free_port().to_string();
+
+    let server = Command::new(bin)
+        .args(["-s", "-I"])
+        .arg(&pf)
+        .args(["-p", &port])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn server");
+    let mut server = ChildGuard(server);
+    wait_for(
+        || pf.exists(),
+        Duration::from_secs(5),
+        "server pidfile written",
+    );
+
+    // A blasting UDP client makes the post-signal drain non-trivial.
+    let client = Command::new(bin)
+        .args(["-c", "127.0.0.1", "-p", &port, "-u", "-b", "0", "-t", "8"])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn client");
+    let mut client = ChildGuard(client);
+    std::thread::sleep(Duration::from_secs(2)); // mid-test
+
+    let pid = server.0.id() as i32;
+    // SAFETY: plain kill(2) on our own child.
+    unsafe {
+        libc::kill(pid, libc::SIGTERM);
+    }
+    std::thread::sleep(Duration::from_millis(300));
+    unsafe {
+        libc::kill(pid, libc::SIGTERM);
+    }
+
+    // Bounded exit: well under the 10 s drain either way (second-signal
+    // escape, or the teardown simply won the race).
+    let exited = common::wait_bounded(&mut server.0, Duration::from_secs(4));
+    assert!(
+        exited.is_some(),
+        "server must exit promptly after the second signal, not ride out the drain"
+    );
+    wait_for(
+        || !pf.exists(),
+        Duration::from_secs(2),
+        "pidfile unlinked on the signal path",
+    );
+    let _ = client.0.kill();
+}


### PR DESCRIPTION
## #158 — signal-exit follow-ups (items 1-3)

- **Windows signal wiring**: `Sigend` analog over `tokio::signal::windows` (Ctrl+C/Break/close/shutdown — iperf3 installs via CRT `signal()` there too), same pidfile-unlink ordering; the main select widens `unix` → `any(unix, windows)`.
- **Pidfile RAII guard**: panic=unwind can no longer strand the file (iperf3 leaks on crash; strictly better, parity-neutral).
- **Second signal during teardown exits immediately**: unix re-registers raw libc handlers (async-signal-safe body: `write`+`unlink`+`_exit`) — a runtime-spawned watcher would be cancelled at the start of the exact rt-drop hang it exists to escape (a still-blasting UDP peer holds the shared drain up to 10 s). Windows keeps a best-effort runtime watcher; close/shutdown events carry the OS's ~5 s force-kill regardless.
- The sigend **stats-dump + SERVER_TERMINATE** parity item is split to its own issue (needs a shutdown channel into the run loops; the #170 partial-summary plumbing is its natural landing).

### Verification
xcheck 7/7 (the Windows arm compiles); pidfile/daemon CLI tests green; full workspace green; clippy/fmt clean. Windows runtime check on mithrandir rides the review round.

Refs #158 (stats-dump remainder tracked separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)