### PR TITLE
fix: adaptive unit auto-scaling with iperf3's precision ladder (#221)

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ General:
   -s, --server                       Run in server mode
   -c, --client <host>                Run in client mode
   -p, --port <PORT>                  Server port (default: 5201)
-  -f, --format <k|m|g|t>            Report format (default: Mbits)
+  -f, --format <k|m|g|t>            Report format (default: adaptive, like iperf3)
   -i, --interval <secs>             Seconds between periodic reports
   -V, --verbose                      Verbose output
   -J, --json                         JSON output

--- a/riperf3-cli/src/cli.rs
+++ b/riperf3-cli/src/cli.rs
@@ -36,15 +36,11 @@ pub struct Cli {
     pub port: Option<u16>,
 
     /// Format to report: Kbits, Mbits, Gbits, Tbits
-    #[arg(
-        short,
-        long,
-        ignore_case = true,
-        value_enum,
-        value_name = "format",
-        default_value = "m"
-    )]
-    pub format: Format,
+    #[arg(short, long, ignore_case = true, value_enum, value_name = "format")]
+    /// iperf3 has NO default -f: absent, every figure auto-scales
+    /// (unit_snprintf 'a'/'A'). The old forced "m" default printed
+    /// 12120.88 MBytes where iperf3 prints 11.8 GBytes (#221).
+    pub format: Option<Format>,
 
     /// Seconds between periodic throughput reports
     #[arg(short, long, value_name = "interval")]
@@ -481,14 +477,16 @@ impl Cli {
 
         let mut builder = riperf3::ClientBuilder::new(host);
 
-        // Format: K/M/G/T → lowercase char for bits, uppercase for bytes
-        let format_char = match self.format {
-            Format::K => 'k',
-            Format::M => 'm',
-            Format::G => 'g',
-            Format::T => 't',
-        };
-        builder = builder.format_char(format_char);
+        // Format: K/M/G/T → lowercase char for bits, uppercase for bytes;
+        // absent → the library's adaptive default ('a'), like iperf3 (#221).
+        if let Some(f) = &self.format {
+            builder = builder.format_char(match f {
+                Format::K => 'k',
+                Format::M => 'm',
+                Format::G => 'g',
+                Format::T => 't',
+            });
+        }
 
         if let Some(port) = self.port {
             builder = builder.port(Some(port));
@@ -1013,13 +1011,11 @@ mod cli_tests {
             cli.build_server().unwrap()
         }
 
-        /// A `ClientBuilder` pre-seeded with the CLI's unconditional defaults, so
-        /// wiring-test expectations match what `build_client` produces. The CLI
-        /// always sets the report format (default `-f m`), whereas the bare
-        /// library builder defaults to 'a' (auto); without this baseline the
-        /// comparisons would differ only in `format_char`.
+        /// A `ClientBuilder` matching the CLI's no-flag defaults. Since #221
+        /// the CLI no longer forces a format: absent -f, the library's
+        /// adaptive default ('a') stands, like iperf3.
         fn expected_client(host: &str) -> riperf3::ClientBuilder {
-            riperf3::ClientBuilder::new(host).format_char('m')
+            riperf3::ClientBuilder::new(host)
         }
 
         #[test]

--- a/riperf3-cli/src/cli.rs
+++ b/riperf3-cli/src/cli.rs
@@ -36,10 +36,11 @@ pub struct Cli {
     pub port: Option<u16>,
 
     /// Format to report: Kbits, Mbits, Gbits, Tbits
+    // iperf3 has NO default -f: absent, every figure auto-scales
+    // (unit_snprintf 'a'/'A'). The old forced "m" default printed
+    // 12120.88 MBytes where iperf3 prints 11.8 GBytes (#221). NB: a ///
+    // here would leak into clap's --help text (r1 blocker).
     #[arg(short, long, ignore_case = true, value_enum, value_name = "format")]
-    /// iperf3 has NO default -f: absent, every figure auto-scales
-    /// (unit_snprintf 'a'/'A'). The old forced "m" default printed
-    /// 12120.88 MBytes where iperf3 prints 11.8 GBytes (#221).
     pub format: Option<Format>,
 
     /// Seconds between periodic throughput reports

--- a/riperf3-cli/src/cli.rs
+++ b/riperf3-cli/src/cli.rs
@@ -478,8 +478,9 @@ impl Cli {
 
         let mut builder = riperf3::ClientBuilder::new(host);
 
-        // Format: K/M/G/T → lowercase char for bits, uppercase for bytes;
-        // absent → the library's adaptive default ('a'), like iperf3 (#221).
+        // Format: each letter maps to its bit-rate char (#241 tracks the
+        // uppercase byte-rate meanings); absent → the library's adaptive
+        // default ('a'), like iperf3 (#221).
         if let Some(f) = &self.format {
             builder = builder.format_char(match f {
                 Format::K => 'k',

--- a/riperf3-cli/src/cli.rs
+++ b/riperf3-cli/src/cli.rs
@@ -742,7 +742,8 @@ mod cli_tests {
             assert!(cli.server);
             assert!(cli.client.is_none());
             assert_eq!(cli.port, None);
-            assert_eq!(cli.format, Format::M);
+            // #221: no -f means ADAPTIVE (None) — iperf3 has no default format.
+            assert_eq!(cli.format, None);
             assert_eq!(cli.interval, None);
             assert!(!cli.verbose);
             assert_eq!(cli.debug, None);
@@ -752,7 +753,8 @@ mod cli_tests {
             assert!(!cli.server);
             assert_eq!(cli.client, Some("localhost".to_string()));
             assert_eq!(cli.port, None);
-            assert_eq!(cli.format, Format::M);
+            // #221: no -f means ADAPTIVE (None) — iperf3 has no default format.
+            assert_eq!(cli.format, None);
             assert_eq!(cli.interval, None);
             assert!(!cli.verbose);
             assert_eq!(cli.debug, None);
@@ -771,28 +773,28 @@ mod cli_tests {
         #[test]
         fn test_common_format() {
             let cli = Cli::parse_from(["riperf3", "--server", "--format", "k"]);
-            assert_eq!(cli.format, Format::K);
+            assert_eq!(cli.format, Some(Format::K));
 
             let cli = Cli::parse_from(["riperf3", "--client", "localhost", "--format", "g"]);
-            assert_eq!(cli.format, Format::G);
+            assert_eq!(cli.format, Some(Format::G));
 
             let cli = Cli::parse_from(["riperf3", "--server", "--format", "t"]);
-            assert_eq!(cli.format, Format::T);
+            assert_eq!(cli.format, Some(Format::T));
 
             let cli = Cli::parse_from(["riperf3", "--client", "localhost", "--format", "m"]);
-            assert_eq!(cli.format, Format::M);
+            assert_eq!(cli.format, Some(Format::M));
 
             let cli = Cli::parse_from(["riperf3", "--server", "--format", "M"]);
-            assert_eq!(cli.format, Format::M);
+            assert_eq!(cli.format, Some(Format::M));
 
             let cli = Cli::parse_from(["riperf3", "--client", "localhost", "--format", "T"]);
-            assert_eq!(cli.format, Format::T);
+            assert_eq!(cli.format, Some(Format::T));
 
             let cli = Cli::parse_from(["riperf3", "--server", "--format", "G"]);
-            assert_eq!(cli.format, Format::G);
+            assert_eq!(cli.format, Some(Format::G));
 
             let cli = Cli::parse_from(["riperf3", "--client", "localhost", "--format", "K"]);
-            assert_eq!(cli.format, Format::K);
+            assert_eq!(cli.format, Some(Format::K));
         }
     }
 

--- a/riperf3-cli/src/cli.rs
+++ b/riperf3-cli/src/cli.rs
@@ -1784,7 +1784,8 @@ mod cli_tests {
 
         #[test]
         fn format_wired() {
-            // The CLI always sets a format (default 'm'); `-f g` must propagate.
+            // An explicit `-f g` must propagate (absent -f, the lib default
+            // 'a' stands — #221).
             let cli = Cli::parse_from(["riperf3", "-c", "h", "-f", "g"]);
             let c = build_client_from_cli(&cli);
             assert_eq!(c, expected_client("h").format_char('g').build().unwrap());

--- a/riperf3/src/reporter.rs
+++ b/riperf3/src/reporter.rs
@@ -158,7 +158,12 @@ pub(crate) fn emit_json_stream_line(line: &str) {
 /// Print one interval line.
 pub fn print_interval(interval: &StreamInterval, format_char: char) {
     let id = fmt_id_role(interval.stream_id, interval.role_tag);
-    let transfer = units::format_bytes(interval.bytes as f64, format_char.to_ascii_uppercase());
+    // The Transfer column is ALWAYS adaptive — iperf3 hardcodes 'A' at every
+    // transfer site (iperf_api.c:4012/4252/4434/4705); -f drives only the
+    // Bitrate column (r1 review, live-verified: iperf3 -f m still prints
+    // "12.5 GBytes"). to_ascii_uppercase(format_char) was the last way to
+    // reproduce the #221 fixed-unit symptom.
+    let transfer = units::format_bytes(interval.bytes as f64, 'A');
     let seconds = interval.end - interval.start;
     let bits_per_sec = if seconds > 0.0 {
         interval.bytes as f64 * 8.0 / seconds
@@ -243,7 +248,7 @@ pub fn lost_percent(lost: i64, total: i64) -> f64 {
 /// rendered output can be unit-tested without capturing stdout.
 pub fn format_summary_line(summary: &StreamSummary, format_char: char) -> String {
     let id = fmt_id_role(summary.stream_id, summary.role_tag);
-    let transfer = units::format_bytes(summary.bytes as f64, format_char.to_ascii_uppercase());
+    let transfer = units::format_bytes(summary.bytes as f64, 'A');
     let seconds = summary.end - summary.start;
     let bits_per_sec = if seconds > 0.0 {
         summary.bytes as f64 * 8.0 / seconds
@@ -1564,7 +1569,9 @@ mod tests {
         // Pin the rendered aggregate value, not just the presence of a SUM
         // row: the SUM line must render the summed bytes (6000), so a
         // regression that printed a per-stream or zero value would be caught.
-        let expected_transfer = units::format_bytes(6_000.0, 'M');
+        // 'A': the Transfer column is always adaptive (#221) — -f drives
+        // only the Bitrate column, like iperf3.
+        let expected_transfer = units::format_bytes(6_000.0, 'A');
         assert!(
             sum_line.contains(&expected_transfer),
             "SUM must render summed transfer {expected_transfer:?}; got {sum_line:?}"

--- a/riperf3/src/reporter.rs
+++ b/riperf3/src/reporter.rs
@@ -156,21 +156,30 @@ pub(crate) fn emit_json_stream_line(line: &str) {
 }
 
 /// Print one interval line.
-pub fn print_interval(interval: &StreamInterval, format_char: char) {
-    let id = fmt_id_role(interval.stream_id, interval.role_tag);
+/// The interval row's (Transfer, Bitrate) cell pair. Pure so the
+/// Transfer-always-'A' rule is PINNABLE (r2 review: the print path's 'A'
+/// was mutation-silent — no test passes -f, and absent -f both variants
+/// render identically).
+fn interval_cells(bytes: u64, start: f64, end: f64, format_char: char) -> (String, String) {
     // The Transfer column is ALWAYS adaptive — iperf3 hardcodes 'A' at every
     // transfer site (iperf_api.c:4012/4252/4434/4705); -f drives only the
     // Bitrate column (r1 review, live-verified: iperf3 -f m still prints
     // "12.5 GBytes"). to_ascii_uppercase(format_char) was the last way to
     // reproduce the #221 fixed-unit symptom.
-    let transfer = units::format_bytes(interval.bytes as f64, 'A');
-    let seconds = interval.end - interval.start;
+    let transfer = units::format_bytes(bytes as f64, 'A');
+    let seconds = end - start;
     let bits_per_sec = if seconds > 0.0 {
-        interval.bytes as f64 * 8.0 / seconds
+        bytes as f64 * 8.0 / seconds
     } else {
         0.0
     };
-    let rate = units::format_rate(bits_per_sec, format_char);
+    (transfer, units::format_rate(bits_per_sec, format_char))
+}
+
+pub fn print_interval(interval: &StreamInterval, format_char: char) {
+    let id = fmt_id_role(interval.stream_id, interval.role_tag);
+    let (transfer, rate) =
+        interval_cells(interval.bytes, interval.start, interval.end, format_char);
 
     let omit_tag = if interval.omitted { "(omitted) " } else { "" };
 
@@ -1272,6 +1281,17 @@ pub fn spawn_interval_reporter(
 
 #[cfg(test)]
 mod tests {
+    /// #221 r2: the interval row's Transfer stays adaptive under an explicit
+    /// -f while Bitrate follows it — pinned on the pure helper (the print
+    /// path was mutation-silent).
+    #[test]
+    fn interval_cells_transfer_always_adaptive() {
+        let (transfer, rate) = interval_cells(12_120_000_000, 0.0, 1.0, 'm');
+        assert_eq!(transfer, "11.3 GBytes");
+        assert!(rate.ends_with(" Mbits/sec"), "{rate}");
+        assert!(rate.starts_with("96960"), "{rate}");
+    }
+
     use super::*;
 
     #[test]

--- a/riperf3/src/reporter.rs
+++ b/riperf3/src/reporter.rs
@@ -155,7 +155,6 @@ pub(crate) fn emit_json_stream_line(line: &str) {
     let _ = std::io::stdout().flush();
 }
 
-/// Print one interval line.
 /// The interval row's (Transfer, Bitrate) cell pair. Pure so the
 /// Transfer-always-'A' rule is PINNABLE (r2 review: the print path's 'A'
 /// was mutation-silent — no test passes -f, and absent -f both variants
@@ -176,6 +175,7 @@ fn interval_cells(bytes: u64, start: f64, end: f64, format_char: char) -> (Strin
     (transfer, units::format_rate(bits_per_sec, format_char))
 }
 
+/// Print one interval line.
 pub fn print_interval(interval: &StreamInterval, format_char: char) {
     let id = fmt_id_role(interval.stream_id, interval.role_tag);
     let (transfer, rate) =
@@ -1281,6 +1281,8 @@ pub fn spawn_interval_reporter(
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+
     /// #221 r2: the interval row's Transfer stays adaptive under an explicit
     /// -f while Bitrate follows it — pinned on the pure helper (the print
     /// path was mutation-silent).
@@ -1291,8 +1293,6 @@ mod tests {
         assert!(rate.ends_with(" Mbits/sec"), "{rate}");
         assert!(rate.starts_with("96960"), "{rate}");
     }
-
-    use super::*;
 
     #[test]
     fn stream_interval_tcp_basic() {

--- a/riperf3/src/units.rs
+++ b/riperf3/src/units.rs
@@ -124,6 +124,7 @@ mod tests {
         assert_eq!(format_bytes(16.0, 'A'), "16.0 Bytes");
         assert_eq!(format_bytes(50.0, 'A'), "50.0 Bytes");
         assert_eq!(format_rate(0.0, 'a'), "0.00 bits/sec");
+        assert_eq!(format_bytes(1.0, 'a'), "8.00 bits");
         assert_eq!(format_bytes(500.0, 'A'), "500 Bytes");
         assert_eq!(format_bytes(1024.0, 'A'), "1.00 KBytes");
         assert_eq!(format_bytes(1024.0 * 1024.0 * 1.5, 'A'), "1.50 MBytes");

--- a/riperf3/src/units.rs
+++ b/riperf3/src/units.rs
@@ -70,7 +70,7 @@ fn adaptive_bytes(bytes: f64) -> String {
     } else if bytes >= K {
         format!("{} KBytes", ladder(bytes / K))
     } else {
-        format!("{:.0} Bytes", bytes)
+        format!("{} Bytes", ladder(bytes))
     }
 }
 
@@ -89,7 +89,7 @@ fn adaptive_bits(bits: f64) -> String {
     } else if bits >= K {
         format!("{} Kbits", ladder(bits / K))
     } else {
-        format!("{:.0} bits", bits)
+        format!("{} bits", ladder(bits))
     }
 }
 
@@ -108,7 +108,7 @@ fn adaptive_rate(bits_per_sec: f64) -> String {
     } else if bits_per_sec >= K {
         format!("{} Kbits/sec", ladder(bits_per_sec / K))
     } else {
-        format!("{:.0} bits/sec", bits_per_sec)
+        format!("{} bits/sec", ladder(bits_per_sec))
     }
 }
 
@@ -118,6 +118,12 @@ mod tests {
 
     #[test]
     fn format_bytes_adaptive() {
+        // The ladder applies at the sub-unit floor too (r1 blocker —
+        // iperf3's canonical stall row is "0.00 Bytes  0.00 bits/sec").
+        assert_eq!(format_bytes(0.0, 'A'), "0.00 Bytes");
+        assert_eq!(format_bytes(16.0, 'A'), "16.0 Bytes");
+        assert_eq!(format_bytes(50.0, 'A'), "50.0 Bytes");
+        assert_eq!(format_rate(0.0, 'a'), "0.00 bits/sec");
         assert_eq!(format_bytes(500.0, 'A'), "500 Bytes");
         assert_eq!(format_bytes(1024.0, 'A'), "1.00 KBytes");
         assert_eq!(format_bytes(1024.0 * 1024.0 * 1.5, 'A'), "1.50 MBytes");

--- a/riperf3/src/units.rs
+++ b/riperf3/src/units.rs
@@ -13,25 +13,44 @@ pub fn format_bytes(bytes: f64, format_char: char) -> String {
     match format_char {
         'A' => adaptive_bytes(bytes),
         'a' => adaptive_bits(bytes * 8.0),
-        'K' => format!("{:.2} KBytes", bytes / 1024.0),
-        'k' => format!("{:.2} Kbits", bytes * 8.0 / 1000.0),
-        'M' => format!("{:.2} MBytes", bytes / (1024.0 * 1024.0)),
-        'm' => format!("{:.2} Mbits", bytes * 8.0 / 1_000_000.0),
-        'G' => format!("{:.2} GBytes", bytes / (1024.0 * 1024.0 * 1024.0)),
-        'g' => format!("{:.2} Gbits", bytes * 8.0 / 1_000_000_000.0),
-        'T' => format!("{:.2} TBytes", bytes / (1024.0 * 1024.0 * 1024.0 * 1024.0)),
-        't' => format!("{:.2} Tbits", bytes * 8.0 / 1_000_000_000_000.0),
+        'K' => format!("{} KBytes", ladder(bytes / 1024.0)),
+        'k' => format!("{} Kbits", ladder(bytes * 8.0 / 1000.0)),
+        'M' => format!("{} MBytes", ladder(bytes / (1024.0 * 1024.0))),
+        'm' => format!("{} Mbits", ladder(bytes * 8.0 / 1_000_000.0)),
+        'G' => format!("{} GBytes", ladder(bytes / (1024.0 * 1024.0 * 1024.0))),
+        'g' => format!("{} Gbits", ladder(bytes * 8.0 / 1_000_000_000.0)),
+        'T' => format!(
+            "{} TBytes",
+            ladder(bytes / (1024.0 * 1024.0 * 1024.0 * 1024.0))
+        ),
+        't' => format!("{} Tbits", ladder(bytes * 8.0 / 1_000_000_000_000.0)),
         _ => adaptive_bytes(bytes),
+    }
+}
+
+/// iperf3's unit_snprintf precision ladder (#221): the printed figure keeps
+/// ~3 significant digits — < 9.995 → 2 dp, < 99.95 → 1 dp, else 0 dp. The
+/// boundaries are round-aware (units.c: "9.995 would be rounded to 10.0",
+/// "99.95 would be rounded to 100"). iperf3 also left-pads to a 4-char
+/// minimum (%4.Xf); riperf3's row templates own column alignment, so the
+/// pad is theirs, not this function's.
+fn ladder(n: f64) -> String {
+    if n < 9.995 {
+        format!("{n:.2}")
+    } else if n < 99.95 {
+        format!("{n:.1}")
+    } else {
+        format!("{n:.0}")
     }
 }
 
 /// Format a bits-per-second rate for display.
 pub fn format_rate(bits_per_sec: f64, format_char: char) -> String {
     match format_char {
-        'k' | 'K' => format!("{:.2} Kbits/sec", bits_per_sec / 1000.0),
-        'm' | 'M' => format!("{:.2} Mbits/sec", bits_per_sec / 1_000_000.0),
-        'g' | 'G' => format!("{:.2} Gbits/sec", bits_per_sec / 1_000_000_000.0),
-        't' | 'T' => format!("{:.2} Tbits/sec", bits_per_sec / 1_000_000_000_000.0),
+        'k' | 'K' => format!("{} Kbits/sec", ladder(bits_per_sec / 1000.0)),
+        'm' | 'M' => format!("{} Mbits/sec", ladder(bits_per_sec / 1_000_000.0)),
+        'g' | 'G' => format!("{} Gbits/sec", ladder(bits_per_sec / 1_000_000_000.0)),
+        't' | 'T' => format!("{} Tbits/sec", ladder(bits_per_sec / 1_000_000_000_000.0)),
         _ => adaptive_rate(bits_per_sec),
     }
 }
@@ -43,13 +62,13 @@ fn adaptive_bytes(bytes: f64) -> String {
     const T: f64 = G * 1024.0;
 
     if bytes >= T {
-        format!("{:.2} TBytes", bytes / T)
+        format!("{} TBytes", ladder(bytes / T))
     } else if bytes >= G {
-        format!("{:.2} GBytes", bytes / G)
+        format!("{} GBytes", ladder(bytes / G))
     } else if bytes >= M {
-        format!("{:.2} MBytes", bytes / M)
+        format!("{} MBytes", ladder(bytes / M))
     } else if bytes >= K {
-        format!("{:.2} KBytes", bytes / K)
+        format!("{} KBytes", ladder(bytes / K))
     } else {
         format!("{:.0} Bytes", bytes)
     }
@@ -62,13 +81,13 @@ fn adaptive_bits(bits: f64) -> String {
     const T: f64 = G * 1000.0;
 
     if bits >= T {
-        format!("{:.2} Tbits", bits / T)
+        format!("{} Tbits", ladder(bits / T))
     } else if bits >= G {
-        format!("{:.2} Gbits", bits / G)
+        format!("{} Gbits", ladder(bits / G))
     } else if bits >= M {
-        format!("{:.2} Mbits", bits / M)
+        format!("{} Mbits", ladder(bits / M))
     } else if bits >= K {
-        format!("{:.2} Kbits", bits / K)
+        format!("{} Kbits", ladder(bits / K))
     } else {
         format!("{:.0} bits", bits)
     }
@@ -81,13 +100,13 @@ fn adaptive_rate(bits_per_sec: f64) -> String {
     const T: f64 = G * 1000.0;
 
     if bits_per_sec >= T {
-        format!("{:.2} Tbits/sec", bits_per_sec / T)
+        format!("{} Tbits/sec", ladder(bits_per_sec / T))
     } else if bits_per_sec >= G {
-        format!("{:.2} Gbits/sec", bits_per_sec / G)
+        format!("{} Gbits/sec", ladder(bits_per_sec / G))
     } else if bits_per_sec >= M {
-        format!("{:.2} Mbits/sec", bits_per_sec / M)
+        format!("{} Mbits/sec", ladder(bits_per_sec / M))
     } else if bits_per_sec >= K {
-        format!("{:.2} Kbits/sec", bits_per_sec / K)
+        format!("{} Kbits/sec", ladder(bits_per_sec / K))
     } else {
         format!("{:.0} bits/sec", bits_per_sec)
     }
@@ -111,9 +130,51 @@ mod tests {
     #[test]
     fn format_bytes_fixed_units() {
         let bytes = 1024.0 * 1024.0; // 1 MiB
-        assert_eq!(format_bytes(bytes, 'K'), "1024.00 KBytes");
+                                     // iperf3's magnitude ladder applies to FIXED units too
+                                     // (unit_snprintf formats after conversion): >=999.5 -> %.0f.
+        assert_eq!(format_bytes(bytes, 'K'), "1024 KBytes");
         assert_eq!(format_bytes(bytes, 'M'), "1.00 MBytes");
         assert_eq!(format_bytes(bytes, 'G'), "0.00 GBytes");
+    }
+
+    /// iperf3's t_units.c expectations, adjusted only for riperf3's baked
+    /// plural "s" (iperf3's row formats append it): the magnitude ladder is
+    /// <9.995 -> %.2f, <99.95 -> %.1f, else %.0f (#221).
+    #[test]
+    fn iperf3_t_units_pins() {
+        let gib4 = 4.0 * 1024.0 * 1024.0 * 1024.0;
+        let tib4 = gib4 * 1024.0;
+        let pib4 = tib4 * 1024.0;
+        assert_eq!(format_bytes(1024.0, 'A'), "1.00 KBytes");
+        assert_eq!(format_bytes(1024.0 * 1024.0, 'A'), "1.00 MBytes");
+        assert_eq!(format_bytes(1000.0, 'k'), "8.00 Kbits");
+        assert_eq!(format_bytes(1000.0 * 1000.0, 'a'), "8.00 Mbits");
+        assert_eq!(format_bytes(gib4, 'A'), "4.00 GBytes");
+        assert_eq!(format_bytes(gib4, 'a'), "34.4 Gbits");
+        assert_eq!(format_bytes(tib4, 'A'), "4.00 TBytes");
+        assert_eq!(format_bytes(tib4, 'a'), "35.2 Tbits");
+        // Past the TERA cap the number grows; %.0f keeps it integral.
+        assert_eq!(format_bytes(pib4, 'A'), "4096 TBytes");
+        assert_eq!(format_bytes(pib4, 'a'), "36029 Tbits");
+    }
+
+    /// The ladder boundaries are ROUND-aware (iperf3's 9.995/99.95/999.5
+    /// comments: "9.995 would be rounded to 10.0"), and the issue's own
+    /// examples render correctly (#221: 12120.88 MBytes -> 11.8 GBytes
+    /// class; the GT row was 11.7 GBytes / 101 Gbits/sec).
+    #[test]
+    fn ladder_boundaries_and_issue_examples() {
+        // 11.7 GBytes (the live GT row figure)
+        let b = 11.7 * 1024.0 * 1024.0 * 1024.0;
+        assert_eq!(format_bytes(b, 'A'), "11.7 GBytes");
+        // 101 Gbits/sec (>=99.95 -> %.0f)
+        assert_eq!(format_rate(101.0e9, 'a'), "101 Gbits/sec");
+        // boundary: 9.994 stays 2dp, 9.996 promotes to 1dp ("10.0")
+        assert_eq!(format_rate(9.994e9, 'a'), "9.99 Gbits/sec");
+        assert_eq!(format_rate(9.996e9, 'a'), "10.0 Gbits/sec");
+        // boundary: 99.94 stays 1dp, 99.96 promotes to 0dp ("100")
+        assert_eq!(format_rate(99.94e9, 'a'), "99.9 Gbits/sec");
+        assert_eq!(format_rate(99.96e9, 'a'), "100 Gbits/sec");
     }
 
     #[test]
@@ -125,7 +186,8 @@ mod tests {
     #[test]
     fn format_rate_fixed() {
         assert_eq!(format_rate(1_000_000_000.0, 'g'), "1.00 Gbits/sec");
-        assert_eq!(format_rate(1_000_000_000.0, 'm'), "1000.00 Mbits/sec");
+        // ladder: 1000 >= 999.5 -> %.0f
+        assert_eq!(format_rate(1_000_000_000.0, 'm'), "1000 Mbits/sec");
     }
 
     #[test]


### PR DESCRIPTION
## #221: unit auto-scaling — the default AND the precision ladder

Two distinct bugs produced `12120.88 MBytes  101677.27 Mbits/sec`:

1. **The CLI forced `-f m` as a default.** iperf3 has no `-f` default — absent the flag, `unit_snprintf('a'/'A')` auto-scales everything. The library's builder already defaulted to adaptive; the CLI was overriding it. `-f` is now `Option<Format>`, and the wiring-test baseline drops its `format_char('m')` compensation (whose own comment documented the mismatch).

2. **Everything printed `{:.2}`.** iperf3's ladder keeps ~3 significant digits: `<9.995 → %.2f`, `<99.95 → %.1f`, else `%.0f` — with round-aware boundaries (units.c: "9.995 would be rounded to 10.0"). Applied to adaptive *and* fixed modes (`-f m` of 1 Gbit is `1000 Mbits/sec`, not `1000.00`).

**Pins:** iperf3's own `t_units.c` expectations (adjusted only for riperf3's baked plural `s` — iperf3's row formats append it), the promotion boundaries, and the GT row class (`11.7 GBytes` / `101 Gbits/sec`). Red-first: 4 tests red against the old formatting.

**Live token parity** (loopback `-t 1`, no flags):

```
riperf3:  [  1]  0.00-1.00  sec  11.6 GBytes  100 Gbits/sec     0
iperf3:   [  5]   0.00-1.00   sec  11.7 GBytes   101 Gbits/sec    0
```

Unit tokens and figure precision now match; the residual column-gap/width differences are the row-template layer, which rides the #222 missing-text-lines work (where full-row GT diffing happens anyway).

**Scope note:** iperf3 also left-pads figures to a 4-char minimum (`%4.Xf`); riperf3's row templates own column alignment, so the pad lives with them, not in the unit formatter — `ladder()`'s rustdoc says so explicitly.

Closes #221.
