### PR TITLE
fix: per-tick text separator at -P > 1; --json-stream-full-output (#204, #213)

### DIFF
--- a/riperf3-cli/src/cli.rs
+++ b/riperf3-cli/src/cli.rs
@@ -274,6 +274,11 @@ pub struct Cli {
     #[arg(long)]
     pub json_stream: bool,
 
+    /// With --json-stream, also print the complete monolithic JSON document
+    /// after the stream ends
+    #[arg(long = "json-stream-full-output")]
+    pub json_stream_full_output: bool,
+
     /// Enable UDP GSO/GRO
     #[arg(long)]
     pub gsro: bool,
@@ -557,6 +562,9 @@ impl Cli {
         if self.json_stream {
             builder = builder.json_stream(true);
         }
+        if self.json_stream_full_output {
+            builder = builder.json_stream_full_output(true);
+        }
         if self.udp_counters_64bit {
             builder = builder.udp_counters_64bit(true);
         }
@@ -663,6 +671,9 @@ impl Cli {
         }
         if self.json_stream {
             builder = builder.json_stream(true);
+        }
+        if self.json_stream_full_output {
+            builder = builder.json_stream_full_output(true);
         }
         if let Some(secs) = self.idle_timeout {
             builder = builder.idle_timeout(secs);
@@ -1563,6 +1574,27 @@ mod cli_tests {
             let cli = Cli::parse_from(["riperf3", "-c", "h", "--json-stream"]);
             let c = build_client_from_cli(&cli);
             assert_eq!(c, expected_client("h").json_stream(true).build().unwrap());
+        }
+
+        // #213: the full-output leg rides json-stream.
+        #[test]
+        fn json_stream_full_output_wired() {
+            let cli = Cli::parse_from([
+                "riperf3",
+                "-c",
+                "h",
+                "--json-stream",
+                "--json-stream-full-output",
+            ]);
+            let c = build_client_from_cli(&cli);
+            assert_eq!(
+                c,
+                expected_client("h")
+                    .json_stream(true)
+                    .json_stream_full_output(true)
+                    .build()
+                    .unwrap()
+            );
         }
 
         // sendmmsg(2) is Linux/FreeBSD/NetBSD-only (stream.rs); build() rejects

--- a/riperf3-cli/tests/bidir_intervals.rs
+++ b/riperf3-cli/tests/bidir_intervals.rs
@@ -430,3 +430,54 @@ fn tcp_bidir_text_interval_sums_split_per_direction() {
         );
     }
 }
+
+const SEPARATOR: &str = "- - - - - - - - - - - - - - - - - - - - - - - - -";
+
+/// #204: at -P > 1, every tick after the first opens with iperf3's
+/// report_bw_separator line (iperf_print_intermediate: first interval →
+/// header, else if num_streams > 1 → separator). At P=1 the only separator
+/// is the end-block one.
+#[test]
+fn parallel_text_ticks_open_with_separator() {
+    let ps = free_port().to_string();
+    let mut server = spawn_server(&ps);
+    let out = run_capturing(
+        &["-c", "127.0.0.1", "-p", &ps, "-t", "3", "-i", "1", "-P", "2"],
+        Duration::from_secs(20),
+        "tcp P2 text",
+    );
+    let seps = out.matches(SEPARATOR).count();
+    // 3 ticks → 2 per-tick separators (ticks 2 and 3) + the end-block one.
+    assert!(
+        seps >= 3,
+        "expected per-tick separators at P=2 (>=3 incl. end block), got {seps}:\n{out}"
+    );
+    // Shape: a separator line sits between tick SUM rows (not only at the end).
+    let first_sum = out.find("[SUM]").expect("SUM rows at P=2");
+    let sep_after_sum = out[first_sum..].find(SEPARATOR).map(|i| i + first_sum);
+    let summary_hdr = out.rfind("- - -").unwrap();
+    assert!(
+        sep_after_sum.unwrap_or(usize::MAX) < summary_hdr,
+        "a separator must appear mid-run, between ticks:\n{out}"
+    );
+    let _ = server.0.kill();
+}
+
+/// #204 negative: P=1 prints NO per-tick separator (num_streams == 1) — only
+/// the end-block one.
+#[test]
+fn single_stream_text_has_only_the_end_separator() {
+    let ps = free_port().to_string();
+    let mut server = spawn_server(&ps);
+    let out = run_capturing(
+        &["-c", "127.0.0.1", "-p", &ps, "-t", "3", "-i", "1"],
+        Duration::from_secs(20),
+        "tcp P1 text",
+    );
+    assert_eq!(
+        out.matches(SEPARATOR).count(),
+        1,
+        "P=1 must print exactly the end-block separator:\n{out}"
+    );
+    let _ = server.0.kill();
+}

--- a/riperf3-cli/tests/bidir_intervals.rs
+++ b/riperf3-cli/tests/bidir_intervals.rs
@@ -457,11 +457,21 @@ fn parallel_text_ticks_open_with_separator() {
         Duration::from_secs(20),
         "tcp P2 text",
     );
-    let seps = out.matches(SEPARATOR).count();
-    // 3 ticks → 2 per-tick separators (ticks 2 and 3) + the end-block one.
+    // Tie the count to the ticks that actually PRINTED (review r2): under
+    // scheduler load a tick can starve and fold into the end block, so a
+    // wall-clock ">= 3" flakes at 2-core. Each printed tick at P=2 carries
+    // exactly one interval [SUM] row before the end-block separator;
+    // iperf3's rule gives T-1 per-tick separators + the end-block one.
+    let summary_sep = out.rfind(SEPARATOR).expect("end-block separator");
+    let ticks = out[..summary_sep].matches("[SUM]").count();
     assert!(
-        seps >= 3,
-        "expected per-tick separators at P=2 (>=3 incl. end block), got {seps}:\n{out}"
+        ticks >= 2,
+        "need >=2 printed ticks to exercise the mid-run separator:\n{out}"
+    );
+    let seps = out.matches(SEPARATOR).count();
+    assert_eq!(
+        seps, ticks,
+        "T-1 per-tick separators + the end-block one (T={ticks}):\n{out}"
     );
     // Shape: a separator line sits between tick SUM rows (not only at the end).
     let first_sum = out.find("[SUM]").expect("SUM rows at P=2");

--- a/riperf3-cli/tests/bidir_intervals.rs
+++ b/riperf3-cli/tests/bidir_intervals.rs
@@ -442,7 +442,18 @@ fn parallel_text_ticks_open_with_separator() {
     let ps = free_port().to_string();
     let mut server = spawn_server(&ps);
     let out = run_capturing(
-        &["-c", "127.0.0.1", "-p", &ps, "-t", "3", "-i", "1", "-P", "2"],
+        &[
+            "-c",
+            "127.0.0.1",
+            "-p",
+            &ps,
+            "-t",
+            "3",
+            "-i",
+            "1",
+            "-P",
+            "2",
+        ],
         Duration::from_secs(20),
         "tcp P2 text",
     );

--- a/riperf3-cli/tests/json_stream.rs
+++ b/riperf3-cli/tests/json_stream.rs
@@ -211,3 +211,81 @@ fn server_json_stream_is_valid_ndjson() {
         .unwrap();
     assert_valid_ndjson(&out, "server");
 }
+
+/// #213: --json-stream-full-output is the third leg of discard_json — the
+/// NDJSON stream is followed by the complete monolithic -J document
+/// (iperf_api.c:5323 keeps print_full_json under the flag), with populated
+/// intervals.
+#[test]
+fn json_stream_full_output_appends_the_monolithic_document() {
+    let ps = free_port().to_string();
+    let server = Command::new(env!("CARGO_BIN_EXE_riperf3"))
+        .args(["-s", "-1", "-p", &ps])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn server");
+    let mut server = ChildGuard(server);
+    std::thread::sleep(Duration::from_millis(200));
+    let out = run_capturing(
+        &[
+            "-c",
+            "127.0.0.1",
+            "-p",
+            &ps,
+            "-t",
+            "2",
+            "-i",
+            "1",
+            "--json-stream",
+            "--json-stream-full-output",
+        ],
+        Duration::from_secs(20),
+        "json-stream full-output",
+    );
+    // The NDJSON part still leads (event-enveloped single lines)…
+    let first = out.lines().next().expect("output");
+    assert!(
+        first.starts_with("{\"event\":"),
+        "stream still leads: {first}"
+    );
+    // …and a pretty multi-line document follows the `end` event.
+    let end_pos = out.find("{\"event\":\"end\"").expect("end event");
+    let doc_pos = out[end_pos..]
+        .find("{\n")
+        .map(|i| i + end_pos)
+        .expect("a pretty monolithic document must follow the end event");
+    let doc: Value = serde_json::from_str(out[doc_pos..].trim()).expect("document parses");
+    assert!(
+        doc["intervals"].as_array().is_some_and(|a| !a.is_empty()),
+        "the document carries populated intervals (discard_json off)"
+    );
+    assert!(doc["end"].is_object());
+    let _ = server.0.kill();
+}
+
+/// #213 negative: without the flag, nothing follows the end event.
+#[test]
+fn json_stream_without_full_output_ends_at_the_end_event() {
+    let ps = free_port().to_string();
+    let server = Command::new(env!("CARGO_BIN_EXE_riperf3"))
+        .args(["-s", "-1", "-p", &ps])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn server");
+    let mut server = ChildGuard(server);
+    std::thread::sleep(Duration::from_millis(200));
+    let out = run_capturing(
+        &["-c", "127.0.0.1", "-p", &ps, "-t", "2", "--json-stream"],
+        Duration::from_secs(20),
+        "json-stream plain",
+    );
+    let end_pos = out.find("{\"event\":\"end\"").expect("end event");
+    let tail = out[end_pos..].lines().skip(1).collect::<Vec<_>>().join("");
+    assert!(
+        tail.trim().is_empty(),
+        "nothing may follow the end event without the flag: {tail:?}"
+    );
+    let _ = server.0.kill();
+}

--- a/riperf3-cli/tests/json_stream.rs
+++ b/riperf3-cli/tests/json_stream.rs
@@ -289,3 +289,53 @@ fn json_stream_without_full_output_ends_at_the_end_event() {
     );
     let _ = server.0.kill();
 }
+
+/// #213 (server role): the server keeps intervals under the flag and its
+/// stdout carries the trailing document after its own NDJSON stream.
+#[test]
+fn server_json_stream_full_output_appends_the_document() {
+    let ps = free_port().to_string();
+    let server = Command::new(env!("CARGO_BIN_EXE_riperf3"))
+        .args([
+            "-s",
+            "-1",
+            "-p",
+            &ps,
+            "--json-stream",
+            "--json-stream-full-output",
+        ])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn server");
+    let mut server = ChildGuard(server);
+    std::thread::sleep(Duration::from_millis(200));
+    let _ = run_capturing(
+        &["-c", "127.0.0.1", "-p", &ps, "-t", "2", "-i", "1"],
+        Duration::from_secs(20),
+        "plain client",
+    );
+    let deadline = std::time::Instant::now() + Duration::from_secs(10);
+    while server.0.try_wait().expect("try_wait").is_none() {
+        assert!(std::time::Instant::now() < deadline, "server did not exit");
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    let mut out = String::new();
+    server
+        .0
+        .stdout
+        .take()
+        .unwrap()
+        .read_to_string(&mut out)
+        .unwrap();
+    let end_pos = out.find("{\"event\":\"end\"").expect("server end event");
+    let doc_pos = out[end_pos..]
+        .find("{\n")
+        .map(|i| i + end_pos)
+        .expect("server document follows its stream");
+    let doc: Value = serde_json::from_str(out[doc_pos..].trim()).expect("server document parses");
+    assert!(
+        doc["intervals"].as_array().is_some_and(|a| !a.is_empty()),
+        "server-side intervals retained under the flag"
+    );
+}

--- a/riperf3/src/client.rs
+++ b/riperf3/src/client.rs
@@ -47,6 +47,7 @@ pub struct Client {
     pub(crate) verbose: bool,
     pub(crate) json_output: bool,
     pub(crate) json_stream: bool,
+    pub(crate) json_stream_full_output: bool,
     pub(crate) bytes_to_send: Option<u64>,
     pub(crate) blocks_to_send: Option<u64>,
     pub(crate) repeating_payload: bool,
@@ -958,7 +959,10 @@ impl Client {
                     json_stream: self.json_stream,
                     print: print_intervals,
                     blksize,
-                    keep_intervals: false,
+                    // The client keeps intervals only under
+                    // --json-stream-full-output (iperf3's discard_json,
+                    // second leg) (#213).
+                    keep_intervals: self.json_stream_full_output,
                     bidir: self.bidir,
                     is_server: false,
                 },
@@ -1682,10 +1686,17 @@ impl Client {
             start_meta,
             test_duration,
         );
+        let report = input.build();
         crate::reporter::emit_json_stream_line(&crate::json_report::json_stream_event(
             "end",
-            &input.build().end,
+            &report.end,
         ));
+        // --json-stream-full-output: the complete monolithic document also
+        // prints after the stream, like iperf_json_finish keeping
+        // print_full_json under the flag (iperf_api.c:5323) (#213).
+        if self.json_stream_full_output {
+            println!("{}", serde_json::to_string_pretty(&report).unwrap());
+        }
     }
 }
 
@@ -1732,6 +1743,7 @@ pub struct ClientBuilder {
     verbose: bool,
     json_output: bool,
     json_stream: bool,
+    json_stream_full_output: bool,
     bytes_to_send: Option<u64>,
     blocks_to_send: Option<u64>,
     repeating_payload: bool,
@@ -1790,6 +1802,7 @@ impl Default for ClientBuilder {
             verbose: false,
             json_output: false,
             json_stream: false,
+            json_stream_full_output: false,
             bytes_to_send: None,
             blocks_to_send: None,
             repeating_payload: false,
@@ -2006,6 +2019,14 @@ impl ClientBuilder {
     /// `--json-stream`: stream line-delimited interval JSON during the test.
     pub fn json_stream(mut self, enabled: bool) -> Self {
         self.json_stream = enabled;
+        self
+    }
+
+    /// With json-stream, also print the complete monolithic JSON document
+    /// after the stream ends — iperf3's `--json-stream-full-output`, the
+    /// third leg of its discard_json condition (#213).
+    pub fn json_stream_full_output(mut self, enabled: bool) -> Self {
+        self.json_stream_full_output = enabled;
         self
     }
 
@@ -2453,6 +2474,7 @@ impl ClientBuilder {
             verbose: self.verbose,
             json_output: self.json_output,
             json_stream: self.json_stream,
+            json_stream_full_output: self.json_stream_full_output,
             // 0 means "no limit" in iperf3 (`-n 0`/`-k 0` run a plain duration
             // test — its end-condition checks gate on the value), so normalize
             // to unset here rather than ending the test instantly (#140).

--- a/riperf3/src/reporter.rs
+++ b/riperf3/src/reporter.rs
@@ -710,6 +710,9 @@ pub fn spawn_interval_reporter(
         ticker.tick().await; // skip the immediate first tick
 
         let mut interval_num: u64 = 0;
+        // #204: the first tick prints under the start-of-run header; later
+        // ticks at -P > 1 open with the separator.
+        let mut first_tick = true;
         let mut header_printed = false;
         // `-O/--omit` (#31): a real warm-up phase, like iperf3 — ticks during
         // it emit `omitted` intervals on a 0..omit timeline, then the boundary
@@ -995,6 +998,17 @@ pub fn spawn_interval_reporter(
                 // then a combined SUM mixing both directions, even at bidir
                 // P=1 (#143/#187 + review r1 n1).
                 if config.print && !config.json_stream {
+                    // iperf3's iperf_print_intermediate, first stream of a
+                    // tick: the FIRST interval prints the header (riperf3
+                    // prints it at reporter start), every later tick at
+                    // num_streams > 1 opens with the separator — including
+                    // the first post-omit tick; live iperf3 -O does NOT
+                    // reprint the header at the boundary (#204).
+                    let multi_stream = fwd.count > 1 || rev.count > 1;
+                    if !first_tick && multi_stream {
+                        print_separator();
+                    }
+                    first_tick = false;
                     for (acc, dir_is_sender) in [(&fwd, fwd_is_sender), (&rev, !fwd_is_sender)] {
                         for (row_is_sender, row) in &tick_rows {
                             if *row_is_sender == dir_is_sender {

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -623,8 +623,6 @@ impl Server {
                     json_stream: self.json_stream,
                     print: print_intervals,
                     blksize: cfg.blksize,
-                    // iperf3's discard_json: a json-stream server RETAINS the
-                    // interval objects when the client asked for output (#168).
                     // iperf3's discard_json: a json-stream run RETAINS the
                     // interval objects when the client asked for output OR
                     // under --json-stream-full-output (#168, #213).

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -165,6 +165,7 @@ pub struct Server {
     pub(crate) json_output: bool,
     /// Stream line-delimited interval JSON during the test (`--json-stream`).
     pub(crate) json_stream: bool,
+    pub(crate) json_stream_full_output: bool,
 }
 
 /// Best-effort source IP the kernel would use to reach `client_addr`, paired
@@ -624,7 +625,11 @@ impl Server {
                     blksize: cfg.blksize,
                     // iperf3's discard_json: a json-stream server RETAINS the
                     // interval objects when the client asked for output (#168).
-                    keep_intervals: want_server_output && self.json_stream,
+                    // iperf3's discard_json: a json-stream run RETAINS the
+                    // interval objects when the client asked for output OR
+                    // under --json-stream-full-output (#168, #213).
+                    keep_intervals: self.json_stream
+                        && (want_server_output || self.json_stream_full_output),
                     bidir: cfg.bidir,
                     is_server: true,
                 },
@@ -1635,10 +1640,16 @@ impl Server {
             start_time_millis,
             interval_data,
         );
+        let report = input.build();
         crate::reporter::emit_json_stream_line(&crate::json_report::json_stream_event(
             "end",
-            &input.build().end,
+            &report.end,
         ));
+        // --json-stream-full-output: the monolithic document follows the
+        // stream, like iperf_json_finish under the flag (#213).
+        if self.json_stream_full_output {
+            println!("{}", serde_json::to_string_pretty(&report).unwrap());
+        }
     }
 
     /// `--json-stream`: emit the server's `start` event (#62), before any interval
@@ -1698,6 +1709,7 @@ pub struct ServerBuilder {
     use_pkcs1_padding: bool,
     json_output: bool,
     json_stream: bool,
+    json_stream_full_output: bool,
 }
 
 impl Default for ServerBuilder {
@@ -1721,6 +1733,7 @@ impl Default for ServerBuilder {
             use_pkcs1_padding: false,
             json_output: false,
             json_stream: false,
+            json_stream_full_output: false,
         }
     }
 }
@@ -1758,6 +1771,14 @@ impl ServerBuilder {
     /// Stream line-delimited interval JSON during the test (`--json-stream`).
     pub fn json_stream(mut self, enabled: bool) -> Self {
         self.json_stream = enabled;
+        self
+    }
+
+    /// With json-stream, also print the complete monolithic JSON document
+    /// after the stream ends — iperf3's `--json-stream-full-output`, the
+    /// third leg of its discard_json condition (#213).
+    pub fn json_stream_full_output(mut self, enabled: bool) -> Self {
+        self.json_stream_full_output = enabled;
         self
     }
 
@@ -1918,6 +1939,7 @@ impl ServerBuilder {
             use_pkcs1_padding: self.use_pkcs1_padding,
             json_output: self.json_output,
             json_stream: self.json_stream,
+            json_stream_full_output: self.json_stream_full_output,
         })
     }
 }


### PR DESCRIPTION
## Small parity batch 5

### #204 — per-tick `- - - -` separator
`iperf_print_intermediate` (first stream of a tick): first interval → header; else if `num_streams > 1` → `report_bw_separator` (iperf_api.c:4695-4701). The gate maps to the per-direction counts that #201's SUM logic established — bidir P=1 prints two rows per tick but `num_streams==1`, so no separator, matching iperf3. **Live A/B** on identical `-t 2 -O 1 -i 1 -P 2` runs: 3 separators in both tools; iperf3 does **not** reprint the header after the omit boundary (probed live — the restamp does not retrigger the first-interval comparison), and neither do we.

### #213 — `--json-stream-full-output`
The third leg of discard_json (iperf_api.c:3900): intervals retained on both roles, and the complete monolithic document prints after the `end` event (iperf_api.c:5323's `print_full_json`). Flag without `--json-stream` is a getopt-faithful no-op.

Red-first tests: separator shape at P=2 / P=1-negative; trailing-document presence with populated intervals / absence-negative; builder wired test.

Fixes #204. Fixes #213.

🤖 Generated with [Claude Code](https://claude.com/claude-code)