### PR TITLE
fix: --json-stream wins the mode dispatch over -J on both roles (#220)

### DIFF
--- a/riperf3-cli/tests/json_stream.rs
+++ b/riperf3-cli/tests/json_stream.rs
@@ -433,6 +433,12 @@ fn json_flag_plus_stream_full_output_appends_the_document() {
         .expect("the monolithic document follows under full-output");
     let doc: Value = serde_json::from_str(out[doc_pos..].trim()).expect("document parses");
     assert!(doc["end"].is_object());
+    // Self-contained hybrid coverage (r1 n2): the doc's intervals are
+    // populated, like the #213 plain-stream analog asserts.
+    assert!(
+        doc["intervals"].as_array().is_some_and(|a| !a.is_empty()),
+        "hybrid full-output doc carries populated intervals: {doc}"
+    );
 }
 
 /// Server `-s -J --json-stream`: stream wins on the server role too.

--- a/riperf3-cli/tests/json_stream.rs
+++ b/riperf3-cli/tests/json_stream.rs
@@ -339,3 +339,137 @@ fn server_json_stream_full_output_appends_the_document() {
         "server-side intervals retained under the flag"
     );
 }
+
+// ---------------------------------------------------------------------------
+// #220: -J + --json-stream — iperf3's OPT_JSON_STREAM implies -J
+// (iperf_api.c:1280-1282), so the hybrid IS stream mode: the full event
+// stream including `end`, with the monolithic document only under
+// --json-stream-full-output. riperf3's json_output-wins dispatch emitted a
+// TRUNCATED stream (start+intervals, no end event) followed by the doc.
+// ---------------------------------------------------------------------------
+
+/// Client `-J --json-stream`: pure stream behavior — an `end` event arrives,
+/// and nothing follows it.
+#[test]
+fn json_flag_plus_stream_behaves_as_stream_mode() {
+    let port = free_port();
+    let ps = port.to_string();
+    let mut server = ChildGuard(
+        Command::new(env!("CARGO_BIN_EXE_riperf3"))
+            .args(["-s", "-1", "-p", &ps])
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("spawn server"),
+    );
+
+    let out = run_capturing(
+        &[
+            "-c",
+            "127.0.0.1",
+            "-p",
+            &ps,
+            "-t",
+            "2",
+            "-i",
+            "1",
+            "-J",
+            "--json-stream",
+        ],
+        Duration::from_secs(20),
+        "client -J --json-stream",
+    );
+    let _ = server.0.wait();
+
+    assert_valid_ndjson(&out, "client hybrid");
+    let end_pos = out
+        .find("{\"event\":\"end\"")
+        .unwrap_or_else(|| panic!("stream mode emits the end event (#220): {out}"));
+    let tail = out[end_pos..].lines().skip(1).collect::<Vec<_>>().join("");
+    assert!(
+        tail.trim().is_empty(),
+        "no monolithic document after end without --json-stream-full-output: {tail:?}"
+    );
+}
+
+/// The hybrid + --json-stream-full-output: the document still follows the
+/// end event (the #213 behavior is mode-independent).
+#[test]
+fn json_flag_plus_stream_full_output_appends_the_document() {
+    let port = free_port();
+    let ps = port.to_string();
+    let mut server = ChildGuard(
+        Command::new(env!("CARGO_BIN_EXE_riperf3"))
+            .args(["-s", "-1", "-p", &ps])
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("spawn server"),
+    );
+
+    let out = run_capturing(
+        &[
+            "-c",
+            "127.0.0.1",
+            "-p",
+            &ps,
+            "-t",
+            "2",
+            "-J",
+            "--json-stream",
+            "--json-stream-full-output",
+        ],
+        Duration::from_secs(20),
+        "client hybrid full-output",
+    );
+    let _ = server.0.wait();
+
+    let end_pos = out.find("{\"event\":\"end\"").expect("end event");
+    let doc_pos = out[end_pos..]
+        .find("{\n")
+        .map(|i| i + end_pos)
+        .expect("the monolithic document follows under full-output");
+    let doc: Value = serde_json::from_str(out[doc_pos..].trim()).expect("document parses");
+    assert!(doc["end"].is_object());
+}
+
+/// Server `-s -J --json-stream`: stream wins on the server role too.
+#[test]
+fn server_json_flag_plus_stream_behaves_as_stream_mode() {
+    let port = free_port();
+    let ps = port.to_string();
+    let mut server = ChildGuard(
+        Command::new(env!("CARGO_BIN_EXE_riperf3"))
+            .args(["-s", "-1", "-J", "--json-stream", "-p", &ps])
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("spawn server"),
+    );
+
+    let _ = common::run_client_ok(
+        &["-c", "127.0.0.1", "-p", &ps, "-t", "2", "-i", "1"],
+        Duration::from_secs(20),
+        "client",
+    );
+
+    wait_bounded(&mut server.0, Duration::from_secs(20), "server");
+    let mut out = String::new();
+    server
+        .0
+        .stdout
+        .take()
+        .unwrap()
+        .read_to_string(&mut out)
+        .unwrap();
+
+    assert_valid_ndjson(&out, "server hybrid");
+    let end_pos = out
+        .find("{\"event\":\"end\"")
+        .unwrap_or_else(|| panic!("server stream mode emits the end event (#220): {out}"));
+    let tail = out[end_pos..].lines().skip(1).collect::<Vec<_>>().join("");
+    assert!(
+        tail.trim().is_empty(),
+        "no document after end on the server either: {tail:?}"
+    );
+}

--- a/riperf3/src/client.rs
+++ b/riperf3/src/client.rs
@@ -1332,18 +1332,14 @@ impl Client {
         test_duration: f64,
         error: Option<&str>,
     ) {
-        if self.json_output {
-            self.print_results_json(
-                streams,
-                cpu_start,
-                remote_cpu,
-                blksize,
-                interval_data,
-                start_meta,
-                test_duration,
-                error,
-            );
-        } else if self.json_stream {
+        // #220: stream mode WINS when both flags are set — iperf3's
+        // OPT_JSON_STREAM implies -J (iperf_api.c:1280-1282), so `-J
+        // --json-stream` IS stream mode (full event stream incl. `end`; the
+        // monolithic doc only under --json-stream-full-output, which the
+        // stream arm already honors). The old json_output-first dispatch
+        // emitted a truncated stream (no end event) followed by the doc.
+        // The CLI's error-sink dispatch has always been stream-first (#198).
+        if self.json_stream {
             // iperf3's NDJSON tail order is: error?, server_output_json,
             // server_output_text, end (iperf_api.c:5310-5323) (#170 + #168).
             if let Some(e) = error {
@@ -1379,6 +1375,17 @@ impl Client {
                 interval_data,
                 start_meta,
                 test_duration,
+            );
+        } else if self.json_output {
+            self.print_results_json(
+                streams,
+                cpu_start,
+                remote_cpu,
+                blksize,
+                interval_data,
+                start_meta,
+                test_duration,
+                error,
             );
         } else {
             self.print_results_text(streams, remote_cpu, blksize, test_duration);

--- a/riperf3/src/client.rs
+++ b/riperf3/src/client.rs
@@ -2158,6 +2158,10 @@ impl ClientBuilder {
     }
 
     /// `--json-stream`: stream line-delimited interval JSON during the test.
+    /// Combined with [`Self::json`], stream mode WINS — iperf3's
+    /// OPT_JSON_STREAM implies -J, so the hybrid is simply stream mode
+    /// (full event stream incl. `end`; the monolithic document only with
+    /// [`Self::json_stream_full_output`]) (#220).
     pub fn json_stream(mut self, enabled: bool) -> Self {
         self.json_stream = enabled;
         self

--- a/riperf3/src/client.rs
+++ b/riperf3/src/client.rs
@@ -2136,6 +2136,7 @@ impl ClientBuilder {
 
     /// `-J/--json`: emit the results as iperf3-schema JSON on stdout instead
     /// of text.
+    /// When combined with [`Self::json_stream`], stream mode wins (#220).
     pub fn json_output(mut self, enabled: bool) -> Self {
         self.json_output = enabled;
         self
@@ -2158,7 +2159,7 @@ impl ClientBuilder {
     }
 
     /// `--json-stream`: stream line-delimited interval JSON during the test.
-    /// Combined with [`Self::json`], stream mode WINS — iperf3's
+    /// Combined with [`Self::json_output`], stream mode WINS — iperf3's
     /// OPT_JSON_STREAM implies -J, so the hybrid is simply stream mode
     /// (full event stream incl. `end`; the monolithic document only with
     /// [`Self::json_stream_full_output`]) (#220).

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -1887,6 +1887,8 @@ impl ServerBuilder {
     }
 
     /// Stream line-delimited interval JSON during the test (`--json-stream`).
+    /// Combined with [`Self::json`], stream mode WINS — iperf3's
+    /// OPT_JSON_STREAM implies -J (#220), same rule as the client builder.
     pub fn json_stream(mut self, enabled: bool) -> Self {
         self.json_stream = enabled;
         self

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -945,26 +945,11 @@ impl Server {
             let _ = &server_results;
         }
 
-        if self.json_output {
-            // Emit the iperf3-schema JSON report on stdout (#50); reuse the
-            // pre-exchange build when --get-server-output attached it (#33).
-            let report = prebuilt_report.unwrap_or_else(|| {
-                self.build_report(
-                    &streams,
-                    &cfg,
-                    &params,
-                    &cpu_util,
-                    test_duration,
-                    &cookie,
-                    &accepted_host,
-                    accepted_port,
-                    test_start_millis,
-                    &interval_data,
-                    report_error.as_deref(),
-                )
-            });
-            self.print_results_json(&report);
-        } else if self.json_stream {
+        // #220: stream mode WINS when both flags are set — iperf3's
+        // OPT_JSON_STREAM implies -J, so `-s -J --json-stream` IS stream
+        // mode (the client-side dispatch and the CLI error sinks already
+        // follow this rule).
+        if self.json_stream {
             // A terminated/interrupted run emits the discrete `error` event
             // BEFORE `end`, like iperf_json_finish on both roles
             // (iperf_api.c:5310-5323) — without this the r1 stderr gating
@@ -989,6 +974,25 @@ impl Server {
                 &interval_data,
                 report_error.as_deref(),
             );
+        } else if self.json_output {
+            // Emit the iperf3-schema JSON report on stdout (#50); reuse the
+            // pre-exchange build when --get-server-output attached it (#33).
+            let report = prebuilt_report.unwrap_or_else(|| {
+                self.build_report(
+                    &streams,
+                    &cfg,
+                    &params,
+                    &cpu_util,
+                    test_duration,
+                    &cookie,
+                    &accepted_host,
+                    accepted_port,
+                    test_start_millis,
+                    &interval_data,
+                    report_error.as_deref(),
+                )
+            });
+            self.print_results_json(&report);
         } else if !was_captured {
             // Print summary: per-stream lines plus aggregate [SUM] row(s) for
             // parallel streams (issue #4), via the shared path the client uses.

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -1881,13 +1881,14 @@ impl ServerBuilder {
     }
 
     /// Emit the results as iperf3-schema JSON on stdout instead of text (`-J`).
+    /// When combined with [`Self::json_stream`], stream mode wins (#220).
     pub fn json_output(mut self, enabled: bool) -> Self {
         self.json_output = enabled;
         self
     }
 
     /// Stream line-delimited interval JSON during the test (`--json-stream`).
-    /// Combined with [`Self::json`], stream mode WINS — iperf3's
+    /// Combined with [`Self::json_output`], stream mode WINS — iperf3's
     /// OPT_JSON_STREAM implies -J (#220), same rule as the client builder.
     pub fn json_stream(mut self, enabled: bool) -> Self {
         self.json_stream = enabled;


### PR DESCRIPTION
## #220: `-J --json-stream` is stream mode

iperf3's `OPT_JSON_STREAM` **implies** `-J` (iperf_api.c:1280-1282) — there is no hybrid mode. riperf3's `json_output`-wins dispatch produced one anyway: a truncated event stream (`start` + `interval`s, **no `end` event**) followed by the monolithic document. Parsers following the stream contract never saw the run end.

Two-line-shaped fix (the dispatch order in `print_results` client-side and the server's results dispatch — stream arm first, `-J` arm second), zero changes to the mode-derivation flags, which already computed the hybrid correctly. The CLI's error-sink dispatch has been stream-first since #198 with a comment citing exactly this iperf3 rule; the lib now agrees with its own CLI.

`--json-stream-full-output` (#213) keeps working in the hybrid — the doc rides after the `end` event, as in plain stream mode.

**TDD:** three red-first tests in `json_stream.rs`: client hybrid streams through `end` with nothing after; hybrid + full-output appends the document; server hybrid ditto (the server had the same backwards dispatch — the issue cited the client path).

Closes #220.
