### PR TITLE
fix: --timestamps prefix covers vprintln and the server banner (#216)

### DIFF
--- a/riperf3-cli/tests/get_server_output.rs
+++ b/riperf3-cli/tests/get_server_output.rs
@@ -335,3 +335,72 @@ fn regex_lite_timestamp(line: &str) -> bool {
         && b[4].is_ascii_digit()
         && b[5] == b':'
 }
+
+/// #216: iperf3 prefixes EVERY iperf_printf line — the server's listening
+/// banner and verbose lines included (iperf_api.c:995/1017,
+/// iperf_server_api.c:137). A literal strftime format (no % directives)
+/// renders verbatim, making the assertion deterministic.
+#[test]
+fn server_banner_carries_the_timestamp_prefix() {
+    let ps = free_port().to_string();
+    let server = spawn_server_capturing(&["--timestamps=TSTAMP "], &ps);
+    let _ = run_capturing(
+        &["-c", "127.0.0.1", "-p", &ps, "-t", "1"],
+        Duration::from_secs(20),
+        "client for ts server",
+    );
+    let out = collect_stdout(server);
+    let banner = out
+        .lines()
+        .find(|l| l.contains("Server listening on"))
+        .expect("banner printed");
+    assert!(
+        banner.starts_with("TSTAMP "),
+        "the listening banner must carry the prefix: {banner:?}"
+    );
+    let sep = out
+        .lines()
+        .find(|l| l.contains("-----------"))
+        .expect("separator printed");
+    assert!(
+        sep.starts_with("TSTAMP "),
+        "the separator banner line too: {sep:?}"
+    );
+}
+
+/// #216: the client's verbose lines (vprintln!) carry the prefix — live
+/// iperf3 prefixes "Connecting to host" under -V --timestamps.
+#[test]
+fn client_verbose_lines_carry_the_timestamp_prefix() {
+    let ps = free_port().to_string();
+    let server = std::process::Command::new(env!("CARGO_BIN_EXE_riperf3"))
+        .args(["-s", "-1", "-p", &ps])
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .spawn()
+        .expect("spawn server");
+    let mut server = common::ChildGuard(server);
+    let out = run_capturing(
+        &[
+            "-c",
+            "127.0.0.1",
+            "-p",
+            &ps,
+            "-t",
+            "1",
+            "-V",
+            "--timestamps=TSTAMP ",
+        ],
+        Duration::from_secs(20),
+        "verbose timestamps",
+    );
+    let connecting = out
+        .lines()
+        .find(|l| l.contains("Connecting to host"))
+        .expect("verbose connect line");
+    assert!(
+        connecting.starts_with("TSTAMP "),
+        "vprintln lines must carry the prefix: {connecting:?}"
+    );
+    let _ = server.0.kill();
+}

--- a/riperf3/src/macros.rs
+++ b/riperf3/src/macros.rs
@@ -189,7 +189,8 @@ macro_rules! vprintln {
         {
             log::info!($($arg)*);
             let line = format!(
-                "{}{}",
+                "{}{}{}",
+                $crate::macros::output_timestamp_prefix(),
                 $crate::macros::output_title_prefix(),
                 format_args!($($arg)*)
             );

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -192,6 +192,14 @@ fn demux_local_addr_for(
 }
 
 impl Server {
+    /// A non-report stdout line (the listening banner): iperf3 routes these
+    /// through iperf_printf too, so they carry the `--timestamps` prefix
+    /// (#216). Not tee'd into the --get-server-output capture — iperf3's
+    /// banner prints before the test's JSON/capture exists.
+    fn banner_line(line: &str) {
+        println!("{}{line}", crate::macros::output_timestamp_prefix());
+    }
+
     pub async fn run(&self) -> Result<()> {
         // Daemonizing (`-s -D`) is a process-level concern handled by the binary
         // *before* the tokio runtime is built — `daemon()` forks, and a fork from
@@ -208,11 +216,19 @@ impl Server {
         // "Server listening" banners are suppressed) so the document parses
         // cleanly; match that.
         let json = self.json_output || self.json_stream;
+        // Run-scoped, BEFORE the banner: iperf3 prefixes every iperf_printf
+        // line, the listening banner included (#216). --timestamps is the
+        // server's own flag (not exchanged), so run scope is its natural
+        // home; the per-test guard this replaces missed the banner.
+        let _ts_guard = (!json)
+            .then_some(self.timestamps.as_deref())
+            .flatten()
+            .map(crate::macros::OutputTimestampGuard::set);
         let sep = "-----------------------------------------------------------";
         if !json {
-            println!("{sep}");
-            println!("Server listening on {}", self.port);
-            println!("{sep}");
+            Self::banner_line(sep);
+            Self::banner_line(&format!("Server listening on {}", self.port));
+            Self::banner_line(sep);
         }
 
         loop {
@@ -232,9 +248,9 @@ impl Server {
                 break;
             }
             if !json {
-                println!("{sep}");
-                println!("Server listening on {}", self.port);
-                println!("{sep}");
+                Self::banner_line(sep);
+                Self::banner_line(&format!("Server listening on {}", self.port));
+                Self::banner_line(sep);
             }
         }
         Ok(())
@@ -299,15 +315,9 @@ impl Server {
         // server_output event).
         let capture = (want_server_output && !self.json_output && !self.json_stream)
             .then(crate::macros::OutputCaptureGuard::start);
-        // --timestamps prefixes every text report line — through titled(), so
-        // the capture above tees the PREFIXED line like iperf3's linebuffer
-        // (#168). Run-scoped; never in the machine-JSON modes.
-        let _ts_guard = (!self.json_output && !self.json_stream)
-            .then_some(self.timestamps.as_deref())
-            .flatten()
-            // The bare-flag "%c " default is clap's default_missing_value;
-            // by here the format is always concrete.
-            .map(crate::macros::OutputTimestampGuard::set);
+        // The timestamp guard is run-scoped — set in `run()` before the
+        // banner (#216) — so the capture above tees PREFIXED lines like
+        // iperf3's linebuffer (#168) with nothing to do per test.
 
         // ---- Auth validation (after params, before streams) ----
         if let (Some(ref privkey_path), Some(ref users_path)) =


### PR DESCRIPTION
## #216 — prefix line coverage

iperf3 prefixes **every** `iperf_printf` line (banner at iperf_server_api.c:137, verbose lines, separators); riperf3 rendered the prefix only inside `titled()` report lines (#215's review found this live: `-V --timestamps=%T-` left `Connecting to host …` bare).

- `vprintln!` prepends the timestamp prefix before the title prefix (iperf_printf's order).
- The server banner routes through a prefixed `banner_line`; the timestamp guard moves to `run()` scope **before** the banner (the per-test guard structurally couldn't cover it). `--timestamps` is the server's own un-exchanged flag, so run scope is its natural home.
- The banner stays out of the `--get-server-output` capture — iperf3's banner prints before the test's capture exists.

Red-first with a literal strftime format (`TSTAMP ` — no `%` directives, renders verbatim) for deterministic assertions.

Fixes #216.

🤖 Generated with [Claude Code](https://claude.com/claude-code)