### PR TITLE
fix: render --timestamps with strftime and the user FORMAT (#202)

### DIFF
--- a/riperf3-cli/tests/get_server_output.rs
+++ b/riperf3-cli/tests/get_server_output.rs
@@ -288,7 +288,9 @@ fn json_stream_client_emits_server_output_event_before_end() {
 fn timestamped_server_capture_carries_prefixes() {
     let port = free_port();
     let ps = port.to_string();
-    let server = spawn_server_capturing(&["--timestamps"], &ps);
+    // Explicit format: the faithful default is "%c " (locale datetime, e.g.
+    // "Wed Jun 11 ..."), which has no stable shape to assert (#202).
+    let server = spawn_server_capturing(&["--timestamps=%H:%M:%S "], &ps);
     let out = run_capturing(
         &[
             "-c",

--- a/riperf3/src/client.rs
+++ b/riperf3/src/client.rs
@@ -165,12 +165,12 @@ impl Client {
             .then(|| crate::macros::OutputTitleGuard::set(self.title.clone()));
         // --timestamps prefixes every text report line, run-scoped like the
         // title; never in the machine-JSON modes (#168).
-        let _ts_guard =
-            (self.timestamps.is_some() && !self.json_output && !self.json_stream).then(|| {
-                crate::macros::OutputTimestampGuard::set(
-                    self.timestamps.as_deref().unwrap_or("%c "),
-                )
-            });
+        let _ts_guard = (!self.json_output && !self.json_stream)
+            .then(|| self.timestamps.as_deref())
+            .flatten()
+            // The bare-flag "%c " default is clap's default_missing_value;
+            // by here the format is always concrete.
+            .map(crate::macros::OutputTimestampGuard::set);
 
         // ---- Generate cookie and connect ----
         let cookie = protocol::make_cookie();

--- a/riperf3/src/client.rs
+++ b/riperf3/src/client.rs
@@ -166,7 +166,7 @@ impl Client {
         // --timestamps prefixes every text report line, run-scoped like the
         // title; never in the machine-JSON modes (#168).
         let _ts_guard = (!self.json_output && !self.json_stream)
-            .then(|| self.timestamps.as_deref())
+            .then_some(self.timestamps.as_deref())
             .flatten()
             // The bare-flag "%c " default is clap's default_missing_value;
             // by here the format is always concrete.

--- a/riperf3/src/client.rs
+++ b/riperf3/src/client.rs
@@ -165,8 +165,12 @@ impl Client {
             .then(|| crate::macros::OutputTitleGuard::set(self.title.clone()));
         // --timestamps prefixes every text report line, run-scoped like the
         // title; never in the machine-JSON modes (#168).
-        let _ts_guard = (self.timestamps.is_some() && !self.json_output && !self.json_stream)
-            .then(crate::macros::OutputTimestampGuard::set);
+        let _ts_guard =
+            (self.timestamps.is_some() && !self.json_output && !self.json_stream).then(|| {
+                crate::macros::OutputTimestampGuard::set(
+                    self.timestamps.as_deref().unwrap_or("%c "),
+                )
+            });
 
         // ---- Generate cookie and connect ----
         let cookie = protocol::make_cookie();

--- a/riperf3/src/macros.rs
+++ b/riperf3/src/macros.rs
@@ -67,7 +67,8 @@ impl Drop for OutputCaptureGuard {
 /// active, `titled` prepends the rendered prefix to EVERY report line, so the
 /// console and the --get-server-output capture both carry it — iperf3 buffers
 /// the PREFIXED linebuffer. (Same one-run-at-a-time process-global caveat.)
-static OUTPUT_TIMESTAMPS: RwLock<bool> = RwLock::new(false);
+/// Holds the strftime FORMAT string (#202); iperf3's default is "%c ".
+static OUTPUT_TIMESTAMPS: RwLock<Option<String>> = RwLock::new(None);
 
 pub(crate) struct OutputTimestampGuard;
 
@@ -78,9 +79,9 @@ impl OutputTimestampGuard {
     /// the exact server-clobbers-client topology of the lib's
     /// `timestamps_runs` test (#168 review r1 n3). Mirrors OutputTitleGuard,
     /// whose construct-only-when-titled shape has no such mode.
-    pub(crate) fn set() -> Self {
+    pub(crate) fn set(format: &str) -> Self {
         if let Ok(mut g) = OUTPUT_TIMESTAMPS.write() {
-            *g = true;
+            *g = Some(format.to_string());
         }
         OutputTimestampGuard
     }
@@ -89,7 +90,7 @@ impl OutputTimestampGuard {
 impl Drop for OutputTimestampGuard {
     fn drop(&mut self) {
         if let Ok(mut g) = OUTPUT_TIMESTAMPS.write() {
-            *g = false;
+            *g = None;
         }
     }
 }
@@ -98,10 +99,44 @@ impl Drop for OutputTimestampGuard {
 /// HH:MM:SS (UTC) — the custom strftime FORMAT argument is a recorded
 /// fidelity gap, tracked separately from #168.
 pub(crate) fn output_timestamp_prefix() -> String {
-    let on = OUTPUT_TIMESTAMPS.read().map(|g| *g).unwrap_or(false);
-    if !on {
+    let fmt = match OUTPUT_TIMESTAMPS.read() {
+        Ok(g) => match g.as_deref() {
+            Some(f) => f.to_string(),
+            None => return String::new(),
+        },
+        Err(_) => return String::new(),
+    };
+    render_timestamp(&fmt)
+}
+
+/// Unix: localtime + strftime with the stored FORMAT, exactly iperf3's
+/// iperf_printf (default "%c " — the trailing space lives in the format;
+/// user formats are used verbatim) (#202).
+#[cfg(unix)]
+fn render_timestamp(fmt: &str) -> String {
+    let Ok(cfmt) = std::ffi::CString::new(fmt) else {
         return String::new();
+    };
+    let now = unsafe { libc::time(std::ptr::null_mut()) };
+    let mut tm: libc::tm = unsafe { std::mem::zeroed() };
+    // SAFETY: localtime_r fills `tm` from a valid time_t; strftime writes at
+    // most buf.len()-1 bytes plus NUL and returns the byte count (0 = didn't
+    // fit or empty result — both render as no prefix).
+    unsafe {
+        if libc::localtime_r(&now, &mut tm).is_null() {
+            return String::new();
+        }
+        let mut buf = [0u8; 128];
+        let n = libc::strftime(buf.as_mut_ptr().cast(), buf.len(), cfmt.as_ptr(), &tm);
+        String::from_utf8_lossy(&buf[..n]).into_owned()
     }
+}
+
+/// Windows fallback: libc's msvc surface has no strftime/localtime_r, and
+/// native Windows has no iperf3 ground truth to match — keep the simple
+/// HH:MM:SS UTC shape (#202).
+#[cfg(not(unix))]
+fn render_timestamp(_fmt: &str) -> String {
     let secs = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap_or_default()
@@ -167,6 +202,26 @@ macro_rules! vprintln {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// #202: the prefix renders the STORED strftime format (was hardcoded
+    /// HH:MM:SS UTC ignoring the argument).
+    #[cfg(unix)]
+    #[test]
+    fn timestamp_prefix_honors_the_format() {
+        let _g = OutputTimestampGuard::set("%Y ");
+        let p = output_timestamp_prefix();
+        assert!(
+            p.len() == 5 && p[..4].bytes().all(|b| b.is_ascii_digit()) && p.ends_with(' '),
+            "%Y must render the 4-digit year: {p:?}"
+        );
+        drop(_g);
+        assert_eq!(output_timestamp_prefix(), "", "cleared on drop");
+        let _g = OutputTimestampGuard::set("%c ");
+        assert!(
+            !output_timestamp_prefix().is_empty(),
+            "the %c default renders non-empty"
+        );
+    }
 
     // #34: iperf3 prefixes client lines with "<title>:  " (colon + two spaces),
     // and the prefix must be cleared when the run ends so it can't leak.

--- a/riperf3/src/macros.rs
+++ b/riperf3/src/macros.rs
@@ -73,9 +73,9 @@ static OUTPUT_TIMESTAMPS: RwLock<Option<String>> = RwLock::new(None);
 pub(crate) struct OutputTimestampGuard;
 
 impl OutputTimestampGuard {
-    /// Construct ONLY when timestamps are active (callers use
-    /// `cond.then(OutputTimestampGuard::set)`): an unconditional `set(false)`
-    /// from a concurrent in-process run would clobber another run's `true` —
+    /// Construct ONLY when timestamps are active (callers gate then
+    /// `.map(OutputTimestampGuard::set)`): an unconditional clear from a
+    /// concurrent in-process run would clobber another run's stored format —
     /// the exact server-clobbers-client topology of the lib's
     /// `timestamps_runs` test (#168 review r1 n3). Mirrors OutputTitleGuard,
     /// whose construct-only-when-titled shape has no such mode.

--- a/riperf3/src/macros.rs
+++ b/riperf3/src/macros.rs
@@ -96,8 +96,8 @@ impl Drop for OutputTimestampGuard {
 }
 
 /// The rendered `--timestamps` prefix for the current line, or "" when off.
-/// HH:MM:SS (UTC) — the custom strftime FORMAT argument is a recorded
-/// fidelity gap, tracked separately from #168.
+/// Rendered from the run's stored strftime FORMAT (#202; unix), with a
+/// documented HH:MM:SS fallback on Windows — see `render_timestamp`.
 pub(crate) fn output_timestamp_prefix() -> String {
     let fmt = match OUTPUT_TIMESTAMPS.read() {
         Ok(g) => match g.as_deref() {

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -302,8 +302,12 @@ impl Server {
         // --timestamps prefixes every text report line — through titled(), so
         // the capture above tees the PREFIXED line like iperf3's linebuffer
         // (#168). Run-scoped; never in the machine-JSON modes.
-        let _ts_guard = (self.timestamps.is_some() && !self.json_output && !self.json_stream)
-            .then(crate::macros::OutputTimestampGuard::set);
+        let _ts_guard =
+            (self.timestamps.is_some() && !self.json_output && !self.json_stream).then(|| {
+                crate::macros::OutputTimestampGuard::set(
+                    self.timestamps.as_deref().unwrap_or("%c "),
+                )
+            });
 
         // ---- Auth validation (after params, before streams) ----
         if let (Some(ref privkey_path), Some(ref users_path)) =

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -302,12 +302,12 @@ impl Server {
         // --timestamps prefixes every text report line — through titled(), so
         // the capture above tees the PREFIXED line like iperf3's linebuffer
         // (#168). Run-scoped; never in the machine-JSON modes.
-        let _ts_guard =
-            (self.timestamps.is_some() && !self.json_output && !self.json_stream).then(|| {
-                crate::macros::OutputTimestampGuard::set(
-                    self.timestamps.as_deref().unwrap_or("%c "),
-                )
-            });
+        let _ts_guard = (!self.json_output && !self.json_stream)
+            .then(|| self.timestamps.as_deref())
+            .flatten()
+            // The bare-flag "%c " default is clap's default_missing_value;
+            // by here the format is always concrete.
+            .map(crate::macros::OutputTimestampGuard::set);
 
         // ---- Auth validation (after params, before streams) ----
         if let (Some(ref privkey_path), Some(ref users_path)) =

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -303,7 +303,7 @@ impl Server {
         // the capture above tees the PREFIXED line like iperf3's linebuffer
         // (#168). Run-scoped; never in the machine-JSON modes.
         let _ts_guard = (!self.json_output && !self.json_stream)
-            .then(|| self.timestamps.as_deref())
+            .then_some(self.timestamps.as_deref())
             .flatten()
             // The bare-flag "%c " default is clap's default_missing_value;
             // by here the format is always concrete.


### PR DESCRIPTION
## #202 — `--timestamps[=FORMAT]` fidelity

The renderer ignored the FORMAT and printed hardcoded `HH:MM:SS` UTC; iperf3's `iperf_printf` renders **localtime through strftime** with the stored format, default `"%c "` (trailing space inside the format; user formats verbatim — iperf.h's `TIMESTAMP_FORMAT`).

- The run-scoped guard (from #203) now stores the format; unix renders via `localtime_r` + `strftime`.
- Windows keeps the HH:MM:SS fallback — the libc crate's msvc surface has no strftime (verified against 0.2.164 and latest), and native Windows has no iperf3 ground truth to match (documented in-code).
- The CLI's bare `--timestamps` already carried `default_missing_value = "%c "`; it now takes effect. Composes with #212's bare-repeat reset pin.
- Tests: a macros unit pin (format honored, cleared on drop, `%c` non-empty) + the capture CLI test moves to an explicit format (locale `%c` has no stable shape to assert).

The remaining prefix-coverage residue — banner lines and `vprintln!` output never carry the prefix, where iperf3 prefixes every `iperf_printf` line — is split to **#216** (review r1 finding 1).

Fixes #202 (strftime/FORMAT rendering; the line-coverage residue continues in #216).

🤖 Generated with [Claude Code](https://claude.com/claude-code)