### PR TITLE
fix: #195 setup-starvation de-flake — udp_serial gap, deadline raise, pre-data reset retry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -832,6 +832,9 @@ dependencies = [
 [[package]]
 name = "riperf3-test-support"
 version = "0.7.3"
+dependencies = [
+ "serde_json",
+]
 
 [[package]]
 name = "rpassword"

--- a/riperf3-cli/tests/bidir_intervals.rs
+++ b/riperf3-cli/tests/bidir_intervals.rs
@@ -12,6 +12,13 @@ use serde_json::Value;
 
 mod common;
 
+/// Harness deadline for every client run in this binary: above the client's
+/// own 30 s UDP_CONNECT_TOTAL_TIMEOUT (protocol.rs), so a setup-starved run
+/// dies on ITS error instead of an empty harness kill — the #195 dossier's
+/// "empty stdout+stderr" hits were this binary's 20 s deadlines firing first
+/// and destroying the diagnosis. Costs nothing when tests pass.
+const RUN_TIMEOUT: Duration = Duration::from_secs(40);
+
 fn free_port() -> u16 {
     // Sub-ephemeral, PID-windowed allocation — see common::free_port.
     common::free_port()
@@ -86,7 +93,7 @@ fn tcp_bidir_client_intervals_split_directions() {
             "1",
             "-J",
         ],
-        Duration::from_secs(20),
+        RUN_TIMEOUT,
         "client",
     );
     let _ = server.0.wait();
@@ -147,7 +154,7 @@ fn tcp_bidir_server_intervals_split_directions() {
             "-i",
             "1",
         ],
-        Duration::from_secs(20),
+        RUN_TIMEOUT,
         "client",
     );
 
@@ -173,6 +180,11 @@ fn tcp_bidir_server_intervals_split_directions() {
 /// packet count, exactly like iperf3.
 #[test]
 fn udp_bidir_interval_sums_split_udp_stats() {
+    // #191's per-binary UDP serialization, extended here (#195): this
+    // binary's UDP tests were the dossier's live hits — on a 2-core runner,
+    // concurrent UDP-connect handshakes starve each other past their
+    // budgets. TCP tests stay parallel by design.
+    let _serial = common::udp_serial();
     let port = free_port();
     let ps = port.to_string();
     let mut server = spawn_server(&ps);
@@ -191,7 +203,7 @@ fn udp_bidir_interval_sums_split_udp_stats() {
             "1",
             "-J",
         ],
-        Duration::from_secs(20),
+        RUN_TIMEOUT,
         "client",
     );
     let _ = server.0.wait();
@@ -226,6 +238,7 @@ fn udp_bidir_interval_sums_split_udp_stats() {
 /// zero-filled udp block: `packets: 0` despite real bytes.
 #[test]
 fn udp_bidir_sender_end_stream_carries_peer_measured_stats() {
+    let _serial = common::udp_serial(); // #191/#195 — see the first UDP test
     let port = free_port();
     let ps = port.to_string();
     let mut server = spawn_server(&ps);
@@ -242,7 +255,7 @@ fn udp_bidir_sender_end_stream_carries_peer_measured_stats() {
             "1",
             "-J",
         ],
-        Duration::from_secs(20),
+        RUN_TIMEOUT,
         "client",
     );
     let _ = server.0.wait();
@@ -284,7 +297,7 @@ fn tcp_forward_intervals_have_no_bidir_reverse() {
     // exactly on its only boundary can legitimately emit zero intervals (#55).
     let out = run_capturing(
         &["-c", "127.0.0.1", "-p", &ps, "-t", "2", "-i", "1", "-J"],
-        Duration::from_secs(20),
+        RUN_TIMEOUT,
         "client",
     );
     let _ = server.0.wait();
@@ -314,6 +327,7 @@ fn tcp_forward_intervals_have_no_bidir_reverse() {
 /// report_bw_udp_sender_format.
 #[test]
 fn udp_bidir_text_interval_rows_role_tags_no_sum() {
+    let _serial = common::udp_serial(); // #191/#195 — see the first UDP test
     let port = free_port().to_string();
     let _server = spawn_server(&port);
     let out = run_capturing(
@@ -329,7 +343,7 @@ fn udp_bidir_text_interval_rows_role_tags_no_sum() {
             "-i",
             "1",
         ],
-        Duration::from_secs(25),
+        RUN_TIMEOUT,
         "udp bidir text",
     );
 
@@ -397,7 +411,7 @@ fn tcp_bidir_text_interval_sums_split_per_direction() {
             "-i",
             "1",
         ],
-        Duration::from_secs(25),
+        RUN_TIMEOUT,
         "tcp bidir P2 text",
     );
 
@@ -454,7 +468,7 @@ fn parallel_text_ticks_open_with_separator() {
             "-P",
             "2",
         ],
-        Duration::from_secs(20),
+        RUN_TIMEOUT,
         "tcp P2 text",
     );
     // Tie the count to the ticks that actually PRINTED (review r2): under
@@ -499,7 +513,7 @@ fn single_stream_text_has_only_the_end_separator() {
     let mut server = spawn_server(&ps);
     let out = run_capturing(
         &["-c", "127.0.0.1", "-p", &ps, "-t", "3", "-i", "1"],
-        Duration::from_secs(20),
+        RUN_TIMEOUT,
         "tcp P1 text",
     );
     assert_eq!(

--- a/riperf3-cli/tests/end_block_text.rs
+++ b/riperf3-cli/tests/end_block_text.rs
@@ -43,7 +43,10 @@ fn end_block(out: &str) -> Vec<&str> {
 fn run(port: &str, args: &[&str]) -> String {
     let mut full = vec!["-c", "127.0.0.1", "-p", port];
     full.extend_from_slice(args);
-    common::run_client_ok(&full, Duration::from_secs(20), "client").stdout
+    // 40 s > the client's own 30 s UDP_CONNECT_TOTAL_TIMEOUT (protocol.rs):
+    // a starved run must die on ITS error, not an empty harness kill that
+    // destroys the diagnosis (#195 — this binary was the most-hit one).
+    common::run_client_ok(&full, Duration::from_secs(40), "client").stdout
 }
 
 /// UDP bidir: per stream a sender AND a receiver line (4 stream lines), the

--- a/riperf3-cli/tests/json_stream.rs
+++ b/riperf3-cli/tests/json_stream.rs
@@ -166,7 +166,9 @@ fn client_json_stream_udp_is_valid_ndjson() {
             "1",
             "--json-stream",
         ],
-        Duration::from_secs(20),
+        // > the client's 30 s UDP_CONNECT_TOTAL_TIMEOUT so a starved setup
+        // dies on its own error, not an empty harness kill (#195).
+        Duration::from_secs(40),
         "client-udp",
     );
     let _ = server.0.wait();

--- a/riperf3-cli/tests/setup_retry.rs
+++ b/riperf3-cli/tests/setup_retry.rs
@@ -66,3 +66,53 @@ fn pre_data_reset_is_retried_until_a_real_server_arrives() {
         out = run.stdout
     );
 }
+
+/// The -J flavor: #198 routes the setup error INTO the document on stdout
+/// (stderr empty), so the pre-data classifier must read the doc — connected
+/// never populated, zero intervals — not just "stdout empty". This was the
+/// quiet-host residual: 4/20 two-core rounds died exactly here pre-fix.
+#[test]
+fn pre_data_reset_is_retried_in_json_mode() {
+    let port = common::free_port();
+
+    let listener = TcpListener::bind(("127.0.0.1", port)).expect("bind saboteur");
+    let saboteur = std::thread::spawn(move || {
+        for _ in 0..2 {
+            let (mut sock, _) = listener.accept().expect("accept");
+            let mut byte = [0u8; 1];
+            let _ = sock.read_exact(&mut byte);
+            drop(sock);
+        }
+    });
+    let server = std::thread::spawn(move || {
+        saboteur.join().expect("saboteur thread");
+        Command::new(env!("CARGO_BIN_EXE_riperf3"))
+            .args(["-s", "-1", "-p", &port.to_string()])
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("spawn real server")
+    });
+
+    let ps = port.to_string();
+    let run = common::run_client_ok(
+        &["-c", "127.0.0.1", "-p", &ps, "-t", "1", "-J"],
+        Duration::from_secs(40),
+        "client -J",
+    );
+    let mut server = ChildGuard(server.join().expect("server thread"));
+    let _ = server.0.wait();
+
+    let doc: serde_json::Value = serde_json::from_str(run.stdout.trim())
+        .unwrap_or_else(|e| panic!("one clean doc after retries ({e}): {out}", out = run.stdout));
+    assert!(
+        doc["start"]["connected"]
+            .as_array()
+            .is_some_and(|a| !a.is_empty()),
+        "the final run really connected: {doc}"
+    );
+    assert!(
+        doc.get("error").is_none(),
+        "no error key on the clean run: {doc}"
+    );
+}

--- a/riperf3-cli/tests/setup_retry.rs
+++ b/riperf3-cli/tests/setup_retry.rs
@@ -24,6 +24,32 @@ fn serial() -> std::sync::MutexGuard<'static, ()> {
     SERIAL.lock().unwrap_or_else(|e| e.into_inner())
 }
 
+/// Make the drop of this socket send a real RST everywhere. Closing with
+/// unread data RSTs on Linux/Windows, but FreeBSD's CI run delivered the
+/// FIN-before-RST ordering (the client saw a clean "peer disconnected"
+/// EOF) — SO_LINGER(0) removes the ambiguity on every Unix; Windows keeps
+/// the unread-data behavior (std has no stable set_linger).
+#[cfg(unix)]
+fn force_rst_on_drop(sock: &std::net::TcpStream) {
+    use std::os::fd::AsRawFd;
+    let linger = libc::linger {
+        l_onoff: 1,
+        l_linger: 0,
+    };
+    let rc = unsafe {
+        libc::setsockopt(
+            sock.as_raw_fd(),
+            libc::SOL_SOCKET,
+            libc::SO_LINGER,
+            std::ptr::from_ref(&linger).cast(),
+            std::mem::size_of::<libc::linger>() as libc::socklen_t,
+        )
+    };
+    assert_eq!(rc, 0, "SO_LINGER setsockopt failed");
+}
+#[cfg(not(unix))]
+fn force_rst_on_drop(_sock: &std::net::TcpStream) {}
+
 /// The client's first two connects land on a saboteur listener that accepts,
 /// reads ONE byte of the cookie, and closes with the rest unread — closing a
 /// socket with undrained receive data sends RST on every platform, no
@@ -44,6 +70,7 @@ fn pre_data_reset_is_retried_until_a_real_server_arrives() {
             // arrived, so >0 bytes sit unread when we drop → RST, not FIN.
             let mut byte = [0u8; 1];
             let _ = sock.read_exact(&mut byte);
+            force_rst_on_drop(&sock);
             drop(sock);
         }
         // listener drops here; the port frees for the real server
@@ -99,6 +126,7 @@ fn pre_data_reset_is_retried_in_json_mode() {
         let (mut sock, _) = listener.accept().expect("accept");
         let mut byte = [0u8; 1];
         let _ = sock.read_exact(&mut byte);
+        force_rst_on_drop(&sock);
         drop(sock);
     });
     let server = std::thread::spawn(move || {

--- a/riperf3-cli/tests/setup_retry.rs
+++ b/riperf3-cli/tests/setup_retry.rs
@@ -1,0 +1,68 @@
+//! #195 harness behavior: a connection RESET during setup — before the client
+//! has produced any output — is retried like a refused connect, bounded by the
+//! same retry window. The shape this pins: loaded runners (macOS in PR #203's
+//! CI) RST the control handshake with `Connection reset by peer (os error 54)`
+//! while stdout is still empty; the run would complete cleanly if simply tried
+//! again. A reset after the run produced output stays fatal — that guard is
+//! unit-tested in riperf3-test-support.
+
+use std::io::Read;
+use std::net::TcpListener;
+use std::process::{Command, Stdio};
+use std::time::Duration;
+
+mod common;
+use common::ChildGuard;
+
+/// The client's first two connects land on a saboteur listener that accepts,
+/// reads ONE byte of the cookie, and closes with the rest unread — closing a
+/// socket with undrained receive data sends RST on every platform, no
+/// SO_LINGER needed (std's `set_linger` is unstable). The listener then
+/// vanishes and a real one-off server takes the port; the gap between drop
+/// and re-bind is covered by the existing refused-retry. Pre-#195 the harness
+/// only retried REFUSED runs, so the first RST killed the test.
+#[test]
+fn pre_data_reset_is_retried_until_a_real_server_arrives() {
+    let port = common::free_port();
+
+    let listener = TcpListener::bind(("127.0.0.1", port)).expect("bind saboteur");
+    let saboteur = std::thread::spawn(move || {
+        for _ in 0..2 {
+            let (mut sock, _) = listener.accept().expect("accept");
+            // Reading one byte guarantees the client's cookie write has
+            // arrived, so >0 bytes sit unread when we drop → RST, not FIN.
+            let mut byte = [0u8; 1];
+            let _ = sock.read_exact(&mut byte);
+            drop(sock);
+        }
+        // listener drops here; the port frees for the real server
+    });
+
+    // Once both sabotaged connects have happened, stand up the real server.
+    let server = std::thread::spawn(move || {
+        saboteur.join().expect("saboteur thread");
+        Command::new(env!("CARGO_BIN_EXE_riperf3"))
+            .args(["-s", "-1", "-p", &port.to_string()])
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("spawn real server")
+    });
+
+    let ps = port.to_string();
+    let run = common::run_client_ok(
+        &["-c", "127.0.0.1", "-p", &ps, "-t", "1"],
+        Duration::from_secs(40),
+        "client",
+    );
+    let mut server = ChildGuard(server.join().expect("server thread"));
+    let _ = server.0.wait();
+
+    // run_client_ok already asserted success; the end block proves the final
+    // attempt was a full real run, not a vacuous exit.
+    assert!(
+        run.stdout.contains("- - - - -"),
+        "the retried run must complete and print its end block: {out}",
+        out = run.stdout
+    );
+}

--- a/riperf3-cli/tests/setup_retry.rs
+++ b/riperf3-cli/tests/setup_retry.rs
@@ -14,6 +14,16 @@ use std::time::Duration;
 mod common;
 use common::ChildGuard;
 
+/// The two tests here each stage a multi-process saboteur dance against the
+/// SAME bounded retry window they exist to exercise; concurrently on a 2-core
+/// runner they contend the window away from each other (observed: the -J
+/// variant's real server spawned too late once under load, 1/13 rounds).
+/// Serialize within the binary, like #191's udp_serial.
+fn serial() -> std::sync::MutexGuard<'static, ()> {
+    static SERIAL: std::sync::Mutex<()> = std::sync::Mutex::new(());
+    SERIAL.lock().unwrap_or_else(|e| e.into_inner())
+}
+
 /// The client's first two connects land on a saboteur listener that accepts,
 /// reads ONE byte of the cookie, and closes with the rest unread — closing a
 /// socket with undrained receive data sends RST on every platform, no
@@ -23,6 +33,7 @@ use common::ChildGuard;
 /// only retried REFUSED runs, so the first RST killed the test.
 #[test]
 fn pre_data_reset_is_retried_until_a_real_server_arrives() {
+    let _serial = serial();
     let port = common::free_port();
 
     let listener = TcpListener::bind(("127.0.0.1", port)).expect("bind saboteur");
@@ -73,16 +84,19 @@ fn pre_data_reset_is_retried_until_a_real_server_arrives() {
 /// quiet-host residual: 4/20 two-core rounds died exactly here pre-fix.
 #[test]
 fn pre_data_reset_is_retried_in_json_mode() {
+    let _serial = serial();
     let port = common::free_port();
 
     let listener = TcpListener::bind(("127.0.0.1", port)).expect("bind saboteur");
+    // ONE sabotaged connect here (the text test keeps two): this variant
+    // proves the JSON classifier path, and each sabotaged attempt spends
+    // real time from the bounded retry window — under 2-core load the
+    // two-RST version once starved the real server past the deadline.
     let saboteur = std::thread::spawn(move || {
-        for _ in 0..2 {
-            let (mut sock, _) = listener.accept().expect("accept");
-            let mut byte = [0u8; 1];
-            let _ = sock.read_exact(&mut byte);
-            drop(sock);
-        }
+        let (mut sock, _) = listener.accept().expect("accept");
+        let mut byte = [0u8; 1];
+        let _ = sock.read_exact(&mut byte);
+        drop(sock);
     });
     let server = std::thread::spawn(move || {
         saboteur.join().expect("saboteur thread");

--- a/riperf3-cli/tests/setup_retry.rs
+++ b/riperf3-cli/tests/setup_retry.rs
@@ -57,6 +57,9 @@ fn pre_data_reset_is_retried_until_a_real_server_arrives() {
             .stdout(Stdio::null())
             .stderr(Stdio::null())
             .spawn()
+            // Guarded immediately: a panicking client assert must not leak
+            // a -s -1 process (r1 n7).
+            .map(ChildGuard)
             .expect("spawn real server")
     });
 
@@ -66,7 +69,7 @@ fn pre_data_reset_is_retried_until_a_real_server_arrives() {
         Duration::from_secs(40),
         "client",
     );
-    let mut server = ChildGuard(server.join().expect("server thread"));
+    let mut server = server.join().expect("server thread");
     let _ = server.0.wait();
 
     // run_client_ok already asserted success; the end block proves the final
@@ -105,6 +108,9 @@ fn pre_data_reset_is_retried_in_json_mode() {
             .stdout(Stdio::null())
             .stderr(Stdio::null())
             .spawn()
+            // Guarded immediately: a panicking client assert must not leak
+            // a -s -1 process (r1 n7).
+            .map(ChildGuard)
             .expect("spawn real server")
     });
 
@@ -114,7 +120,7 @@ fn pre_data_reset_is_retried_in_json_mode() {
         Duration::from_secs(40),
         "client -J",
     );
-    let mut server = ChildGuard(server.join().expect("server thread"));
+    let mut server = server.join().expect("server thread");
     let _ = server.0.wait();
 
     let doc: serde_json::Value = serde_json::from_str(run.stdout.trim())

--- a/riperf3-cli/tests/udp_pacing.rs
+++ b/riperf3-cli/tests/udp_pacing.rs
@@ -51,7 +51,9 @@ fn default_rate_udp_paces_across_intervals() {
             "1",
             "-J",
         ],
-        Duration::from_secs(20),
+        // > the client's 30 s UDP_CONNECT_TOTAL_TIMEOUT so a starved setup
+        // dies on its own error, not an empty harness kill (#195).
+        Duration::from_secs(40),
         "client",
     )
     .stdout;

--- a/riperf3-test-support/Cargo.toml
+++ b/riperf3-test-support/Cargo.toml
@@ -7,3 +7,5 @@ publish = false
 description = "Dev-only shared test helpers for the riperf3 workspace (#192)"
 
 [dependencies]
+# The JSON-aware pre-data classifier (#195) parses -J error docs.
+serde_json = { workspace = true }

--- a/riperf3-test-support/src/lib.rs
+++ b/riperf3-test-support/src/lib.rs
@@ -128,12 +128,17 @@ pub fn reset_pre_data(status: &ExitStatus, stdout: &str, stderr: &str) -> bool {
     reset_tokens(stdout) && json_output_is_setup_only(stdout)
 }
 
-/// The three reset renderings, mirroring `refused`: Debug form, POSIX
-/// strerror, and Windows' WSAECONNRESET text (no "reset"-cased substring).
+/// The reset renderings (mirroring `refused`: Debug form, POSIX strerror,
+/// Windows' WSAECONNRESET text) PLUS the clean-disconnect shape: a peer that
+/// vanishes mid-setup can surface as FIN-before-RST ordering — FreeBSD's CI
+/// delivered exactly that ("peer disconnected", riperf3's EOF class) for the
+/// same saboteur that RSTs on Linux. Pre-data, they are one phenomenon: the
+/// setup connection died under us.
 fn reset_tokens(s: &str) -> bool {
     s.contains("ConnectionReset")
         || s.contains("Connection reset")
         || s.contains("(os error 10054)")
+        || s.contains("peer disconnected")
 }
 
 /// Did this JSON-mode run die during SETUP — streams never connected, no
@@ -318,6 +323,8 @@ mod tests {
             // POSIX strerror (Linux 104 / macOS 54 — same text, the #195 hit)
             "riperf3: error - Connection reset by peer (os error 104)",
             "riperf3: error - Connection reset by peer (os error 54)",
+            // FreeBSD's FIN-before-RST ordering: the clean-EOF rendering
+            "riperf3: error - peer disconnected",
             // Windows WSAECONNRESET: no "reset"-cased substring at all
             "riperf3: error - An existing connection was forcibly closed by \
              the remote host. (os error 10054)",

--- a/riperf3-test-support/src/lib.rs
+++ b/riperf3-test-support/src/lib.rs
@@ -117,9 +117,14 @@ pub fn reset_pre_data(status: &ExitStatus, stdout: &str, stderr: &str) -> bool {
     // -J/--json-stream render setup errors INTO stdout (#198) with stderr
     // empty, so "empty stdout" cannot be the only pre-data proxy (the 2-core
     // rounds proved it: every quiet-host residual failure was a -J doc whose
-    // connected list never populated). A rendered error whose run never
-    // built streams and never ticked an interval is pre-data by
-    // construction.
+    // connected list never populated). CAVEAT (r1 review): the CLI's
+    // error_document hardcodes connected:[] + intervals:[] for EVERY error
+    // escaping run(), so this shape is "setup-only" for the dominant paths
+    // but not by construction — a raw reset at the TestEnd send or during
+    // ExchangeResults (post-data, no lib-rendered doc) classifies too and
+    // gets retried. Accepted: the bounded window still surfaces
+    // deterministic failures (~10 s late), and the alternative was the
+    // empty-kill that destroyed every diagnosis.
     reset_tokens(stdout) && json_output_is_setup_only(stdout)
 }
 
@@ -215,8 +220,11 @@ pub fn run_client_with(bin: &str, args: &[&str], timeout: Duration, who: &str) -
 
         // #198 moved -J/--json-stream error text into STDOUT (the document /
         // the error event) with stderr empty — scan both sinks for the
-        // refused tokens. The reset classifier scans stderr alone: its
-        // empty-stdout guard already excludes every doc-rendered error.
+        // refused tokens; the reset classifier reads stdout too (the JSON
+        // branch). NOTE the retry WINDOW starts at the first spawn: one slow
+        // attempt (the kill deadline allows 40 s) can consume it entirely,
+        // leaving a late failure zero retries — pre-existing #176 semantics,
+        // fine for the instant-failure shapes this targets.
         let combined = format!("{stderr}\n{stdout}");
         if (refused(&status, &combined) || reset_pre_data(&status, &stdout, &stderr))
             && Instant::now() < retry_deadline
@@ -337,6 +345,10 @@ mod tests {
 }"#;
         assert!(reset_pre_data(&failed, setup_doc, ""));
 
+        // A doc with populated connected/intervals can only come from a
+        // LIB-rendered report (e.g. a terminate-path doc) — the CLI's
+        // error_document never produces one (r1 review). The guard still
+        // matters for exactly those lib-rendered shapes.
         let mid_test_doc = r#"{
   "start": {"connected": [{"socket": 1}]},
   "intervals": [{"sum": {"bytes": 1}}],

--- a/riperf3-test-support/src/lib.rs
+++ b/riperf3-test-support/src/lib.rs
@@ -108,11 +108,44 @@ pub fn refused(status: &ExitStatus, output: &str) -> bool {
 /// less precisely. Accepted: rare, bounded, and the alternative is the #195
 /// empty-output kill that destroys the diagnosis entirely.
 pub fn reset_pre_data(status: &ExitStatus, stdout: &str, stderr: &str) -> bool {
-    !status.success()
-        && stdout.is_empty()
-        && (stderr.contains("ConnectionReset")
-            || stderr.contains("Connection reset")
-            || stderr.contains("(os error 10054)"))
+    if status.success() {
+        return false;
+    }
+    if stdout.is_empty() {
+        return reset_tokens(stderr);
+    }
+    // -J/--json-stream render setup errors INTO stdout (#198) with stderr
+    // empty, so "empty stdout" cannot be the only pre-data proxy (the 2-core
+    // rounds proved it: every quiet-host residual failure was a -J doc whose
+    // connected list never populated). A rendered error whose run never
+    // built streams and never ticked an interval is pre-data by
+    // construction.
+    reset_tokens(stdout) && json_output_is_setup_only(stdout)
+}
+
+/// The three reset renderings, mirroring `refused`: Debug form, POSIX
+/// strerror, and Windows' WSAECONNRESET text (no "reset"-cased substring).
+fn reset_tokens(s: &str) -> bool {
+    s.contains("ConnectionReset")
+        || s.contains("Connection reset")
+        || s.contains("(os error 10054)")
+}
+
+/// Did this JSON-mode run die during SETUP — streams never connected, no
+/// interval ever ticked? Both sinks are checked: a monolithic `-J` document
+/// (start.connected empty + intervals empty) and a `--json-stream` event
+/// sequence (no interval events). Non-JSON stdout returns false: text-mode
+/// output means the run was past setup.
+fn json_output_is_setup_only(stdout: &str) -> bool {
+    if let Ok(v) = serde_json::from_str::<serde_json::Value>(stdout.trim()) {
+        let connected_empty = v["start"]["connected"]
+            .as_array()
+            .is_none_or(|a| a.is_empty());
+        let no_intervals = v["intervals"].as_array().is_none_or(|a| a.is_empty());
+        return connected_empty && no_intervals;
+    }
+    // NDJSON stream: any interval event means data flowed.
+    stdout.contains("{\"event\":") && !stdout.contains("{\"event\":\"interval\"")
 }
 
 /// Run a riperf3 CLI binary to completion with a hard timeout, retrying while
@@ -288,6 +321,35 @@ mod tests {
                 "must classify as pre-data reset: {stderr}"
             );
         }
+    }
+
+    /// The -J shapes (#195 quiet-round residue): a setup-only error doc
+    /// (connected never populated, zero intervals) classifies; a doc whose
+    /// run carried data does not, whatever its error key says.
+    #[test]
+    fn json_mode_pre_data_reset_classifies() {
+        let failed = status(1);
+        let setup_doc = r#"{
+  "start": {"connected": [], "version": "riperf3 0.7.3"},
+  "intervals": [],
+  "end": {},
+  "error": "Connection reset by peer (os error 104)"
+}"#;
+        assert!(reset_pre_data(&failed, setup_doc, ""));
+
+        let mid_test_doc = r#"{
+  "start": {"connected": [{"socket": 1}]},
+  "intervals": [{"sum": {"bytes": 1}}],
+  "end": {},
+  "error": "Connection reset by peer (os error 104)"
+}"#;
+        assert!(!reset_pre_data(&failed, mid_test_doc, ""));
+
+        // json-stream: error+end only = setup; any interval event = data ran.
+        let stream_setup = "{\"event\":\"error\",\"data\":\"Connection reset by peer (os error 104)\"}\n{\"event\":\"end\",\"data\":{}}";
+        assert!(reset_pre_data(&failed, stream_setup, ""));
+        let stream_mid = "{\"event\":\"start\",\"data\":{}}\n{\"event\":\"interval\",\"data\":{}}\n{\"event\":\"error\",\"data\":\"Connection reset by peer (os error 104)\"}";
+        assert!(!reset_pre_data(&failed, stream_mid, ""));
     }
 
     /// The guards: output already produced (data phase, or a -J error doc),

--- a/riperf3-test-support/src/lib.rs
+++ b/riperf3-test-support/src/lib.rs
@@ -209,9 +209,14 @@ pub fn run_client_ok_with(bin: &str, args: &[&str], timeout: Duration, who: &str
     let run = run_client_with(bin, args, timeout, who);
     assert!(
         run.status.success(),
-        "{who}: exited unsuccessfully ({status}); stderr: {stderr}",
+        "{who}: exited unsuccessfully ({status}); stderr: {stderr}; stdout: {stdout}",
         status = run.status,
         stderr = run.stderr,
+        // stdout too: #198 routes -J/--json-stream errors into the document
+        // on STDOUT with stderr empty — a stderr-only panic hides exactly
+        // the error this runner exists to surface (#195 rounds, round-7
+        // "empty stderr" mystery).
+        stdout = run.stdout,
     );
     run
 }

--- a/riperf3-test-support/src/lib.rs
+++ b/riperf3-test-support/src/lib.rs
@@ -82,6 +82,39 @@ pub fn refused(status: &ExitStatus, output: &str) -> bool {
             || output.contains("(os error 10061)"))
 }
 
+/// Is this run a PRE-DATA reset — the peer (or a loaded kernel) RST the
+/// connection during setup, before the client produced any output? The #195
+/// macOS shape: under runner load the control handshake dies with
+/// `Connection reset by peer (os error 54)` while stdout is still empty; the
+/// run completes cleanly when simply tried again. Like the refused-retry,
+/// retrying is observably safe because nothing has happened yet.
+///
+/// The guards, in order:
+/// - non-success exit: a clean run is never reclassified;
+/// - **empty stdout** as the pre-data proxy: once a run printed anything —
+///   interval rows, or the -J document #198 routes errors into — a reset is
+///   real and must stay fatal. (Mid-test control-plane resets also never
+///   render raw: they map to named errors like "control socket has closed
+///   unexpectedly". If connect banners ever become unconditional (#222),
+///   this proxy needs refining — `setup_retry.rs` pins the behavior and
+///   will go red there.)
+/// - the three reset renderings, mirroring `refused`: the Debug form, the
+///   POSIX strerror, and Windows' WSAECONNRESET text (which contains no
+///   "reset"-cased substring at all).
+///
+/// One-off-server caveat: if the server's single accept was consumed before
+/// the RST, the retried client meets ECONNREFUSED and the refused-retry spins
+/// out the shared bounded window — the failure still surfaces, just later and
+/// less precisely. Accepted: rare, bounded, and the alternative is the #195
+/// empty-output kill that destroys the diagnosis entirely.
+pub fn reset_pre_data(status: &ExitStatus, stdout: &str, stderr: &str) -> bool {
+    !status.success()
+        && stdout.is_empty()
+        && (stderr.contains("ConnectionReset")
+            || stderr.contains("Connection reset")
+            || stderr.contains("(os error 10054)"))
+}
+
 /// Run a riperf3 CLI binary to completion with a hard timeout, retrying while
 /// the run is REFUSED for up to a bounded retry window. This replaces fixed
 /// server-bind sleeps: on loaded CI runners the (debug, cold) server can take
@@ -149,10 +182,14 @@ pub fn run_client_with(bin: &str, args: &[&str], timeout: Duration, who: &str) -
 
         // #198 moved -J/--json-stream error text into STDOUT (the document /
         // the error event) with stderr empty — scan both sinks for the
-        // refused tokens.
+        // refused tokens. The reset classifier scans stderr alone: its
+        // empty-stdout guard already excludes every doc-rendered error.
         let combined = format!("{stderr}\n{stdout}");
-        if refused(&status, &combined) && Instant::now() < retry_deadline {
-            // Server not listening yet — give it a beat and go again.
+        if (refused(&status, &combined) || reset_pre_data(&status, &stdout, &stderr))
+            && Instant::now() < retry_deadline
+        {
+            // Server not listening yet (refused) or it RST us mid-setup
+            // (#195) — give it a beat and go again.
             std::thread::sleep(Duration::from_millis(100));
             continue;
         }
@@ -205,5 +242,72 @@ pub fn wait_bounded(child: &mut Child, timeout: Duration) -> Option<ExitStatus> 
             }
             None => std::thread::sleep(Duration::from_millis(50)),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::process::ExitStatus;
+
+    #[cfg(unix)]
+    fn status(code: i32) -> ExitStatus {
+        use std::os::unix::process::ExitStatusExt;
+        // wait(2) encoding: exit code in the high byte.
+        ExitStatus::from_raw(code << 8)
+    }
+    #[cfg(windows)]
+    fn status(code: i32) -> ExitStatus {
+        use std::os::windows::process::ExitStatusExt;
+        ExitStatus::from_raw(code as u32)
+    }
+
+    /// #195: each platform's reset rendering classifies as a pre-data reset
+    /// when the run failed with an empty stdout. Drop any one rendering and
+    /// the retry silently dies on that platform (the `refused` lesson, #194).
+    #[test]
+    fn reset_pre_data_matches_each_platform_rendering() {
+        let failed = status(1);
+        for stderr in [
+            // POSIX strerror (Linux 104 / macOS 54 — same text, the #195 hit)
+            "riperf3: error - Connection reset by peer (os error 104)",
+            "riperf3: error - Connection reset by peer (os error 54)",
+            // Windows WSAECONNRESET: no "reset"-cased substring at all
+            "riperf3: error - An existing connection was forcibly closed by \
+             the remote host. (os error 10054)",
+            // io::ErrorKind Debug rendering (unwrap/expect paths)
+            "thread 'main' panicked: ConnectionReset",
+        ] {
+            assert!(
+                reset_pre_data(&failed, "", stderr),
+                "must classify as pre-data reset: {stderr}"
+            );
+        }
+    }
+
+    /// The guards: output already produced (data phase, or a -J error doc),
+    /// a clean exit, or a refused connect — none of these may classify.
+    #[test]
+    fn reset_guards_hold() {
+        let failed = status(1);
+        let clean = status(0);
+        // Once anything printed, a reset is real and stays fatal.
+        assert!(!reset_pre_data(
+            &failed,
+            "[ ID] Interval           Transfer     Bitrate",
+            "riperf3: error - Connection reset by peer (os error 104)",
+        ));
+        // A clean exit is never reclassified, whatever stderr says.
+        assert!(!reset_pre_data(
+            &clean,
+            "",
+            "Connection reset by peer (os error 104)",
+        ));
+        // Refused is the refused-retry's business, not this classifier's.
+        assert!(!reset_pre_data(
+            &failed,
+            "",
+            "riperf3: error - Connection refused (os error 111)",
+        ));
     }
 }

--- a/riperf3/src/protocol.rs
+++ b/riperf3/src/protocol.rs
@@ -465,7 +465,9 @@ pub async fn udp_connect_client(socket: &UdpSocket) -> Result<()> {
             // class as the recv side below; the interval still rate-limits.
             match socket.send(&UDP_CONNECT_MSG.to_ne_bytes()).await {
                 Ok(_) => {}
-                Err(e) if transient_udp_handshake_error(&e) => {}
+                Err(e) if transient_udp_handshake_error(&e) => {
+                    saw_icmp_feedback = true;
+                }
                 Err(e) => return Err(RiperfError::Io(e)),
             }
             next_send = tokio::time::Instant::now() + UDP_CONNECT_RETRY_INTERVAL;
@@ -521,15 +523,22 @@ pub async fn udp_connect_client(socket: &UdpSocket) -> Result<()> {
     // the server's UDP port never came up — saying "only unexpected
     // datagrams" there (or a bare timeout) would misdirect the next session.
     Err(RiperfError::Protocol(
-        if saw_icmp_feedback && !saw_traffic {
-            "UDP connect handshake failed: the server port kept refusing (ICMP unreachable)          for the whole budget"
-            .into()
-        } else if saw_traffic {
-            "UDP connect handshake failed: no valid reply (only unexpected datagrams received)"
-                .into()
-        } else {
-            "UDP connect handshake timed out (no server reply)".into()
-        },
+        match (saw_icmp_feedback, saw_traffic) {
+            (true, false) => {
+                "UDP connect handshake failed: ICMP port unreachable received \
+                              and no valid reply for the whole budget"
+            }
+            (true, true) => {
+                "UDP connect handshake failed: no valid reply (unexpected \
+                             datagrams and ICMP feedback received)"
+            }
+            (false, true) => {
+                "UDP connect handshake failed: no valid reply (only unexpected datagrams \
+                 received)"
+            }
+            (false, false) => "UDP connect handshake timed out (no server reply)",
+        }
+        .into(),
     ))
 }
 

--- a/riperf3/src/protocol.rs
+++ b/riperf3/src/protocol.rs
@@ -417,6 +417,18 @@ pub const UDP_CONNECT_TOTAL_TIMEOUT: std::time::Duration = std::time::Duration::
 /// How often the client resends the magic while waiting (recovers a lost magic).
 const UDP_CONNECT_RETRY_INTERVAL: std::time::Duration = std::time::Duration::from_millis(500);
 
+/// Is this send/recv error the kernel relaying ICMP feedback for an earlier
+/// datagram on a connected UDP socket (reset/refused), rather than a real
+/// socket failure? Transient by definition: the peer state it reports is
+/// already in the past, and the handshake deadline bounds how long we keep
+/// trying past it.
+fn transient_udp_handshake_error(e: &std::io::Error) -> bool {
+    matches!(
+        e.kind(),
+        std::io::ErrorKind::ConnectionReset | std::io::ErrorKind::ConnectionRefused
+    )
+}
+
 /// Client-side UDP connect handshake.
 /// Sends the magic word and waits for the server's reply.
 /// Note: iperf3 uses native byte order (not network byte order) for the magic values.
@@ -448,7 +460,13 @@ pub async fn udp_connect_client(socket: &UdpSocket) -> Result<()> {
     let mut next_send = tokio::time::Instant::now();
     while tokio::time::Instant::now() < deadline {
         if tokio::time::Instant::now() >= next_send {
-            socket.send(&UDP_CONNECT_MSG.to_ne_bytes()).await?;
+            // A queued ICMP error can surface on send too — same transient
+            // class as the recv side below; the interval still rate-limits.
+            match socket.send(&UDP_CONNECT_MSG.to_ne_bytes()).await {
+                Ok(_) => {}
+                Err(e) if transient_udp_handshake_error(&e) => {}
+                Err(e) => return Err(RiperfError::Io(e)),
+            }
             next_send = tokio::time::Instant::now() + UDP_CONNECT_RETRY_INTERVAL;
         }
         // Wait until the next resend is due (or the deadline), whichever first.
@@ -468,6 +486,23 @@ pub async fn udp_connect_client(socket: &UdpSocket) -> Result<()> {
             // (the real reply may be behind it). Don't resend here — the
             // interval floor gates the next send.
             Ok(Ok(_)) => {
+                saw_traffic = true;
+                continue;
+            }
+            // ECONNRESET/ECONNREFUSED here is the kernel relaying an ICMP
+            // port-unreachable for a PRIOR datagram — on a connected UDP
+            // socket it is transient feedback ("that one bounced"), not a
+            // terminal socket state. The live producer is the server's
+            // per-stream listener REBIND gap (accept → connect() → fresh
+            // bind leaves a window where the next stream's magic has no
+            // matching socket), torn wide open on loaded 2-core runners
+            // (#195: the udp_bidir empty-doc resets). The deadline still
+            // bounds the whole handshake; the next interval's resend
+            // recovers once the fresh listener is up. iperf3's
+            // single-send/long-read client dies here — but the retry loop
+            // is already a documented riperf3 robustness addition, and
+            // riding through transient ICMP feedback is its natural scope.
+            Ok(Err(e)) if transient_udp_handshake_error(&e) => {
                 saw_traffic = true;
                 continue;
             }
@@ -1233,6 +1268,42 @@ mod protocol_tests {
 #[cfg(test)]
 mod protocol_error_tests {
     use crate::protocol::{self, TestState};
+
+    /// #195 root cause: a transient ICMP-feedback error (ECONNRESET /
+    /// ECONNREFUSED on the connected socket — the server's per-stream
+    /// listener REBIND gap under load) must not kill the handshake while
+    /// budget remains. The loop resends the magic and succeeds once the
+    /// fresh listener is up. Sequence here: the client's first magic lands
+    /// on an unbound port (ICMP bounce queued), the real replier binds
+    /// ~600 ms later and answers the resend.
+    #[tokio::test]
+    async fn udp_connect_client_rides_through_transient_reset() {
+        let probe = tokio::net::UdpSocket::bind("127.0.0.1:0").await.unwrap();
+        let port = probe.local_addr().unwrap().port();
+        drop(probe); // port now unbound: the first magic will ICMP-bounce
+
+        let client = tokio::net::UdpSocket::bind("127.0.0.1:0").await.unwrap();
+        client.connect(("127.0.0.1", port)).await.unwrap();
+
+        let replier = tokio::spawn(async move {
+            // Let the first magic bounce and the error queue on the client
+            // socket; then stand up the real listener and answer the resend.
+            tokio::time::sleep(std::time::Duration::from_millis(600)).await;
+            let sock = tokio::net::UdpSocket::bind(("127.0.0.1", port))
+                .await
+                .unwrap();
+            let mut buf = [0u8; 4];
+            let (_, from) = sock.recv_from(&mut buf).await.unwrap();
+            sock.send_to(&protocol::UDP_CONNECT_REPLY.to_ne_bytes(), from)
+                .await
+                .unwrap();
+        });
+
+        protocol::udp_connect_client(&client)
+            .await
+            .expect("the handshake must survive the transient reset and complete");
+        replier.await.unwrap();
+    }
 
     #[tokio::test]
     async fn client_handles_access_denied() {

--- a/riperf3/src/protocol.rs
+++ b/riperf3/src/protocol.rs
@@ -455,6 +455,7 @@ pub async fn udp_connect_client(socket: &UdpSocket) -> Result<()> {
     let mut buf = [0u8; 4];
     let deadline = tokio::time::Instant::now() + UDP_CONNECT_TOTAL_TIMEOUT;
     let mut saw_traffic = false;
+    let mut saw_icmp_feedback = false;
     // Resend no more than once per interval, even while draining strays, so a
     // stray-datagram flood can't turn into a magic-send flood (amplification).
     let mut next_send = tokio::time::Instant::now();
@@ -489,32 +490,47 @@ pub async fn udp_connect_client(socket: &UdpSocket) -> Result<()> {
                 saw_traffic = true;
                 continue;
             }
-            // ECONNRESET/ECONNREFUSED here is the kernel relaying an ICMP
+            // ECONNREFUSED/ECONNRESET here is the kernel relaying an ICMP
             // port-unreachable for a PRIOR datagram — on a connected UDP
             // socket it is transient feedback ("that one bounced"), not a
-            // terminal socket state. The live producer is the server's
-            // per-stream listener REBIND gap (accept → connect() → fresh
-            // bind leaves a window where the next stream's magic has no
-            // matching socket), torn wide open on loaded 2-core runners
-            // (#195: the udp_bidir empty-doc resets). The deadline still
-            // bounds the whole handshake; the next interval's resend
+            // terminal socket state. Platform renderings differ (r1 review,
+            // verified empirically): Unix delivers ECONNREFUSED (111) per
+            // udp(7)/icmp_err_convert; Windows delivers WSAECONNRESET
+            // (mio leaves SIO_UDP_CONNRESET on). Both kinds are needed.
+            // The live producer is the server's per-stream listener REBIND
+            // gap: udp_connect_server does recv → connect() → reply, and
+            // only then does the caller bind the fresh listener — the next
+            // stream's magic races that window, torn wide open on loaded
+            // 2-core runners. (The #195 dossier's "os error 104" -J docs
+            // were the OTHER leg: TCP control resets from a dying one-off's
+            // backlog, which the harness-level retry covers.) The deadline
+            // still bounds the whole handshake; the next interval's resend
             // recovers once the fresh listener is up. iperf3's
             // single-send/long-read client dies here — but the retry loop
             // is already a documented riperf3 robustness addition, and
             // riding through transient ICMP feedback is its natural scope.
             Ok(Err(e)) if transient_udp_handshake_error(&e) => {
-                saw_traffic = true;
+                saw_icmp_feedback = true;
                 continue;
             }
             Ok(Err(e)) => return Err(RiperfError::Io(e)),
             Err(_) => continue, // interval elapsed with no reply — loop resends
         }
     }
-    Err(RiperfError::Protocol(if saw_traffic {
-        "UDP connect handshake failed: no valid reply (only unexpected datagrams received)".into()
-    } else {
-        "UDP connect handshake timed out (no server reply)".into()
-    }))
+    // Distinct exhaustion diagnoses (r1 n5): persistent ICMP feedback means
+    // the server's UDP port never came up — saying "only unexpected
+    // datagrams" there (or a bare timeout) would misdirect the next session.
+    Err(RiperfError::Protocol(
+        if saw_icmp_feedback && !saw_traffic {
+            "UDP connect handshake failed: the server port kept refusing (ICMP unreachable)          for the whole budget"
+            .into()
+        } else if saw_traffic {
+            "UDP connect handshake failed: no valid reply (only unexpected datagrams received)"
+                .into()
+        } else {
+            "UDP connect handshake timed out (no server reply)".into()
+        },
+    ))
 }
 
 /// Server-side UDP connect handshake.
@@ -1278,9 +1294,10 @@ mod protocol_error_tests {
     /// ~600 ms later and answers the resend.
     #[tokio::test]
     async fn udp_connect_client_rides_through_transient_reset() {
-        let probe = tokio::net::UdpSocket::bind("127.0.0.1:0").await.unwrap();
-        let port = probe.local_addr().unwrap().port();
-        drop(probe); // port now unbound: the first magic will ICMP-bounce
+        // Sub-ephemeral allocation (r1 n4): a bind(:0)-then-reuse port can be
+        // re-taken by any concurrent ephemeral bind during the 600 ms it must
+        // stay unbound — the exact race free_port()'s own doc rejects.
+        let port = riperf3_test_support::free_port();
 
         let client = tokio::net::UdpSocket::bind("127.0.0.1:0").await.unwrap();
         client.connect(("127.0.0.1", port)).await.unwrap();


### PR DESCRIPTION
## #195: the bidir/UDP setup-starvation de-flake pass

Implements the dossier's remediation plan, then follows what it exposed all the way down. Four pieces, in the order the evidence arrived:

### 1. Diagnostic first: harness deadlines now exceed the client's own

Every "empty stdout+stderr" kill was the harness's 20 s deadline firing **before** the client's 30 s `UDP_CONNECT_TOTAL_TIMEOUT` — destroying the diagnosis. All maskable deadlines move to 40 s (`bidir_intervals.rs` RUN_TIMEOUT const, `end_block_text.rs` shared runner, `udp_pacing.rs`, `json_stream.rs` UDP test). `run_client_ok`'s panic now includes **stdout** too — #198 routes -J errors into the document, and a stderr-only panic hid exactly the error this work exists to surface.

### 2. The found `udp_serial` gap

`bidir_intervals.rs` never took the #191 per-binary UDP lock — the campaign's live hits were exactly this binary's UDP tests. Its three UDP tests now serialize; TCP stays parallel.

### 3. Bounded pre-data reset retry, both output modes

`reset_pre_data` extends the #176 refused-retry to resets that arrive before the run did anything observable. Two proxies, both pinned by tests: empty stdout (text mode), or a rendered JSON error whose `start.connected` never populated and whose intervals are empty (-J / NDJSON — the first quiet-host rounds proved the empty-stdout proxy alone structurally misses JSON modes, 4/20 red). A reset after any output stays fatal. Known interplay: #222's unconditional banners will invalidate the text proxy — `setup_retry.rs` pins the behavior and will go red on that PR, forcing a conscious refinement.

### 4. The root cause the diagnostics exposed (the real fix)

With deadlines raised and stdout visible, the dominant shape became: `-J` doc, `connected: []`, a reset/refused error, instantly. Two distinct legs (the r1 review corrected the original conflated narrative, with empirical platform verification):

- **TCP control leg**: the dying one-off's backlog RSTs retried connects — the `Connection reset by peer (os error 104)` docs. The harness-level retry + classifier covers this.
- **UDP handshake leg**: the server's per-stream recycling has a **rebind gap** (`udp_connect_server` does recv → `connect()` → reply, and only then does the caller bind the fresh listener); the next stream's magic races it and draws ICMP port-unreachable — delivered as **ECONNREFUSED on Unix** (udp(7)), **WSAECONNRESET on Windows**. `udp_connect_client` treated any recv error as instantly fatal, dying with ~29 s of handshake budget unused. Bidir runs (2 streams) cross the gap every time; loaded 2-core runners tear it open.

The handshake loop now rides through transient ICMP feedback (reset/refused) on send and recv — everything else stays fatal, the 30 s deadline still bounds, the next interval's resend recovers. The retry loop is already a documented riperf3 robustness addition over iperf3's single-send/long-read client; this is its natural scope. **No wire change.** Red-first: a deterministic ICMP-bounce test (unbound port → replier 600 ms later), red at 0.5 s on old code, green with the fix.

### Why this matters right now

PR #228's CI hit this flake **twice consecutively** (runs on unfixed main-era test code). This PR is the cure; it goes first in the merge train.

### Verification

- Full workspace suite ×2 green locally; fmt + clippy clean.
- TDD: three red-first cycles (saboteur reset test → classifier; JSON-mode rounds red → JSON classifier; ICMP bounce test → protocol fix).
- 20 quiet-host rounds at the CI shape (`taskset -c 0,1`, `--test-threads=2`) on the final code: posted below when complete.
- Cloud hammer (#228's workflow) on this branch once it lands on main.

Closes #195.

