### PR TITLE
fix: reporter end-race — the final flush runs after the senders stop (#159)

### DIFF
--- a/riperf3/src/client.rs
+++ b/riperf3/src/client.rs
@@ -1276,8 +1276,15 @@ impl Client {
         // the final interval or the summary (#55). The reporter prioritises this
         // `finish` over `done` (see its select), so the final interval still
         // flushes; we then wait for it before tearing the streams down.
-        reporter_end.finish(end_secs);
+        // #159: stop the senders FIRST and give their in-flight catch-up the
+        // teardown grace to land in the counters, THEN signal the flush —
+        // iperf3 reads its counters after the threads join, so the intervals
+        // always cover what the END block accounts. The [last_boundary,
+        // end_secs] window stays authoritative (#55) — late-landing bytes
+        // belong to the window they were sent in.
         done.store(true, Ordering::Relaxed);
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        reporter_end.finish(end_secs);
         if let Some(handle) = interval_handle {
             let _ = handle.await;
         }

--- a/riperf3/src/client.rs
+++ b/riperf3/src/client.rs
@@ -1271,11 +1271,9 @@ impl Client {
             }
         };
 
-        // End of test: hand the reporter the authoritative end time, then stop
-        // the senders immediately (`done`) so no bytes leak past the deadline into
-        // the final interval or the summary (#55). The reporter prioritises this
-        // `finish` over `done` (see its select), so the final interval still
-        // flushes; we then wait for it before tearing the streams down.
+        // End of test (#55 window, #159 order): stop the senders, let the
+        // catch-up land, then hand the reporter the authoritative end time —
+        // the flush below reads settled counters.
         // #159: stop the senders FIRST and give their in-flight catch-up the
         // teardown grace to land in the counters, THEN signal the flush —
         // iperf3 reads its counters after the threads join, so the intervals

--- a/riperf3/src/reporter.rs
+++ b/riperf3/src/reporter.rs
@@ -2050,6 +2050,7 @@ mod end_race_tests {
     use super::*;
     use std::sync::atomic::AtomicBool;
 
+    #[allow(clippy::type_complexity)] // a test harness 5-tuple, not API
     fn harness(
         interval_secs: f64,
     ) -> (

--- a/riperf3/src/reporter.rs
+++ b/riperf3/src/reporter.rs
@@ -507,9 +507,13 @@ pub struct CollectedIntervals {
 /// authoritative elapsed test time at the exact moment the run ends; the reporter
 /// then flushes one final interval `[last_boundary, end_secs]` and stops. Using the
 /// driver's measured end time (rather than the reporter's own late, polled
-/// detection) keeps the final interval's boundary and bitrate exact, and because
-/// the driver signals *before* it tears the streams down, the final flush still
-/// reads live TCP_INFO.
+/// detection) keeps the final interval's boundary and bitrate exact. Since
+/// #159 the driver stops the senders FIRST (with the teardown grace) and
+/// signals `finish` after, so the flush's snapshot includes a starved
+/// sender's catch-up burst — iperf3 reads its counters after the threads
+/// join, and the intervals must cover what the END block accounts. The
+/// stream sockets are still open at flush time (task-join, not teardown),
+/// so the final interval's TCP_INFO read stays live.
 #[derive(Debug)]
 pub struct ReporterEnd {
     notify: tokio::sync::Notify,
@@ -1210,9 +1214,26 @@ pub fn spawn_interval_reporter(
                     break;
                 }
                 _ = ticker.tick() => {
-                    // `done` without a `finish` is the error/early-teardown path:
-                    // stop without inventing a final interval.
                     if done.load(Ordering::Relaxed) {
+                        // #159: the driver now stops the senders BEFORE
+                        // signalling the final flush, so `done` can be
+                        // visible a beat before the notify. A normal end
+                        // delivers `finish` momentarily — wait bounded,
+                        // then re-arm the notify so the end arm (which owns
+                        // the flush) runs next iteration. An error/early-
+                        // teardown path never calls finish: the timeout
+                        // keeps teardown prompt, and no final interval is
+                        // invented (the pre-#159 semantic, preserved).
+                        if tokio::time::timeout(
+                            Duration::from_secs(2),
+                            reporter_end.notify.notified(),
+                        )
+                        .await
+                        .is_ok()
+                        {
+                            reporter_end.notify.notify_one();
+                            continue;
+                        }
                         break;
                     }
                     interval_num += 1;
@@ -2012,5 +2033,134 @@ mod interval_reporter_tests {
             "no trailing empty interval for an idle receiver tail; got {} intervals",
             g.intervals.len()
         );
+    }
+}
+
+#[cfg(test)]
+mod end_race_tests {
+    //! #159 — the reporter end-race, pinned at the component level
+    //! (deterministic, no load): the final flush must run AFTER the senders
+    //! stopped, so a starved sender's catch-up burst is counted by the
+    //! interval the END block already accounts. Pre-fix shapes: a ticker
+    //! tick observing `done` before `finish` exited without flushing (the
+    //! dropped final interval, the #207 forensics mode); and with every
+    //! byte starved into the catch-up, the old flush-before-stop order saw
+    //! residual 0 and skipped (the original empty-intervals hit).
+
+    use super::*;
+    use std::sync::atomic::AtomicBool;
+
+    fn harness(
+        interval_secs: f64,
+    ) -> (
+        Arc<crate::stream::StreamCounters>,
+        Arc<AtomicBool>,
+        Arc<ReporterEnd>,
+        Arc<Mutex<CollectedIntervals>>,
+        JoinHandle<()>,
+    ) {
+        let counters = Arc::new(crate::stream::StreamCounters::default());
+        let done = Arc::new(AtomicBool::new(false));
+        let reporter_end = Arc::new(ReporterEnd::new());
+        let collector = Arc::new(Mutex::new(CollectedIntervals::default()));
+        let handle = spawn_interval_reporter(
+            IntervalReporterConfig {
+                interval_secs,
+                protocol: TransportProtocol::Tcp,
+                format_char: 'a',
+                omit_secs: 0,
+                forceflush: false,
+                json_stream: false,
+                print: false,
+                blksize: 1024,
+                bidir: false,
+                is_server: false,
+                keep_intervals: false,
+            },
+            vec![IntervalStreamRef {
+                id: 1,
+                is_sender: true,
+                counters: counters.clone(),
+                udp_recv_stats: None,
+                raw_fd: None,
+            }],
+            done.clone(),
+            reporter_end.clone(),
+            Some(collector.clone()),
+            None,
+            None,
+        )
+        .expect("reporter spawns");
+        (counters, done, reporter_end, collector, handle)
+    }
+
+    fn collected_bytes(collector: &Arc<Mutex<CollectedIntervals>>) -> u64 {
+        let c = collector.lock().unwrap();
+        c.intervals
+            .iter()
+            .flat_map(|i| i.streams.iter())
+            .map(|s| s.bytes)
+            .sum()
+    }
+
+    /// The dropped-final-interval shape: `done` lands between ticks, the
+    /// next tick observes it, `finish` arrives a beat later — the flush
+    /// must still happen and cover the tail.
+    #[tokio::test]
+    async fn tick_observing_done_waits_for_finish_and_flushes() {
+        let (counters, done, reporter_end, collector, handle) = harness(0.05);
+
+        counters.record_sent(1000);
+        tokio::time::sleep(std::time::Duration::from_millis(120)).await;
+
+        counters.record_sent(500); // the partial tail
+        done.store(true, Ordering::Relaxed);
+        tokio::time::sleep(std::time::Duration::from_millis(120)).await;
+
+        reporter_end.finish(0.3);
+        handle.await.expect("reporter exits");
+
+        assert_eq!(
+            collected_bytes(&collector),
+            1500,
+            "the final interval must cover the tail the END block accounts (#159)"
+        );
+    }
+
+    /// The catch-up shape: bytes landing AFTER `done` (the starved sender's
+    /// burst draining during the teardown grace) but before `finish` belong
+    /// to the final interval.
+    #[tokio::test]
+    async fn catchup_bytes_after_done_land_in_the_final_interval() {
+        let (counters, done, reporter_end, collector, handle) = harness(1.0);
+
+        counters.record_sent(1000);
+        done.store(true, Ordering::Relaxed);
+        counters.record_sent(300); // the catch-up burst
+        reporter_end.finish(0.4);
+        handle.await.expect("reporter exits");
+
+        assert_eq!(
+            collected_bytes(&collector),
+            1300,
+            "catch-up bytes between done and finish are part of the run (#159)"
+        );
+    }
+
+    /// The error-path semantic survives: a bare `done` with no `finish`
+    /// still tears down promptly and invents no final interval.
+    #[tokio::test]
+    async fn bare_done_without_finish_exits_without_inventing_intervals() {
+        let (counters, done, _reporter_end, collector, handle) = harness(0.05);
+
+        counters.record_sent(1000);
+        done.store(true, Ordering::Relaxed);
+        let start = std::time::Instant::now();
+        handle.await.expect("reporter exits");
+        assert!(
+            start.elapsed() < std::time::Duration::from_secs(5),
+            "bounded teardown on the error path"
+        );
+        assert!(collected_bytes(&collector) <= 1000);
     }
 }

--- a/riperf3/src/reporter.rs
+++ b/riperf3/src/reporter.rs
@@ -511,9 +511,13 @@ pub struct CollectedIntervals {
 /// #159 the driver stops the senders FIRST (with the teardown grace) and
 /// signals `finish` after, so the flush's snapshot includes a starved
 /// sender's catch-up burst — iperf3 reads its counters after the threads
-/// join, and the intervals must cover what the END block accounts. The
-/// stream sockets are still open at flush time (task-join, not teardown),
-/// so the final interval's TCP_INFO read stays live.
+/// join, and the intervals must cover what the END block accounts.
+/// TRADE-OFF (r1 review): the sender task owns its TcpStream and drops it
+/// when its loop exits on `done`, so the final partial interval's TCP_INFO
+/// read usually hits a closed fd and takes the #55 stale-extremes fallback
+/// (Cwnd/RTT from the last boundary, Retr 0) where iperf3 — sockets open
+/// through its end exchange — reads live. Cosmetic on a sub-interval
+/// window; #245 tracks keeping the sockets alive through the flush.
 #[derive(Debug)]
 pub struct ReporterEnd {
     notify: tokio::sync::Notify,
@@ -1183,6 +1187,16 @@ pub fn spawn_interval_reporter(
             tokio::select! {
                 biased;
                 _ = reporter_end.notify.notified() => {
+                    // #159 invariant: the drivers stop the senders BEFORE
+                    // signalling the flush — a finish without done means a
+                    // driver regressed to the pre-#159 order, whose damage
+                    // only resurfaces as the windows-latest starvation flake
+                    // family (the expensive #207 forensics). Debug-only: the
+                    // race-prone shapes live in CI's debug builds.
+                    debug_assert!(
+                        done.load(Ordering::Relaxed),
+                        "reporter finish() signalled before done — the #159 driver order regressed"
+                    );
                     // #55: the run ended part-way through an interval. Flush one
                     // final interval `[last_boundary, end_secs]` using the
                     // driver's authoritative end time, then stop.
@@ -1791,6 +1805,8 @@ mod interval_reporter_tests {
         // as the client/server driver does.
         counters.record_sent(500);
         tokio::time::sleep(Duration::from_millis(120)).await; // ~1.42s
+                                                              // #159 invariant: done precedes finish (the driver order).
+        done.store(true, Ordering::Relaxed);
         reporter_end.finish(report_start.elapsed().as_secs_f64());
         let _ = handle.await;
 
@@ -1868,6 +1884,8 @@ mod interval_reporter_tests {
         tokio::time::sleep(Duration::from_millis(300)).await;
         counters.record_sent(2000);
         tokio::time::sleep(Duration::from_millis(300)).await;
+        // #159 invariant: done precedes finish (the driver order).
+        done.store(true, Ordering::Relaxed);
         reporter_end.finish(report_start.elapsed().as_secs_f64());
         let _ = handle.await;
 
@@ -1951,6 +1969,8 @@ mod interval_reporter_tests {
         // boundary. The authoritative end time is exactly 1.0, so the remainder is
         // zero-length and must be dropped despite these residual bytes.
         counters.record_sent(777);
+        // #159 invariant: done precedes finish (the driver order).
+        done.store(true, Ordering::Relaxed);
         reporter_end.finish(1.0);
         let _ = handle.await;
 
@@ -2023,6 +2043,8 @@ mod interval_reporter_tests {
 
         // end_secs trails the 0.5 boundary (as TEST_END would), but the tail is
         // empty — the residual-bytes guard must drop it.
+        // #159 invariant: done precedes finish (the driver order).
+        done.store(true, Ordering::Relaxed);
         reporter_end.finish(0.62);
         let _ = handle.await;
 

--- a/riperf3/src/reporter.rs
+++ b/riperf3/src/reporter.rs
@@ -1192,12 +1192,11 @@ pub fn spawn_interval_reporter(
 
         loop {
             // Wait for either the next interval boundary or the driver's
-            // end-of-test signal. `biased` checks the end signal FIRST: the driver
-            // sets `done` immediately after `finish` (to stop the senders at the
-            // deadline), so the notify must win that race — otherwise the tick
-            // branch would observe `done` and exit without flushing the final
-            // interval. When `finish` and a boundary tick are both ready, that
-            // boundary's data is folded into the recovered final interval below.
+            // end-of-test signal. `biased` checks the end signal FIRST so a
+            // coincident boundary tick's data folds into the recovered final
+            // interval below rather than emitting twice. (The driver order is
+            // done → grace → finish since #159; the tick arm's own done
+            // handling waits for the finish signal.)
             tokio::select! {
                 biased;
                 _ = reporter_end.notify.notified() => {

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -765,10 +765,8 @@ impl Server {
         }
 
         // ---- Shut down streams ----
-        // Hand the reporter the authoritative end time, then stop the streams
-        // (`done`) so no received bytes leak past the deadline into the final
-        // interval (#55). The reporter prioritises `finish` over `done`, so the
-        // final interval still flushes; wait for it before tearing streams down.
+        // #55 window, #159 order: stop the streams, let the catch-up land,
+        // then hand the reporter the authoritative end time for the flush.
         let measured_elapsed = report_start.elapsed().as_secs_f64();
         // The reporter's timeline restarted at the omit boundary (#31), so its
         // authoritative end time is post-omit; clamp for runs that died inside

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -773,8 +773,11 @@ impl Server {
         // The reporter's timeline restarted at the omit boundary (#31), so its
         // authoritative end time is post-omit; clamp for runs that died inside
         // the warm-up.
-        reporter_end.finish((measured_elapsed - cfg.omit as f64).max(0.0));
+        // #159: senders stop first, the catch-up grace runs, THEN the flush
+        // is signalled (see the client-side twin for the full rationale).
         done.store(true, Ordering::Relaxed);
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        reporter_end.finish((measured_elapsed - cfg.omit as f64).max(0.0));
         if let Some(handle) = interval_handle {
             let _ = handle.await;
         }
@@ -803,8 +806,8 @@ impl Server {
             }
         }
 
-        // Wait briefly then join tasks (senders may be blocked on write)
-        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        // (The pre-results grace moved up to the #159 stop-then-flush
+        // sequence; the counters are already settled here.)
 
         let mut result_streams = Vec::new();
         // Summary window + bitrate: the measured elapsed for a byte/block-limited


### PR DESCRIPTION
## #159: the reporter end-race — flush after the senders stop

The issue's root-cause comment called for exactly this: *"the faithful fix (intervals always cover the run, like iperf3's synchronous end reporting) needs the flush to happen after the senders are stopped/joined, which reorders the #55 authoritative-end-time design — a deliberate redesign, not a ride-along."*

**Old order:** `finish(end_secs)` → final flush (gated `residual_bytes > 0` at the snapshot) → `done` → senders stop. A starved sender's catch-up burst landing between the snapshot and `done` was invisible to the intervals but counted by the END block — the array under-covered the run it accounts (the windows-latest dropped-tick family, #207's forensics). With *everything* starved into the catch-up, the residual gate skipped the flush outright — the original empty-intervals shape.

**New order** (both roles): `done` → the 100 ms teardown grace, moved up (the catch-up lands in the counters) → `finish` → flush. iperf3 reads its counters after `pthread_join`; same semantics. The `[last_boundary, end_secs]` **window stays authoritative** (#55) — late-landing bytes belong to the window they were sent in, and the full suite (including the #55 pins) is green.

The reporter's tick arm previously exited bare on observing `done` (correct under the old order, a dropped final interval under the new): it now waits (bounded, 2 s) for the `finish` signal and re-arms the notify so the end arm — which owns the flush — runs. An error path that never calls `finish` still tears down promptly with no invented interval (the pre-existing semantic, pinned).

### TDD

Component-level, deterministic, in-crate (the reporter is `pub(crate)`):
- `tick_observing_done_waits_for_finish_and_flushes` — **red on main** (1000 collected vs 1500 sent)
- `catchup_bytes_after_done_land_in_the_final_interval` — pins the new driver-order contract
- `bare_done_without_finish_exits_without_inventing_intervals` — the error-path negative

### Verification beyond the suite

- 20× 2-core rounds (`taskset -c 0,1`, `--test-threads=2`) on the udp_pacing + bidir_intervals binaries: posted below.
- Cloud hammer on this branch (it inherits hammer.yml), **windows-latest** — where this family lived: posted below.

Closes #159.
