### PR TITLE
fix: per-stream UDP packets/lost_percent provenance (#238, #239)

### DIFF
--- a/riperf3/src/json_report.rs
+++ b/riperf3/src/json_report.rs
@@ -1315,7 +1315,11 @@ impl ReportInput {
                     packets,
                     // #238: the pct exists only over a sender-side
                     // denominator; absent sender count -> 0.0 (GT's
-                    // `if (sender_packet_count)` else-branch).
+                    // `if (sender_packet_count - sender_omitted_packet_count
+                    // > 0)` else-branch at :4288; the bare-truthiness form is
+                    // the PACKETS fallback at :4311 — equivalent here at
+                    // omit=0, the per-stream omit subtraction being #31/#214
+                    // scope).
                     lost_percent: if has_sender_count {
                         pct_lost(u.lost_packets, packets)
                     } else {
@@ -1648,7 +1652,9 @@ mod tests {
 
         // (3) client receiver whose peer reported ZERO sender bytes — the
         // measured-packets fallback engages for `packets`, but the pct
-        // denominator is gone (GT's `if (sender_packet_count)` is falsy).
+        // denominator is gone (GT's pct gate at :4288 — the
+        // `sender_packet_count - sender_omitted_packet_count > 0` test —
+        // fails on zero).
         let mut input = base_input();
         input.protocol = TransportProtocol::Udp;
         input.streams = vec![udp_stream(1, false, blk * 96, Some(0), 0.001, 4, 96)];

--- a/riperf3/src/json_report.rs
+++ b/riperf3/src/json_report.rs
@@ -1255,7 +1255,12 @@ impl ReportInput {
                     let blk = self.blksize.max(1) as u64;
                     (s.local_bytes, (s.local_bytes / blk) as i64, true)
                 } else {
-                    // Sender count absent pre-exchange (#238) — plain
+                    // Sender count absent on EVERY server run, not just
+                    // terminated ones (#238): GT's server does receive the
+                    // client's per-stream figures (get_results,
+                    // iperf_api.c:2942) but PRINTS first — reporter_callback
+                    // at iperf_server_api.c:277 runs before the exchange at
+                    // :280 — so they never reach its report. Plain
                     // forward-UDP server docs included, not just bidir.
                     (0, u.packets, false)
                 }

--- a/riperf3/src/json_report.rs
+++ b/riperf3/src/json_report.rs
@@ -1243,23 +1243,32 @@ impl ReportInput {
             // parity) while still carrying the packet/loss/jitter it measured. A
             // stream the server sent has no receiver stats, so its sent packet
             // count is derived from the bytes it pushed.
-            let (bytes, packets) = if self.is_server {
+            // The third element says whether `packets` carries SENDER-side
+            // provenance: iperf3's pct denominator is strictly the sender
+            // count, and the two figures have ASYMMETRIC fallbacks when it's
+            // absent — `packets` falls back to the measured receiver count
+            // (iperf_api.c:4311), lost_percent goes to 0.0 (:4288-4293
+            // else-branch), never the measured pct (#238; live-proven on a
+            // terminated bidir probe — iperf3 0 vs riperf3's old 14.75).
+            let (bytes, packets, has_sender_count) = if self.is_server {
                 if s.is_sender {
                     let blk = self.blksize.max(1) as u64;
-                    (s.local_bytes, (s.local_bytes / blk) as i64)
+                    (s.local_bytes, (s.local_bytes / blk) as i64, true)
                 } else {
-                    (0, u.packets)
+                    // Sender count absent pre-exchange (#238) — plain
+                    // forward-UDP server docs included, not just bidir.
+                    (0, u.packets, false)
                 }
             } else if s.is_sender && s.udp.is_none() && self.error.is_some() {
                 // Terminated before the exchange (#170): no peer-measured
                 // stats — iperf3 reports the sender's LOCAL packet count.
                 let blk = self.blksize.max(1) as u64;
-                (s.local_bytes, (s.local_bytes / blk) as i64)
+                (s.local_bytes, (s.local_bytes / blk) as i64, true)
             } else if !s.is_sender && self.error.is_some() {
                 // Terminated receiver stream (-R): `bytes` is a SENDER-side
                 // count the dead peer never reported — iperf3 emits 0 while
                 // keeping the locally measured packets (#170 r2 f2).
-                (0, u.packets)
+                (0, u.packets, false)
             } else if !s.is_sender {
                 // #214 (3): `bytes` is a SENDER-side count — a stream this
                 // client RECEIVED reports the peer's exchanged sent figure
@@ -1267,17 +1276,24 @@ impl ReportInput {
                 // local only when the peer never reported one. `packets`
                 // follows the same provenance (r2 review): derive from the
                 // sender-side bytes like the server arm, with the measured
-                // count as the zero-bytes fallback.
+                // count as the zero-bytes fallback — for `packets` ONLY;
+                // the pct has no such fallback in iperf3 (#238).
                 let bytes = s.remote_bytes.unwrap_or(s.local_bytes);
                 let blk = self.blksize.max(1) as u64;
-                let packets = if bytes > 0 {
-                    (bytes / blk) as i64
+                if bytes > 0 {
+                    (bytes, (bytes / blk) as i64, true)
                 } else {
-                    u.packets
-                };
-                (bytes, packets)
+                    (bytes, u.packets, false)
+                }
             } else {
-                (s.local_bytes, u.packets)
+                // #239: a client SENDER stream reports its LOCAL sent count
+                // (sender_packet_count = sp->packet_count, iperf_api.c:
+                // 4220-4221), not the peer-measured #182 figure — they
+                // diverge under forward trailing loss. The peer-measured
+                // jitter/lost VALUES stay on the entry below; exact tail-
+                // partial-datagram counts are #235's residue.
+                let blk = self.blksize.max(1) as u64;
+                (s.local_bytes, (s.local_bytes / blk) as i64, true)
             };
             return EndStream {
                 sender: None,
@@ -1292,12 +1308,14 @@ impl ReportInput {
                     jitter_ms: u.jitter_secs * 1000.0,
                     lost_packets: u.lost_packets,
                     packets,
-                    // r3 review (F1): the denominator follows the same
-                    // sender-side provenance as `packets` — iperf3's
-                    // per-stream pct divides by the sender count
-                    // (iperf_api.c:4288-4293). `packets` already holds the
-                    // arm-appropriate figure (derived, or measured fallback).
-                    lost_percent: pct_lost(u.lost_packets, packets),
+                    // #238: the pct exists only over a sender-side
+                    // denominator; absent sender count -> 0.0 (GT's
+                    // `if (sender_packet_count)` else-branch).
+                    lost_percent: if has_sender_count {
+                        pct_lost(u.lost_packets, packets)
+                    } else {
+                        0.0
+                    },
                     out_of_order: u.out_of_order,
                     sender: s.is_sender,
                 }),
@@ -1569,6 +1587,115 @@ mod tests {
             intervals: vec![],
             streams: vec![],
         }
+    }
+
+    /// #238: iperf3's per-stream lost_percent denominator is STRICTLY the
+    /// sender-side count; when that count is absent it emits 0.0
+    /// (iperf_api.c:4288-4293 else-branch) — NEVER the receiver-measured
+    /// count, even though `packets` DOES fall back to it (:4311). Live-proven
+    /// on a terminated bidir probe (#233 r4: iperf3 `lost_percent: 0` where
+    /// riperf3 said 14.75). The three sender-count-absent arms:
+    #[test]
+    fn udp_lost_percent_zero_when_sender_count_absent() {
+        let blk = 131_072u64;
+
+        // (1) SERVER receiving stream — sender count absent pre-exchange
+        // (plain forward-UDP server docs included, not just bidir).
+        let mut input = base_input();
+        input.protocol = TransportProtocol::Udp;
+        input.is_server = true;
+        input.streams = vec![udp_stream(1, false, blk * 96, None, 0.001, 4, 96)];
+        let v = serde_json::to_value(input.build()).unwrap();
+        let u = &v["end"]["streams"][0]["udp"];
+        assert_eq!(
+            u["packets"],
+            serde_json::json!(96i64),
+            "packets keeps the measured fallback (:4311): {u}"
+        );
+        assert_eq!(
+            u["lost_percent"].as_f64(),
+            Some(0.0),
+            "sender count absent -> 0.0, never the measured pct: {u}"
+        );
+
+        // (2) client receiver on a TERMINATED run (#170) — the peer's sent
+        // figure never arrived.
+        let mut input = base_input();
+        input.protocol = TransportProtocol::Udp;
+        input.error = Some("error - the server has terminated".into());
+        input.streams = vec![udp_stream(
+            1,
+            false,
+            blk * 96,
+            Some(blk * 100),
+            0.001,
+            4,
+            96,
+        )];
+        let v = serde_json::to_value(input.build()).unwrap();
+        let u = &v["end"]["streams"][0]["udp"];
+        assert_eq!(u["packets"], serde_json::json!(96i64));
+        assert_eq!(
+            u["lost_percent"].as_f64(),
+            Some(0.0),
+            "the #233 r4 live shape — iperf3 emits 0 on terminated streams: {u}"
+        );
+
+        // (3) client receiver whose peer reported ZERO sender bytes — the
+        // measured-packets fallback engages for `packets`, but the pct
+        // denominator is gone (GT's `if (sender_packet_count)` is falsy).
+        let mut input = base_input();
+        input.protocol = TransportProtocol::Udp;
+        input.streams = vec![udp_stream(1, false, blk * 96, Some(0), 0.001, 4, 96)];
+        let v = serde_json::to_value(input.build()).unwrap();
+        let u = &v["end"]["streams"][0]["udp"];
+        assert_eq!(u["packets"], serde_json::json!(96i64));
+        assert_eq!(u["lost_percent"].as_f64(), Some(0.0), "{u}");
+    }
+
+    /// #239: a client SENDER stream's packets/lost_percent use the LOCAL
+    /// sent count (sender_packet_count = sp->packet_count,
+    /// iperf_api.c:4220-4221), not the peer-measured #182 figure — they
+    /// diverge under forward trailing loss (the receiver's highest-seq view
+    /// trails what was sent). The peer-measured jitter/lost VALUES stay on
+    /// the entry; only the packets/pct provenance changes. Exact-count
+    /// (tail partial datagrams) is #235's residue.
+    #[test]
+    fn udp_client_sender_packets_use_local_count() {
+        let blk = 131_072u64;
+        let mut input = base_input();
+        input.protocol = TransportProtocol::Udp;
+        // Sent 100 blocks; the receiver measured highest-seq 99 with 2 lost.
+        input.streams = vec![udp_stream(
+            1,
+            true,
+            blk * 100,
+            Some(blk * 99),
+            0.0015,
+            2,
+            99,
+        )];
+        let v = serde_json::to_value(input.build()).unwrap();
+        let u = &v["end"]["streams"][0]["udp"];
+        assert_eq!(
+            u["packets"],
+            serde_json::json!(100i64),
+            "the LOCAL sent count, not the peer-measured 99: {u}"
+        );
+        assert!(
+            (u["lost_percent"].as_f64().unwrap() - 2.0).abs() < 1e-9,
+            "2/100 on the sender denominator (not 2/99): {u}"
+        );
+        assert!(
+            (u["jitter_ms"].as_f64().unwrap() - 1.5).abs() < 1e-9,
+            "peer-measured jitter VALUE stays (#182): {u}"
+        );
+        assert_eq!(
+            u["lost_packets"],
+            serde_json::json!(2i64),
+            "peer-measured loss VALUE stays: {u}"
+        );
+        assert_eq!(u["bytes"], serde_json::json!(blk * 100));
     }
 
     fn udp_stream(


### PR DESCRIPTION
> **GT** = ground truth: the pinned reference **iperf 3.21**, built from source at commit `d39cf41526626b4e5a130f115d931cd6cbdffc19`, that riperf3's wire/behavior faithfulness is captured from and verified against (source-line citations like `iperf_api.c:4288` refer to that tree).

Fixes #238. Fixes #239.

The two sibling per-stream UDP provenance rules, batched (same function, same family — the wave-2 pacing plan).

## #238 — lost_percent's denominator is strictly sender-side, with an asymmetric fallback

GT computes the per-stream pct only over `sender_packet_count`; when it's absent, `packets` falls back to the receiver-measured count (iperf_api.c:4311) but `lost_percent` goes to **0.0** (:4288-4293 else-branch) — never the measured percentage. Live-proven during #233's r4: terminated bidir, iperf3 `lost_percent: 0` vs riperf3 `14.75`.

Fixed at all three sender-count-absent arms (the `(bytes, packets)` match now carries `has_sender_count`):
- server receiving streams (plain forward-UDP server docs too, not just bidir)
- the client's terminated (#170) receiver arm
- the zero-sender-bytes fallback of the client receiving arm

The old r3-F1 comment claiming the pct "already holds the arm-appropriate figure" (i.e. shares the measured fallback) was the comment #238's widening flagged as wrong — corrected in place.

## #239 — client sender entries use the LOCAL sent count

A client SENDER stream's `packets`/`lost_percent` used the peer-measured `u.packets` (#182 exchange figure) where GT uses the local `sp->packet_count` (:4220-4221) — divergent under forward trailing loss. Now derived from local bytes, same as the server sender arm. The peer-measured `jitter_ms`/`lost_packets` **values** stay on the entry (that part of #182 was correct). Exact tail-partial-datagram counts remain #235's scope (needs `remote_packets` plumbed through the exchange — next in the wave).

## Tests (red-first)

- Three #238 fixtures, each pinning the asymmetry in one assert pair: `packets` keeps the measured figure AND pct is 0.0 (red: 4.17/4.17/4.17 measured pcts)
- The #239 fixture: packets 100 (local) vs the peer's 99, pct 2/100, with the peer jitter/lost values asserted retained (red: packets 99, pct 2.02)
- The existing #233 aggregate pins (sent-side denominators, the 4/100 per-stream receiving pct) stay green — aggregate-level provenance was #233's scope and is untouched.

Gate clean. Note for the reviewer: lossless loopback runs can't distinguish these shapes live (everything prints 0.0/equal counts without loss); the GT evidence is the #233-review live captures cited above, and the fixtures encode them.

