### PR TITLE
feat: the upfront max-duration check + the faithful duration watchdog (#230)

### DIFF
--- a/riperf3-cli/tests/self_terminate.rs
+++ b/riperf3-cli/tests/self_terminate.rs
@@ -175,109 +175,425 @@ fn bitrate_limit_json_server_doc_carries_prefixed_error() {
     );
 }
 
-/// #237: the duration timer must be ONE absolute deadline. With
-/// --server-bitrate-limit also set, the 1 Hz under-limit rate ticks re-enter
-/// the select loop; a sleep() recreated per iteration restarts from zero on
-/// every tick, so any max duration > ~1s never fires and a -t 10 run goes
-/// the full 10 s. A 1T limit never trips, even on fast loopback (100G
-/// does); the 1 s max duration must still cut the run at ~1 s with the
-/// same SERVER_ERROR(160) shapes as the plain timer path. NOTE: shares #230's test interplay —
-/// the upfront requested-duration check will reject `-t 10` vs a 1 s limit
-/// at param exchange when it lands; this test then needs the within-limit
-/// wall-clock-overrun trigger too (noted on #230).
+// ---------------------------------------------------------------------------
+// #230 — the upfront requested-duration check (iperf 3.21 GT, live-captured
+// 2026-06-11): with --server-max-duration set, the SERVER rejects at param
+// exchange when (time + omit) > max OR time == 0 (iperf_api.c:2666) — and a
+// -n/-k client sends time 0 (iperf_api.c:1981), so EVERY byte/block-limited
+// run is "unbounded" and rejected. The relay is cleanup_server's
+// SERVER_ERROR + (IEMAXSERVERTESTDURATIONEXCEEDED=37, errno) pair; the test
+// never starts (no Accepted line, no streams, no summaries).
+//
+//   client (text): stdout ONLY "Connecting to host...", stderr
+//                  `iperf3: SERVER ERROR - <strerror(37)>` +
+//                  `iperf3: error - <strerror(37)>`, exit 1
+//   server (text): stderr `iperf3: error - <strerror(37)>`, one-off exit 0,
+//                  stdout has NO "Accepted connection" line
+//   client (-J):   single doc, error key = strerror(37), stderr empty
+//   server (-J):   the SKELETON doc — start {connected:[], version,
+//                  system_info} only, intervals [], end {}, error key with
+//                  iperf_err's "error - " prefix
+//   server (--json-stream): {"event":"error","data":"error - <msg>"} then
+//                  {"event":"end","data":{}} — no start event
+// ---------------------------------------------------------------------------
+
+const MAXDUR_MSG: &str = "client's requested duration exceeds the server's maximum permitted limit";
+
+/// The headline text shapes, both roles: -t 6 vs max 2 is refused at param
+/// exchange — instantly, with no test start on either side.
 #[test]
-fn max_duration_timer_survives_rate_ticks() {
+fn upfront_reject_text_shapes() {
     let ps = common::free_port().to_string();
-    let server = spawn_server(
-        &["--server-bitrate-limit", "1T", "--server-max-duration", "1"],
-        &ps,
-    );
+    let server = spawn_server(&["--server-max-duration", "2"], &ps);
     std::thread::sleep(Duration::from_millis(300));
 
     let start = Instant::now();
     let client = common::run_client(
-        &["-c", "127.0.0.1", "-p", &ps, "-t", "10"],
+        &["-c", "127.0.0.1", "-p", &ps, "-t", "6"],
         Duration::from_secs(40),
-        "client -t 10",
+        "client -t 6",
     );
     let elapsed = start.elapsed();
-    let (_sout, serr, scode) = finish(server, Duration::from_secs(10), "server");
+    let (sout, serr, scode) = finish(server, Duration::from_secs(10), "server");
 
     assert!(
-        elapsed < Duration::from_secs(6),
-        "rate ticks must not reset the duration timer (#237) — a 1 s max \
-         duration left this -t 10 run running for {elapsed:?}"
+        elapsed < Duration::from_secs(4),
+        "the upfront check refuses BEFORE the test starts (GT: instantaneous), \
+         not via any timer: {elapsed:?}"
     );
-    // Lower bound (r2): tokio timers never fire early, so this is
-    // structurally flake-safe — and it catches an instant-fire deadline
-    // (e.g. an unguarded already-past sleep_until) the upper bound can't.
+    assert_eq!(client.status.code(), Some(1), "client errexits like iperf3");
     assert!(
-        elapsed >= Duration::from_secs(1),
-        "the timer must not fire BEFORE the 1 s max duration: {elapsed:?}"
+        client
+            .stderr
+            .contains(&format!("riperf3: SERVER ERROR - {MAXDUR_MSG}")),
+        "the relayed strerror(37) line: {stderr}",
+        stderr = client.stderr
     );
+    assert!(
+        client
+            .stderr
+            .contains(&format!("riperf3: error - {MAXDUR_MSG}")),
+        "the errexit line with the adopted i_errno: {stderr}",
+        stderr = client.stderr
+    );
+    assert!(
+        client.stdout.contains("Connecting to host")
+            && !client.stdout.contains("- - - - -")
+            && !client.stdout.contains("connected to"),
+        "client stdout is ONLY the Connecting line (GT capture): {out}",
+        out = client.stdout
+    );
+
+    assert!(
+        serr.contains(&format!("riperf3: error - {MAXDUR_MSG}")),
+        "server reports the refusal on stderr: {serr}"
+    );
+    assert_eq!(scode, 0, "iperf3's one-off exits 0 on the refusal path");
+    assert!(
+        !sout.contains("Accepted connection"),
+        "GT skips on_connect on the refusal path — no Accepted line: {sout}"
+    );
+    assert!(
+        !sout.contains("- - - - -"),
+        "no summary block — the test never ran: {sout}"
+    );
+}
+
+/// -t 0 means an unbounded request: GT's `duration == 0` clause refuses it
+/// against ANY max (live-verified vs max 5).
+#[test]
+fn upfront_reject_time_zero() {
+    let ps = common::free_port().to_string();
+    let server = spawn_server(&["--server-max-duration", "5"], &ps);
+    std::thread::sleep(Duration::from_millis(300));
+
+    let client = common::run_client(
+        &["-c", "127.0.0.1", "-p", &ps, "-t", "0"],
+        Duration::from_secs(40),
+        "client -t 0",
+    );
+    let (_sout, serr, scode) = finish(server, Duration::from_secs(10), "server");
+
     assert_eq!(client.status.code(), Some(1));
     assert!(
         client
             .stderr
-            .contains("riperf3: SERVER ERROR - server test duration expired"),
-        "client adopts strerror(IESERVERTESTDURATIONEXPIRED): {stderr}",
+            .contains(&format!("riperf3: SERVER ERROR - {MAXDUR_MSG}")),
+        "-t 0 is rejected by the duration==0 clause: {stderr}",
         stderr = client.stderr
     );
-    assert!(
-        serr.contains(
-            "riperf3: error - server test duration expired - test is terminated by the server"
-        ),
-        "the server's literal timer line: {serr}"
-    );
+    assert!(serr.contains(&format!("riperf3: error - {MAXDUR_MSG}")));
     assert_eq!(scode, 0);
 }
 
-/// --server-max-duration via the wall-clock timer: the literal server line
-/// vs the client's strerror, the same SERVER_ERROR shapes. NOTE (r1 review,
-/// live-verified): iperf3's upfront check rejects `-n` runs too (it tests
-/// the default `-t 10` sent alongside, iperf_api.c:2666) — so when #230
-/// lands faithfully, this test's `-n` run gets rejected at param exchange
-/// and the TIMER arm needs a new trigger (e.g. a `-t`-within-limit run that
-/// overruns on wall clock). Revisit this test in #230; noted there.
+/// A -n run sends `time: 0` on the wire (iperf_api.c:1981) and is refused by
+/// the `duration == 0` clause — even against max 11, which the old
+/// "tests the default -t 10" theory would let pass. Pins BOTH the client's
+/// time-zeroing and the server's 0-clause.
 #[test]
-fn max_duration_timer_relays_expired() {
+fn upfront_reject_n_run_via_zero_duration_clause() {
     let ps = common::free_port().to_string();
-    let server = spawn_server(&["--server-max-duration", "1"], &ps);
+    let server = spawn_server(&["--server-max-duration", "11"], &ps);
     std::thread::sleep(Duration::from_millis(300));
 
     let start = Instant::now();
     let client = common::run_client(
-        &["-c", "127.0.0.1", "-p", &ps, "-n", "1T"],
+        &["-c", "127.0.0.1", "-p", &ps, "-n", "100M"],
         Duration::from_secs(40),
-        "client -n",
+        "client -n 100M",
     );
     let elapsed = start.elapsed();
     let (_sout, serr, scode) = finish(server, Duration::from_secs(10), "server");
 
     assert!(
-        elapsed < Duration::from_secs(20),
-        "the server timer must cut an unbounded -n run: {elapsed:?}"
+        elapsed < Duration::from_secs(4),
+        "refused upfront, not after a transfer: {elapsed:?}"
     );
     assert_eq!(client.status.code(), Some(1));
     assert!(
         client
             .stderr
-            .contains("riperf3: SERVER ERROR - server test duration expired"),
-        "client adopts strerror(IESERVERTESTDURATIONEXPIRED): {stderr}",
+            .contains(&format!("riperf3: SERVER ERROR - {MAXDUR_MSG}")),
+        "a byte-limited run is unbounded-duration and must be refused \
+         (GT live: -n vs max 11 rejects): {stderr}",
+        stderr = client.stderr
+    );
+    assert!(serr.contains(&format!("riperf3: error - {MAXDUR_MSG}")));
+    assert_eq!(scode, 0);
+}
+
+/// The boundary is `(time + omit) > max`, strictly: -t 2 -O 2 vs max 3 is
+/// refused (4 > 3), while -t 2 -O 1 vs max 3 runs to completion (3 <= 3) —
+/// the within-limit survival case, which also pins that the refusal logic
+/// doesn't fire on requests it must allow.
+#[test]
+fn upfront_reject_omit_counts_and_boundary_is_strict() {
+    // 2 + 2 > 3: refused.
+    let ps = common::free_port().to_string();
+    let server = spawn_server(&["--server-max-duration", "3"], &ps);
+    std::thread::sleep(Duration::from_millis(300));
+    let client = common::run_client(
+        &["-c", "127.0.0.1", "-p", &ps, "-t", "2", "-O", "2"],
+        Duration::from_secs(40),
+        "client -t 2 -O 2",
+    );
+    let (_sout, serr, scode) = finish(server, Duration::from_secs(10), "server");
+    assert_eq!(
+        client.status.code(),
+        Some(1),
+        "omit counts toward the requested duration (GT: (time+omit) > max): {stderr}",
+        stderr = client.stderr
+    );
+    assert!(client
+        .stderr
+        .contains(&format!("riperf3: SERVER ERROR - {MAXDUR_MSG}")));
+    assert!(serr.contains(&format!("riperf3: error - {MAXDUR_MSG}")));
+    assert_eq!(scode, 0);
+
+    // 2 + 1 <= 3: runs to completion with a normal summary.
+    let ps = common::free_port().to_string();
+    let server = spawn_server(&["--server-max-duration", "3"], &ps);
+    std::thread::sleep(Duration::from_millis(300));
+    let start = Instant::now();
+    let client = common::run_client(
+        &["-c", "127.0.0.1", "-p", &ps, "-t", "2", "-O", "1"],
+        Duration::from_secs(40),
+        "client -t 2 -O 1",
+    );
+    let elapsed = start.elapsed();
+    let (sout, serr, scode) = finish(server, Duration::from_secs(10), "server");
+    assert_eq!(
+        client.status.code(),
+        Some(0),
+        "within-limit requests must run (boundary is >, not >=): {stderr}",
         stderr = client.stderr
     );
     assert!(
-        client
-            .stderr
-            .contains("riperf3: error - server test duration expired"),
-        "the errexit line: {stderr}",
+        elapsed >= Duration::from_secs(3),
+        "the within-limit run really ran its 2s + 1s omit: {elapsed:?}"
+    );
+    assert!(
+        client.stdout.contains("- - - - -"),
+        "normal summary block: {out}",
+        out = client.stdout
+    );
+    assert!(
+        serr.trim().is_empty(),
+        "no refusal line for a within-limit run: {serr}"
+    );
+    assert_eq!(scode, 0);
+    assert!(sout.contains("Accepted connection"));
+}
+
+/// -J shapes, both roles (GT capture 2026-06-11): single docs; the client's
+/// error key carries the bare strerror; the server emits the SKELETON doc —
+/// start has only connected/version/system_info (no accepted_connection, no
+/// cookie, no test_start), intervals [], end {}, and the "error - " prefix.
+#[test]
+fn upfront_reject_json_doc_shapes() {
+    let ps = common::free_port().to_string();
+    let server = spawn_server(&["--server-max-duration", "2", "-J"], &ps);
+    std::thread::sleep(Duration::from_millis(300));
+
+    let client = common::run_client(
+        &["-c", "127.0.0.1", "-p", &ps, "-t", "6", "-J"],
+        Duration::from_secs(40),
+        "client -J",
+    );
+    let (sout, serr, scode) = finish(server, Duration::from_secs(10), "server -J");
+
+    // Client doc.
+    assert_eq!(client.status.code(), Some(1));
+    assert!(
+        client.stderr.trim().is_empty(),
+        "-J keeps the client's stderr empty: {stderr}",
         stderr = client.stderr
+    );
+    let doc: serde_json::Value = serde_json::from_str(client.stdout.trim()).unwrap_or_else(|e| {
+        panic!(
+            "client -J stdout must be one document ({e}): {out}",
+            out = client.stdout
+        )
+    });
+    assert_eq!(
+        doc["error"].as_str(),
+        Some(MAXDUR_MSG),
+        "client doc adopts the relayed strerror: {doc}"
+    );
+
+    // Server skeleton doc.
+    assert!(serr.trim().is_empty(), "server -J stderr empty: {serr}");
+    assert_eq!(scode, 0);
+    let doc: serde_json::Value = serde_json::from_str(sout.trim())
+        .unwrap_or_else(|e| panic!("server -J stdout must be one document ({e}): {sout}"));
+    assert_eq!(
+        doc["error"].as_str(),
+        Some(format!("error - {MAXDUR_MSG}").as_str()),
+        "iperf_err's in-doc prefix wart: {doc}"
+    );
+    assert_eq!(
+        doc["intervals"].as_array().map(Vec::len),
+        Some(0),
+        "no intervals — the test never ran: {doc}"
+    );
+    assert_eq!(
+        doc["end"].as_object().map(serde_json::Map::len),
+        Some(0),
+        "end is an EMPTY object on the refusal skeleton (GT): {doc}"
+    );
+    let start_obj = doc["start"].as_object().expect("start object");
+    assert_eq!(
+        start_obj["connected"].as_array().map(Vec::len),
+        Some(0),
+        "start.connected is empty: {doc}"
+    );
+    assert!(
+        start_obj.contains_key("version") && start_obj.contains_key("system_info"),
+        "skeleton start keeps version/system_info: {doc}"
+    );
+    for absent in ["accepted_connection", "cookie", "test_start", "timestamp"] {
+        assert!(
+            !start_obj.contains_key(absent),
+            "GT's refusal skeleton has NO {absent} key: {doc}"
+        );
+    }
+}
+
+/// --json-stream refuse shape (GT capture): exactly two events — the
+/// prefixed error, then `end` with an EMPTY data object. No start event.
+#[test]
+fn upfront_reject_json_stream_events() {
+    let ps = common::free_port().to_string();
+    let server = spawn_server(&["--server-max-duration", "2", "--json-stream"], &ps);
+    std::thread::sleep(Duration::from_millis(300));
+
+    let _client = common::run_client(
+        &["-c", "127.0.0.1", "-p", &ps, "-t", "6"],
+        Duration::from_secs(40),
+        "client",
+    );
+    let (sout, serr, scode) = finish(server, Duration::from_secs(10), "server --json-stream");
+
+    assert!(serr.trim().is_empty(), "json-stream stderr empty: {serr}");
+    assert_eq!(scode, 0);
+    let lines: Vec<&str> = sout.lines().filter(|l| !l.trim().is_empty()).collect();
+    assert_eq!(
+        lines.len(),
+        2,
+        "exactly error + end events (GT: no start event on refusal): {sout}"
+    );
+    let ev0: serde_json::Value = serde_json::from_str(lines[0]).expect("error event parses");
+    assert_eq!(ev0["event"].as_str(), Some("error"));
+    assert_eq!(
+        ev0["data"].as_str(),
+        Some(format!("error - {MAXDUR_MSG}").as_str())
+    );
+    let ev1: serde_json::Value = serde_json::from_str(lines[1]).expect("end event parses");
+    assert_eq!(ev1["event"].as_str(), Some("end"));
+    assert_eq!(
+        ev1["data"].as_object().map(serde_json::Map::len),
+        Some(0),
+        "end data is an empty object: {sout}"
+    );
+}
+
+/// A persistent (non-one-off) server refuses test #1 and serves test #2
+/// normally (GT live: the refusal doesn't poison the accept loop).
+#[test]
+fn upfront_reject_persistent_server_serves_next_test() {
+    let ps = common::free_port().to_string();
+    // No -1: spawn the persistent shape by hand.
+    let mut server = ChildGuard(
+        Command::new(env!("CARGO_BIN_EXE_riperf3"))
+            .args(["-s", "-p", &ps, "--server-max-duration", "3"])
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .expect("spawn persistent server"),
+    );
+    std::thread::sleep(Duration::from_millis(300));
+
+    let refused = common::run_client(
+        &["-c", "127.0.0.1", "-p", &ps, "-t", "6"],
+        Duration::from_secs(40),
+        "refused client",
+    );
+    assert_eq!(refused.status.code(), Some(1));
+    assert!(refused
+        .stderr
+        .contains(&format!("riperf3: SERVER ERROR - {MAXDUR_MSG}")));
+
+    let served = common::run_client(
+        &["-c", "127.0.0.1", "-p", &ps, "-t", "1"],
+        Duration::from_secs(40),
+        "served client",
+    );
+    assert_eq!(
+        served.status.code(),
+        Some(0),
+        "the server must serve the next test after a refusal: {stderr}",
+        stderr = served.stderr
+    );
+    assert!(served.stdout.contains("- - - - -"), "normal summary");
+
+    let _ = server.0.kill();
+    let _ = server.0.wait();
+}
+
+/// The in-flight 160-watchdog, post-#230: GT arms it for EVERY duration test
+/// at (time + omit + 40s grace), flag-independent (create_server_timers,
+/// iperf_server_api.c:380-395) — --server-max-duration arms NOTHING. A
+/// wedged client (SIGSTOP mid-test) must trip it at ~duration+40, the server
+/// must print server_timer_proc's literal line, CLOSE its streams (GT does;
+/// a plain join hangs forever on the silent socket — the PR #247 r1 probe
+/// measured 169 s), and one-off exit 0. --server-bitrate-limit 1T keeps the
+/// 1 Hz rate ticks live the whole wait: the #237 tick-immunity pin at the
+/// new anchor (a per-iteration recreated sleep would never fire).
+#[cfg(unix)]
+#[test]
+fn watchdog_fires_at_duration_plus_grace_despite_rate_ticks() {
+    let ps = common::free_port().to_string();
+    let server = spawn_server(&["--server-bitrate-limit", "1T"], &ps);
+    std::thread::sleep(Duration::from_millis(300));
+
+    let client = ChildGuard(
+        Command::new(env!("CARGO_BIN_EXE_riperf3"))
+            .args(["-c", "127.0.0.1", "-p", &ps, "-t", "5"])
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("spawn client"),
+    );
+    let start = Instant::now();
+    // Wedge the client mid-TEST_RUNNING: well past stream setup (~0.3s even
+    // on loaded 2-core runners), well before its own 5s end.
+    std::thread::sleep(Duration::from_millis(1500));
+    let stop = Command::new("kill")
+        .args(["-STOP", &client.0.id().to_string()])
+        .status()
+        .expect("send SIGSTOP");
+    assert!(stop.success(), "SIGSTOP delivered");
+
+    // The watchdog deadline is 5 + 0 + 40 = 45s from test start. Allow
+    // scheduling slack above; the lower bound is structural (tokio timers
+    // never fire early).
+    let (_sout, serr, scode) = finish(server, Duration::from_secs(60), "server");
+    let elapsed = start.elapsed();
+    assert!(
+        elapsed >= Duration::from_secs(44),
+        "the watchdog must not fire before duration+grace (45s): {elapsed:?}"
+    );
+    assert!(
+        elapsed < Duration::from_secs(58),
+        "the watchdog must fire at ~45s and the server must EXIT (a hung \
+         stream join means the GT socket-close mirror is missing): {elapsed:?}"
     );
     assert!(
         serr.contains(
             "riperf3: error - server test duration expired - test is terminated by the server"
         ),
-        "the server's literal timer line (iperf_err in server_timer_proc): {serr}"
+        "server_timer_proc's literal line: {serr}"
     );
-    assert_eq!(scode, 0);
+    assert_eq!(scode, 0, "one-off exits 0 on self-terminate");
+    // ChildGuard SIGKILLs the wedged client on drop.
 }

--- a/riperf3/src/client.rs
+++ b/riperf3/src/client.rs
@@ -760,7 +760,18 @@ impl Client {
             TransportProtocol::Tcp => p.tcp = Some(true),
             TransportProtocol::Udp => p.udp = Some(true),
         }
-        p.time = Some(self.duration as i32);
+        // GT zeroes the wire `time` for byte/block-limited runs
+        // (iperf_api.c:1981: -n/-k without -t → duration 0), and its server's
+        // upfront max-duration check treats 0 as "unbounded request" (#230).
+        // Mirror the lib's own end-condition priority — bytes/blocks win, so
+        // duration is not the end condition and must not go on the wire.
+        p.time = Some(
+            if self.bytes_to_send.is_some() || self.blocks_to_send.is_some() {
+                0
+            } else {
+                self.duration as i32
+            },
+        );
         p.omit = Some(self.omit as i32);
         p.parallel = Some(self.num_streams as i32);
         p.len = Some(blksize as i32);

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -899,7 +899,10 @@ impl Server {
         // wedged/silent peer cannot hold the post-loop joins hostage (a
         // receiver parked in stream.read() never re-checks `done`; the
         // PR #247 r1 probe measured a 169 s hang against a SIGSTOP'd client).
-        // Abort drops each task's socket at its next await point.
+        // The real work is on the TCP async tasks (abort drops the socket at
+        // the next await); the UDP runners are spawn_blocking, where abort
+        // is a no-op once running — their joins stay bounded anyway by the
+        // 500 ms read-timeout + `done` polling in the blocking loops.
         if server_error.is_some() {
             for s in &streams {
                 s.task.abort();
@@ -1962,13 +1965,11 @@ impl Server {
             "client's requested duration exceeds the server's maximum permitted limit";
         protocol::send_server_error(ctrl, 37).await?;
         if self.json_stream {
-            crate::reporter::emit_json_stream_line(&crate::json_report::json_stream_event(
-                "error",
+            // #198's pre-test error tail (error event + empty end event) is
+            // byte-identical to GT's refusal events — reuse it (r1 item 8),
+            // routed through the stream emitter for its flush.
+            crate::reporter::emit_json_stream_line(&crate::json_report::error_stream_events(
                 &format!("error - {MSG}"),
-            ));
-            crate::reporter::emit_json_stream_line(&crate::json_report::json_stream_event(
-                "end",
-                &serde_json::Map::<String, serde_json::Value>::new(),
             ));
         } else if self.json_output {
             println!(
@@ -2182,8 +2183,11 @@ impl ServerBuilder {
         self
     }
 
-    /// `--server-max-duration`: abort any test that runs longer than `secs`
-    /// seconds (unset: no limit).
+    /// `--server-max-duration`: refuse, at param exchange, any test whose
+    /// requested duration + omit exceeds `secs` — or whose duration is
+    /// unbounded (`-n`/`-k`/`-t 0`) — exactly like iperf3's upfront check
+    /// (#230). It arms no timer; the in-flight watchdog is duration-anchored
+    /// and independent of this flag. Unset (or 0): no limit.
     pub fn server_max_duration(mut self, secs: u32) -> Self {
         self.server_max_duration = Some(secs);
         self

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -362,6 +362,24 @@ impl Server {
         // speak, and real iperf3 clients never send these values — dropping
         // the control connection is the safe shape for a hostile peer.
         let cfg = TestConfig::from_params(&params)?;
+
+        // #230: GT's upfront requested-duration check — the tail of
+        // get_parameters (iperf_api.c:2666): with --server-max-duration set,
+        // refuse at param exchange when (time + omit) > max, or when the
+        // request is unbounded (time == 0 — which is every -n/-k run, since
+        // the client zeroes the wire duration, iperf_api.c:1981, and -t 0).
+        // GT runs this BEFORE auth and skips on_connect entirely (the goto
+        // error_handling path), so it sits ahead of the connect block and
+        // the capture guard. cfg.duration already mirrors GT's server-side
+        // default (absent time → 10). The flag arms NO timer — the in-flight
+        // watchdog below is duration-anchored and flag-independent, like
+        // GT's create_server_timers.
+        if let Some(max) = self.server_max_duration.filter(|&m| m > 0) {
+            if cfg.duration.saturating_add(cfg.omit) > max || cfg.duration == 0 {
+                return self.refuse_max_duration(&mut ctrl).await;
+            }
+        }
+
         // --get-server-output (#33): when the client asks and this server is
         // in text mode, TEE the console report into the exchange buffer
         // (iperf3's iperf_printf dual-write — the console stays live).
@@ -777,10 +795,21 @@ impl Server {
             )
         };
 
-        // ---- Wait for TEST_END (with optional max duration and bitrate limit) ----
+        // ---- Wait for TEST_END (with the duration watchdog and bitrate limit) ----
         let bitrate_limit = self.server_bitrate_limit;
         let test_start = report_start;
-        let max_dur_secs = self.server_max_duration.unwrap_or(0) as u64;
+        // #230: GT's in-flight 160-watchdog (create_server_timers,
+        // iperf_server_api.c:380-395) arms for EVERY test with a nonzero
+        // requested duration, at (time + omit + grace) where grace =
+        // max_rtt(4) × state_transitions(10) = 40 s — flag-independent.
+        // --server-max-duration arms nothing here; it only drives the
+        // upfront param-exchange check. Unbounded (-n/-k/-t 0) requests get
+        // no watchdog, exactly like GT's `if (test->duration != 0)` gate.
+        const WATCHDOG_GRACE_SECS: u64 = 40;
+        let watchdog_secs = match cfg.duration {
+            0 => 0,
+            d => (d as u64).saturating_add(cfg.omit as u64) + WATCHDOG_GRACE_SECS,
+        };
 
         let mut rate_check = tokio::time::interval(std::time::Duration::from_secs(1));
         rate_check.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
@@ -788,13 +817,13 @@ impl Server {
 
         // #237: ONE absolute deadline, pinned before the loop. A sleep()
         // recreated inside select! restarts from zero every time another arm
-        // (the 1 Hz rate ticks) re-enters the loop, so a max duration > ~1 s
+        // (the 1 Hz rate ticks) re-enters the loop, so a deadline > ~1 s
         // could never fire. Guarded below, so the 0-when-unset deadline
         // (already in the past) is never polled.
-        let max_dur_deadline = tokio::time::sleep_until(tokio::time::Instant::from_std(
-            test_start + std::time::Duration::from_secs(max_dur_secs),
+        let watchdog_deadline = tokio::time::sleep_until(tokio::time::Instant::from_std(
+            test_start + std::time::Duration::from_secs(watchdog_secs),
         ));
-        tokio::pin!(max_dur_deadline);
+        tokio::pin!(watchdog_deadline);
 
         // #224 (iperf 3.21 ground truth): a SELF-terminated test (bitrate
         // limit / max duration) relays SERVER_ERROR + i_errno and skips BOTH
@@ -853,7 +882,7 @@ impl Server {
                         }
                     }
                 }
-                _ = &mut max_dur_deadline, if max_dur_secs > 0 => {
+                _ = &mut watchdog_deadline, if watchdog_secs > 0 => {
                     // #224: iperf3's server_timer_proc — SERVER_ERROR +
                     // IESERVERTESTDURATIONEXPIRED(160) on the wire.
                     protocol::send_server_error(&mut ctrl, 160).await?;
@@ -864,6 +893,21 @@ impl Server {
         }
 
         // ---- Shut down streams ----
+        // GT mirror (#230): a self-terminated test CLOSES its data sockets at
+        // once — server_timer_proc frees every stream + ctrl_sck on the 160
+        // path, cleanup_server pthread_cancels on the rate path — so a
+        // wedged/silent peer cannot hold the post-loop joins hostage (a
+        // receiver parked in stream.read() never re-checks `done`; the
+        // PR #247 r1 probe measured a 169 s hang against a SIGSTOP'd client).
+        // Abort drops each task's socket at its next await point.
+        if server_error.is_some() {
+            for s in &streams {
+                s.task.abort();
+            }
+            if let Some(h) = &udp_demux_handle {
+                h.abort();
+            }
+        }
         // #55 window, #159 order: stop the streams, let the catch-up land,
         // then hand the reporter the authoritative end time for the flush.
         let measured_elapsed = report_start.elapsed().as_secs_f64();
@@ -1902,6 +1946,39 @@ impl Server {
             Ok(s) => println!("{s}"),
             Err(e) => eprintln!("riperf3: error - failed to serialize JSON: {e}"),
         }
+    }
+
+    /// #230: refuse a test at param exchange (GT's upfront requested-duration
+    /// check). Sends cleanup_server's relay — SERVER_ERROR + the
+    /// (IEMAXSERVERTESTDURATIONEXCEEDED=37, errno) pair — then renders GT's
+    /// refusal shapes per output mode (live-captured, iperf 3.21): text gets
+    /// the one stderr line; -J gets the skeleton error document (no
+    /// accepted_connection/cookie — GT skips on_connect on this path); a
+    /// --json-stream server gets the error + empty-end event pair with no
+    /// start event. Returns Ok: iperf3's one-off exits 0 here, and a
+    /// persistent server goes on to serve the next test.
+    async fn refuse_max_duration(&self, ctrl: &mut tokio::net::TcpStream) -> Result<()> {
+        const MSG: &str =
+            "client's requested duration exceeds the server's maximum permitted limit";
+        protocol::send_server_error(ctrl, 37).await?;
+        if self.json_stream {
+            crate::reporter::emit_json_stream_line(&crate::json_report::json_stream_event(
+                "error",
+                &format!("error - {MSG}"),
+            ));
+            crate::reporter::emit_json_stream_line(&crate::json_report::json_stream_event(
+                "end",
+                &serde_json::Map::<String, serde_json::Value>::new(),
+            ));
+        } else if self.json_output {
+            println!(
+                "{}",
+                crate::json_report::error_document(&format!("error - {MSG}"))
+            );
+        } else {
+            eprintln!("riperf3: error - {MSG}");
+        }
+        Ok(())
     }
 
     /// `--json-stream`: emit the server's `end` event (#62). The interval events

--- a/riperf3/tests/integration.rs
+++ b/riperf3/tests/integration.rs
@@ -1771,7 +1771,10 @@ mod unimplemented_flags {
 
     #[tokio::test]
     async fn server_max_duration() {
-        // Server with max_duration=2 should terminate a test that runs longer
+        // #230: --server-max-duration is an UPFRONT param-exchange check in
+        // iperf3 (iperf_api.c:2666), not a timer — a -t 10 request against
+        // max 2 is refused before the test starts, with the strerror of
+        // IEMAXSERVERTESTDURATIONEXCEEDED(37) relayed to the client.
         let port = next_port();
         let server = ServerBuilder::new()
             .port(Some(port))
@@ -1781,7 +1784,6 @@ mod unimplemented_flags {
             .unwrap();
         let server_task = tokio::spawn(async move { server.run().await });
         tokio::time::sleep(Duration::from_millis(200)).await;
-        // Client tries to run 10 seconds but server should cut it at 2
         let client = ClientBuilder::new("127.0.0.1")
             .port(Some(port))
             .duration(10)
@@ -1791,21 +1793,21 @@ mod unimplemented_flags {
         let result = client.run().await;
         let elapsed = start.elapsed();
         assert!(
-            elapsed.as_secs() < 5,
-            "server-max-duration didn't cut test: {elapsed:?}"
+            elapsed.as_secs() < 4,
+            "the refusal is upfront — no transfer, no timer wait: {elapsed:?}"
         );
-        // #224 ground truth (iperf 3.21): the timer relays SERVER_ERROR with
-        // IESERVERTESTDURATIONEXPIRED; the client adopts its strerror. (When
-        // the upfront requested-duration check lands, this -t run will be
-        // rejected at param exchange instead - revisit then.)
         let err = result.expect_err("the relayed SERVER_ERROR is the client's error");
-        assert_eq!(err.to_string(), "server test duration expired", "{err:?}");
+        assert_eq!(
+            err.to_string(),
+            "client's requested duration exceeds the server's maximum permitted limit",
+            "{err:?}"
+        );
         // The server side errors to ITS sink but run() is Ok - iperf3's
-        // one-off exits 0 on self-terminate (live-verified, the #224 wart).
+        // one-off exits 0 on the refusal path (live-verified, the #224 wart).
         let joined = server_task.await.expect("server task");
         assert!(
             joined.is_ok(),
-            "server self-terminate is not a run() error: {joined:?}"
+            "server refusal is not a run() error: {joined:?}"
         );
     }
 


### PR DESCRIPTION
> **GT** = ground truth: the pinned reference **iperf 3.21**, built from source at commit `d39cf41526626b4e5a130f115d931cd6cbdffc19`, that riperf3's wire/behavior faithfulness is captured from and verified against (source-line citations like `iperf_api.c:4288` refer to that tree).

Fixes #230.

## What GT actually does (live-captured + source-verified, iperf 3.21)

The issue's original fix shape understated the surface. Three findings reshaped it:

1. **The upfront check** (`get_parameters`' tail, iperf_api.c:2666): `(time + omit) > max || time == 0` → errno **37**, before auth, before `on_connect` (no Accepted line, no streams). Both PR #247 reviewers captured the shapes independently.
2. **`-n`/`-k` clients send `time: 0`** (iperf_api.c:1981) — NOT the default 10 the issue comment theorized. Live: GT rejects `-n` even against max **11**. riperf3's client sent the un-zeroed default 10, so the 0-clause could never catch it — fixed (and mirrors the lib's bytes>blocks>duration end-condition priority).
3. **The flag arms NO timer.** GT's only 160 source is the `create_server_timers` watchdog: `(time + omit + 40s grace)`, armed for **every** bounded-duration test, flag-independent (iperf_server_api.c:380-395) — PR #247's r2 recorded the span here so the rework wouldn't keep an unfaithful trigger. The in-flight timer is now exactly that (keeping #237's pinned-deadline mechanism), and `server_timer_proc`'s socket-closing is mirrored by aborting stream tasks on BOTH self-terminate arms — which also fixes the wedged-peer join hang #247's r1 measured at 169 s (GT exits immediately; that finding is otherwise still unfiled).

## Refusal shapes (all GT-captured this session)

- text: client `SERVER ERROR -` + errexit lines, exit 1, stdout only `Connecting to host...`; server one stderr line, one-off exit 0, **no Accepted line**
- `-J`: client doc adopts the bare strerror; server emits the **skeleton** document (`start{connected:[],version,system_info}`, `intervals:[]`, `end:{}`, `error - ` prefix) — #198's `error_document` was already byte-shaped for this
- `--json-stream`: `error` event + **empty** `end` event, no start event
- persistent server refuses test #1, serves test #2 (GT-verified live)

## Cross-tool proof

All four riperf3↔GT pairings byte-identical modulo the binary-name prefix, including `-n` vs max 11 rejecting in both directions (the wire-zeroing proof — pairing 4 ran a full transfer before this change).

## Tests (red-first)

7 upfront tests + the unix wedged-client watchdog test (SIGSTOP mid-test; fires at ~45s **with 1 Hz rate ticks live** — the #237 tick-immunity pin carried to the new anchor — and the server *exits*, pinning the abort mirror; red = 60s timeout) + the reshaped lib test. Within-limit survival is covered (`-t 2 -O 1` vs max 3 runs to completion). Suite: 11/11 in 45s; gate clean.

## Coverage note

Client-side 160 receipt is now unreachable against a live client — true of GT as well (its 160 only ever hits wedged/dead peers). The relay machinery stays covered via the 27 and 37 paths.

