### PR TITLE
fix: pin the max-duration timer as one absolute deadline (#237)

### DIFF
--- a/riperf3-cli/tests/self_terminate.rs
+++ b/riperf3-cli/tests/self_terminate.rs
@@ -175,6 +175,56 @@ fn bitrate_limit_json_server_doc_carries_prefixed_error() {
     );
 }
 
+/// #237: the duration timer must be ONE absolute deadline. With
+/// --server-bitrate-limit also set, the 1 Hz under-limit rate ticks re-enter
+/// the select loop; a sleep() recreated per iteration restarts from zero on
+/// every tick, so any max duration > ~1s never fires and a -t 10 run goes
+/// the full 10 s. A 1T limit never trips, even on fast loopback (100G
+/// does); the 1 s max duration must still cut the run at ~1 s with the
+/// same SERVER_ERROR(160) shapes as the plain timer path. NOTE: shares #230's test interplay —
+/// the upfront requested-duration check will reject `-t 10` vs a 1 s limit
+/// at param exchange when it lands; this test then needs the within-limit
+/// wall-clock-overrun trigger too (noted on #230).
+#[test]
+fn max_duration_timer_survives_rate_ticks() {
+    let ps = common::free_port().to_string();
+    let server = spawn_server(
+        &["--server-bitrate-limit", "1T", "--server-max-duration", "1"],
+        &ps,
+    );
+    std::thread::sleep(Duration::from_millis(300));
+
+    let start = Instant::now();
+    let client = common::run_client(
+        &["-c", "127.0.0.1", "-p", &ps, "-t", "10"],
+        Duration::from_secs(40),
+        "client -t 10",
+    );
+    let elapsed = start.elapsed();
+    let (_sout, serr, scode) = finish(server, Duration::from_secs(10), "server");
+
+    assert!(
+        elapsed < Duration::from_secs(6),
+        "rate ticks must not reset the duration timer (#237) — a 1 s max \
+         duration left this -t 10 run running for {elapsed:?}"
+    );
+    assert_eq!(client.status.code(), Some(1));
+    assert!(
+        client
+            .stderr
+            .contains("riperf3: SERVER ERROR - server test duration expired"),
+        "client adopts strerror(IESERVERTESTDURATIONEXPIRED): {stderr}",
+        stderr = client.stderr
+    );
+    assert!(
+        serr.contains(
+            "riperf3: error - server test duration expired - test is terminated by the server"
+        ),
+        "the server's literal timer line: {serr}"
+    );
+    assert_eq!(scode, 0);
+}
+
 /// --server-max-duration via the wall-clock timer: the literal server line
 /// vs the client's strerror, the same SERVER_ERROR shapes. NOTE (r1 review,
 /// live-verified): iperf3's upfront check rejects `-n` runs too (it tests

--- a/riperf3-cli/tests/self_terminate.rs
+++ b/riperf3-cli/tests/self_terminate.rs
@@ -208,6 +208,13 @@ fn max_duration_timer_survives_rate_ticks() {
         "rate ticks must not reset the duration timer (#237) — a 1 s max \
          duration left this -t 10 run running for {elapsed:?}"
     );
+    // Lower bound (r2): tokio timers never fire early, so this is
+    // structurally flake-safe — and it catches an instant-fire deadline
+    // (e.g. an unguarded already-past sleep_until) the upper bound can't.
+    assert!(
+        elapsed >= Duration::from_secs(1),
+        "the timer must not fire BEFORE the 1 s max duration: {elapsed:?}"
+    );
     assert_eq!(client.status.code(), Some(1));
     assert!(
         client

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -786,6 +786,16 @@ impl Server {
         rate_check.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
         rate_check.tick().await; // skip immediate tick
 
+        // #237: ONE absolute deadline, pinned before the loop. A sleep()
+        // recreated inside select! restarts from zero every time another arm
+        // (the 1 Hz rate ticks) re-enters the loop, so a max duration > ~1 s
+        // could never fire. Guarded below, so the 0-when-unset deadline
+        // (already in the past) is never polled.
+        let max_dur_deadline = tokio::time::sleep_until(tokio::time::Instant::from_std(
+            test_start + std::time::Duration::from_secs(max_dur_secs),
+        ));
+        tokio::pin!(max_dur_deadline);
+
         // #224 (iperf 3.21 ground truth): a SELF-terminated test (bitrate
         // limit / max duration) relays SERVER_ERROR + i_errno and skips BOTH
         // the exchange and the local summary dump; the message lands on the
@@ -843,7 +853,7 @@ impl Server {
                         }
                     }
                 }
-                _ = tokio::time::sleep(std::time::Duration::from_secs(max_dur_secs)), if max_dur_secs > 0 => {
+                _ = &mut max_dur_deadline, if max_dur_secs > 0 => {
                     // #224: iperf3's server_timer_proc — SERVER_ERROR +
                     // IESERVERTESTDURATIONEXPIRED(160) on the wire.
                     protocol::send_server_error(&mut ctrl, 160).await?;


### PR DESCRIPTION
> **GT** = ground truth: the pinned reference **iperf 3.21**, built from source at commit `d39cf41526626b4e5a130f115d931cd6cbdffc19`, that riperf3's wire/behavior faithfulness is captured from and verified against (source-line citations like `iperf_api.c:4288` refer to that tree).

Fixes #237.

## The bug

`handle_one_test`'s `select!` loop recreated the `tokio::time::sleep(max_dur_secs)` future on every loop iteration. With `--server-bitrate-limit` AND `--server-max-duration` both set, every 1 Hz under-limit rate-check tick re-entered the loop and reset the duration timer from zero — for any max duration > ~1s the watchdog could never fire. Red test observed a `-t 10` run going the full **10.3s** under a 1s limit.

## The fix

One absolute deadline — `tokio::time::sleep_until(test_start + max_dur)` — pinned once before the loop, so re-entering the select cannot restart it. Any future loop arms inherit the same immunity (the issue's stated fix shape). The 0-when-unset deadline stays behind the existing `max_dur_secs > 0` guard and is never polled when the flag is off.

## Tests

- `max_duration_timer_survives_rate_ticks` (red-first): `--server-bitrate-limit 1T` (never trips — note: 100G DOES trip on this box's loopback, found while pinning red) + `--server-max-duration 1` vs a `-t 10` client. Red at 10.3s; green at ~1.45s, 5/5 stable. Asserts the same SERVER_ERROR(160) wire shapes as the existing timer test (client strerror lines + the server's literal `server_timer_proc` line, exit codes).
- Existing `self_terminate` suite: 5/5 green.
- Gate (clippy/fmt/workspace tests): clean.

## #230 interplay (documented in the test)

When #230's upfront requested-duration check lands, `-t 10` vs a 1s limit gets rejected at param exchange — both this test and `max_duration_timer_relays_expired` will need the within-limit wall-clock-overrun trigger. Noted on #230, which is next in the wave.

