### PR TITLE
feat: the server's -V placeholder rows for the unmeasured half (#246)

### DIFF
--- a/riperf3-cli/tests/server_placeholders.rs
+++ b/riperf3-cli/tests/server_placeholders.rs
@@ -1,0 +1,146 @@
+//! #246 — the server's `-V` placeholder rows for the unmeasured half
+//! (iperf 3.21 GT, live-captured 2026-06-11; iperf_locale.c:468-471):
+//!
+//!   [  5] (sender statistics not available)     <- before a receiver row
+//!   [  5] (receiver statistics not available)   <- after a sender row
+//!   [SUM] (sender statistics not available)     <- the P>1 aggregate twin
+//!
+//! Every GT site is gated on `test->verbose` (iperf_api.c:4280/4324/4371/
+//! 4395, SUM :4451): a NON-verbose server prints nothing for the unmeasured
+//! half (riperf3 already matched that), and the client never prints
+//! placeholders at all — it measures/exchanges both halves.
+
+use std::process::{Command, Stdio};
+use std::time::Duration;
+
+mod common;
+use common::ChildGuard;
+
+const SENDER_NA: &str = "] (sender statistics not available)";
+const RECEIVER_NA: &str = "] (receiver statistics not available)";
+
+fn spawn_server(extra: &[&str], port: &str) -> ChildGuard {
+    let mut args = vec!["-s", "-1", "-p", port];
+    args.extend_from_slice(extra);
+    ChildGuard(
+        Command::new(env!("CARGO_BIN_EXE_riperf3"))
+            .args(&args)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .expect("spawn server"),
+    )
+}
+
+fn collect(mut child: ChildGuard, who: &str) -> String {
+    use std::io::Read;
+    let deadline = std::time::Instant::now() + Duration::from_secs(10);
+    while child.0.try_wait().expect("try_wait").is_none() {
+        assert!(std::time::Instant::now() < deadline, "{who}: did not exit");
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    let mut out = String::new();
+    if let Some(mut s) = child.0.stdout.take() {
+        let _ = s.read_to_string(&mut out);
+    }
+    out
+}
+
+fn run(server_extra: &[&str], client_extra: &[&str]) -> (String, String) {
+    let ps = common::free_port().to_string();
+    let server = spawn_server(server_extra, &ps);
+    std::thread::sleep(Duration::from_millis(300));
+    let mut args = vec!["-c", "127.0.0.1", "-p", &ps, "-t", "1", "-b", "5M"];
+    args.extend_from_slice(client_extra);
+    let client = common::run_client(&args, Duration::from_secs(30), "client");
+    let sout = collect(server, "server");
+    assert_eq!(client.status.code(), Some(0), "{}", client.stderr);
+    (sout, client.stdout)
+}
+
+/// The final block of the server's output (after the dashed separator).
+fn final_block(sout: &str) -> &str {
+    sout.rsplit("- - - - - - -")
+        .next()
+        .expect("final summary separator")
+}
+
+/// Forward -V: GT prints the sender placeholder BETWEEN the header and the
+/// receiver row (the sender row's canonical slot).
+#[test]
+fn verbose_forward_server_prints_sender_placeholder_before_receiver_row() {
+    let (sout, _) = run(&["-V"], &[]);
+    let block = final_block(&sout);
+    let ph = block
+        .find(SENDER_NA)
+        .unwrap_or_else(|| panic!("no sender placeholder in the -V final block: {block}"));
+    let recv_row = block
+        .find("            receiver")
+        .or_else(|| block.find("  receiver"))
+        .expect("receiver row");
+    assert!(
+        ph < recv_row,
+        "the placeholder takes the sender row's slot, BEFORE the receiver row: {block}"
+    );
+    assert!(
+        !block.contains(RECEIVER_NA),
+        "the measured half gets no placeholder: {block}"
+    );
+}
+
+/// Reverse -V: the receiver placeholder comes AFTER the sender row.
+#[test]
+fn verbose_reverse_server_prints_receiver_placeholder_after_sender_row() {
+    let (sout, _) = run(&["-V"], &["-R"]);
+    let block = final_block(&sout);
+    let ph = block
+        .find(RECEIVER_NA)
+        .unwrap_or_else(|| panic!("no receiver placeholder in the -V final block: {block}"));
+    let send_row = block.find("  sender").expect("sender row");
+    assert!(
+        ph > send_row,
+        "the placeholder takes the receiver row's slot, AFTER the sender row: {block}"
+    );
+    assert!(!block.contains(SENDER_NA), "{block}");
+}
+
+/// P=2 -V: one placeholder per stream plus the [SUM] twin, each in its
+/// direction's slot (GT live: `[SUM] (sender statistics not available)`
+/// directly before the SUM receiver row).
+#[test]
+fn verbose_parallel_server_prints_per_stream_and_sum_placeholders() {
+    let (sout, _) = run(&["-V"], &["-P", "2"]);
+    let block = final_block(&sout);
+    assert_eq!(
+        block.matches(SENDER_NA).count(),
+        3,
+        "two per-stream placeholders + the SUM twin: {block}"
+    );
+    let sum_lines: Vec<&str> = block.lines().filter(|l| l.starts_with("[SUM]")).collect();
+    assert_eq!(
+        sum_lines.len(),
+        2,
+        "exactly the SUM placeholder + the SUM receiver row: {block}"
+    );
+    assert!(
+        sum_lines[0].contains(SENDER_NA) && sum_lines[1].contains("receiver"),
+        "the SUM placeholder precedes the SUM receiver row (GT order): {block}"
+    );
+}
+
+/// The verbose gate: a PLAIN server prints no placeholder (GT same), and a
+/// -V CLIENT never prints one on either side (it measures both halves).
+#[test]
+fn placeholders_are_verbose_only_and_server_only() {
+    let (sout, _) = run(&[], &[]);
+    assert!(
+        !sout.contains("statistics not available"),
+        "non-verbose server prints nothing for the unmeasured half: {sout}"
+    );
+
+    let (_, cout) = run(&[], &["-V"]);
+    assert!(
+        !cout.contains("statistics not available"),
+        "the client never prints placeholders: {cout}"
+    );
+}

--- a/riperf3-cli/tests/server_placeholders.rs
+++ b/riperf3-cli/tests/server_placeholders.rs
@@ -163,7 +163,9 @@ fn verbose_udp_parallel_server_prints_no_sum_placeholder() {
         "no [SUM] placeholder on UDP (GT's UDP sum block has no such branch): {block}"
     );
     assert!(
-        block.lines().any(|l| l.starts_with("[SUM]") && l.contains("receiver")),
+        block
+            .lines()
+            .any(|l| l.starts_with("[SUM]") && l.contains("receiver")),
         "the measured UDP SUM receiver row still prints: {block}"
     );
 }

--- a/riperf3-cli/tests/server_placeholders.rs
+++ b/riperf3-cli/tests/server_placeholders.rs
@@ -126,6 +126,26 @@ fn verbose_parallel_server_prints_per_stream_and_sum_placeholders() {
         sum_lines[0].contains(SENDER_NA) && sum_lines[1].contains("receiver"),
         "the SUM placeholder precedes the SUM receiver row (GT order): {block}"
     );
+    // r2 mutation (d): the server's row ORDER itself — per-stream rows
+    // first, [SUM] rows after — was unpinned (a SUMs-first re-inline
+    // survived the whole suite while producing grossly un-GT output).
+    let last_stream_row = block
+        .lines()
+        .enumerate()
+        .filter(|(_, l)| l.starts_with("[  ") && l.contains("sec"))
+        .map(|(i, _)| i)
+        .last()
+        .expect("per-stream rows");
+    let first_sum_row = block
+        .lines()
+        .enumerate()
+        .find(|(_, l)| l.starts_with("[SUM]"))
+        .map(|(i, _)| i)
+        .expect("SUM rows");
+    assert!(
+        last_stream_row < first_sum_row,
+        "per-stream rows precede every [SUM] row (GT order): {block}"
+    );
 }
 
 /// The verbose gate: a PLAIN server prints no placeholder (GT same), and a

--- a/riperf3-cli/tests/server_placeholders.rs
+++ b/riperf3-cli/tests/server_placeholders.rs
@@ -144,3 +144,56 @@ fn placeholders_are_verbose_only_and_server_only() {
         "the client never prints placeholders: {cout}"
     );
 }
+
+/// r1 blocker: GT's UDP summary-sum block has NO placeholder branch
+/// (iperf_api.c:4517-4538 silently skips the unmeasured half's SUM row;
+/// only the TCP/SCTP block has the [SUM] twins at :4451/:4463/:4483) — a
+/// UDP -P 2 -V server prints per-stream placeholders but NEVER a [SUM] one.
+#[test]
+fn verbose_udp_parallel_server_prints_no_sum_placeholder() {
+    let (sout, _) = run(&["-V"], &["-u", "-P", "2"]);
+    let block = final_block(&sout);
+    assert_eq!(
+        block.matches(SENDER_NA).count(),
+        2,
+        "per-stream UDP placeholders only — GT prints no UDP [SUM] twin: {block}"
+    );
+    assert!(
+        !block.contains(&format!("[SUM{SENDER_NA}")),
+        "no [SUM] placeholder on UDP (GT's UDP sum block has no such branch): {block}"
+    );
+    assert!(
+        block.lines().any(|l| l.starts_with("[SUM]") && l.contains("receiver")),
+        "the measured UDP SUM receiver row still prints: {block}"
+    );
+}
+
+/// Bidir -V: both placeholder kinds appear, each adjacent to its stream's
+/// measured row, and placeholder lines carry NO bidir role tag — GT prints
+/// a plain `[  5] (sender statistics not available)`, never `[  5][RX-S]`
+/// (live capture; r1 mutation (c) survived without this pin).
+#[test]
+fn verbose_bidir_server_placeholders_carry_no_role_tag() {
+    let (sout, _) = run(&["-V"], &["--bidir"]);
+    let block = final_block(&sout);
+    let phs: Vec<&str> = block
+        .lines()
+        .filter(|l| l.contains("statistics not available"))
+        .collect();
+    assert_eq!(
+        phs.len(),
+        2,
+        "one placeholder per direction (sender twin for the RX stream, \
+         receiver twin for the TX stream): {block}"
+    );
+    for ph in &phs {
+        assert!(
+            !ph.contains("][") && !ph.contains("-S]"),
+            "placeholder rows carry NO role tag (GT shape): {ph}"
+        );
+    }
+    assert!(
+        block.contains(SENDER_NA) && block.contains(RECEIVER_NA),
+        "both directions get their twin: {block}"
+    );
+}

--- a/riperf3/src/reporter.rs
+++ b/riperf3/src/reporter.rs
@@ -310,21 +310,24 @@ pub fn print_summary(summary: &StreamSummary, format_char: char) {
     ));
 }
 
-/// Build the full set of final-report lines for a set of per-stream summaries:
-/// the per-stream lines followed by aggregate `[SUM]` rows. Pure and testable.
-/// Both the client and the server route their final report through this so the
-/// two sides stay consistent: issue #4 was the final `[SUM]` row being omitted
-/// for `-P > 1` (the client fix landed first, then the server), and a single
-/// shared path keeps either side from regressing independently.
+/// The final report's row set for a set of per-stream summaries: the
+/// per-stream rows followed by aggregate `[SUM]` rows. BOTH printers (the
+/// client's and the server's) consume this single source so the two sides
+/// stay consistent: issue #4 was the final `[SUM]` row being omitted for
+/// `-P > 1` (the client fix landed first, then the server), and a shared
+/// row source keeps either side from regressing independently (r1 item 3).
+fn final_summary_rows(per_stream: &[StreamSummary]) -> Vec<StreamSummary> {
+    let mut rows = per_stream.to_vec();
+    rows.extend(sum_summaries(per_stream));
+    rows
+}
+
+/// Build the full set of final-report lines. Pure and testable.
 pub fn final_report_lines(per_stream: &[StreamSummary], format_char: char) -> Vec<String> {
-    let mut lines: Vec<String> = per_stream
+    final_summary_rows(per_stream)
         .iter()
         .map(|s| format_summary_line(s, format_char))
-        .collect();
-    for sum in sum_summaries(per_stream) {
-        lines.push(format_summary_line(&sum, format_char));
-    }
-    lines
+        .collect()
 }
 
 /// Print the final report (per-stream summaries + aggregate `[SUM]` rows).
@@ -337,7 +340,8 @@ pub fn print_final_summaries(per_stream: &[StreamSummary], format_char: char) {
 /// The server's `-V` placeholder for the unmeasured half of a summary row
 /// (#246): GT's report_*_not_available formats (iperf_locale.c:468-471) —
 /// a plain `[%3d]`/`[SUM]` prefix with NO bidir role tag, gated on verbose
-/// at every GT site (iperf_api.c:4280/4324/4371/4395, SUM at :4451).
+/// at every GT site (per-stream: iperf_api.c:4268/4280/4324/4371/4395;
+/// SUM, TCP-only: :4451/:4463 sender, :4483 receiver).
 fn not_available_line(stream_id: i32, half: &str) -> String {
     format!("[{}] ({half} statistics not available)", fmt_id(stream_id))
 }
@@ -345,24 +349,29 @@ fn not_available_line(stream_id: i32, half: &str) -> String {
 /// Server-role final report (#246): like [`print_final_summaries`], but
 /// under `-V` each row's unmeasured half renders GT's placeholder in that
 /// half's canonical slot — "(sender ...)" BEFORE a receiver row (the sender
-/// row prints first in iperf3's pair), "(receiver ...)" AFTER a sender row,
-/// `[SUM]` rows included. The client never prints placeholders: it measures
-/// or exchanges both halves of every stream.
+/// row prints first in iperf3's pair), "(receiver ...)" AFTER a sender row.
+/// `[SUM]` rows get the twin ONLY for TCP: GT's UDP summary-sum block
+/// (iperf_api.c:4517-4538) has no placeholder branch and silently skips the
+/// unmeasured half (r1 blocker — live-verified: a UDP -P 2 -V GT server
+/// prints per-stream placeholders but never a [SUM] one). The client never
+/// prints placeholders: it measures or exchanges both halves.
 pub fn print_final_summaries_server(
     per_stream: &[StreamSummary],
     format_char: char,
     verbose: bool,
 ) {
-    let sums = sum_summaries(per_stream);
-    for s in per_stream.iter().chain(sums.iter()) {
-        if verbose && !s.is_sender {
+    for s in final_summary_rows(per_stream) {
+        // UDP SUM rows carry datagram stats; that's GT's no-placeholder arm.
+        let udp_sum = s.stream_id < 0 && s.total_packets.is_some();
+        let placeholder = verbose && !udp_sum;
+        if placeholder && !s.is_sender {
             titled(format_args!(
                 "{}",
                 not_available_line(s.stream_id, "sender")
             ));
         }
-        titled(format_args!("{}", format_summary_line(s, format_char)));
-        if verbose && s.is_sender {
+        titled(format_args!("{}", format_summary_line(&s, format_char)));
+        if placeholder && s.is_sender {
             titled(format_args!(
                 "{}",
                 not_available_line(s.stream_id, "receiver")

--- a/riperf3/src/reporter.rs
+++ b/riperf3/src/reporter.rs
@@ -334,6 +334,43 @@ pub fn print_final_summaries(per_stream: &[StreamSummary], format_char: char) {
     }
 }
 
+/// The server's `-V` placeholder for the unmeasured half of a summary row
+/// (#246): GT's report_*_not_available formats (iperf_locale.c:468-471) —
+/// a plain `[%3d]`/`[SUM]` prefix with NO bidir role tag, gated on verbose
+/// at every GT site (iperf_api.c:4280/4324/4371/4395, SUM at :4451).
+fn not_available_line(stream_id: i32, half: &str) -> String {
+    format!("[{}] ({half} statistics not available)", fmt_id(stream_id))
+}
+
+/// Server-role final report (#246): like [`print_final_summaries`], but
+/// under `-V` each row's unmeasured half renders GT's placeholder in that
+/// half's canonical slot — "(sender ...)" BEFORE a receiver row (the sender
+/// row prints first in iperf3's pair), "(receiver ...)" AFTER a sender row,
+/// `[SUM]` rows included. The client never prints placeholders: it measures
+/// or exchanges both halves of every stream.
+pub fn print_final_summaries_server(
+    per_stream: &[StreamSummary],
+    format_char: char,
+    verbose: bool,
+) {
+    let sums = sum_summaries(per_stream);
+    for s in per_stream.iter().chain(sums.iter()) {
+        if verbose && !s.is_sender {
+            titled(format_args!(
+                "{}",
+                not_available_line(s.stream_id, "sender")
+            ));
+        }
+        titled(format_args!("{}", format_summary_line(s, format_char)));
+        if verbose && s.is_sender {
+            titled(format_args!(
+                "{}",
+                not_available_line(s.stream_id, "receiver")
+            ));
+        }
+    }
+}
+
 /// Derive the aggregate `[SUM]` rows for the final report from the per-stream
 /// summaries. Returns one SUM per (role, line-direction) group that has more
 /// than one stream — matching iperf3, which prints a `[SUM]` for parallel

--- a/riperf3/src/reporter.rs
+++ b/riperf3/src/reporter.rs
@@ -359,10 +359,14 @@ pub fn print_final_summaries_server(
     per_stream: &[StreamSummary],
     format_char: char,
     verbose: bool,
+    protocol: crate::TransportProtocol,
 ) {
+    let is_udp = matches!(protocol, crate::TransportProtocol::Udp);
     for s in final_summary_rows(per_stream) {
-        // UDP SUM rows carry datagram stats; that's GT's no-placeholder arm.
-        let udp_sum = s.stream_id < 0 && s.total_packets.is_some();
+        // r2 item 2: the protocol arrives explicitly — shape-sniffing the
+        // row (total_packets presence) was sound but fragile against a
+        // poisoned-stats fallback flipping a UDP SUM into the TCP arm.
+        let udp_sum = s.stream_id < 0 && is_udp;
         let placeholder = verbose && !udp_sum;
         if placeholder && !s.is_sender {
             titled(format_args!(

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -997,7 +997,7 @@ impl Server {
                 vprintln!("Test Complete. Summary Results:");
             }
             crate::reporter::print_final_header(cfg.protocol, cfg.bidir, with_retr);
-            crate::reporter::print_final_summaries(&summaries, 'a');
+            crate::reporter::print_final_summaries_server(&summaries, 'a', self.verbose);
             if self.verbose && streams.iter().any(|s| s.is_sender) {
                 // GT gates the CPU line on the SENDING side (iperf_api.c:
                 // 4563): a -R server prints it, with ZERO remote figures —
@@ -1161,7 +1161,7 @@ impl Server {
                 vprintln!("Test Complete. Summary Results:");
             }
             crate::reporter::print_final_header(cfg.protocol, cfg.bidir, with_retr);
-            crate::reporter::print_final_summaries(&summaries, 'a');
+            crate::reporter::print_final_summaries_server(&summaries, 'a', self.verbose);
             if self.verbose && streams.iter().any(|s| s.is_sender) {
                 // GT gates the CPU line on the SENDING side (iperf_api.c:
                 // 4563): a -R server prints it, with ZERO remote figures —

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -997,7 +997,12 @@ impl Server {
                 vprintln!("Test Complete. Summary Results:");
             }
             crate::reporter::print_final_header(cfg.protocol, cfg.bidir, with_retr);
-            crate::reporter::print_final_summaries_server(&summaries, 'a', self.verbose);
+            crate::reporter::print_final_summaries_server(
+                &summaries,
+                'a',
+                self.verbose,
+                cfg.protocol,
+            );
             if self.verbose && streams.iter().any(|s| s.is_sender) {
                 // GT gates the CPU line on the SENDING side (iperf_api.c:
                 // 4563): a -R server prints it, with ZERO remote figures —
@@ -1161,7 +1166,12 @@ impl Server {
                 vprintln!("Test Complete. Summary Results:");
             }
             crate::reporter::print_final_header(cfg.protocol, cfg.bidir, with_retr);
-            crate::reporter::print_final_summaries_server(&summaries, 'a', self.verbose);
+            crate::reporter::print_final_summaries_server(
+                &summaries,
+                'a',
+                self.verbose,
+                cfg.protocol,
+            );
             if self.verbose && streams.iter().any(|s| s.is_sender) {
                 // GT gates the CPU line on the SENDING side (iperf_api.c:
                 // 4563): a -R server prints it, with ZERO remote figures —


### PR DESCRIPTION
> **GT** = ground truth: the pinned reference **iperf 3.21**, built from source at commit `d39cf41526626b4e5a130f115d931cd6cbdffc19`, that riperf3's wire/behavior faithfulness is captured from and verified against (source-line citations like `iperf_api.c:4288` refer to that tree).

Fixes #246.

## The discovery that reshaped the issue

The placeholder rows are **`-V`-gated in GT** — every emission site checks `test->verbose` (iperf_api.c:4280/4324/4371/4395, `[SUM]` at :4451; formats in iperf_locale.c:468-471). A plain GT server prints *nothing* for the unmeasured half — which riperf3 already matched. The issue's "visible in every live GT server capture" evidence came from the `-V` baselines. Live-verified both ways this session (plain captures: no placeholder; `-V` captures: fwd/`-R`/`-P 2`/`--bidir`/UDP all show them).

## Shape rule (GT captures)

The placeholder takes the missing half's canonical slot: sender placeholder **before** a receiver row, receiver placeholder **after** a sender row, `[SUM]` twin for P>1, **no bidir role tag** on placeholder rows. Row-driven, so UDP and bidir fall out of the same arm.

## Implementation

`print_final_summaries_server(per_stream, fmt, verbose)` in the reporter; both server render sites call it (the client keeps the untouched printer — GT's client never prints placeholders). Live side-by-side: the riperf3 `-V` forward final block matches GT line-for-line.

## Tests (red-first)

fwd before-receiver position, `-R` after-sender position, P=2 per-stream + `[SUM]` ordering, and the double gate pin (plain server: nothing; `-V` client: never). 3 red → green; the gate pin was green from the start (correct non-verbose behavior preserved).

## Known adjacent divergence (out of scope)

GT's bidir `-V` block interleaves per-pass congestion/CPU lines between the direction groups (its two-pass loop structure); riperf3 prints them once at the end — pre-existing #243-class block-layout territory, placeholders land in the right slots either way. Noted for the wave ledger.

## Merge-train note

Both call sites textually collide with PR #250's `-f` wiring (same lines: `'a'` → `self.format_char`). Whichever merges second takes a trivial rebase to `print_final_summaries_server(&summaries, self.format_char, self.verbose)`.

