### PR TITLE
fix: faithful SERVER_ERROR relay on self-terminate + single JSON render on terminate (#224, #225)

### DIFF
--- a/riperf3-cli/src/main.rs
+++ b/riperf3-cli/src/main.rs
@@ -67,16 +67,34 @@ fn main() -> std::process::ExitCode {
     match run(cli) {
         Ok(()) => std::process::ExitCode::SUCCESS,
         Err(e) => {
+            // #225: on ServerTerminated the lib has ALREADY rendered the
+            // partial report — error key inside — into the active JSON sink
+            // before returning; re-rendering here concatenated a second
+            // document (or a second error+end event pair), which breaks
+            // every -J consumer. iperf3 emits exactly one. Text mode is
+            // exempt: its stderr line is iperf3's errexit shape, and the
+            // lib's text dump carries no error line.
+            let lib_already_rendered = e.downcast_ref::<riperf3::RiperfError>().is_some_and(|le| {
+                matches!(
+                    le,
+                    riperf3::RiperfError::ServerTerminated
+                        | riperf3::RiperfError::ServerErrorRelayed(_)
+                )
+            });
             // --json-stream wins over -J when combined: iperf3's
             // --json-stream gates iperf_json_finish into stream events
             // (review r1 f2, live-verified).
             if json_stream {
-                println!(
-                    "{}",
-                    riperf3::json_report::error_stream_events(&e.to_string())
-                );
+                if !lib_already_rendered {
+                    println!(
+                        "{}",
+                        riperf3::json_report::error_stream_events(&e.to_string())
+                    );
+                }
             } else if json {
-                println!("{}", riperf3::json_report::error_document(&e.to_string()));
+                if !lib_already_rendered {
+                    println!("{}", riperf3::json_report::error_document(&e.to_string()));
+                }
             } else {
                 let line = format!("riperf3: error - {e}");
                 let logged = logfile.as_deref().and_then(|path| {

--- a/riperf3-cli/tests/self_terminate.rs
+++ b/riperf3-cli/tests/self_terminate.rs
@@ -75,12 +75,16 @@ fn bitrate_limit_text_relays_server_error_no_summaries() {
     // Client: both iperf3 stderr lines, error exit, no summary block.
     assert_eq!(client.status.code(), Some(1), "client errexits like iperf3");
     assert!(
-        client.stderr.contains(&format!("riperf3: SERVER ERROR - {BITRATE_MSG}")),
+        client
+            .stderr
+            .contains(&format!("riperf3: SERVER ERROR - {BITRATE_MSG}")),
         "the relayed line (iperf_err on SERVER_ERROR receipt): {stderr}",
         stderr = client.stderr
     );
     assert!(
-        client.stderr.contains(&format!("riperf3: error - {BITRATE_MSG}")),
+        client
+            .stderr
+            .contains(&format!("riperf3: error - {BITRATE_MSG}")),
         "the errexit line with the ADOPTED i_errno: {stderr}",
         stderr = client.stderr
     );
@@ -97,7 +101,10 @@ fn bitrate_limit_text_relays_server_error_no_summaries() {
         serr.contains(&format!("riperf3: error - {BITRATE_MSG}")),
         "server reports the limit breach on stderr: {serr}"
     );
-    assert_eq!(scode, 0, "iperf3's one-off exits 0 on this path (live-verified)");
+    assert_eq!(
+        scode, 0,
+        "iperf3's one-off exits 0 on this path (live-verified)"
+    );
     assert!(
         !sout.contains("- - - - -"),
         "no final summary block on self-terminate: {sout}"
@@ -194,12 +201,16 @@ fn max_duration_timer_relays_expired() {
     );
     assert_eq!(client.status.code(), Some(1));
     assert!(
-        client.stderr.contains("riperf3: SERVER ERROR - server test duration expired"),
+        client
+            .stderr
+            .contains("riperf3: SERVER ERROR - server test duration expired"),
         "client adopts strerror(IESERVERTESTDURATIONEXPIRED): {stderr}",
         stderr = client.stderr
     );
     assert!(
-        client.stderr.contains("riperf3: error - server test duration expired"),
+        client
+            .stderr
+            .contains("riperf3: error - server test duration expired"),
         "the errexit line: {stderr}",
         stderr = client.stderr
     );

--- a/riperf3-cli/tests/self_terminate.rs
+++ b/riperf3-cli/tests/self_terminate.rs
@@ -175,11 +175,13 @@ fn bitrate_limit_json_server_doc_carries_prefixed_error() {
     );
 }
 
-/// --server-max-duration via the wall-clock timer (a `-n` run whose duration
-/// the server cannot know upfront): the literal server line vs the client's
-/// strerror, the same SERVER_ERROR shapes. `-n` keeps this test pinned to the
-/// TIMER arm even after the upfront requested-duration check (iperf3 rejects
-/// `-t`-exceeding runs at param exchange) lands later.
+/// --server-max-duration via the wall-clock timer: the literal server line
+/// vs the client's strerror, the same SERVER_ERROR shapes. NOTE (r1 review,
+/// live-verified): iperf3's upfront check rejects `-n` runs too (it tests
+/// the default `-t 10` sent alongside, iperf_api.c:2666) — so when #230
+/// lands faithfully, this test's `-n` run gets rejected at param exchange
+/// and the TIMER arm needs a new trigger (e.g. a `-t`-within-limit run that
+/// overruns on wall clock). Revisit this test in #230; noted there.
 #[test]
 fn max_duration_timer_relays_expired() {
     let ps = common::free_port().to_string();

--- a/riperf3-cli/tests/self_terminate.rs
+++ b/riperf3-cli/tests/self_terminate.rs
@@ -1,0 +1,213 @@
+//! #224 — server self-terminate parity (--server-bitrate-limit /
+//! --server-max-duration). Ground truth (iperf 3.21, live-captured 2026-06-11
+//! on the pinned interop build): both paths use the **SERVER_ERROR (-2)**
+//! control state with an (i_errno, errno) u32-pair payload — NOT
+//! SERVER_TERMINATE — and neither side dumps a final summary:
+//!
+//!   server (text):  stderr `iperf3: error - <msg>`, NO summary block, exit 0
+//!   server (-J):    single doc, error key `error - <msg>` (iperf_err's
+//!                   prefix wart, faithfully mirrored), stderr empty, exit 0
+//!   client (text):  stderr `iperf3: SERVER ERROR - <strerror>` then
+//!                   `iperf3: error - <strerror>`, NO summary, exit 1
+//!   client (-J):    single doc, error key = the strerror, stderr empty
+//!
+//! The bitrate message is iperf_strerror(IETOTALRATE=27); the duration-timer
+//! pair is the literal server line "server test duration expired - test is
+//! terminated by the server" vs the client's strerror(IESERVERTESTDURATION-
+//! EXPIRED=160) "server test duration expired".
+
+use std::io::Read;
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+mod common;
+use common::ChildGuard;
+
+const BITRATE_MSG: &str = "total required bandwidth is larger than server limit";
+
+fn spawn_server(extra: &[&str], port: &str) -> ChildGuard {
+    let mut args = vec!["-s", "-1", "-p", port];
+    args.extend_from_slice(extra);
+    ChildGuard(
+        Command::new(env!("CARGO_BIN_EXE_riperf3"))
+            .args(&args)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .expect("spawn server"),
+    )
+}
+
+/// Bounded wait that captures both pipes and the exit code.
+fn finish(mut child: ChildGuard, timeout: Duration, who: &str) -> (String, String, i32) {
+    let deadline = Instant::now() + timeout;
+    while child.0.try_wait().expect("try_wait").is_none() {
+        assert!(Instant::now() < deadline, "{who}: did not exit");
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    let status = child.0.try_wait().expect("try_wait").unwrap();
+    let mut out = String::new();
+    if let Some(mut s) = child.0.stdout.take() {
+        let _ = s.read_to_string(&mut out);
+    }
+    let mut err = String::new();
+    if let Some(mut s) = child.0.stderr.take() {
+        let _ = s.read_to_string(&mut err);
+    }
+    (out, err, status.code().unwrap_or(-1))
+}
+
+/// Text mode, both roles: the error relays with iperf3's exact stderr shapes,
+/// neither side prints a final summary, server exits 0 / client exits 1.
+#[test]
+fn bitrate_limit_text_relays_server_error_no_summaries() {
+    let ps = common::free_port().to_string();
+    let server = spawn_server(&["--server-bitrate-limit", "1K"], &ps);
+    std::thread::sleep(Duration::from_millis(300));
+
+    let client = common::run_client(
+        &["-c", "127.0.0.1", "-p", &ps, "-t", "5"],
+        Duration::from_secs(40),
+        "client",
+    );
+    let (sout, serr, scode) = finish(server, Duration::from_secs(10), "server");
+
+    // Client: both iperf3 stderr lines, error exit, no summary block.
+    assert_eq!(client.status.code(), Some(1), "client errexits like iperf3");
+    assert!(
+        client.stderr.contains(&format!("riperf3: SERVER ERROR - {BITRATE_MSG}")),
+        "the relayed line (iperf_err on SERVER_ERROR receipt): {stderr}",
+        stderr = client.stderr
+    );
+    assert!(
+        client.stderr.contains(&format!("riperf3: error - {BITRATE_MSG}")),
+        "the errexit line with the ADOPTED i_errno: {stderr}",
+        stderr = client.stderr
+    );
+    assert!(
+        !client.stdout.contains("- - - - -"),
+        "iperf3's client prints NO summary on SERVER_ERROR (the dump is the \
+         SERVER_TERMINATE path, not this one): {out}",
+        out = client.stdout
+    );
+
+    // Server: the iperf_err line, exit 0 (the one-off wart, faithfully), no
+    // summary after its interval ticks.
+    assert!(
+        serr.contains(&format!("riperf3: error - {BITRATE_MSG}")),
+        "server reports the limit breach on stderr: {serr}"
+    );
+    assert_eq!(scode, 0, "iperf3's one-off exits 0 on this path (live-verified)");
+    assert!(
+        !sout.contains("- - - - -"),
+        "no final summary block on self-terminate: {sout}"
+    );
+}
+
+/// -J client: exactly ONE document (the whole stdout must parse as a single
+/// JSON value), the error key carries the strerror, stderr stays empty.
+#[test]
+fn bitrate_limit_json_client_single_doc_with_relayed_error() {
+    let ps = common::free_port().to_string();
+    let server = spawn_server(&["--server-bitrate-limit", "1K"], &ps);
+    std::thread::sleep(Duration::from_millis(300));
+
+    let client = common::run_client(
+        &["-c", "127.0.0.1", "-p", &ps, "-t", "5", "-J"],
+        Duration::from_secs(40),
+        "client -J",
+    );
+    let _ = finish(server, Duration::from_secs(10), "server");
+
+    assert_eq!(client.status.code(), Some(1));
+    assert!(
+        client.stderr.trim().is_empty(),
+        "-J keeps stderr empty (the error rides the doc): {stderr}",
+        stderr = client.stderr
+    );
+    let doc: serde_json::Value = serde_json::from_str(client.stdout.trim()).unwrap_or_else(|e| {
+        panic!(
+            "client -J stdout must be EXACTLY one document ({e}): {out}",
+            out = client.stdout
+        )
+    });
+    assert_eq!(
+        doc["error"].as_str(),
+        Some(BITRATE_MSG),
+        "the doc adopts the relayed strerror: {doc}"
+    );
+}
+
+/// -J server: the full document still emits (intervals and all) with the
+/// error key carrying iperf_err's `error - ` prefix wart, stderr empty,
+/// exit 0 — live-verified against iperf 3.21.
+#[test]
+fn bitrate_limit_json_server_doc_carries_prefixed_error() {
+    let ps = common::free_port().to_string();
+    let server = spawn_server(&["--server-bitrate-limit", "1K", "-J"], &ps);
+    std::thread::sleep(Duration::from_millis(300));
+
+    let _client = common::run_client(
+        &["-c", "127.0.0.1", "-p", &ps, "-t", "5"],
+        Duration::from_secs(40),
+        "client",
+    );
+    let (sout, serr, scode) = finish(server, Duration::from_secs(10), "server -J");
+
+    assert!(
+        serr.trim().is_empty(),
+        "JSON mode keeps stderr silent: {serr}"
+    );
+    assert_eq!(scode, 0);
+    let doc: serde_json::Value = serde_json::from_str(sout.trim())
+        .unwrap_or_else(|e| panic!("server -J stdout must be one document ({e}): {sout}"));
+    assert_eq!(
+        doc["error"].as_str(),
+        Some(format!("error - {BITRATE_MSG}").as_str()),
+        "iperf_err's in-doc prefix wart, mirrored exactly: {doc}"
+    );
+}
+
+/// --server-max-duration via the wall-clock timer (a `-n` run whose duration
+/// the server cannot know upfront): the literal server line vs the client's
+/// strerror, the same SERVER_ERROR shapes. `-n` keeps this test pinned to the
+/// TIMER arm even after the upfront requested-duration check (iperf3 rejects
+/// `-t`-exceeding runs at param exchange) lands later.
+#[test]
+fn max_duration_timer_relays_expired() {
+    let ps = common::free_port().to_string();
+    let server = spawn_server(&["--server-max-duration", "1"], &ps);
+    std::thread::sleep(Duration::from_millis(300));
+
+    let start = Instant::now();
+    let client = common::run_client(
+        &["-c", "127.0.0.1", "-p", &ps, "-n", "1T"],
+        Duration::from_secs(40),
+        "client -n",
+    );
+    let elapsed = start.elapsed();
+    let (_sout, serr, scode) = finish(server, Duration::from_secs(10), "server");
+
+    assert!(
+        elapsed < Duration::from_secs(20),
+        "the server timer must cut an unbounded -n run: {elapsed:?}"
+    );
+    assert_eq!(client.status.code(), Some(1));
+    assert!(
+        client.stderr.contains("riperf3: SERVER ERROR - server test duration expired"),
+        "client adopts strerror(IESERVERTESTDURATIONEXPIRED): {stderr}",
+        stderr = client.stderr
+    );
+    assert!(
+        client.stderr.contains("riperf3: error - server test duration expired"),
+        "the errexit line: {stderr}",
+        stderr = client.stderr
+    );
+    assert!(
+        serr.contains(
+            "riperf3: error - server test duration expired - test is terminated by the server"
+        ),
+        "the server's literal timer line (iperf_err in server_timer_proc): {serr}"
+    );
+    assert_eq!(scode, 0);
+}

--- a/riperf3-cli/tests/signal_terminate.rs
+++ b/riperf3-cli/tests/signal_terminate.rs
@@ -187,9 +187,8 @@ fn server_sigterm_json_client_emits_exactly_one_doc() {
         cerr.trim().is_empty(),
         "-J keeps stderr empty (the error rides the doc): {cerr:?}"
     );
-    let doc: serde_json::Value = serde_json::from_str(cout.trim()).unwrap_or_else(|e| {
-        panic!("client -J stdout must be EXACTLY one document ({e}): {cout}")
-    });
+    let doc: serde_json::Value = serde_json::from_str(cout.trim())
+        .unwrap_or_else(|e| panic!("client -J stdout must be EXACTLY one document ({e}): {cout}"));
     assert_eq!(
         doc["error"].as_str(),
         Some("the server has terminated"),
@@ -210,7 +209,17 @@ fn server_sigterm_json_stream_client_single_error_end_pair() {
     let ps = free_port().to_string();
     let server = spawn(&["-s", "-1", "-p", &ps]);
     std::thread::sleep(Duration::from_millis(300));
-    let client = spawn(&["-c", "127.0.0.1", "-p", &ps, "-t", "10", "-i", "1", "--json-stream"]);
+    let client = spawn(&[
+        "-c",
+        "127.0.0.1",
+        "-p",
+        &ps,
+        "-t",
+        "10",
+        "-i",
+        "1",
+        "--json-stream",
+    ]);
     std::thread::sleep(Duration::from_secs(2));
 
     let spid = server.0.id() as i32;

--- a/riperf3-cli/tests/signal_terminate.rs
+++ b/riperf3-cli/tests/signal_terminate.rs
@@ -162,6 +162,76 @@ fn server_json_doc_carries_the_terminate_error_key() {
     );
 }
 
+/// #225: a `-J` CLIENT whose server terminates mid-test emits EXACTLY ONE
+/// document — the lib already rendered the partial report with the error key
+/// before returning ServerTerminated, and the CLI's generic error path must
+/// not append a second `error_document`. Two concatenated docs break every
+/// JSON consumer; iperf3 emits one (stderr empty, error rides the doc).
+#[test]
+fn server_sigterm_json_client_emits_exactly_one_doc() {
+    let ps = free_port().to_string();
+    let server = spawn(&["-s", "-1", "-p", &ps]);
+    std::thread::sleep(Duration::from_millis(300));
+    let client = spawn(&["-c", "127.0.0.1", "-p", &ps, "-t", "10", "-i", "1", "-J"]);
+    std::thread::sleep(Duration::from_secs(2));
+
+    let spid = server.0.id() as i32;
+    unsafe {
+        libc::kill(spid, libc::SIGTERM);
+    }
+    let _ = wait_with_output_bounded(server, Duration::from_secs(5), "server");
+
+    let (cout, cerr, ccode) = wait_with_output_bounded(client, Duration::from_secs(8), "client -J");
+    assert_eq!(ccode, 1, "terminate-by-peer is the error path");
+    assert!(
+        cerr.trim().is_empty(),
+        "-J keeps stderr empty (the error rides the doc): {cerr:?}"
+    );
+    let doc: serde_json::Value = serde_json::from_str(cout.trim()).unwrap_or_else(|e| {
+        panic!("client -J stdout must be EXACTLY one document ({e}): {cout}")
+    });
+    assert_eq!(
+        doc["error"].as_str(),
+        Some("the server has terminated"),
+        "the single doc carries IESERVERTERM: {doc}"
+    );
+    assert!(
+        doc["intervals"].as_array().is_some_and(|a| !a.is_empty()),
+        "the doc is the lib's PARTIAL report (data ran ~2 s), not the CLI's \
+         empty error doc: {doc}"
+    );
+}
+
+/// #225, stream flavor: a `--json-stream` client on server-terminate emits
+/// exactly one error event and one end event — not the lib's pair plus the
+/// CLI's `error_stream_events` pair.
+#[test]
+fn server_sigterm_json_stream_client_single_error_end_pair() {
+    let ps = free_port().to_string();
+    let server = spawn(&["-s", "-1", "-p", &ps]);
+    std::thread::sleep(Duration::from_millis(300));
+    let client = spawn(&["-c", "127.0.0.1", "-p", &ps, "-t", "10", "-i", "1", "--json-stream"]);
+    std::thread::sleep(Duration::from_secs(2));
+
+    let spid = server.0.id() as i32;
+    unsafe {
+        libc::kill(spid, libc::SIGTERM);
+    }
+    let _ = wait_with_output_bounded(server, Duration::from_secs(5), "server");
+
+    let (cout, cerr, ccode) =
+        wait_with_output_bounded(client, Duration::from_secs(8), "client --json-stream");
+    assert_eq!(ccode, 1);
+    assert!(cerr.trim().is_empty(), "stderr silent: {cerr:?}");
+    let errors = cout.matches("{\"event\":\"error\"").count();
+    let ends = cout.matches("{\"event\":\"end\"").count();
+    assert_eq!(
+        (errors, ends),
+        (1, 1),
+        "exactly one error+end pair (lib renders, CLI must not re-render):\n{cout}"
+    );
+}
+
 /// #210 review r2 d: the server's json-stream emits the discrete `error`
 /// event BEFORE `end` on terminate (iperf_json_finish is role-agnostic);
 /// stderr stays empty.

--- a/riperf3/src/client.rs
+++ b/riperf3/src/client.rs
@@ -191,6 +191,11 @@ enum ControlEvent {
     /// SERVER_TERMINATE arrived: stop, render a partial summary, error with
     /// iperf3's IESERVERTERM.
     Terminated,
+    /// SERVER_ERROR arrived (#224): the server failed and is relaying its
+    /// (i_errno, errno) pair; the PAYLOAD is still on the socket — the
+    /// consumer reads it outside the select (watch_control must stay
+    /// cancel-safe: a single 1-byte read).
+    ServerError,
     /// The control connection died (EOF or I/O error): iperf3's select sees
     /// it immediately and errexits with IECTRLCLOSE.
     Closed,
@@ -224,6 +229,7 @@ async fn watch_control(ctrl: &mut tokio::net::TcpStream) -> ControlEvent {
     loop {
         match protocol::recv_state(ctrl).await {
             Ok(TestState::ServerTerminate) => return ControlEvent::Terminated,
+            Ok(TestState::ServerError) => return ControlEvent::ServerError,
             Ok(other) => {
                 log::debug!("ignoring control state {other:?} during the data phase");
             }
@@ -477,6 +483,43 @@ impl Client {
                                 measured_secs,
                             ));
                         }
+                        Some(ControlEvent::ServerError) => {
+                            // #224: read the relay pair (safe here, outside
+                            // the select) and ADOPT the mapped error like
+                            // iperf_handle_message_client. NO text dump —
+                            // that is SERVER_TERMINATE's shape — but the
+                            // JSON sinks render the full document/events
+                            // with the error inside, like iperf3's json_top
+                            // (the CLI suppresses its generic re-render).
+                            let msg = match protocol::read_server_error_payload(&mut ctrl).await {
+                                Some((i_errno, os_errno)) => {
+                                    crate::error::iperf3_strerror(i_errno, os_errno)
+                                }
+                                None => "server error".to_string(),
+                            };
+                            if self.json_output || self.json_stream {
+                                self.print_results(
+                                    &streams,
+                                    cpu_start.as_ref(),
+                                    None,
+                                    blksize,
+                                    &interval_data,
+                                    &StartMeta {
+                                        cookie: String::from_utf8_lossy(
+                                            &cookie[..protocol::COOKIE_SIZE - 1],
+                                        )
+                                        .into_owned(),
+                                        tcp_mss_default: control_mss,
+                                        start_time_millis: test_start_millis,
+                                    },
+                                    measured_secs,
+                                    Some(&msg),
+                                );
+                            } else {
+                                eprintln!("riperf3: SERVER ERROR - {msg}");
+                            }
+                            return Err(RiperfError::ServerErrorRelayed(msg));
+                        }
                         Some(ControlEvent::Closed) | None => {}
                     }
                     // Test finished — send TestEnd
@@ -516,7 +559,41 @@ impl Client {
                     return Err(RiperfError::AccessDenied);
                 }
                 TestState::ServerError => {
-                    return Err(RiperfError::Protocol("server error".into()));
+                    // #224: read the (i_errno, errno) relay pair and ADOPT
+                    // the mapped error, like iperf_handle_message_client.
+                    // Text mode: the "SERVER ERROR - …" receipt line only
+                    // (iperf_err's shape; no summary dump — that is
+                    // SERVER_TERMINATE's). JSON sinks: render the full
+                    // document/events with the error inside, like iperf3's
+                    // json_top; the CLI suppresses its generic re-render.
+                    let msg = match protocol::read_server_error_payload(&mut ctrl).await {
+                        Some((i_errno, os_errno)) => {
+                            crate::error::iperf3_strerror(i_errno, os_errno)
+                        }
+                        None => "server error".to_string(),
+                    };
+                    if self.json_output || self.json_stream {
+                        self.print_results(
+                            &streams,
+                            cpu_start.as_ref(),
+                            None,
+                            blksize,
+                            &interval_data,
+                            &StartMeta {
+                                cookie: String::from_utf8_lossy(
+                                    &cookie[..protocol::COOKIE_SIZE - 1],
+                                )
+                                .into_owned(),
+                                tcp_mss_default: control_mss,
+                                start_time_millis: test_start_millis,
+                            },
+                            measured_secs,
+                            Some(&msg),
+                        );
+                    } else {
+                        eprintln!("riperf3: SERVER ERROR - {msg}");
+                    }
+                    return Err(RiperfError::ServerErrorRelayed(msg));
                 }
 
                 // iperf_handle_message_client handles SERVER_TERMINATE in

--- a/riperf3/src/client.rs
+++ b/riperf3/src/client.rs
@@ -516,6 +516,11 @@ impl Client {
                                     Some(&msg),
                                 );
                             } else {
+                                // KNOWN CORNER (r1 n5): with --logfile set,
+                                // iperf_err writes this line to the logfile;
+                                // riperf3's logfile plumbing lives in the
+                                // CLI (#198), so this lib line stays on
+                                // stderr. Revisit with the sink plumbing.
                                 eprintln!("riperf3: SERVER ERROR - {msg}");
                             }
                             return Err(RiperfError::ServerErrorRelayed(msg));

--- a/riperf3/src/error.rs
+++ b/riperf3/src/error.rs
@@ -63,6 +63,77 @@ pub enum RiperfError {
 
     #[error("peer disconnected")]
     PeerDisconnected,
+
+    /// iperf3's SERVER_ERROR relay (#224): the server failed mid-test and
+    /// sent its (i_errno, errno) pair on the control connection; the client
+    /// ADOPTS the mapped iperf_strerror text as its own error, exactly like
+    /// iperf_handle_message_client (iperf_client_api.c:392). The Display is
+    /// the mapped message alone — the CLI prefixes it ("riperf3: error - …"),
+    /// matching iperf3's errexit line.
+    #[error("{0}")]
+    ServerErrorRelayed(String),
+}
+
+/// iperf3's iperf_strerror, for the SERVER_ERROR relay codes a client can
+/// receive (#224). The bool is iperf3's `perr`: those codes append
+/// ", errno: <strerror>" when the relayed os errno is non-zero — rendered via
+/// io::Error, whose "(os error N)" suffix is the convention riperf3's raw os
+/// errors already carry (#151). Unknown codes mirror iperf3's literal
+/// "int_errno=%d" fallback (iperf_error.c default case).
+pub(crate) fn iperf3_strerror(i_errno: u32, os_errno: u32) -> String {
+    let (base, perr) = match i_errno {
+        // IETOTALRATE — the --server-bitrate-limit breach
+        27 => (
+            "total required bandwidth is larger than server limit".to_string(),
+            false,
+        ),
+        // IESERVERTERM — a server relaying its own terminate as an error
+        120 => ("the server has terminated".to_string(), false),
+        // IESERVERTESTDURATIONEXPIRED — the --server-max-duration timer
+        160 => ("server test duration expired".to_string(), true),
+        other => (format!("int_errno={other}"), true),
+    };
+    if perr && os_errno > 0 {
+        format!(
+            "{base}, errno: {}",
+            std::io::Error::from_raw_os_error(os_errno as i32)
+        )
+    } else {
+        base
+    }
+}
+
+#[cfg(test)]
+mod strerror_tests {
+    use super::iperf3_strerror;
+
+    /// The #224 relay codes, pinned to iperf 3.21's iperf_error.c strings.
+    #[test]
+    fn maps_the_relay_codes() {
+        assert_eq!(
+            iperf3_strerror(27, 0),
+            "total required bandwidth is larger than server limit"
+        );
+        assert_eq!(iperf3_strerror(120, 0), "the server has terminated");
+        assert_eq!(iperf3_strerror(160, 0), "server test duration expired");
+    }
+
+    /// perr-class codes append the os strerror only when errno > 0; the
+    /// unknown-code fallback is iperf3's literal int_errno=%d.
+    #[test]
+    fn perr_append_and_fallback() {
+        assert_eq!(iperf3_strerror(9999, 0), "int_errno=9999");
+        let with_errno = iperf3_strerror(160, 104);
+        assert!(
+            with_errno.starts_with("server test duration expired, errno: "),
+            "{with_errno}"
+        );
+        // Non-perr codes never append, whatever the errno.
+        assert_eq!(
+            iperf3_strerror(27, 104),
+            "total required bandwidth is larger than server limit"
+        );
+    }
 }
 
 /// Result alias used throughout the library.

--- a/riperf3/src/error.rs
+++ b/riperf3/src/error.rs
@@ -74,26 +74,35 @@ pub enum RiperfError {
     ServerErrorRelayed(String),
 }
 
-/// iperf3's iperf_strerror, for the SERVER_ERROR relay codes a client can
-/// receive (#224). The bool is iperf3's `perr`: those codes append
-/// ", errno: <strerror>" when the relayed os errno is non-zero — rendered via
-/// io::Error, whose "(os error N)" suffix is the convention riperf3's raw os
-/// errors already carry (#151). Unknown codes mirror iperf3's literal
-/// "int_errno=%d" fallback (iperf_error.c default case).
+/// iperf3's SERVER_ERROR relay rendering, client side (#224). The errno
+/// append follows iperf_handle_message_client (iperf_client_api.c:403-404),
+/// which appends ", errno: <strerror>" UNCONDITIONALLY whenever the relayed
+/// os errno is non-zero — for any code (r1 review, live-verified; real
+/// iperf3 servers relay stale/live errno from the bitrate and
+/// cleanup_server sites). Rendered via io::Error, whose "(os error N)"
+/// suffix is the convention riperf3's raw os errors already carry (#151).
+/// CONSCIOUS DEVIATION: iperf_strerror's perr codes emit a dangling ": "
+/// even at errno==0 (live: "server test duration expired: ") — an artifact
+/// we do not mirror. Unknown codes use iperf3's literal "int_errno=%d"
+/// fallback (iperf_error.c default case).
 pub(crate) fn iperf3_strerror(i_errno: u32, os_errno: u32) -> String {
-    let (base, perr) = match i_errno {
+    let base = match i_errno {
         // IETOTALRATE — the --server-bitrate-limit breach
-        27 => (
-            "total required bandwidth is larger than server limit".to_string(),
-            false,
-        ),
+        27 => "total required bandwidth is larger than server limit".to_string(),
+        // IEMAXSERVERTESTDURATIONEXCEEDED — the upfront param-exchange
+        // reject modern iperf3 servers send for over-limit or unbounded
+        // requests. riperf3's own upfront check is #230, but a real iperf3
+        // server can relay this TODAY, so the client must render it.
+        37 => {
+            "client's requested duration exceeds the server's maximum permitted limit".to_string()
+        }
         // IESERVERTERM — a server relaying its own terminate as an error
-        120 => ("the server has terminated".to_string(), false),
+        120 => "the server has terminated".to_string(),
         // IESERVERTESTDURATIONEXPIRED — the --server-max-duration timer
-        160 => ("server test duration expired".to_string(), true),
-        other => (format!("int_errno={other}"), true),
+        160 => "server test duration expired".to_string(),
+        other => format!("int_errno={other}"),
     };
-    if perr && os_errno > 0 {
+    if os_errno > 0 {
         format!(
             "{base}, errno: {}",
             std::io::Error::from_raw_os_error(os_errno as i32)
@@ -118,20 +127,30 @@ mod strerror_tests {
         assert_eq!(iperf3_strerror(160, 0), "server test duration expired");
     }
 
-    /// perr-class codes append the os strerror only when errno > 0; the
-    /// unknown-code fallback is iperf3's literal int_errno=%d.
+    /// The errno append is UNCONDITIONAL on errno > 0 for every code
+    /// (iperf_client_api.c:403-404 — the r1 review corrected the earlier
+    /// perr-gated model with a live probe); errno == 0 appends nothing (the
+    /// dangling-": " iperf_strerror artifact is a documented conscious
+    /// deviation). Unknown codes fall back to iperf3's literal int_errno=%d.
     #[test]
-    fn perr_append_and_fallback() {
+    fn errno_append_and_fallback() {
         assert_eq!(iperf3_strerror(9999, 0), "int_errno=9999");
-        let with_errno = iperf3_strerror(160, 104);
-        assert!(
-            with_errno.starts_with("server test duration expired, errno: "),
-            "{with_errno}"
-        );
-        // Non-perr codes never append, whatever the errno.
+        for (code, base) in [
+            (160u32, "server test duration expired"),
+            (
+                27u32,
+                "total required bandwidth is larger than server limit",
+            ),
+        ] {
+            let with_errno = iperf3_strerror(code, 104);
+            assert!(
+                with_errno.starts_with(&format!("{base}, errno: ")),
+                "{with_errno}"
+            );
+        }
         assert_eq!(
-            iperf3_strerror(27, 104),
-            "total required bandwidth is larger than server limit"
+            iperf3_strerror(37, 0),
+            "client's requested duration exceeds the server's maximum permitted limit"
         );
     }
 }

--- a/riperf3/src/protocol.rs
+++ b/riperf3/src/protocol.rs
@@ -141,6 +141,32 @@ pub async fn send_state(stream: &mut TcpStream, state: TestState) -> Result<()> 
 }
 
 /// Read a state transition (single signed byte) from the control connection.
+/// Send SERVER_ERROR with iperf3's (i_errno, errno) u32-pair payload (#224):
+/// the state byte, then both words big-endian — iperf_server_api.c's Nwrite
+/// pair (the bitrate, duration-timer, and cleanup_server relay sites). The os
+/// errno is always 0 from riperf3: our self-terminate causes carry none.
+pub async fn send_server_error(stream: &mut TcpStream, i_errno: u32) -> Result<()> {
+    send_state(stream, TestState::ServerError).await?;
+    stream.write_all(&i_errno.to_be_bytes()).await?;
+    stream.write_all(&0u32.to_be_bytes()).await?;
+    Ok(())
+}
+
+/// Read SERVER_ERROR's (i_errno, errno) payload. `None` when it never
+/// arrives (a peer that died mid-relay, or a bare -2 sender): the caller
+/// degrades to its generic message — a payloadless SERVER_ERROR must error
+/// cleanly, never hang or panic (tested in-crate).
+pub async fn read_server_error_payload(stream: &mut TcpStream) -> Option<(u32, u32)> {
+    let mut buf = [0u8; 8];
+    match stream.read_exact(&mut buf).await {
+        Ok(_) => Some((
+            u32::from_be_bytes(buf[0..4].try_into().unwrap()),
+            u32::from_be_bytes(buf[4..8].try_into().unwrap()),
+        )),
+        Err(_) => None,
+    }
+}
+
 pub async fn recv_state(stream: &mut TcpStream) -> Result<TestState> {
     let mut buf = [0u8; 1];
     let n = stream.read(&mut buf).await?;
@@ -1270,6 +1296,10 @@ mod protocol_error_tests {
 
     #[tokio::test]
     async fn client_handles_server_error() {
+        // #224: SERVER_ERROR carries an (i_errno, errno) u32-pair payload
+        // (iperf_server_api.c cleanup_server / the bitrate + duration-timer
+        // sites); the client adopts iperf_strerror(i_errno) as ITS error
+        // (iperf_client_api.c:392). Payload here: IETOTALRATE=27, errno=0.
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
 
@@ -1282,6 +1312,12 @@ mod protocol_error_tests {
             protocol::send_state(&mut stream, TestState::ServerError)
                 .await
                 .unwrap();
+            tokio::io::AsyncWriteExt::write_all(
+                &mut stream,
+                &[27u32.to_be_bytes(), 0u32.to_be_bytes()].concat(),
+            )
+            .await
+            .unwrap();
         });
 
         let client = crate::ClientBuilder::new("127.0.0.1")
@@ -1290,7 +1326,41 @@ mod protocol_error_tests {
             .build()
             .unwrap();
         let result = client.run().await;
-        assert!(result.is_err(), "client should error on ServerError");
+        let err = result.expect_err("client should error on ServerError");
+        assert_eq!(
+            err.to_string(),
+            "total required bandwidth is larger than server limit",
+            "the client adopts the relayed iperf_strerror(27): {err:?}"
+        );
+        let _ = server_task.await;
+    }
+
+    /// A SERVER_ERROR whose payload never arrives (peer died mid-relay, or a
+    /// pre-payload sender): still an error, never a hang or a panic.
+    #[tokio::test]
+    async fn client_handles_server_error_without_payload() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        let server_task = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let mut cookie = [0u8; 37];
+            tokio::io::AsyncReadExt::read_exact(&mut stream, &mut cookie)
+                .await
+                .unwrap();
+            protocol::send_state(&mut stream, TestState::ServerError)
+                .await
+                .unwrap();
+            // close without the payload
+        });
+
+        let client = crate::ClientBuilder::new("127.0.0.1")
+            .port(Some(addr.port()))
+            .duration(1)
+            .build()
+            .unwrap();
+        let result = client.run().await;
+        assert!(result.is_err(), "bare SERVER_ERROR is still an error");
         let _ = server_task.await;
     }
 

--- a/riperf3/src/protocol.rs
+++ b/riperf3/src/protocol.rs
@@ -140,7 +140,6 @@ pub async fn send_state(stream: &mut TcpStream, state: TestState) -> Result<()> 
     Ok(())
 }
 
-/// Read a state transition (single signed byte) from the control connection.
 /// Send SERVER_ERROR with iperf3's (i_errno, errno) u32-pair payload (#224):
 /// the state byte, then both words big-endian — iperf_server_api.c's Nwrite
 /// pair (the bitrate, duration-timer, and cleanup_server relay sites). The os

--- a/riperf3/src/protocol.rs
+++ b/riperf3/src/protocol.rs
@@ -167,6 +167,8 @@ pub async fn read_server_error_payload(stream: &mut TcpStream) -> Option<(u32, u
     }
 }
 
+/// Read a state-transition byte from the control connection (r1 n4: this doc
+/// was absorbed by the send_server_error insertion; restored).
 pub async fn recv_state(stream: &mut TcpStream) -> Result<TestState> {
     let mut buf = [0u8; 1];
     let n = stream.read(&mut buf).await?;

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -697,9 +697,18 @@ impl Server {
         rate_check.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
         rate_check.tick().await; // skip immediate tick
 
-        let mut server_terminated = false;
-        // #210: a peer- or self-terminated test skips the results exchange
-        // (the peer is gone / told to stop) but still dumps local results.
+        // #224 (iperf 3.21 ground truth): a SELF-terminated test (bitrate
+        // limit / max duration) relays SERVER_ERROR + i_errno and skips BOTH
+        // the exchange and the local summary dump; the message lands on the
+        // server's own error sink. iperf_strerror(IETOTALRATE) for the rate
+        // arm; the duration arm prints server_timer_proc's LITERAL line
+        // (the client side shows strerror(160) instead).
+        const SELF_TERM_RATE_MSG: &str = "total required bandwidth is larger than server limit";
+        const SELF_TERM_DURATION_MSG: &str =
+            "server test duration expired - test is terminated by the server";
+        let mut server_error: Option<&'static str> = None;
+        // #210: a peer-terminated or interrupted test skips the results
+        // exchange (the peer is gone) but still dumps local results.
         let mut client_terminated = false;
         let mut interrupted: Option<String> = None;
         let mut interrupt_rx = self.interrupt.clone().map(|w| w.0);
@@ -736,22 +745,24 @@ impl Server {
                         let bits_per_sec = total_bytes as f64 * 8.0 / elapsed;
                         if let Some(limit) = bitrate_limit {
                             if bits_per_sec > limit as f64 {
-                                protocol::send_state(&mut ctrl, TestState::ServerTerminate).await?;
-                                server_terminated = true;
+                                // #224: SERVER_ERROR + IETOTALRATE(27), not
+                                // SERVER_TERMINATE (iperf 3.21 GT).
+                                protocol::send_server_error(&mut ctrl, 27).await?;
+                                server_error = Some(SELF_TERM_RATE_MSG);
                                 break;
                             }
                         }
                     }
                 }
                 _ = tokio::time::sleep(std::time::Duration::from_secs(max_dur_secs)), if max_dur_secs > 0 => {
-                    protocol::send_state(&mut ctrl, TestState::ServerTerminate).await?;
-                    server_terminated = true;
+                    // #224: iperf3's server_timer_proc — SERVER_ERROR +
+                    // IESERVERTESTDURATIONEXPIRED(160) on the wire.
+                    protocol::send_server_error(&mut ctrl, 160).await?;
+                    server_error = Some(SELF_TERM_DURATION_MSG);
                     break;
                 }
             }
         }
-
-        let _ = server_terminated;
 
         // ---- Shut down streams ----
         // Hand the reporter the authoritative end time, then stop the streams
@@ -776,8 +787,21 @@ impl Server {
         } else if client_terminated {
             Some("the client has terminated".to_string())
         } else {
-            None
+            // iperf_err's in-doc wart, mirrored exactly: on SELF-terminate
+            // the -J error key carries an "error - " prefix (GT iperf 3.21:
+            // "error - total required bandwidth is larger than server
+            // limit") where the peer-terminate keys carry none.
+            server_error.map(|msg| format!("error - {msg}"))
         };
+        // The self-terminate line on the server's own stderr (iperf_err; the
+        // JSON sinks carry it via report_error instead). iperf3's one-off
+        // still EXITS 0 after this — live-verified wart, mirrored by NOT
+        // returning an error from this path (#224).
+        if let Some(msg) = server_error {
+            if !self.json_output && !self.json_stream {
+                eprintln!("riperf3: error - {msg}");
+            }
+        }
 
         // Wait briefly then join tasks (senders may be blocked on write)
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
@@ -790,6 +814,7 @@ impl Server {
             || params.blockcount.is_some()
             || client_terminated
             || interrupted.is_some()
+            || server_error.is_some()
         {
             // Rebase to the post-omit window (#31): the measured elapsed
             // includes the warm-up the summary must exclude. A terminated
@@ -895,29 +920,32 @@ impl Server {
             (None, None)
         };
         let was_captured = server_output_text.is_some();
-        let server_results = TestResultsJson {
-            cpu_util_total: cpu_util.host_total,
-            cpu_util_user: cpu_util.host_user,
-            cpu_util_system: cpu_util.host_system,
-            // #156: 1 when this side is a retransmit-capable TCP sender
-            // (reverse/bidir), like iperf3's check_sender_has_retransmits.
-            sender_has_retransmits: if streams.iter().any(|s| s.is_sender) {
-                i64::from(
-                    matches!(cfg.protocol, TransportProtocol::Tcp)
-                        && crate::tcp_info::has_retransmit_info(),
-                )
-            } else {
-                -1
-            },
-            // #37: the congestion algorithm actually in effect (read back at stream
-            // creation); None for UDP / unsupported platforms.
-            congestion_used: streams.first().and_then(|s| s.congestion_used.clone()),
-            server_output_text,
-            server_output_json,
-            streams: result_streams,
-        };
 
-        if !client_terminated && interrupted.is_none() {
+        if !client_terminated && interrupted.is_none() && server_error.is_none() {
+            // Built only when the exchange actually runs — it was dead work
+            // on every terminate path (#224).
+            let server_results = TestResultsJson {
+                cpu_util_total: cpu_util.host_total,
+                cpu_util_user: cpu_util.host_user,
+                cpu_util_system: cpu_util.host_system,
+                // #156: 1 when this side is a retransmit-capable TCP sender
+                // (reverse/bidir), like iperf3's check_sender_has_retransmits.
+                sender_has_retransmits: if streams.iter().any(|s| s.is_sender) {
+                    i64::from(
+                        matches!(cfg.protocol, TransportProtocol::Tcp)
+                            && crate::tcp_info::has_retransmit_info(),
+                    )
+                } else {
+                    -1
+                },
+                // #37: the congestion algorithm actually in effect (read back at stream
+                // creation); None for UDP / unsupported platforms.
+                congestion_used: streams.first().and_then(|s| s.congestion_used.clone()),
+                server_output_text,
+                server_output_json,
+                streams: result_streams,
+            };
+
             protocol::send_state(&mut ctrl, TestState::ExchangeResults).await?;
             // iperf3 protocol: server reads client results first, then sends its
             // own. The client's results are not used in the server's own report —
@@ -938,11 +966,6 @@ impl Server {
                     Err(e) => return Err(e),
                 }
             }
-        } else {
-            // A terminated run still uses the built local results for the
-            // report below; the exchange is skipped (iperf3's sigend/peer-
-            // terminate paths never reach it).
-            let _ = &server_results;
         }
 
         if self.json_output {
@@ -989,9 +1012,12 @@ impl Server {
                 &interval_data,
                 report_error.as_deref(),
             );
-        } else if !was_captured {
+        } else if !was_captured && server_error.is_none() {
             // Print summary: per-stream lines plus aggregate [SUM] row(s) for
             // parallel streams (issue #4), via the shared path the client uses.
+            // Also skipped on self-terminate: iperf3 prints NO summary there
+            // (#224 GT — text gets only the stderr line, -J still gets the
+            // full doc via the branch above).
             // Skipped when --get-server-output already rendered them (#33):
             // the pre-exchange render TEE'd to console + capture (iperf3 also
             // prints at TEST_END, before its exchange), so printing here again

--- a/riperf3/tests/integration.rs
+++ b/riperf3/tests/integration.rs
@@ -1803,7 +1803,10 @@ mod unimplemented_flags {
         // The server side errors to ITS sink but run() is Ok - iperf3's
         // one-off exits 0 on self-terminate (live-verified, the #224 wart).
         let joined = server_task.await.expect("server task");
-        assert!(joined.is_ok(), "server self-terminate is not a run() error: {joined:?}");
+        assert!(
+            joined.is_ok(),
+            "server self-terminate is not a run() error: {joined:?}"
+        );
     }
 
     #[tokio::test]
@@ -1840,7 +1843,10 @@ mod unimplemented_flags {
             "{err:?}"
         );
         let joined = server_task.await.expect("server task");
-        assert!(joined.is_ok(), "server self-terminate is not a run() error: {joined:?}");
+        assert!(
+            joined.is_ok(),
+            "server self-terminate is not a run() error: {joined:?}"
+        );
     }
 
     #[tokio::test]

--- a/riperf3/tests/integration.rs
+++ b/riperf3/tests/integration.rs
@@ -1788,13 +1788,22 @@ mod unimplemented_flags {
             .build()
             .unwrap();
         let start = std::time::Instant::now();
-        let _ = client.run().await;
+        let result = client.run().await;
         let elapsed = start.elapsed();
         assert!(
             elapsed.as_secs() < 5,
             "server-max-duration didn't cut test: {elapsed:?}"
         );
-        let _ = server_task.await;
+        // #224 ground truth (iperf 3.21): the timer relays SERVER_ERROR with
+        // IESERVERTESTDURATIONEXPIRED; the client adopts its strerror. (When
+        // the upfront requested-duration check lands, this -t run will be
+        // rejected at param exchange instead - revisit then.)
+        let err = result.expect_err("the relayed SERVER_ERROR is the client's error");
+        assert_eq!(err.to_string(), "server test duration expired", "{err:?}");
+        // The server side errors to ITS sink but run() is Ok - iperf3's
+        // one-off exits 0 on self-terminate (live-verified, the #224 wart).
+        let joined = server_task.await.expect("server task");
+        assert!(joined.is_ok(), "server self-terminate is not a run() error: {joined:?}");
     }
 
     #[tokio::test]
@@ -1815,14 +1824,23 @@ mod unimplemented_flags {
             .build()
             .unwrap();
         let start = std::time::Instant::now();
-        let _ = client.run().await; // may error — server terminates early
+        let result = client.run().await;
         let elapsed = start.elapsed();
         // Should terminate well before 10 seconds
         assert!(
             elapsed.as_secs() < 5,
             "bitrate limit didn't cut test: {elapsed:?}"
         );
-        let _ = server_task.await;
+        // #224 ground truth (iperf 3.21): SERVER_ERROR + IETOTALRATE, the
+        // client adopts iperf_strerror(27); no generic ServerTerminated.
+        let err = result.expect_err("the relayed SERVER_ERROR is the client's error");
+        assert_eq!(
+            err.to_string(),
+            "total required bandwidth is larger than server limit",
+            "{err:?}"
+        );
+        let joined = server_task.await.expect("server task");
+        assert!(joined.is_ok(), "server self-terminate is not a run() error: {joined:?}");
     }
 
     #[tokio::test]


### PR DESCRIPTION
## #224 + #225: terminate-path parity, ground-truthed

Every shape below was live-captured against the pinned interop iperf 3.21 build before writing a line of code — and the ground truth **overturned the issue's assumed fix**: iperf3's self-terminate paths don't "skip the exchange + dump locally" (#224's guess); they use a different control state entirely, **SERVER_ERROR(-2) with an (i_errno, errno) payload relay**, and *neither side dumps a summary*.

### What iperf 3.21 actually does (and riperf3 now mirrors)

| | server | client |
|---|---|---|
| wire | `SERVER_ERROR` + BE u32 pair (27=IETOTALRATE / 160=IESERVERTESTDURATIONEXPIRED), errno 0 | reads the pair, **adopts** `iperf_strerror(i_errno)` as its own error |
| text | `iperf3: error - <msg>` on stderr (the timer prints its literal long line), **no summary**, one-off exits **0** (the wart, mirrored) | `iperf3: SERVER ERROR - <msg>` + `iperf3: error - <msg>` on stderr, **no summary**, exit 1 |
| -J | full doc, error key `error - <msg>` (iperf_err's in-doc prefix wart, mirrored exactly), stderr empty | single doc with the adopted error (iperf3 emits *duplicate* error keys — a cJSON wart; we render the one effective-last value), stderr empty |

The old behavior: server sent SERVER_TERMINATE, then ran the full ExchangeResults dance against a peer it had told to stop, and died with `riperf3: error - early eof`; the client reported a generic "the server has terminated".

Client-side, SERVER_ERROR is handled in **both** control readers: the data-phase `watch_control` (the 8-byte payload read happens in the un-cancelled consumer — the watch stays a cancel-safe 1-byte read) and the post/pre-test state machine. That second arm also makes riperf3 a better citizen against **real iperf3 servers**, which relay errors (cleanup_server) riperf3 itself never sends — unknown codes mirror iperf3's literal `int_errno=%d` fallback, perr-class codes append the os strerror.

### #225: exactly one render

The lib renders the report (error key inside) into the JSON sinks before returning `ServerTerminated` — and now `ServerErrorRelayed` — but the CLI's generic error path re-rendered, concatenating a **second document** (`-J`) or a second error+end event pair (`--json-stream`). Traced live: 2 docs on stdout, stderr empty (the issue's stderr guess was close but the real leak was the doc). The CLI now suppresses its render for lib-rendered variants; text mode keeps its stderr line, which is iperf3's errexit shape.

### Known conscious deviations (r1-review-verified)

- iperf3's SERVER_ERROR-path `-J` docs carry an **empty** `end` object; riperf3 populates the full summary stats there (consistent with its existing terminate-path convention — strictly more information, flagged for transparency).
- iperf3's dup-error-key docs: the client doc's effective value is the LAST key; the server's duration-path doc carries the timer literal plus a junk `select failed` key (effective-FIRST, r2 live capture). riperf3 renders the single meaningful value in both — same information, one key.
- `iperf_strerror`'s perr codes emit a dangling `": "` at errno==0; not mirrored.
- With `--logfile`, iperf3 writes the receipt line to the logfile; riperf3's lib line stays on stderr (sink plumbing is CLI-side, #198) — noted in-code.

### TDD

Eight behavioral reds committed first (commit 1), all from GT: 4× `self_terminate.rs` (new), 2× `signal_terminate.rs` (#225 single-doc/single-pair), 2× tightened lib tests (the old `let _ =` looseness). Plus in-crate unit tests for the strerror mapping (codes, perr-append, fallback) and the payload round-trip/payloadless degradation.

### Scope discipline

Found during GT, **filed not fixed**: #230 (iperf3 also has an *upfront* requested-duration reject at param exchange — riperf3 runs tests iperf3 would refuse; param-exchange blast radius = own PR), #231 (client idle-phase interrupt arms, the #223-r1-n4 ledger item, now tracked).

Closes #224. Closes #225.


