### PR TITLE
fix: error-sink parity — -J document, json-stream events, logfile line, getopt exit codes (#198)

### DIFF
--- a/riperf3-cli/src/main.rs
+++ b/riperf3-cli/src/main.rs
@@ -19,12 +19,24 @@ fn main() -> std::process::ExitCode {
                     let _ = e.print();
                     return std::process::ExitCode::SUCCESS;
                 }
+                // Wording-coupled detection (r1 n5): holds while the mode
+                // group is the only required argument; the usage_errors test
+                // pins it against a clap bump changing the rendering.
                 ErrorKind::MissingRequiredArgument
                     if e.to_string().contains("--server") && e.to_string().contains("--client") =>
                 {
                     eprintln!(
                         "riperf3: parameter error - must either be a client (-c) or server (-s)"
                     );
+                    print_usage_trailer();
+                    return std::process::ExitCode::FAILURE;
+                }
+                ErrorKind::ArgumentConflict
+                    if e.to_string().contains("--server") && e.to_string().contains("--client") =>
+                {
+                    // iperf3's IESERVCLIENT (live: exit 1 + usage trailer).
+                    eprintln!("riperf3: parameter error - cannot be both server and client");
+                    print_usage_trailer();
                     return std::process::ExitCode::FAILURE;
                 }
                 _ => {
@@ -34,6 +46,17 @@ fn main() -> std::process::ExitCode {
             }
         }
     };
+    // Parse-class rejections (#65/#100/#140) resolve BEFORE the sink
+    // dispatch below: iperf3's iperf_exit only emits the JSON document when
+    // json_top exists and only writes the logfile when outfile is open —
+    // both post-parse — so parse-time errors go to STDERR in every mode
+    // (#198 review r1 f1, live-verified: `iperf3 -s -t 5 -J` errors in
+    // plain text on stderr with empty stdout).
+    if let Some(msg) = parse_class_rejection(&cli) {
+        eprintln!("riperf3: error - {msg}");
+        return std::process::ExitCode::FAILURE;
+    }
+
     // The error SINK is chosen by mode, like iperf_errexit (#198): -J puts
     // the message in a JSON document on stdout (nothing on stderr),
     // --json-stream emits an error event + empty end event, --logfile gets
@@ -44,13 +67,16 @@ fn main() -> std::process::ExitCode {
     match run(cli) {
         Ok(()) => std::process::ExitCode::SUCCESS,
         Err(e) => {
-            if json {
-                println!("{}", riperf3::json_report::error_document(&e.to_string()));
-            } else if json_stream {
+            // --json-stream wins over -J when combined: iperf3's
+            // --json-stream gates iperf_json_finish into stream events
+            // (review r1 f2, live-verified).
+            if json_stream {
                 println!(
                     "{}",
                     riperf3::json_report::error_stream_events(&e.to_string())
                 );
+            } else if json {
+                println!("{}", riperf3::json_report::error_document(&e.to_string()));
             } else {
                 let line = format!("riperf3: error - {e}");
                 let logged = logfile.as_deref().and_then(|path| {
@@ -75,6 +101,41 @@ fn main() -> std::process::ExitCode {
     }
 }
 
+/// iperf3's parameter-error usage trailer (usage_shortstr + the --help hint).
+fn print_usage_trailer() {
+    eprintln!();
+    eprintln!("Usage: riperf3 [-s|-c host] [options]");
+    eprintln!("Try `riperf3 --help' for more information.");
+}
+
+/// The parse-class rejections (#65 client-only-on-server, #100
+/// server-only-on-client, #140 conflicting end conditions): iperf3 raises
+/// these in parse_arguments, before any output sink exists, so they print to
+/// stderr in every mode. The messages embed iperf3's canonical IE* text as a
+/// substring and add the offending flag name, which iperf3 omits.
+fn parse_class_rejection(cli: &Cli) -> Option<String> {
+    if cli.server {
+        if let Some(flag) = cli.first_client_only_violation() {
+            return Some(format!(
+                "some option you are trying to set is client only: \
+                 {flag} cannot be used with -s/--server"
+            ));
+        }
+    }
+    if cli.client.is_some() {
+        if let Some(flag) = cli.first_server_only_violation() {
+            return Some(format!(
+                "some option you are trying to set is server only: \
+                 {flag} cannot be used with -c/--client"
+            ));
+        }
+        if cli.end_conditions_conflict() {
+            return Some(cli::END_CONDITIONS_MSG.to_string());
+        }
+    }
+    None
+}
+
 fn run(cli: Cli) -> std::result::Result<(), Box<dyn std::error::Error>> {
     configure_log4rs(cli.debug.unwrap_or(0));
 
@@ -84,36 +145,6 @@ fn run(cli: Cli) -> std::result::Result<(), Box<dyn std::error::Error>> {
     // does any work. The message embeds iperf3's canonical IECLIENTONLY text as
     // a substring (so anything matching iperf3's string still matches) and adds
     // the offending flag name, which iperf3 omits.
-    if cli.server {
-        if let Some(flag) = cli.first_client_only_violation() {
-            return Err(format!(
-                "some option you are trying to set is client only: \
-                 {flag} cannot be used with -s/--server"
-            )
-            .into());
-        }
-    }
-
-    // Reject server-only options on the client (#100), symmetric to the
-    // client-only check above. iperf3 raises IESERVERONLY at parse time for any
-    // option whose parse arm sets `server_flag` (e.g. -D, -1, --idle-timeout,
-    // --rsa-private-key-path, --use-pkcs1-padding); mirror that exact set so a
-    // riperf3 client rejects the same options, before any side effects.
-    if cli.client.is_some() {
-        if let Some(flag) = cli.first_server_only_violation() {
-            return Err(format!(
-                "some option you are trying to set is server only: \
-                 {flag} cannot be used with -c/--client"
-            )
-            .into());
-        }
-        // Conflicting end conditions (#140): iperf3 raises IEENDCONDITIONS in
-        // parse_arguments — before pidfile/logfile/affinity — so this check
-        // also runs ahead of the side effects below.
-        if cli.end_conditions_conflict() {
-            return Err(cli::END_CONDITIONS_MSG.into());
-        }
-    }
 
     // Daemonize BEFORE building the tokio runtime. `daemon()` forks, and forking
     // a process that already has a multi-threaded runtime leaves the child with

--- a/riperf3-cli/src/main.rs
+++ b/riperf3-cli/src/main.rs
@@ -8,22 +8,74 @@ mod cli;
 use cli::Cli;
 
 fn main() -> std::process::ExitCode {
-    match run() {
+    // iperf3's getopt path exits 1 on usage errors (clap defaults to 2), and
+    // a bare invocation raises its exact parameter-error sentence (#198).
+    let cli = match Cli::try_parse() {
+        Ok(cli) => cli,
+        Err(e) => {
+            use clap::error::ErrorKind;
+            match e.kind() {
+                ErrorKind::DisplayHelp | ErrorKind::DisplayVersion => {
+                    let _ = e.print();
+                    return std::process::ExitCode::SUCCESS;
+                }
+                ErrorKind::MissingRequiredArgument
+                    if e.to_string().contains("--server") && e.to_string().contains("--client") =>
+                {
+                    eprintln!(
+                        "riperf3: parameter error - must either be a client (-c) or server (-s)"
+                    );
+                    return std::process::ExitCode::FAILURE;
+                }
+                _ => {
+                    let _ = e.print();
+                    return std::process::ExitCode::FAILURE;
+                }
+            }
+        }
+    };
+    // The error SINK is chosen by mode, like iperf_errexit (#198): -J puts
+    // the message in a JSON document on stdout (nothing on stderr),
+    // --json-stream emits an error event + empty end event, --logfile gets
+    // the text line when set, plain text goes to stderr (#151).
+    let json = cli.json;
+    let json_stream = cli.json_stream;
+    let logfile = cli.logfile.clone();
+    match run(cli) {
         Ok(()) => std::process::ExitCode::SUCCESS,
         Err(e) => {
-            // iperf3's iperf_errexit shape ("iperf3: error - <text>", exit 1)
-            // instead of Rust's Debug rendering; ours carries the actual
-            // binary name. The Display strings already mirror iperf3's IE*
-            // wording where riperf3 implements the same rejections (#151).
-            eprintln!("riperf3: error - {e}");
+            if json {
+                println!("{}", riperf3::json_report::error_document(&e.to_string()));
+            } else if json_stream {
+                println!(
+                    "{}",
+                    riperf3::json_report::error_stream_events(&e.to_string())
+                );
+            } else {
+                let line = format!("riperf3: error - {e}");
+                let logged = logfile.as_deref().and_then(|path| {
+                    use std::io::Write;
+                    std::fs::OpenOptions::new()
+                        .create(true)
+                        .append(true)
+                        .open(path)
+                        .and_then(|mut f| writeln!(f, "{line}"))
+                        .ok()
+                });
+                if logged.is_none() {
+                    // iperf3's iperf_errexit shape ("iperf3: error - <text>",
+                    // exit 1) instead of Rust's Debug rendering; the Display
+                    // strings mirror iperf3's IE* wording (#151). Also the
+                    // fallback when the logfile cannot be opened.
+                    eprintln!("{line}");
+                }
+            }
             std::process::ExitCode::FAILURE
         }
     }
 }
 
-fn run() -> std::result::Result<(), Box<dyn std::error::Error>> {
-    let cli = Cli::parse();
-
+fn run(cli: Cli) -> std::result::Result<(), Box<dyn std::error::Error>> {
     configure_log4rs(cli.debug.unwrap_or(0));
 
     // Reject client-only options on the server (#65) before any side effects

--- a/riperf3-cli/tests/error_format.rs
+++ b/riperf3-cli/tests/error_format.rs
@@ -143,6 +143,21 @@ fn usage_errors_exit_one() {
         stderr.contains("parameter error - must either be a client (-c) or server (-s)"),
         "iperf3's exact no-mode sentence: {stderr:?}"
     );
+    // -s -c h: iperf3's IESERVCLIENT sentence (review r1 n4).
+    let out = std::process::Command::new(bin)
+        .args(["-s", "-c", "h"])
+        .output()
+        .unwrap();
+    assert_eq!(out.status.code(), Some(1));
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("parameter error - cannot be both server and client"),
+        "IESERVCLIENT sentence: {stderr:?}"
+    );
+    assert!(
+        stderr.contains("Usage: riperf3 [-s|-c host] [options]"),
+        "the usage trailer rides parameter errors: {stderr:?}"
+    );
     // --help / --version still exit 0.
     let out = std::process::Command::new(bin)
         .arg("--help")
@@ -154,4 +169,28 @@ fn usage_errors_exit_one() {
         .output()
         .unwrap();
     assert_eq!(out.status.code(), Some(0));
+}
+
+/// #198 review r1 f1: parse-class rejections (#65/#100/#140) print to STDERR
+/// in every mode — iperf3's iperf_exit only mode-sinks POST-parse errors
+/// (json_top exists / outfile open). Live: `iperf3 -s -t 5 -J` errors in
+/// plain text on stderr with empty stdout.
+#[test]
+fn parse_class_errors_stay_on_stderr_even_with_json() {
+    let bin = env!("CARGO_BIN_EXE_riperf3");
+    let out = std::process::Command::new(bin)
+        .args(["-s", "-t", "5", "-J"])
+        .output()
+        .unwrap();
+    assert_eq!(out.status.code(), Some(1));
+    assert!(
+        out.stdout.is_empty(),
+        "no JSON document for a parse-class error: {:?}",
+        String::from_utf8_lossy(&out.stdout)
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("riperf3: error - ") && stderr.contains("client only"),
+        "the #65 rejection stays plain text on stderr: {stderr:?}"
+    );
 }

--- a/riperf3-cli/tests/error_format.rs
+++ b/riperf3-cli/tests/error_format.rs
@@ -33,3 +33,120 @@ fn connect_failure_prints_iperf3_error_shape_and_exits_1() {
         "Rust Debug rendering must be gone, got: {stderr}"
     );
 }
+
+/// #198 item 1: with -J, a failed run puts the message in the JSON document's
+/// "error" key on STDOUT and prints NOTHING to stderr — iperf3's iperf_errexit
+/// json path (live-captured shape: start{connected:[],version,system_info},
+/// intervals:[], end:{}, error).
+#[test]
+fn json_mode_errors_emit_the_document_not_stderr() {
+    let bin = env!("CARGO_BIN_EXE_riperf3");
+    let out = std::process::Command::new(bin)
+        .args(["-c", "127.0.0.1", "-p", "1", "-J"])
+        .output()
+        .unwrap();
+    let (stdout, stderr) = (
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+    assert_eq!(out.status.code(), Some(1));
+    assert!(
+        stderr.trim().is_empty(),
+        "iperf3 prints nothing to stderr under -J: {stderr:?}"
+    );
+    let doc: serde_json::Value =
+        serde_json::from_str(stdout.trim()).expect("stdout is the JSON document");
+    assert!(doc["error"]
+        .as_str()
+        .is_some_and(|e| e.contains("unable to connect")));
+    assert!(doc["start"]["connected"].as_array().is_some_and(Vec::is_empty));
+    assert!(doc["intervals"].as_array().is_some_and(Vec::is_empty));
+    assert!(doc["end"].is_object());
+}
+
+/// #198 item 1 (json-stream): the pre-test failure emits an `error` event then
+/// an empty `end` event — live iperf3 shape — and nothing on stderr.
+#[test]
+fn json_stream_errors_emit_error_then_empty_end_events() {
+    let bin = env!("CARGO_BIN_EXE_riperf3");
+    let out = std::process::Command::new(bin)
+        .args(["-c", "127.0.0.1", "-p", "1", "--json-stream"])
+        .output()
+        .unwrap();
+    assert_eq!(out.status.code(), Some(1));
+    let (stdout, stderr) = (
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+    assert!(stderr.trim().is_empty(), "stderr: {stderr:?}");
+    let lines: Vec<&str> = stdout.trim().lines().collect();
+    assert!(
+        lines[0].starts_with("{\"event\":\"error\",\"data\":\"unable to connect"),
+        "first event: {:?}",
+        lines.first()
+    );
+    assert_eq!(
+        lines.last().copied(),
+        Some("{\"event\":\"end\",\"data\":{}}"),
+        "the stream still closes with an empty end event"
+    );
+}
+
+/// #198 item 2: with --logfile, the error line lands in the LOGFILE (iperf3
+/// writes to outfile when it isn't stdout), not stderr.
+#[cfg(unix)]
+#[test]
+fn logfile_receives_the_error_line() {
+    let dir = std::env::temp_dir();
+    let log = dir.join(format!("riperf3-errlog-{}.log", std::process::id()));
+    let _ = std::fs::remove_file(&log);
+    let bin = env!("CARGO_BIN_EXE_riperf3");
+    let out = std::process::Command::new(bin)
+        .args([
+            "-c",
+            "127.0.0.1",
+            "-p",
+            "1",
+            "--logfile",
+            log.to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+    assert_eq!(out.status.code(), Some(1));
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.trim().is_empty(), "stderr: {stderr:?}");
+    let logged = std::fs::read_to_string(&log).expect("logfile written");
+    assert!(
+        logged.contains("riperf3: error - unable to connect"),
+        "the error line goes to the logfile: {logged:?}"
+    );
+    let _ = std::fs::remove_file(&log);
+}
+
+/// #198 items 3+4: usage errors exit 1 like iperf3's getopt path (clap's
+/// default is 2), and the bare invocation prints iperf3's exact parameter
+/// error.
+#[test]
+fn usage_errors_exit_one() {
+    let bin = env!("CARGO_BIN_EXE_riperf3");
+    let out = std::process::Command::new(bin)
+        .arg("--bogus")
+        .output()
+        .unwrap();
+    assert_eq!(out.status.code(), Some(1), "unknown flag exits 1");
+    let out = std::process::Command::new(bin).output().unwrap();
+    assert_eq!(out.status.code(), Some(1), "bare invocation exits 1");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("parameter error - must either be a client (-c) or server (-s)"),
+        "iperf3's exact no-mode sentence: {stderr:?}"
+    );
+    // --help / --version still exit 0.
+    let out = std::process::Command::new(bin).arg("--help").output().unwrap();
+    assert_eq!(out.status.code(), Some(0));
+    let out = std::process::Command::new(bin)
+        .arg("--version")
+        .output()
+        .unwrap();
+    assert_eq!(out.status.code(), Some(0));
+}

--- a/riperf3-cli/tests/error_format.rs
+++ b/riperf3-cli/tests/error_format.rs
@@ -59,7 +59,9 @@ fn json_mode_errors_emit_the_document_not_stderr() {
     assert!(doc["error"]
         .as_str()
         .is_some_and(|e| e.contains("unable to connect")));
-    assert!(doc["start"]["connected"].as_array().is_some_and(Vec::is_empty));
+    assert!(doc["start"]["connected"]
+        .as_array()
+        .is_some_and(Vec::is_empty));
     assert!(doc["intervals"].as_array().is_some_and(Vec::is_empty));
     assert!(doc["end"].is_object());
 }
@@ -142,7 +144,10 @@ fn usage_errors_exit_one() {
         "iperf3's exact no-mode sentence: {stderr:?}"
     );
     // --help / --version still exit 0.
-    let out = std::process::Command::new(bin).arg("--help").output().unwrap();
+    let out = std::process::Command::new(bin)
+        .arg("--help")
+        .output()
+        .unwrap();
     assert_eq!(out.status.code(), Some(0));
     let out = std::process::Command::new(bin)
         .arg("--version")

--- a/riperf3-cli/tests/udp_demux.rs
+++ b/riperf3-cli/tests/udp_demux.rs
@@ -99,7 +99,10 @@ fn run_demux_udp(extra: &[&str], who: &str) -> Value {
         let out = reader.join().expect("join stdout reader");
         let err = err_reader.join().expect("join stderr reader");
 
-        if common::refused(&exit, &err) && Instant::now() < retry_deadline {
+        // #198: -J error text lands in stdout (the document), stderr empty —
+        // scan both for the refused tokens.
+        let combined = format!("{err}\n{out}");
+        if common::refused(&exit, &combined) && Instant::now() < retry_deadline {
             // Server not listening yet — give it a beat and go again.
             std::thread::sleep(Duration::from_millis(100));
             continue;

--- a/riperf3-test-support/src/lib.rs
+++ b/riperf3-test-support/src/lib.rs
@@ -75,11 +75,11 @@ pub struct ClientRun {
 /// drop any one and the refused-retry silently dies on that platform,
 /// reopening the #176 bind-race flake class (#194 review r2 found exactly
 /// that on windows-latest).
-pub fn refused(status: &ExitStatus, stderr: &str) -> bool {
+pub fn refused(status: &ExitStatus, output: &str) -> bool {
     !status.success()
-        && (stderr.contains("ConnectionRefused")
-            || stderr.contains("Connection refused")
-            || stderr.contains("(os error 10061)"))
+        && (output.contains("ConnectionRefused")
+            || output.contains("Connection refused")
+            || output.contains("(os error 10061)"))
 }
 
 /// Run a riperf3 CLI binary to completion with a hard timeout, retrying while
@@ -147,7 +147,11 @@ pub fn run_client_with(bin: &str, args: &[&str], timeout: Duration, who: &str) -
             .read_to_string(&mut stderr)
             .unwrap();
 
-        if refused(&status, &stderr) && Instant::now() < retry_deadline {
+        // #198 moved -J/--json-stream error text into STDOUT (the document /
+        // the error event) with stderr empty — scan both sinks for the
+        // refused tokens.
+        let combined = format!("{stderr}\n{stdout}");
+        if refused(&status, &combined) && Instant::now() < retry_deadline {
             // Server not listening yet — give it a beat and go again.
             std::thread::sleep(Duration::from_millis(100));
             continue;

--- a/riperf3/src/json_report.rs
+++ b/riperf3/src/json_report.rs
@@ -154,6 +154,50 @@ pub struct Report {
 /// notably the cJSON-style float rendering (`ser_f64`, #57) — so a streamed
 /// `start` / `interval` / `end` object is byte-for-byte the same as the
 /// corresponding section of the batched `-J` report.
+/// The minimal pre-test error document for `-J` runs (#198): iperf3's
+/// iperf_errexit emits `{start:{connected:[],version,system_info},
+/// intervals:[], end:{}, error}` on stdout and nothing to stderr
+/// (live-captured against 3.20+). Pretty-printed like the normal `-J` body.
+pub fn error_document(error: &str) -> String {
+    // Field-ordered structs, not serde_json::json! — its maps serialize
+    // alphabetically, breaking iperf3's start/intervals/end/error order
+    // (the #168 envelope lesson).
+    #[derive(Serialize)]
+    struct ErrStart {
+        connected: [(); 0],
+        version: String,
+        system_info: String,
+    }
+    #[derive(Serialize)]
+    struct ErrDoc {
+        start: ErrStart,
+        intervals: [(); 0],
+        end: serde_json::Map<String, serde_json::Value>,
+        error: String,
+    }
+    serde_json::to_string_pretty(&ErrDoc {
+        start: ErrStart {
+            connected: [],
+            version: format!("riperf3 {}", env!("CARGO_PKG_VERSION")),
+            system_info: crate::utils::system_info(),
+        },
+        intervals: [],
+        end: serde_json::Map::new(),
+        error: error.to_string(),
+    })
+    .unwrap()
+}
+
+/// The `--json-stream` pre-test error tail (#198): an `error` event followed
+/// by an empty `end` event, iperf3's JSONStream_Output order on errexit.
+pub fn error_stream_events(error: &str) -> String {
+    format!(
+        "{}\n{}",
+        json_stream_event("error", &error),
+        json_stream_event("end", &serde_json::json!({}))
+    )
+}
+
 pub(crate) fn json_stream_event<T: Serialize>(event: &'static str, data: &T) -> String {
     #[derive(Serialize)]
     struct Event<'a, T: Serialize> {


### PR DESCRIPTION
## #198 — iperf_errexit sink parity

| Mode | iperf3 (live-captured) | riperf3 before | now |
|---|---|---|---|
| `-J` | document with `error` key on stdout, stderr EMPTY | stderr line, no JSON | document, byte-shape-identical key order |
| `--json-stream` | `error` event + empty `end` event | stderr line | matching events |
| `--logfile` | error line into the logfile | always stderr | logfile (stderr fallback if unopenable) |
| usage errors | exit 1 (getopt) | exit 2 (clap) | exit 1; bare invocation prints iperf3's exact parameter-error sentence |

Notes for review:
- The `-J` document uses field-ordered structs — `serde_json::json!` maps alphabetize (the #168 envelope lesson). Live A/B against 3.20+: top-level and `start` key order identical.
- clap's richer usage messages are kept (recorded deviation); the exit code is the script-visible contract.
- The refused-retry matcher (test-support + the udp_demux inline twin) scans stdout too now — JSON-mode error text no longer reaches stderr, which silently disabled the retry.

Red-first: 4 CLI tests. Fixes #198.

🤖 Generated with [Claude Code](https://claude.com/claude-code)