### PR TITLE
fix: -f uppercase = byte-rates, and the server-side -f wiring (#241, #242)

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ General:
   -s, --server                       Run in server mode
   -c, --client <host>                Run in client mode
   -p, --port <PORT>                  Server port (default: 5201)
-  -f, --format <k|m|g|t>            Report format (default: adaptive, like iperf3)
+  -f, --format <kmgtKMGT>           Report format, case-sensitive: lowercase bit-rates, uppercase byte-rates (default: adaptive, like iperf3)
   -i, --interval <secs>             Seconds between periodic reports
   -V, --verbose                      Verbose output
   -J, --json                         JSON output

--- a/riperf3-cli/src/cli.rs
+++ b/riperf3-cli/src/cli.rs
@@ -40,7 +40,10 @@ pub struct Cli {
     // (unit_snprintf 'a'/'A'). The old forced "m" default printed
     // 12120.88 MBytes where iperf3 prints 11.8 GBytes (#221). NB: a ///
     // here would leak into clap's --help text (r1 blocker).
-    #[arg(short, long, ignore_case = true, value_enum, value_name = "format")]
+    // Case-sensitive like iperf3's [kmgtKMGT] (#241): lowercase = bit-rates,
+    // UPPERCASE = byte-rates — ignore_case used to collapse `-f K` into
+    // Kbits, silently a different unit.
+    #[arg(short, long, value_enum, value_name = "format")]
     pub format: Option<Format>,
 
     /// Seconds between periodic throughput reports
@@ -478,16 +481,10 @@ impl Cli {
 
         let mut builder = riperf3::ClientBuilder::new(host);
 
-        // Format: each letter maps to its bit-rate char (#241 tracks the
-        // uppercase byte-rate meanings); absent → the library's adaptive
-        // default ('a'), like iperf3 (#221).
+        // Format (#241): case-sensitive [kmgtKMGT], uppercase = byte-rates;
+        // absent → the library's adaptive default ('a'), like iperf3 (#221).
         if let Some(f) = &self.format {
-            builder = builder.format_char(match f {
-                Format::K => 'k',
-                Format::M => 'm',
-                Format::G => 'g',
-                Format::T => 't',
-            });
+            builder = builder.format_char(f.as_char());
         }
 
         if let Some(port) = self.port {
@@ -657,6 +654,12 @@ impl Cli {
     pub fn build_server(&self) -> std::result::Result<riperf3::Server, Box<dyn std::error::Error>> {
         let mut builder = riperf3::ServerBuilder::new();
 
+        // Format (#242): the server-side -f was silently dropped — never
+        // wired through the builder, every render site hardcoded adaptive.
+        // Same case-sensitive mapping as the client (#241).
+        if let Some(f) = &self.format {
+            builder = builder.format_char(f.as_char());
+        }
         if let Some(port) = self.port {
             builder = builder.port(Some(port));
         }
@@ -721,10 +724,46 @@ impl Cli {
 
 #[derive(Debug, Clone, PartialEq, ValueEnum)]
 pub enum Format {
-    K,
-    M,
-    G,
-    T,
+    /// Kbits/sec
+    #[value(name = "k")]
+    Kbits,
+    /// Mbits/sec
+    #[value(name = "m")]
+    Mbits,
+    /// Gbits/sec
+    #[value(name = "g")]
+    Gbits,
+    /// Tbits/sec
+    #[value(name = "t")]
+    Tbits,
+    /// KBytes/sec
+    #[value(name = "K")]
+    KBytes,
+    /// MBytes/sec
+    #[value(name = "M")]
+    MBytes,
+    /// GBytes/sec
+    #[value(name = "G")]
+    GBytes,
+    /// TBytes/sec
+    #[value(name = "T")]
+    TBytes,
+}
+
+impl Format {
+    /// The unit_snprintf-style char the lib's `format_char` expects.
+    fn as_char(&self) -> char {
+        match self {
+            Format::Kbits => 'k',
+            Format::Mbits => 'm',
+            Format::Gbits => 'g',
+            Format::Tbits => 't',
+            Format::KBytes => 'K',
+            Format::MBytes => 'M',
+            Format::GBytes => 'G',
+            Format::TBytes => 'T',
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -774,29 +813,43 @@ mod cli_tests {
 
         #[test]
         fn test_common_format() {
-            let cli = Cli::parse_from(["riperf3", "--server", "--format", "k"]);
-            assert_eq!(cli.format, Some(Format::K));
+            // #241: case is semantic — all 8 of iperf3's [kmgtKMGT], each to
+            // its own variant, on both roles.
+            for (letter, want) in [
+                ("k", Format::Kbits),
+                ("m", Format::Mbits),
+                ("g", Format::Gbits),
+                ("t", Format::Tbits),
+                ("K", Format::KBytes),
+                ("M", Format::MBytes),
+                ("G", Format::GBytes),
+                ("T", Format::TBytes),
+            ] {
+                let cli = Cli::parse_from(["riperf3", "--server", "--format", letter]);
+                assert_eq!(cli.format, Some(want.clone()), "-f {letter} (server)");
+                let cli = Cli::parse_from(["riperf3", "--client", "localhost", "--format", letter]);
+                assert_eq!(cli.format, Some(want), "-f {letter} (client)");
+            }
+        }
 
-            let cli = Cli::parse_from(["riperf3", "--client", "localhost", "--format", "g"]);
-            assert_eq!(cli.format, Some(Format::G));
-
-            let cli = Cli::parse_from(["riperf3", "--server", "--format", "t"]);
-            assert_eq!(cli.format, Some(Format::T));
-
-            let cli = Cli::parse_from(["riperf3", "--client", "localhost", "--format", "m"]);
-            assert_eq!(cli.format, Some(Format::M));
-
-            let cli = Cli::parse_from(["riperf3", "--server", "--format", "M"]);
-            assert_eq!(cli.format, Some(Format::M));
-
-            let cli = Cli::parse_from(["riperf3", "--client", "localhost", "--format", "T"]);
-            assert_eq!(cli.format, Some(Format::T));
-
-            let cli = Cli::parse_from(["riperf3", "--server", "--format", "G"]);
-            assert_eq!(cli.format, Some(Format::G));
-
-            let cli = Cli::parse_from(["riperf3", "--client", "localhost", "--format", "K"]);
-            assert_eq!(cli.format, Some(Format::K));
+        #[test]
+        fn test_format_chars_match_unit_snprintf() {
+            // The CLI→lib glue: each variant maps to the exact unit_snprintf
+            // char; uppercase survives (the old ignore_case + 4-variant enum
+            // collapsed K to 'k').
+            for (letter, ch) in [
+                ("k", 'k'),
+                ("m", 'm'),
+                ("g", 'g'),
+                ("t", 't'),
+                ("K", 'K'),
+                ("M", 'M'),
+                ("G", 'G'),
+                ("T", 'T'),
+            ] {
+                let cli = Cli::parse_from(["riperf3", "--server", "--format", letter]);
+                assert_eq!(cli.format.unwrap().as_char(), ch, "-f {letter}");
+            }
         }
     }
 

--- a/riperf3-cli/tests/format_flag.rs
+++ b/riperf3-cli/tests/format_flag.rs
@@ -91,14 +91,71 @@ fn server_and_client_each_honor_their_own_format() {
         sout.contains(" KBytes/sec"),
         "server -f K renders KBytes/sec rows (#242 wiring + #241 case): {sout}"
     );
-    assert!(
-        !sout.contains(" Kbits/sec") && !sout.contains(" Gbits/sec"),
-        "no bit-rate rows on a -f K server: {sout}"
-    );
+    // The full bit-rate unit family (r1 blocker: " Mbits/sec" — exactly
+    // what the adaptive default renders at -b 10M — was missing, so a
+    // reverted render site slipped past with the OTHER site satisfying
+    // the positive assert).
+    for reject in [
+        " Kbits/sec",
+        " Mbits/sec",
+        " Gbits/sec",
+        " Tbits/sec",
+        " bits/sec",
+    ] {
+        assert!(
+            !sout.contains(reject),
+            "bit-rate row ({reject}) on a -f K server: {sout}"
+        );
+    }
     assert!(
         sout.contains("MBytes  ") || sout.contains("KBytes  "),
         "the Transfer column stays adaptive bytes (#221's always-'A' rule): {sout}"
     );
+}
+
+/// --get-server-output relays the SERVER's own format in the captured block
+/// (GT live, r1: a -f K server's relayed rows say KBytes/sec even for a
+/// plain client) — pins the capture-path render site, which the two-sided
+/// test above cannot see (r1 mutation c1 survived without this).
+#[test]
+fn get_server_output_carries_the_server_format() {
+    let ps = common::free_port().to_string();
+    let server = spawn_server(&["-f", "K"], &ps);
+    std::thread::sleep(Duration::from_millis(300));
+
+    let client = common::run_client(
+        &[
+            "-c",
+            "127.0.0.1",
+            "-p",
+            &ps,
+            "-t",
+            "1",
+            "-b",
+            "10M",
+            "--get-server-output",
+        ],
+        Duration::from_secs(30),
+        "client --get-server-output",
+    );
+    let _ = collect(server, "server -f K");
+
+    assert_eq!(client.status.code(), Some(0), "{}", client.stderr);
+    let block = client
+        .stdout
+        .split("Server output:")
+        .nth(1)
+        .unwrap_or_else(|| panic!("no Server output block: {}", client.stdout));
+    assert!(
+        block.contains(" KBytes/sec"),
+        "the captured server block renders the SERVER's -f K: {block}"
+    );
+    for reject in [" Kbits/sec", " Mbits/sec", " Gbits/sec", " bits/sec"] {
+        assert!(
+            !block.contains(reject),
+            "bit-rate leak ({reject}) in the captured block: {block}"
+        );
+    }
 }
 
 /// Case is semantic end-to-end: `-f k` (bits) and `-f K` (bytes) produce

--- a/riperf3-cli/tests/format_flag.rs
+++ b/riperf3-cli/tests/format_flag.rs
@@ -1,0 +1,147 @@
+//! #241/#242 — the `-f` format surface, live text shapes (iperf 3.21 GT,
+//! captured 2026-06-11):
+//!
+//! - UPPERCASE letters are byte-rates: `-f K` prints `1278 KBytes/sec` for a
+//!   10 Mbit/s run (unit_snprintf converts bytes with 1024 divisors and only
+//!   multiplies by 8 for lowercase, units.c:299-344).
+//! - The Transfer column stays adaptive ('A') regardless of -f; the flag
+//!   drives only the Bitrate column (#221's rule, both roles).
+//! - The SERVER honors its own -f the same way (live: a `-f K` GT server
+//!   prints `KBytes/sec` on its interval and receiver rows) — riperf3's
+//!   server silently ignored -f entirely (#242).
+
+use std::process::{Command, Stdio};
+use std::time::Duration;
+
+mod common;
+use common::ChildGuard;
+
+fn spawn_server(extra: &[&str], port: &str) -> ChildGuard {
+    let mut args = vec!["-s", "-1", "-p", port];
+    args.extend_from_slice(extra);
+    ChildGuard(
+        Command::new(env!("CARGO_BIN_EXE_riperf3"))
+            .args(&args)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .expect("spawn server"),
+    )
+}
+
+fn collect(mut child: ChildGuard, who: &str) -> String {
+    use std::io::Read;
+    let deadline = std::time::Instant::now() + Duration::from_secs(10);
+    while child.0.try_wait().expect("try_wait").is_none() {
+        assert!(std::time::Instant::now() < deadline, "{who}: did not exit");
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    let mut out = String::new();
+    if let Some(mut s) = child.0.stdout.take() {
+        let _ = s.read_to_string(&mut out);
+    }
+    out
+}
+
+/// One run, both pins: a `-f K` server renders BYTE-rates on its own rows
+/// (#242: the flag must reach the render sites at all; #241: uppercase must
+/// mean KBytes/sec) while the `-f m` client renders Mbits/sec — each side's
+/// own flag, independently, like iperf3.
+#[test]
+fn server_and_client_each_honor_their_own_format() {
+    let ps = common::free_port().to_string();
+    let server = spawn_server(&["-f", "K"], &ps);
+    std::thread::sleep(Duration::from_millis(300));
+
+    let client = common::run_client(
+        &[
+            "-c",
+            "127.0.0.1",
+            "-p",
+            &ps,
+            "-t",
+            "1",
+            "-b",
+            "10M",
+            "-f",
+            "m",
+        ],
+        Duration::from_secs(30),
+        "client -f m",
+    );
+    let sout = collect(server, "server -f K");
+
+    assert_eq!(client.status.code(), Some(0), "{}", client.stderr);
+
+    // Client: its own -f m everywhere a rate renders; no adaptive leakage.
+    assert!(
+        client.stdout.contains(" Mbits/sec"),
+        "client -f m renders Mbits/sec rows: {out}",
+        out = client.stdout
+    );
+    assert!(
+        !client.stdout.contains(" KBytes/sec"),
+        "the server's format must not leak into the client: {out}",
+        out = client.stdout
+    );
+
+    // Server: -f K = byte-rates on interval AND summary rows (GT live shape
+    // `1278 KBytes/sec`), Transfer column still adaptive Bytes.
+    assert!(
+        sout.contains(" KBytes/sec"),
+        "server -f K renders KBytes/sec rows (#242 wiring + #241 case): {sout}"
+    );
+    assert!(
+        !sout.contains(" Kbits/sec") && !sout.contains(" Gbits/sec"),
+        "no bit-rate rows on a -f K server: {sout}"
+    );
+    assert!(
+        sout.contains("MBytes  ") || sout.contains("KBytes  "),
+        "the Transfer column stays adaptive bytes (#221's always-'A' rule): {sout}"
+    );
+}
+
+/// Case is semantic end-to-end: `-f k` (bits) and `-f K` (bytes) produce
+/// different units on the same run shape. Today clap's ignore_case collapses
+/// them to the same enum variant.
+#[test]
+fn client_uppercase_k_is_byte_rate_lowercase_is_bit_rate() {
+    for (flag, want, reject) in [
+        ("k", " Kbits/sec", " KBytes/sec"),
+        ("K", " KBytes/sec", " Kbits/sec"),
+    ] {
+        let ps = common::free_port().to_string();
+        let server = spawn_server(&[], &ps);
+        std::thread::sleep(Duration::from_millis(300));
+
+        let client = common::run_client(
+            &[
+                "-c",
+                "127.0.0.1",
+                "-p",
+                &ps,
+                "-t",
+                "1",
+                "-b",
+                "10M",
+                "-f",
+                flag,
+            ],
+            Duration::from_secs(30),
+            "client -f case",
+        );
+        let _ = collect(server, "server");
+
+        assert_eq!(client.status.code(), Some(0), "{}", client.stderr);
+        assert!(
+            client.stdout.contains(want),
+            "-f {flag} must render {want}: {out}",
+            out = client.stdout
+        );
+        assert!(
+            !client.stdout.contains(reject),
+            "-f {flag} must NOT render {reject}: {out}",
+            out = client.stdout
+        );
+    }
+}

--- a/riperf3/src/client.rs
+++ b/riperf3/src/client.rs
@@ -2578,8 +2578,11 @@ impl ClientBuilder {
         self
     }
 
-    /// `-f/--format`: report units — `k`/`m`/`g`/`t` for bits, uppercase for
-    /// bytes; the default `'a'` picks adaptively.
+    /// `-f/--format`: report units — `k`/`m`/`g`/`t` for bit-rates, uppercase
+    /// `K`/`M`/`G`/`T` for byte-rates (#241); the default `'a'` picks
+    /// adaptively, and any other char falls back to adaptive. The Transfer
+    /// column is always adaptive bytes, like iperf3 (#221); this drives the
+    /// Bitrate column.
     pub fn format_char(mut self, c: char) -> Self {
         self.format_char = c;
         self

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -169,6 +169,9 @@ pub struct Server {
     /// dumps stats, sends SERVER_TERMINATE, and `run()` returns.
     pub(crate) interrupt: Option<crate::client::InterruptWatch>,
     pub(crate) json_stream_full_output: bool,
+    /// `-f` unit format for the text report (#242): the server-side flag was
+    /// silently ignored — every render site hardcoded the adaptive default.
+    pub(crate) format_char: char,
 }
 
 /// Best-effort source IP the kernel would use to reach `client_addr`, paired
@@ -240,7 +243,6 @@ impl Server {
             // -V reprints version/uname EVERY accept round, like GT's
             // iperf_run_server loop (r1 item 12; #222).
             if self.verbose {
-                // (Already inside the !json gate.)
                 vprintln!("riperf3 {}", env!("CARGO_PKG_VERSION"));
                 vprintln!("{}", crate::utils::system_info());
             }
@@ -752,7 +754,8 @@ impl Server {
                 crate::reporter::IntervalReporterConfig {
                     interval_secs: 1.0,
                     protocol: cfg.protocol,
-                    format_char: 'a',
+                    // #242: the wired -f (was a hardcoded adaptive default).
+                    format_char: self.format_char,
                     omit_secs: cfg.omit,
                     forceflush: self.forceflush,
                     json_stream: self.json_stream,
@@ -997,7 +1000,7 @@ impl Server {
                 vprintln!("Test Complete. Summary Results:");
             }
             crate::reporter::print_final_header(cfg.protocol, cfg.bidir, with_retr);
-            crate::reporter::print_final_summaries(&summaries, 'a');
+            crate::reporter::print_final_summaries(&summaries, self.format_char);
             if self.verbose && streams.iter().any(|s| s.is_sender) {
                 // GT gates the CPU line on the SENDING side (iperf_api.c:
                 // 4563): a -R server prints it, with ZERO remote figures —
@@ -1161,7 +1164,7 @@ impl Server {
                 vprintln!("Test Complete. Summary Results:");
             }
             crate::reporter::print_final_header(cfg.protocol, cfg.bidir, with_retr);
-            crate::reporter::print_final_summaries(&summaries, 'a');
+            crate::reporter::print_final_summaries(&summaries, self.format_char);
             if self.verbose && streams.iter().any(|s| s.is_sender) {
                 // GT gates the CPU line on the SENDING side (iperf_api.c:
                 // 4563): a -R server prints it, with ZERO remote figures —
@@ -2006,6 +2009,7 @@ pub struct ServerBuilder {
     json_stream: bool,
     interrupt: Option<crate::client::InterruptWatch>,
     json_stream_full_output: bool,
+    format_char: char,
 }
 
 impl Default for ServerBuilder {
@@ -2031,6 +2035,8 @@ impl Default for ServerBuilder {
             json_stream: false,
             interrupt: None,
             json_stream_full_output: false,
+            // iperf3 has NO default -f: every figure auto-scales (#221).
+            format_char: 'a',
         }
     }
 }
@@ -2109,6 +2115,15 @@ impl ServerBuilder {
     /// seconds (unset: no limit).
     pub fn server_max_duration(mut self, secs: u32) -> Self {
         self.server_max_duration = Some(secs);
+        self
+    }
+
+    /// `-f` unit format for the text report (#242), unit_snprintf chars:
+    /// lowercase `kmgt` = bit-rates, UPPERCASE `KMGT` = byte-rates (#241),
+    /// `'a'`/`'A'` adaptive. The Transfer column is always adaptive bytes,
+    /// like iperf3 (#221); this drives the Bitrate column.
+    pub fn format_char(mut self, c: char) -> Self {
+        self.format_char = c;
         self
     }
 
@@ -2250,6 +2265,7 @@ impl ServerBuilder {
             json_stream: self.json_stream,
             interrupt: self.interrupt.clone(),
             json_stream_full_output: self.json_stream_full_output,
+            format_char: self.format_char,
         })
     }
 }
@@ -2496,6 +2512,17 @@ mod tests {
         fn server_builder_verbose() {
             let s = ServerBuilder::new().verbose(true).build().unwrap();
             assert!(s.verbose);
+        }
+
+        #[test]
+        fn server_builder_format_char() {
+            // #242: -f is wired to Server.format_char (the render sites used
+            // to hardcode 'a'); uppercase byte-rate chars survive (#241).
+            let s = ServerBuilder::new().format_char('K').build().unwrap();
+            assert_eq!(s.format_char, 'K');
+            // iperf3 has no default -f: adaptive.
+            let s = ServerBuilder::new().build().unwrap();
+            assert_eq!(s.format_char, 'a');
         }
 
         #[test]

--- a/riperf3/src/units.rs
+++ b/riperf3/src/units.rs
@@ -45,12 +45,29 @@ fn ladder(n: f64) -> String {
 }
 
 /// Format a bits-per-second rate for display.
+///
+/// Same char table as [`format_bytes`] (#241): lowercase = bit-rates with
+/// 1000 divisors, UPPERCASE = byte-rates with 1024 divisors — GT's
+/// unit_snprintf takes bytes and only multiplies by 8 for the lowercase
+/// set (units.c:299-302), so `-f K` means KBytes/sec, never Kbits.
 pub fn format_rate(bits_per_sec: f64, format_char: char) -> String {
+    let bytes_per_sec = bits_per_sec / 8.0;
     match format_char {
-        'k' | 'K' => format!("{} Kbits/sec", ladder(bits_per_sec / 1000.0)),
-        'm' | 'M' => format!("{} Mbits/sec", ladder(bits_per_sec / 1_000_000.0)),
-        'g' | 'G' => format!("{} Gbits/sec", ladder(bits_per_sec / 1_000_000_000.0)),
-        't' | 'T' => format!("{} Tbits/sec", ladder(bits_per_sec / 1_000_000_000_000.0)),
+        'k' => format!("{} Kbits/sec", ladder(bits_per_sec / 1000.0)),
+        'm' => format!("{} Mbits/sec", ladder(bits_per_sec / 1_000_000.0)),
+        'g' => format!("{} Gbits/sec", ladder(bits_per_sec / 1_000_000_000.0)),
+        't' => format!("{} Tbits/sec", ladder(bits_per_sec / 1_000_000_000_000.0)),
+        'K' => format!("{} KBytes/sec", ladder(bytes_per_sec / 1024.0)),
+        'M' => format!("{} MBytes/sec", ladder(bytes_per_sec / (1024.0 * 1024.0))),
+        'G' => format!(
+            "{} GBytes/sec",
+            ladder(bytes_per_sec / (1024.0 * 1024.0 * 1024.0))
+        ),
+        'T' => format!(
+            "{} TBytes/sec",
+            ladder(bytes_per_sec / (1024.0 * 1024.0 * 1024.0 * 1024.0))
+        ),
+        'A' => adaptive_rate_bytes(bytes_per_sec),
         _ => adaptive_rate(bits_per_sec),
     }
 }
@@ -90,6 +107,27 @@ fn adaptive_bits(bits: f64) -> String {
         format!("{} Kbits", ladder(bits / K))
     } else {
         format!("{} bits", ladder(bits))
+    }
+}
+
+/// The byte-rate twin of [`adaptive_rate`]: unit_snprintf's uppercase
+/// adaptive arm, 1024-stepped (#241).
+fn adaptive_rate_bytes(bytes_per_sec: f64) -> String {
+    const K: f64 = 1024.0;
+    const M: f64 = K * 1024.0;
+    const G: f64 = M * 1024.0;
+    const T: f64 = G * 1024.0;
+
+    if bytes_per_sec >= T {
+        format!("{} TBytes/sec", ladder(bytes_per_sec / T))
+    } else if bytes_per_sec >= G {
+        format!("{} GBytes/sec", ladder(bytes_per_sec / G))
+    } else if bytes_per_sec >= M {
+        format!("{} MBytes/sec", ladder(bytes_per_sec / M))
+    } else if bytes_per_sec >= K {
+        format!("{} KBytes/sec", ladder(bytes_per_sec / K))
+    } else {
+        format!("{} Bytes/sec", ladder(bytes_per_sec))
     }
 }
 
@@ -195,6 +233,42 @@ mod tests {
         assert_eq!(format_rate(1_000_000_000.0, 'g'), "1.00 Gbits/sec");
         // ladder: 1000 >= 999.5 -> %.0f
         assert_eq!(format_rate(1_000_000_000.0, 'm'), "1000 Mbits/sec");
+    }
+
+    /// #241: uppercase = BYTE-rates — GT's unit_snprintf takes bytes and
+    /// only multiplies by 8 for lowercase (units.c:299-302), with 1024
+    /// divisors for the byte side. Live GT pin (2026-06-11): a 10 Mbit/s
+    /// run under `-f K` prints "1278 KBytes/sec", NOT Kbits.
+    #[test]
+    fn format_rate_uppercase_byte_rates() {
+        assert_eq!(format_rate(8.0 * 1024.0, 'K'), "1.00 KBytes/sec");
+        assert_eq!(format_rate(8.0 * 1024.0 * 1024.0, 'M'), "1.00 MBytes/sec");
+        assert_eq!(
+            format_rate(8.0 * 1024.0 * 1024.0 * 1024.0, 'G'),
+            "1.00 GBytes/sec"
+        );
+        assert_eq!(
+            format_rate(8.0 * 1024.0 * 1024.0 * 1024.0 * 1024.0, 'T'),
+            "1.00 TBytes/sec"
+        );
+        // The precision ladder applies to byte-rates too: 10 Mbit/s ->
+        // 1,310,720 bytes/s -> 1280 KiB/s -> %.0f.
+        assert_eq!(format_rate(10_485_760.0, 'K'), "1280 KBytes/sec");
+        // Case is semantic, not cosmetic.
+        assert_eq!(format_rate(10_485_760.0, 'k'), "10486 Kbits/sec");
+    }
+
+    /// 'A' as a rate format = adaptive BYTE-rate (unit_snprintf's uppercase
+    /// adaptive arm, 1024-stepped). Unreachable from the CLI (GT rejects
+    /// -f A with IEBADFORMAT) but part of the lib's format_char surface.
+    #[test]
+    fn format_rate_adaptive_bytes() {
+        assert_eq!(format_rate(16_384.0, 'A'), "2.00 KBytes/sec");
+        assert_eq!(
+            format_rate(8.0 * 1024.0 * 1024.0 * 1.5, 'A'),
+            "1.50 MBytes/sec"
+        );
+        assert_eq!(format_rate(800.0, 'A'), "100 Bytes/sec");
     }
 
     #[test]


### PR DESCRIPTION
> **GT** = ground truth: the pinned reference **iperf 3.21**, built from source at commit `d39cf41526626b4e5a130f115d931cd6cbdffc19`, that riperf3's wire/behavior faithfulness is captured from and verified against (source-line citations like `iperf_api.c:4288` refer to that tree).

Fixes #241. Fixes #242.

Two halves of the same `-f` surface, batched per the wave-2 pacing plan.

## #241 — uppercase means byte-rates

GT's `unit_snprintf` takes **bytes** and only multiplies by 8 for lowercase formats (units.c:299-302); uppercase `[KMGT]` divide by 1024 and label `KBytes/sec`… Live GT pin: a 10 Mbit/s run under `-f K` prints `1278 KBytes/sec`. riperf3's `ignore_case` clap enum collapsed `-f K` → `Kbits/sec` — silently a different unit, and `format_rate` had no byte-rate path at all.

Now: 8 case-sensitive variants (`#[value(name)]` k/m/g/t/K/M/G/T), byte-rate branches in `format_rate` on the same precision ladder, an adaptive-`'A'` byte-rate arm (CLI-unreachable — GT rejects `-f A` — but part of the lib's `format_char` surface), and `Format::as_char` as the single CLI→lib glue point.

## #242 — the server-side `-f` was silently dropped

`build_server` never wired `self.format`; the interval-reporter spawn and both final-summary sites hardcoded `'a'`. Now `Server`/`ServerBuilder` carry `format_char` (default `'a'` — iperf3 has **no** default `-f`, #221), wired at all three sites. The Transfer column stays always-adaptive per #221's rule; `-f` drives only the Bitrate column — live-verified that's exactly GT's behavior server-side too.

## Live side-by-side

riperf3 `-f K` server: `[ 1] 0.00-1.00 sec 1.25 MBytes 1280 KBytes/sec` (interval + receiver rows) vs GT same shape `1.25 MBytes 1279/1278 KBytes/sec` — same math, units, ladder; figure differences are per-run byte counts, not conversion.

## Tests (red-first)

- units: byte-rate pins for all four uppercase chars + the ladder on byte-rates (`1280 KBytes/sec`) + the k/K case split + adaptive-`'A'`
- CLI: 8-way case-sensitive parse on both roles + the CLI→char glue table
- Integration (new `format_flag.rs`): one two-sided live run — `-f K` server and `-f m` client each honor their own flag with no cross-leakage, Transfer stays adaptive; plus an end-to-end k-vs-K split test
- `server_builder_format_char` (wired flag + no-default)

Also folds in the wave-ledger cosmetic: the review-residue comment at server.rs:246.

## Behavior change note

`-f K/M/G/T` (uppercase) previously produced bit-rates; anyone relying on the collapsed behavior sees byte-rates now — that's the fix, matching iperf3. Clap's error on an invalid letter differs in wording from GT's `IEBADFORMAT` line (pre-existing CLI error-shape convention, not touched here).

