### PR TITLE
ci: Hammer flake-hammer workflow + timeout-minutes on every job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,11 @@ jobs:
   test:
     name: Test (Linux)
     runs-on: ubuntu-latest
+    # Wedge guard, freebsd-test's rationale applied to every job: a hung test
+    # must fail the job in minutes, not burn the 6 h default (the 0.7.2
+    # campaign's local 8 h sender-wedge, translated to CI). Budgets are
+    # generous multiples of observed warm runs.
+    timeout-minutes: 25
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -22,6 +27,7 @@ jobs:
   msrv:
     name: MSRV (1.85)
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@1.85
@@ -33,6 +39,7 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -45,6 +52,7 @@ jobs:
   semver:
     name: SemVer
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
       # Compares the library crate's public API against the latest version
@@ -59,6 +67,7 @@ jobs:
   cross-check:
     name: Cross-platform (${{ matrix.target }})
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     strategy:
       matrix:
         target:
@@ -88,6 +97,9 @@ jobs:
   native-test:
     name: Native test (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
+    # Windows cold-cache builds are the slow tail; 40 is still 9× better than
+    # the default on a wedge.
+    timeout-minutes: 40
     strategy:
       fail-fast: false
       matrix:
@@ -108,6 +120,7 @@ jobs:
   musl-check:
     name: musl check
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/hammer.yml
+++ b/.github/workflows/hammer.yml
@@ -4,21 +4,29 @@ name: Hammer
 # permanent. Replays a test profile across N parallel shard jobs × M suite
 # iterations on the chosen runner OS, to reproduce or rule out low-frequency
 # CI flakes at statistical scale. The standard protocol: hammer the unfixed
-# ref for a red baseline, then hammer the fix at the same scale and require
-# all-green (#178: 5/8 shards red unfixed → 24/24 green fixed).
+# ref for a red baseline, then hammer the fix at the same scale (#178: 5/8
+# shards red unfixed → 24/24 green fixed).
+#
+# Read all-green honestly: 24 samples catch a true 1/20 flake with only
+# ~71% confidence (1 − 0.95²⁴). For rarer flakes, scale `iterations` up —
+# a targeted test_args profile makes hundreds of iterations affordable —
+# rather than treating one all-green dispatch as proof.
 #
 # workflow_dispatch only — never a PR check. The dispatched ref supplies both
-# this workflow file and the tested tree, so a PR branch (which inherits the
-# file from main) can be hammered pre-merge:
+# this workflow file and the tested tree, so a PR branch can be hammered
+# pre-merge once the branch contains this file (branches cut before it
+# reached main 422 on dispatch — merge main into them first):
 #
 #   gh workflow run hammer.yml --ref <branch> \
 #     -f os=windows-latest -f test_args='-p riperf3-cli --test bidir_intervals' \
 #     -f shards=8 -f iterations=3
 #
-# Each shard is its own runner VM under the same 2-core load profile as a
-# real CI job — shards multiply samples, not per-run load. 8×3 ≈ 24 suite
-# runs resolves a ~1/20 flake; a targeted test_args profile runs much faster
-# than the full workspace, so prefer it when the flaky binary is known.
+# Each shard is its own runner VM of the same class real CI jobs use, so the
+# per-run load profile matches CI — shards multiply samples, not load. (Don't
+# bake core counts in here; they change. For local repro, pin to the runner's
+# CURRENT core count — the ci-flake-repro taskset methodology.)
+
+run-name: "Hammer ${{ inputs.os }} ${{ inputs.shards }}×${{ inputs.iterations }} ${{ inputs.test_args || '--workspace' }}"
 
 on:
   workflow_dispatch:
@@ -59,9 +67,15 @@ jobs:
       shards: ${{ steps.gen.outputs.shards }}
     steps:
       - id: gen
+        shell: bash
         env:
           SHARDS: ${{ inputs.shards }}
+        # Validate here, where the error is readable — under plain `bash -e`
+        # a bad value sails through `seq | jq` as `[]` and dies two jobs
+        # later as a cryptic empty-matrix strategy error.
         run: |
+          [[ "$SHARDS" =~ ^[1-9][0-9]*$ ]] \
+            || { echo "::error::shards must be a positive integer, got '$SHARDS'"; exit 1; }
           # "8" → [1,2,…,8] for fromJSON into the matrix.
           echo "shards=$(seq 1 "$SHARDS" | jq -cs .)" >> "$GITHUB_OUTPUT"
 
@@ -69,7 +83,10 @@ jobs:
     name: Shard ${{ matrix.shard }}
     needs: plan
     runs-on: ${{ inputs.os }}
-    timeout-minutes: 60
+    # Cold cache + full workspace × several iterations is the slow tail
+    # (ci.yml budgets 40 for ONE cold Windows run); dispatches are manual
+    # and rare, so headroom is free.
+    timeout-minutes: 90
     strategy:
       fail-fast: false
       matrix:
@@ -81,7 +98,12 @@ jobs:
         with:
           key: hammer-${{ inputs.os }}
           # All shards finishing together would race to save the same cache
-          # key; let shard 1 own the save.
+          # key (benign "unable to reserve" warnings); let shard 1 own the
+          # save. cache-on-failure because the documented FIRST phase of the
+          # protocol is a red baseline — rust-cache's post step is otherwise
+          # gated on job success, and every baseline dispatch would start
+          # cold forever.
+          cache-on-failure: true
           save-if: ${{ matrix.shard == 1 }}
       - name: Run suite ${{ inputs.iterations }}×
         shell: bash
@@ -89,8 +111,12 @@ jobs:
           TEST_ARGS: ${{ inputs.test_args }}
           ITERATIONS: ${{ inputs.iterations }}
         # Keep going after a red iteration — a hammer measures failure RATE,
-        # so every iteration is a sample. Exit code = number of red iterations.
+        # so every iteration is a sample. Exit code = red-iteration count,
+        # capped at 255 (bash exits wrap mod 256 — an uncapped 256 reds
+        # would read as green).
         run: |
+          [[ "$ITERATIONS" =~ ^[1-9][0-9]*$ ]] \
+            || { echo "::error::iterations must be a positive integer, got '$ITERATIONS'"; exit 1; }
           args="${TEST_ARGS:---workspace}"
           fails=0
           for i in $(seq 1 "$ITERATIONS"); do
@@ -103,4 +129,4 @@ jobs:
             echo "::endgroup::"
           done
           echo "shard ${{ matrix.shard }}: $((ITERATIONS - fails))/$ITERATIONS iterations green"
-          exit "$fails"
+          exit "$(( fails > 255 ? 255 : fails ))"

--- a/.github/workflows/hammer.yml
+++ b/.github/workflows/hammer.yml
@@ -74,8 +74,8 @@ jobs:
         # a bad value sails through `seq | jq` as `[]` and dies two jobs
         # later as a cryptic empty-matrix strategy error.
         run: |
-          [[ "$SHARDS" =~ ^[1-9][0-9]*$ ]] \
-            || { echo "::error::shards must be a positive integer, got '$SHARDS'"; exit 1; }
+          [[ "$SHARDS" =~ ^[1-9][0-9]*$ ]] && (( SHARDS <= 256 )) \
+            || { echo "::error::shards must be a positive integer <= 256 (the matrix cap), got '$SHARDS'"; exit 1; }
           # "8" → [1,2,…,8] for fromJSON into the matrix.
           echo "shards=$(seq 1 "$SHARDS" | jq -cs .)" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/hammer.yml
+++ b/.github/workflows/hammer.yml
@@ -1,0 +1,106 @@
+name: Hammer
+
+# Loaded-runner flake hammer — the #178 throwaway-branch technique made
+# permanent. Replays a test profile across N parallel shard jobs × M suite
+# iterations on the chosen runner OS, to reproduce or rule out low-frequency
+# CI flakes at statistical scale. The standard protocol: hammer the unfixed
+# ref for a red baseline, then hammer the fix at the same scale and require
+# all-green (#178: 5/8 shards red unfixed → 24/24 green fixed).
+#
+# workflow_dispatch only — never a PR check. The dispatched ref supplies both
+# this workflow file and the tested tree, so a PR branch (which inherits the
+# file from main) can be hammered pre-merge:
+#
+#   gh workflow run hammer.yml --ref <branch> \
+#     -f os=windows-latest -f test_args='-p riperf3-cli --test bidir_intervals' \
+#     -f shards=8 -f iterations=3
+#
+# Each shard is its own runner VM under the same 2-core load profile as a
+# real CI job — shards multiply samples, not per-run load. 8×3 ≈ 24 suite
+# runs resolves a ~1/20 flake; a targeted test_args profile runs much faster
+# than the full workspace, so prefer it when the flaky binary is known.
+
+on:
+  workflow_dispatch:
+    inputs:
+      os:
+        description: Runner OS
+        type: choice
+        options:
+          - ubuntu-latest
+          - windows-latest
+          - macos-latest
+        default: ubuntu-latest
+      test_args:
+        description: "Args after `cargo test` (empty = --workspace), e.g. -p riperf3-cli --test bidir_intervals"
+        type: string
+        default: ""
+      shards:
+        description: Parallel shard jobs (each its own runner VM)
+        type: string
+        default: "8"
+      iterations:
+        description: Suite iterations per shard
+        type: string
+        default: "3"
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  plan:
+    name: Plan shards
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      shards: ${{ steps.gen.outputs.shards }}
+    steps:
+      - id: gen
+        env:
+          SHARDS: ${{ inputs.shards }}
+        run: |
+          # "8" → [1,2,…,8] for fromJSON into the matrix.
+          echo "shards=$(seq 1 "$SHARDS" | jq -cs .)" >> "$GITHUB_OUTPUT"
+
+  hammer:
+    name: Shard ${{ matrix.shard }}
+    needs: plan
+    runs-on: ${{ inputs.os }}
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: ${{ fromJSON(needs.plan.outputs.shards) }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: hammer-${{ inputs.os }}
+          # All shards finishing together would race to save the same cache
+          # key; let shard 1 own the save.
+          save-if: ${{ matrix.shard == 1 }}
+      - name: Run suite ${{ inputs.iterations }}×
+        shell: bash
+        env:
+          TEST_ARGS: ${{ inputs.test_args }}
+          ITERATIONS: ${{ inputs.iterations }}
+        # Keep going after a red iteration — a hammer measures failure RATE,
+        # so every iteration is a sample. Exit code = number of red iterations.
+        run: |
+          args="${TEST_ARGS:---workspace}"
+          fails=0
+          for i in $(seq 1 "$ITERATIONS"); do
+            echo "::group::iteration $i/$ITERATIONS"
+            # shellcheck disable=SC2086 # word-splitting $args is the contract
+            if ! cargo test $args; then
+              fails=$((fails + 1))
+              echo "::error::shard ${{ matrix.shard }} iteration $i failed"
+            fi
+            echo "::endgroup::"
+          done
+          echo "shard ${{ matrix.shard }}: $((ITERATIONS - fails))/$ITERATIONS iterations green"
+          exit "$fails"

--- a/.github/workflows/interop.yml
+++ b/.github/workflows/interop.yml
@@ -22,6 +22,9 @@ jobs:
   interop:
     name: iperf3 ${{ matrix.iperf3 }}
     runs-on: ubuntu-latest
+    # Wedge guard (see ci.yml's test job): the iperf3 source build + matrix
+    # run completes in well under half this.
+    timeout-minutes: 25
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## CI hardening ahead of the 0.7.4 campaign

Two pieces, both motivated by documented campaign pain:

### 1. `hammer.yml` — the flake hammer, made permanent

The #178 investigation proved the technique: replay the failing job's exact profile across 8 shard runners × 3 iterations to get a statistical red baseline on the unfixed ref, then require all-green at the same scale on the fix (5/8 shards red → 24/24 green). That workflow lived on a throwaway branch and died with it; every future flake investigation re-derives it.

This makes it a permanent `workflow_dispatch`-only workflow (never a PR check, zero per-PR CI cost):

- inputs: `os` (ubuntu/windows/macos), `test_args` (e.g. `-p riperf3-cli --test bidir_intervals`; empty = `--workspace`), `shards` (default 8), `iterations` (default 3)
- each shard is its own runner VM under the same 2-core load profile as real CI — shards multiply samples, not load
- iterations continue past a failure (a hammer measures failure *rate*); shard exit code = red-iteration count
- a PR branch inherits the file from main, so fixes are hammerable pre-merge: `gh workflow run hammer.yml --ref <branch> -f ...`

Immediate consumers: #195 (the bidir/UDP setup-starvation family) and #159 (the reporter end-race redesign), both queued for 0.7.4.

### 2. Top-level `permissions: contents: read` on ci.yml

Added in review round 1: ci.yml was the only workflow without a permissions block (interop.yml and the new hammer.yml both set it). Verified job-by-job in round 2 that nothing in ci.yml needs more than contents:read (checkout, rust-cache and vmactions caching ride `ACTIONS_RUNTIME_TOKEN`, semver-checks' token default only fetches public release binaries).

### 3. `timeout-minutes` on every job

`freebsd-test` already had one, with the rationale in-line; this applies it to the other 8 jobs (test 25, native-test 40 for the Windows cold-cache tail, interop 25, check/lint jobs 15). The 0.7.2 campaign ate 8 hours on a wedged local suite; CI's 6 h default job timeout is the same trap with a meter running.

All three workflows are actionlint-clean (v1.7.12).

