### PR TITLE
fix: idle-server SIGTERM exits promptly — the accept races the interrupt watch (#210 follow-through)

### DIFF
--- a/riperf3-cli/tests/pidfile.rs
+++ b/riperf3-cli/tests/pidfile.rs
@@ -233,11 +233,15 @@ fn idle_server_exits_promptly_on_sigterm() {
         libc::kill(server.0.id() as i32, libc::SIGTERM);
     }
     let exited = common::wait_bounded(&mut server.0, Duration::from_secs(2));
-    assert!(
-        exited.is_some(),
-        "an idle server must exit well under the 5 s dump window; \
-         still alive after {:?}",
-        t0.elapsed()
-    );
+    let status = exited.unwrap_or_else(|| {
+        panic!(
+            "an idle server must exit well under the 5 s dump window; \
+             still alive after {:?}",
+            t0.elapsed()
+        )
+    });
+    // The prompt exit is the GRACEFUL path (exit 0), not an escape hatch
+    // (review r1 n1).
+    assert_eq!(status.code(), Some(0), "graceful signal-normal exit");
     wait_for(|| !pf.exists(), Duration::from_secs(2), "pidfile unlinked");
 }

--- a/riperf3-cli/tests/pidfile.rs
+++ b/riperf3-cli/tests/pidfile.rs
@@ -203,3 +203,41 @@ fn second_signal_during_teardown_exits_immediately() {
         "pidfile unlinked on the hard path",
     );
 }
+
+/// Post-#223 regression (macOS CI red on main): an IDLE server's first
+/// SIGTERM must exit promptly — the accept wait races the interrupt watch.
+/// Without the arm, the signal burned the CLI's full 5 s dump window
+/// (systemd-style stop felt a 5 s hang). Bound: well under the window.
+#[cfg(unix)]
+#[test]
+fn idle_server_exits_promptly_on_sigterm() {
+    let bin = env!("CARGO_BIN_EXE_riperf3");
+    let dir = std::env::temp_dir();
+    let pf = dir.join(format!("riperf3-idle-{}.pid", std::process::id()));
+    let _ = std::fs::remove_file(&pf);
+    let ps = free_port().to_string();
+
+    let server = Command::new(bin)
+        .args(["-s", "-I"])
+        .arg(&pf)
+        .args(["-p", &ps])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn server");
+    let mut server = ChildGuard(server);
+    wait_for(|| pf.exists(), Duration::from_secs(5), "pidfile written");
+
+    let t0 = Instant::now();
+    unsafe {
+        libc::kill(server.0.id() as i32, libc::SIGTERM);
+    }
+    let exited = common::wait_bounded(&mut server.0, Duration::from_secs(2));
+    assert!(
+        exited.is_some(),
+        "an idle server must exit well under the 5 s dump window; \
+         still alive after {:?}",
+        t0.elapsed()
+    );
+    wait_for(|| !pf.exists(), Duration::from_secs(2), "pidfile unlinked");
+}

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -289,20 +289,36 @@ impl Server {
 
     async fn handle_one_test(&self, listener: &tokio::net::TcpListener) -> Result<()> {
         // ---- Accept control connection (with optional idle timeout) ----
-        let (mut ctrl, peer_addr) = if let Some(secs) = self.idle_timeout {
-            match tokio::time::timeout(
-                std::time::Duration::from_secs(secs as u64),
-                listener.accept(),
-            )
-            .await
-            {
-                Ok(result) => result?,
-                Err(_) => {
-                    return Err(RiperfError::Aborted("idle timeout".into()));
+        // The IDLE wait races the interrupt watch (#210 follow-through): an
+        // idle server's first signal must exit promptly — without this arm
+        // it burned the CLI's full 5 s dump window (the post-merge macOS CI
+        // red: systemd-style SIGTERM-while-listening took ~5 s). There is
+        // nothing to dump while idle; returning Ok lets the run loop's
+        // interrupt check exit the serve loop. The post-accept phases
+        // (cookie/param reads) stay interrupt-blind by design — the #158
+        // second-signal wedge test depends on that window.
+        let mut accept_interrupt = self.interrupt.clone().map(|w| w.0);
+        let accepted = tokio::select! {
+            r = async {
+                if let Some(secs) = self.idle_timeout {
+                    match tokio::time::timeout(
+                        std::time::Duration::from_secs(secs as u64),
+                        listener.accept(),
+                    )
+                    .await
+                    {
+                        Ok(result) => result.map_err(RiperfError::from),
+                        Err(_) => Err(RiperfError::Aborted("idle timeout".into())),
+                    }
+                } else {
+                    listener.accept().await.map_err(RiperfError::from)
                 }
-            }
-        } else {
-            listener.accept().await?
+            } => Some(r),
+            _ = crate::client::wait_interrupt(accept_interrupt.as_mut()) => None,
+        };
+        let (mut ctrl, peer_addr) = match accepted {
+            Some(r) => r?,
+            None => return Ok(()),
         };
         if self.verbose {
             vprintln!("Accepted connection from {peer_addr}");


### PR DESCRIPTION
## Post-#223 regression (main CI red)

macOS CI on main's merge commit: `pidfile_unlinked_on_sigterm` — *server did not exit within 5 s of SIGTERM*. The #223 graceful-signal path bounded-awaits the dump for 5 s, but an **idle** server has no interrupt-aware await, so the first signal burned the whole window (the #223 r1 review measured 5.08 s, n4); a systemd-style stop would feel the same hang.

**Fix**: the accept wait (both idle-timeout arms) races the interrupt watch; idle has nothing to dump, so the arm returns into the run loop's existing interrupt check. The post-accept cookie/param phases stay interrupt-blind **by design** — the #158 second-signal wedge test depends on that bounded window (suite still green).

**Pin**: `idle_server_exits_promptly_on_sigterm` (2 s bound; red on main per the CI failure itself, green here). The client-side idle phases (stuck connect) remain the recorded #223-r1-n4 follow-up.

xcheck 7/7; pidfile suite 4/4; workspace green (one #195-class flake under local load, 9/9 in isolation).

Refs #210, #223.

🤖 Generated with [Claude Code](https://claude.com/claude-code)