### PR TITLE
fix: last-wins repeated flags like getopt; omit boundary keeps TCP_INFO extremes (#205, #199)

### DIFF
--- a/riperf3-cli/src/cli.rs
+++ b/riperf3-cli/src/cli.rs
@@ -5,6 +5,10 @@ pub const END_CONDITIONS_MSG: &str = "only one test end condition (-t, -n, -k) m
 
 #[derive(Parser, Debug)]
 #[command(about, author, long_about = None, name = "riperf3", version, disable_version_flag = true)]
+// Last-wins for repeated flags, like iperf3's getopt: wrapper scripts that
+// append override flags to a base command line (`-b 0 ... -b 100M`) must not
+// be rejected by the drop-in (#205).
+#[command(args_override_self = true)]
 #[command(group(
     ArgGroup::new("mode")
         .required(true)
@@ -1164,6 +1168,25 @@ mod cli_tests {
 
         // #167: -S takes iperf3's strtol-base-0 forms (hex/octal), and bad
         // values fail the build with IEBADTOS wording instead of parsing.
+        // #205: repeated flags are last-wins, like iperf3's getopt — wrapper
+        // scripts append override flags to a base line.
+        #[test]
+        fn repeated_flags_are_last_wins() {
+            let cli = Cli::parse_from(["riperf3", "-c", "h", "-b", "0", "-b", "100M"]);
+            let c = build_client_from_cli(&cli);
+            assert_eq!(
+                c,
+                expected_client("h")
+                    .bandwidth_str("100M")
+                    .unwrap()
+                    .build()
+                    .unwrap()
+            );
+            let cli = Cli::parse_from(["riperf3", "-c", "h", "-t", "5", "-t", "30"]);
+            let c = build_client_from_cli(&cli);
+            assert_eq!(c, expected_client("h").duration(30).build().unwrap());
+        }
+
         #[test]
         fn tos_flag_accepts_hex_and_octal() {
             let cli = Cli::parse_from(["riperf3", "-c", "host", "-S", "0x20"]);

--- a/riperf3-cli/src/cli.rs
+++ b/riperf3-cli/src/cli.rs
@@ -1168,25 +1168,6 @@ mod cli_tests {
 
         // #167: -S takes iperf3's strtol-base-0 forms (hex/octal), and bad
         // values fail the build with IEBADTOS wording instead of parsing.
-        // #205: repeated flags are last-wins, like iperf3's getopt — wrapper
-        // scripts append override flags to a base line.
-        #[test]
-        fn repeated_flags_are_last_wins() {
-            let cli = Cli::parse_from(["riperf3", "-c", "h", "-b", "0", "-b", "100M"]);
-            let c = build_client_from_cli(&cli);
-            assert_eq!(
-                c,
-                expected_client("h")
-                    .bandwidth_str("100M")
-                    .unwrap()
-                    .build()
-                    .unwrap()
-            );
-            let cli = Cli::parse_from(["riperf3", "-c", "h", "-t", "5", "-t", "30"]);
-            let c = build_client_from_cli(&cli);
-            assert_eq!(c, expected_client("h").duration(30).build().unwrap());
-        }
-
         #[test]
         fn tos_flag_accepts_hex_and_octal() {
             let cli = Cli::parse_from(["riperf3", "-c", "host", "-S", "0x20"]);
@@ -1202,6 +1183,34 @@ mod cli_tests {
             let cli = Cli::parse_from(["riperf3", "-c", "host", "-S", "256"]);
             let err = cli.build_client().unwrap_err().to_string();
             assert!(err.contains("bad TOS value"), "got: {err}");
+        }
+
+        // #205: repeated flags are last-wins, like iperf3's getopt — wrapper
+        // scripts append override flags to a base line. Pins the value args,
+        // the previously-rejected repeated BOOLS, and the value-optional
+        // reset-to-default (C's bare --timestamps else-leg explicitly resets
+        // to "%c " — iperf_api.c:1566-1573) (review r1 n8).
+        #[test]
+        fn repeated_flags_are_last_wins() {
+            let cli = Cli::parse_from(["riperf3", "-c", "h", "-b", "0", "-b", "100M"]);
+            let c = build_client_from_cli(&cli);
+            assert_eq!(
+                c,
+                expected_client("h")
+                    .bandwidth_str("100M")
+                    .unwrap()
+                    .build()
+                    .unwrap()
+            );
+            let cli = Cli::parse_from(["riperf3", "-c", "h", "-t", "5", "-t", "30"]);
+            let c = build_client_from_cli(&cli);
+            assert_eq!(c, expected_client("h").duration(30).build().unwrap());
+            // Repeated bools parse (previously a hard clap error).
+            let cli = Cli::parse_from(["riperf3", "-c", "h", "-V", "-V"]);
+            assert!(cli.verbose);
+            // Bare repeat of a value-optional flag resets to the default.
+            let cli = Cli::parse_from(["riperf3", "-c", "h", "--timestamps=%H", "--timestamps"]);
+            assert_eq!(cli.timestamps.as_deref(), Some("%c "));
         }
 
         #[test]

--- a/riperf3/src/reporter.rs
+++ b/riperf3/src/reporter.rs
@@ -1132,11 +1132,12 @@ pub fn spawn_interval_reporter(
                         s.counters.set_omit_retransmits(prev_retransmits[i] as i64);
                     }
                     omit_retransmits[i] = prev_retransmits[i];
-                    acc_extremes[i] = StreamExtremes {
-                        stream_id: s.id,
-                        min_rtt: u32::MAX,
-                        ..Default::default()
-                    };
+                    // The TCP_INFO extremes are NOT reset: iperf3's
+                    // iperf_reset_stats clears byte/packet counters, jitter,
+                    // and the retransmit baseline, but stream_max_snd_cwnd/
+                    // snd_wnd/rtt (and even the RTT mean's sum) keep their
+                    // warm-up peaks (#199 — the old full reset under-read
+                    // max_* after an omitted warm-up vs iperf3).
                 }
                 // -n/-k + -O (#31): refill the shared sender budget at the
                 // boundary, where the byte baselines were just snapshotted,


### PR DESCRIPTION
## Small parity batch 4

### #205 — repeated flags are last-wins
`args_override_self = true` on the clap derive: iperf3's getopt takes the last occurrence (`-b 0 … -b 100M` works), and wrapper scripts appending override flags broke against the drop-in. Wired tests pin `-b` and `-t`.

### #199 — `-O` boundary keeps the TCP_INFO extremes
`iperf_reset_stats` (iperf_api.c:3669-3695) clears byte/packet counters, jitter, and the retransmit baseline — but `stream_max_snd_cwnd`/`snd_wnd`/`rtt` (and even the RTT mean's running sum) keep their warm-up peaks. riperf3's boundary fully reset the extremes accumulator, under-reading every `max_*` after an omitted warm-up. The fix is a deletion matching the cited C; a direct red-test needs a TCP_INFO injection seam the reporter doesn't have (recorded for the post-0.8.0 refactor — the change is a deletion whose behavior the reviewer can verify against the C).

Fixes #205. Fixes #199.

🤖 Generated with [Claude Code](https://claude.com/claude-code)