### PR TITLE
fix: TCP bidir sent-aggregates use per-direction retransmit totals (#236)

### DIFF
--- a/riperf3/src/client.rs
+++ b/riperf3/src/client.rs
@@ -208,6 +208,43 @@ enum ControlEvent {
 /// first-byte-ends-the-wait behavior turned stray bytes into a truncated test.
 /// Resolve when the library consumer fires the interrupt watch (#210);
 /// pends forever when no watch is wired, so it is select-safe everywhere.
+/// The per-stream retransmit figure for a `StreamReport` (#236 r1 blocker):
+/// a stream WE sent carries the local TCP_INFO cumulative total (with
+/// iperf3's platform defaults — 0 where retransmit info exists, -1 where it
+/// doesn't); a stream we RECEIVED carries the PEER's exchanged per-stream
+/// total — GT parses it into sp->result->stream_retrans (iperf_api.c:2944)
+/// and its reverse bidir pass sums exactly those — gated on the peer's
+/// sender_has_retransmits flag like GT's RX-pass gate
+/// (other_side_has_retransmits, :4169-4171). Ungated, GT omits the key;
+/// None feeds the same omission through the aggregate sentinel collapse.
+/// The old local-platform default fabricated a 0 on receiving streams where
+/// GT shows the peer's real count.
+fn stream_report_retransmits(
+    is_udp: bool,
+    is_sender: bool,
+    local_total: Option<u32>,
+    peer_has_retransmits: bool,
+    peer_stream_retransmits: Option<i64>,
+) -> Option<i64> {
+    if is_udp {
+        None
+    } else if !is_sender {
+        if peer_has_retransmits {
+            peer_stream_retransmits
+        } else {
+            None
+        }
+    } else {
+        local_total
+            .map(|r| r as i64)
+            .or(Some(if crate::tcp_info::has_retransmit_info() {
+                0
+            } else {
+                -1
+            }))
+    }
+}
+
 pub(crate) async fn wait_interrupt(
     rx: Option<&mut tokio::sync::watch::Receiver<Option<String>>>,
 ) -> String {
@@ -1889,21 +1926,13 @@ impl Client {
                     mean_rtt: e.mean_rtt(),
                     reorder: e.reorder,
                 });
-                let retransmits = if is_udp {
-                    None
-                } else {
-                    // Real cumulative total when TCP_INFO gave us one (forward
-                    // sender). Otherwise (reverse, or a stream we didn't send) use
-                    // iperf3's defaults: 0 on a platform that supports retransmit
-                    // info, -1 where it doesn't.
-                    ext.and_then(|e| e.total_retransmits)
-                        .map(|r| r as i64)
-                        .or(Some(if crate::tcp_info::has_retransmit_info() {
-                            0
-                        } else {
-                            -1
-                        }))
-                };
+                let retransmits = stream_report_retransmits(
+                    is_udp,
+                    s.is_sender,
+                    ext.and_then(|e| e.total_retransmits),
+                    remote_cpu.is_some_and(|r| r.sender_has_retransmits == 1),
+                    server_stream.map(|x| x.retransmits),
+                );
 
                 StreamReport {
                     id: s.id,
@@ -2918,6 +2947,60 @@ impl ClientBuilder {
 
 #[cfg(test)]
 mod tests {
+    mod stream_report_retransmits_quadrants {
+        use crate::client::stream_report_retransmits;
+
+        /// #236 (r1 blocker): the provenance decision the StreamReport build
+        /// feeds from — pinned per quadrant so the attach can't silently
+        /// revert to the local-platform default on receiving streams.
+        #[test]
+        fn receiving_stream_takes_the_peer_exchanged_figure_when_flagged() {
+            assert_eq!(
+                stream_report_retransmits(false, false, None, true, Some(2)),
+                Some(2),
+                "the #236 live shape: peer flag on, exchanged per-stream total"
+            );
+        }
+
+        #[test]
+        fn receiving_stream_is_none_without_the_peer_flag() {
+            // GT's RX-pass gate (other_side_has_retransmits) off -> the key
+            // is omitted; a fabricated 0 here was the r1 blocker.
+            assert_eq!(
+                stream_report_retransmits(false, false, None, false, Some(2)),
+                None
+            );
+            // Flag on but the peer skipped this stream id: nothing to show.
+            assert_eq!(
+                stream_report_retransmits(false, false, None, true, None),
+                None
+            );
+        }
+
+        #[test]
+        fn sending_stream_keeps_the_local_total_and_platform_default() {
+            assert_eq!(
+                stream_report_retransmits(false, true, Some(5), true, Some(2)),
+                Some(5),
+                "a local sender's figure is never clobbered by the peer's"
+            );
+            let default = stream_report_retransmits(false, true, None, false, None);
+            if crate::tcp_info::has_retransmit_info() {
+                assert_eq!(default, Some(0));
+            } else {
+                assert_eq!(default, Some(-1));
+            }
+        }
+
+        #[test]
+        fn udp_streams_carry_none() {
+            assert_eq!(
+                stream_report_retransmits(true, false, Some(5), true, Some(2)),
+                None
+            );
+        }
+    }
+
     // #147 (review r1): the discriminating leak test. The e2e mock below can't
     // pin the fix — run()'s DoneOnDrop guard already stops the SENDERS on any
     // exit, pre-fix included. The real pre-fix leak was the REPORTER task:

--- a/riperf3/src/json_report.rs
+++ b/riperf3/src/json_report.rs
@@ -1925,7 +1925,9 @@ mod tests {
             "the server's reverse = its own send path: {end}"
         );
         assert!(
-            end["sum_sent"].get("retransmits").is_none_or(|r| r.is_null()),
+            end["sum_sent"]
+                .get("retransmits")
+                .is_none_or(|r| r.is_null()),
             "the fwd (client->server) sent aggregate has no figure server-side: {end}"
         );
     }

--- a/riperf3/src/json_report.rs
+++ b/riperf3/src/json_report.rs
@@ -874,8 +874,10 @@ impl ReportInput {
                 // Two flows: forward (client→server, server receives → sender=false)
                 // in sum_sent/sum_received; reverse (server→client, server sends →
                 // sender=true) in the *_bidir_reverse pair. Retransmits, measured on
-                // the server's send path, attach to the reverse (sent) side.
-                sum_sent_bidir_reverse = Some(self.tcp_sum(local_sent, true, retransmits));
+                // the server's send path, attach to the reverse (sent) side —
+                // direction-filtered like GT's per-pass accumulator (#236).
+                sum_sent_bidir_reverse =
+                    Some(self.tcp_sum(local_sent, true, self.retransmits_for(Some(true))));
                 sum_received_bidir_reverse = Some(self.tcp_sum(0, true, None));
                 (
                     self.tcp_sum(0, false, None),
@@ -1038,10 +1040,15 @@ impl ReportInput {
                 (_, true) => 0,
                 _ => local_recv,
             };
-            sum_sent_bidir_reverse = Some(self.tcp_sum(rev_sent, false, None));
+            // #236: per-direction retransmit totals, like GT's per-pass
+            // accumulator — the reverse-sent aggregate carries the PEER's
+            // exchanged counts (riding this host's receiving streams;
+            // live-observed 2), the forward one ONLY the local senders'.
+            sum_sent_bidir_reverse =
+                Some(self.tcp_sum(rev_sent, false, self.retransmits_for(Some(false))));
             sum_received_bidir_reverse = Some(self.tcp_sum(local_recv, false, None));
             (
-                self.tcp_sum(local_sent, true, retransmits),
+                self.tcp_sum(local_sent, true, self.retransmits_for(Some(true))),
                 self.tcp_sum(fwd_recv, true, None),
             )
         } else if is_udp {
@@ -1378,11 +1385,28 @@ impl ReportInput {
         }
     }
 
-    /// Sender-side retransmit total. Collapses the -1 "unavailable" sentinel
-    /// rather than summing it (summing N sentinels would emit a nonsensical -N
-    /// that iperf3 never produces). Real per-stream values arrive with PR2.
+    /// Sender-side retransmit total over every stream. Correct for
+    /// single-direction runs (one direction exists, local or exchanged);
+    /// bidir aggregates must use [`Self::retransmits_for`] — GT's results
+    /// loop runs once per direction with a per-pass total_retransmits
+    /// (iperf_api.c:4138/4235), so the two sent-aggregates never mix (#236).
     fn sender_retransmits(&self) -> Option<i64> {
-        let vals: Vec<i64> = self.streams.iter().filter_map(|s| s.retransmits).collect();
+        self.retransmits_for(None)
+    }
+
+    /// Retransmit total over the streams of one direction (`Some(true)` =
+    /// this host's senders, `Some(false)` = its receiving streams, whose
+    /// `retransmits` carry the PEER's exchanged per-stream counts; `None` =
+    /// every stream). Collapses the -1 "unavailable" sentinel rather than
+    /// summing it (summing N sentinels would emit a nonsensical -N that
+    /// iperf3 never produces).
+    fn retransmits_for(&self, want_sender: Option<bool>) -> Option<i64> {
+        let vals: Vec<i64> = self
+            .streams
+            .iter()
+            .filter(|s| want_sender.is_none_or(|w| s.is_sender == w))
+            .filter_map(|s| s.retransmits)
+            .collect();
         if vals.is_empty() {
             None
         } else if vals.iter().all(|&r| r < 0) {
@@ -1815,6 +1839,16 @@ mod tests {
     }
 
     fn tcp_stream(id: i32, is_sender: bool, local: u64, remote: u64) -> StreamReport {
+        tcp_stream_retr(id, is_sender, local, remote, Some(3))
+    }
+
+    fn tcp_stream_retr(
+        id: i32,
+        is_sender: bool,
+        local: u64,
+        remote: u64,
+        retransmits: Option<i64>,
+    ) -> StreamReport {
         StreamReport {
             id,
             local_host: "127.0.0.1".into(),
@@ -1824,10 +1858,76 @@ mod tests {
             is_sender,
             local_bytes: local,
             remote_bytes: Some(remote),
-            retransmits: Some(3),
+            retransmits,
             tcp_end: None,
             udp: None,
         }
+    }
+
+    /// #236: in TCP bidir, GT's results loop runs once per direction with a
+    /// PER-PASS total_retransmits (iperf_api.c:4138 reset, :4235 accumulate)
+    /// — `sum_sent` carries the local senders' total; `sum_sent_bidir_
+    /// reverse` carries the peer's exchanged per-stream counts riding the
+    /// receiving streams (live-observed: 2, the #233 r1 capture). riperf3
+    /// passed None on the reverse-sent aggregate and, with receiving streams
+    /// now carrying the exchanged figure, an unfiltered sum would mix both
+    /// directions into the forward aggregate.
+    #[test]
+    fn tcp_bidir_reverse_sent_carries_peer_retransmits() {
+        let mut input = base_input();
+        input.bidir = true;
+        input.num_streams = 1;
+        input.streams = vec![
+            // local sender: 3 local retransmits (forward direction)
+            tcp_stream_retr(1, true, 131_072, 131_072, Some(3)),
+            // receiving stream: the peer exchanged 2 for its send side
+            tcp_stream_retr(2, false, 131_072, 131_072, Some(2)),
+        ];
+        let v = serde_json::to_value(input.build()).unwrap();
+        let end = &v["end"];
+        assert_eq!(
+            end["sum_sent"]["retransmits"],
+            serde_json::json!(3i64),
+            "forward = LOCAL senders only, never mixed with the peer's: {end}"
+        );
+        assert_eq!(
+            end["sum_sent_bidir_reverse"]["retransmits"],
+            serde_json::json!(2i64),
+            "the peer's exchanged reverse count (#236): {end}"
+        );
+        for key in ["sum_received", "sum_received_bidir_reverse"] {
+            assert!(
+                end[key].get("retransmits").is_none_or(|r| r.is_null()),
+                "received aggregates carry no retransmits (GT): {end}"
+            );
+        }
+    }
+
+    /// The server-role twin (a green pin guarding the direction-filter
+    /// refactor): the server's reverse channel is what IT sends — local
+    /// retransmits — and the forward pair carries none (the client's
+    /// per-stream retransmits are never exchanged to the server).
+    #[test]
+    fn tcp_bidir_server_reverse_sent_uses_local_retransmits() {
+        let mut input = base_input();
+        input.bidir = true;
+        input.is_server = true;
+        input.num_streams = 1;
+        input.streams = vec![
+            tcp_stream_retr(1, true, 131_072, 0, Some(4)),
+            tcp_stream_retr(2, false, 131_072, 0, None),
+        ];
+        let v = serde_json::to_value(input.build()).unwrap();
+        let end = &v["end"];
+        assert_eq!(
+            end["sum_sent_bidir_reverse"]["retransmits"],
+            serde_json::json!(4i64),
+            "the server's reverse = its own send path: {end}"
+        );
+        assert!(
+            end["sum_sent"].get("retransmits").is_none_or(|r| r.is_null()),
+            "the fwd (client->server) sent aggregate has no figure server-side: {end}"
+        );
     }
 
     /// #170 r3: the terminated-run shapes only existed in live matrices —

--- a/riperf3/src/json_report.rs
+++ b/riperf3/src/json_report.rs
@@ -561,6 +561,10 @@ pub struct StreamReport {
     pub local_bytes: u64,
     /// Bytes the peer reports for the opposite side of this stream, if known.
     pub remote_bytes: Option<u64>,
+    /// Sender-side retransmit total: the LOCAL TCP_INFO cumulative for
+    /// streams this host sent, the PEER's exchanged per-stream figure for
+    /// streams it received (gated on the peer's sender_has_retransmits
+    /// flag; None when ungated) — #236.
     pub retransmits: Option<i64>,
     /// Sender-side TCP_INFO extremes for the `end.streams[].sender` object (PR2).
     /// Only set for streams this host sent (local TCP_INFO); `None` otherwise.
@@ -2734,7 +2738,7 @@ mod tests {
         input.reverse = true;
         let mut s = tcp_stream(1, false, 2_000_000, 2_000_000);
         s.tcp_end = None; // reverse: no local sender TCP_INFO
-        s.retransmits = Some(0); // iperf3 emits 0 here on a retransmit-capable OS
+        s.retransmits = Some(0); // the peer's exchanged count of 0 (flag on)
         input.streams = vec![s];
         let snd =
             serde_json::to_value(input.build()).unwrap()["end"]["streams"][0]["sender"].clone();

--- a/riperf3/src/json_report.rs
+++ b/riperf3/src/json_report.rs
@@ -1905,8 +1905,11 @@ mod tests {
 
     /// The server-role twin (a green pin guarding the direction-filter
     /// refactor): the server's reverse channel is what IT sends — local
-    /// retransmits — and the forward pair carries none (the client's
-    /// per-stream retransmits are never exchanged to the server).
+    /// retransmits — and the forward pair carries none. NOT because the
+    /// client withholds them (the exchange is symmetric, iperf_api.c:2764/
+    /// 2944): GT's server PRINTS before it exchanges (reporter_callback at
+    /// iperf_server_api.c:277 vs iperf_exchange_results at :280), so the
+    /// peer's figures never reach its report (r1 item 4).
     #[test]
     fn tcp_bidir_server_reverse_sent_uses_local_retransmits() {
         let mut input = base_input();


### PR DESCRIPTION
> **GT** = ground truth: the pinned reference **iperf 3.21**, built from source at commit `d39cf41526626b4e5a130f115d931cd6cbdffc19`, that riperf3's wire/behavior faithfulness is captured from and verified against (source-line citations like `iperf_api.c:4288` refer to that tree).

Fixes #236.

## GT semantics (source-verified)

In bidir, GT's results loop runs once per direction with a **per-pass** `total_retransmits` (iperf_api.c:4138 reset, :4235 accumulate, the per-pass gate swap at :4169-4171): `sum_sent` carries the local senders' total; `sum_sent_bidir_reverse` carries the peer's exchanged per-stream counts riding this host's receiving streams.

## What was wrong — three layers, found across the rounds

1. The client's reverse-sent aggregate passed `None` (the filed issue).
2. The unfiltered `sender_retransmits()` mixed directions in the forward aggregate (red test caught 5 = 3 local + 2 peer).
3. **r1 blocker:** the fix above was read-side only — the `StreamReport` build filled receiving streams' retransmits from *local TCP_INFO extremes* (`Some(0)` on Linux), so live output rendered a fabricated `0` where GT emits the peer's exchanged total (r1 live proof: GT server's own count `1`, riperf3 client printed `0`). The original "no live distinguisher" claim here was wrong — loopback bidir does produce retransmits.

## The fix

- `retransmits_for(Some(dir))` in json_report (per-direction totals, sentinel collapse preserved), both bidir arms.
- The attach (r1): receiving streams take the peer's per-stream exchanged figure, gated on the peer's `sender_has_retransmits` flag (GT's RX-pass gate, `other_side_has_retransmits`); ungated → `None` → GT's key omission via the collapse. Also fixes the same fabrication in single-direction `-R` docs (r1 finding 2, same root cause) and per-stream sender sub-objects.
- The provenance decision is `stream_report_retransmits`, quadrant-pinned in unit tests so the attach can't silently revert.
- The server-twin test comment states the real mechanism (GT's server **prints before it exchanges**, iperf_server_api.c:277 vs :280 — not "never exchanged"), per r1 item 4.

## Tests

Red-first fixtures for both aggregate rules (fwd 3-not-5, reverse-sent 2-not-absent), the server twin green pin, and the four provenance quadrants. Gate clean.

