### PR TITLE
fix: arm the interrupt watch at the client's central state wait (#231)

### DIFF
--- a/riperf3-cli/tests/signal_terminate.rs
+++ b/riperf3-cli/tests/signal_terminate.rs
@@ -270,3 +270,60 @@ fn server_json_stream_emits_the_error_event_before_end() {
         "error precedes end, like iperf_json_finish:\n{sout}"
     );
 }
+
+/// #231: a SIGTERM while the client waits BETWEEN states (here: a raw server
+/// that accepts the control connection, reads the cookie, then goes silent —
+/// the client parks in its central recv_state wait, pre-ParamExchange) must
+/// take the same iperf_got_sigend path as a mid-test signal: dump, attempt
+/// CLIENT_TERMINATE, print the signal-normal line, exit 0. GT's
+/// iperf_catch_sigend is armed for the whole run with no phase gate
+/// (iperf_api.c: the client condition in iperf_got_sigend). Pre-#231 the
+/// unarmed wait ignored the first signal entirely (only #211's second-signal
+/// hard exit, which skips the dump, ever fired).
+#[test]
+fn client_sigterm_in_setup_wait_exits_promptly() {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind mock");
+    let port = listener.local_addr().unwrap().port().to_string();
+    let hold = std::thread::spawn(move || {
+        if let Ok((mut s, _)) = listener.accept() {
+            let mut cookie = [0u8; 37];
+            let _ = s.read_exact(&mut cookie);
+            // Stay silent; the socket drops when the thread ends.
+            std::thread::sleep(Duration::from_secs(15));
+        }
+    });
+
+    let client = spawn(&["-c", "127.0.0.1", "-p", &port, "-t", "5"]);
+    // Enough for connect + cookie write + parking in the state wait, even on
+    // a loaded runner; well inside the mock's 15 s silence.
+    std::thread::sleep(Duration::from_millis(700));
+    let cpid = client.0.id() as i32;
+    let killed_at = Instant::now();
+    unsafe {
+        libc::kill(cpid, libc::SIGTERM);
+    }
+
+    let (cout, cerr, ccode) =
+        wait_with_output_bounded(client, Duration::from_secs(8), "client in setup wait");
+    // PROMPTNESS is the pin: the CLI's #211 fallback produces the same exit
+    // shape after its 5 s dump-window timeout, so only the latency separates
+    // "the lib honored the watch" from "the fallback fired".
+    let reacted_in = killed_at.elapsed();
+    assert!(
+        reacted_in < Duration::from_secs(3),
+        "the signal must be honored AT the wait, not via the CLI's 5 s \
+         fallback window (#231): took {reacted_in:?}"
+    );
+    // And the DUMP is the other pin: iperf_got_sigend dumps for clients in
+    // EVERY phase (no phase gate); the fallback path prints no summary.
+    assert!(
+        cout.contains("- - - - -"),
+        "the accumulated-stats dump (empty rows pre-data, like GT): {cout}"
+    );
+    assert!(
+        cerr.contains("interrupt - the client has terminated by signal"),
+        "the signal-normal line from the setup-phase wait: {cerr:?}"
+    );
+    assert_eq!(ccode, 0, "TERM takes the exit-normal path: {cerr:?}");
+    drop(hold); // detached; the spawned thread dies with the process
+}

--- a/riperf3-cli/tests/signal_terminate.rs
+++ b/riperf3-cli/tests/signal_terminate.rs
@@ -327,3 +327,122 @@ fn client_sigterm_in_setup_wait_exits_promptly() {
     assert_eq!(ccode, 0, "TERM takes the exit-normal path: {cerr:?}");
     drop(hold); // detached; the spawned thread dies with the process
 }
+
+/// #231 r2 pin (mutation A): a dump for a test that never STARTED reports a
+/// ZERO-second window — GT's pre-data sigend dump says 0/0/0 where the old
+/// code asserted the requested -t that never ran.
+#[test]
+fn pre_data_interrupt_dump_reports_a_zero_window() {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind mock");
+    let port = listener.local_addr().unwrap().port().to_string();
+    let _hold = std::thread::spawn(move || {
+        if let Ok((mut s, _)) = listener.accept() {
+            let mut cookie = [0u8; 37];
+            let _ = s.read_exact(&mut cookie);
+            std::thread::sleep(Duration::from_secs(15));
+        }
+    });
+
+    let client = spawn(&["-c", "127.0.0.1", "-p", &port, "-t", "5", "-J"]);
+    std::thread::sleep(Duration::from_millis(700));
+    unsafe {
+        libc::kill(client.0.id() as i32, libc::SIGTERM);
+    }
+    let (cout, _cerr, ccode) =
+        wait_with_output_bounded(client, Duration::from_secs(8), "client -J pre-data");
+    assert_eq!(ccode, 0);
+    let doc: serde_json::Value =
+        serde_json::from_str(cout.trim()).unwrap_or_else(|e| panic!("one -J doc ({e}): {cout}"));
+    for key in ["sum_sent", "sum_received"] {
+        assert_eq!(
+            doc["end"][key]["seconds"].as_f64(),
+            Some(0.0),
+            "a never-started test reports a zero window (GT 0/0/0), not the \
+             requested -t: {doc}"
+        );
+    }
+}
+
+/// #231 r2 pin (mutation B): an interrupt AFTER ExchangeResults keeps the
+/// already-exchanged peer halves in the dump, like GT's merged sigend dump.
+/// The mock speaks the full protocol through the exchange (crafted peer
+/// bytes 424242), then stalls before DisplayResults.
+#[test]
+fn post_exchange_interrupt_dump_keeps_the_peer_halves() {
+    use std::io::Write;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::Arc;
+
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind mock");
+    let port = listener.local_addr().unwrap().port().to_string();
+    let exchanged = Arc::new(AtomicBool::new(false));
+    let exchanged_w = exchanged.clone();
+
+    let _mock = std::thread::spawn(move || {
+        let read_exact = |s: &mut std::net::TcpStream, n: usize| -> Vec<u8> {
+            let mut b = vec![0u8; n];
+            s.read_exact(&mut b).expect("mock read");
+            b
+        };
+        let read_json = |s: &mut std::net::TcpStream| {
+            let len = u32::from_be_bytes(read_exact(s, 4).try_into().unwrap()) as usize;
+            read_exact(s, len)
+        };
+        let write_json = |s: &mut std::net::TcpStream, payload: &str| {
+            s.write_all(&(payload.len() as u32).to_be_bytes()).unwrap();
+            s.write_all(payload.as_bytes()).unwrap();
+        };
+
+        let (mut ctrl, _) = listener.accept().expect("ctrl accept");
+        read_exact(&mut ctrl, 37); // cookie
+        ctrl.write_all(&[9u8]).unwrap(); // ParamExchange
+        read_json(&mut ctrl); // params
+        ctrl.write_all(&[10u8]).unwrap(); // CreateStreams
+        let (mut data, _) = listener.accept().expect("data accept");
+        read_exact(&mut data, 37); // data-stream cookie
+        ctrl.write_all(&[1u8]).unwrap(); // TestStart
+        ctrl.write_all(&[2u8]).unwrap(); // TestRunning
+                                         // Drain the -n payload so the sender never blocks, until TestEnd(4)
+                                         // arrives on ctrl.
+        let drain = std::thread::spawn(move || {
+            let mut buf = vec![0u8; 65536];
+            while data.read(&mut buf).map(|n| n > 0).unwrap_or(false) {}
+        });
+        assert_eq!(read_exact(&mut ctrl, 1)[0], 4, "TestEnd");
+        ctrl.write_all(&[13u8]).unwrap(); // ExchangeResults
+        read_json(&mut ctrl); // the client's results
+        write_json(
+            &mut ctrl,
+            r#"{"cpu_util_total":1.5,"cpu_util_user":1.0,"cpu_util_system":0.5,"sender_has_retransmits":0,"streams":[{"id":1,"bytes":424242,"retransmits":0,"jitter":0,"errors":0,"packets":0,"start_time":0,"end_time":1}]}"#,
+        );
+        exchanged_w.store(true, Ordering::SeqCst);
+        // Stall before DisplayResults: the client parks in the state wait.
+        std::thread::sleep(Duration::from_secs(15));
+        drop(drain);
+    });
+
+    let client = spawn(&["-c", "127.0.0.1", "-p", &port, "-n", "100K", "-J"]);
+    let t0 = Instant::now();
+    while !exchanged.load(std::sync::atomic::Ordering::SeqCst) {
+        assert!(
+            t0.elapsed() < Duration::from_secs(10),
+            "mock never reached the exchange"
+        );
+        std::thread::sleep(Duration::from_millis(25));
+    }
+    std::thread::sleep(Duration::from_millis(300)); // park in the state wait
+    unsafe {
+        libc::kill(client.0.id() as i32, libc::SIGTERM);
+    }
+    let (cout, _cerr, ccode) =
+        wait_with_output_bounded(client, Duration::from_secs(8), "client post-exchange");
+    assert_eq!(ccode, 0);
+    let doc: serde_json::Value =
+        serde_json::from_str(cout.trim()).unwrap_or_else(|e| panic!("one -J doc ({e}): {cout}"));
+    assert_eq!(
+        doc["end"]["sum_received"]["bytes"].as_i64(),
+        Some(424242),
+        "the exchanged peer half must survive into the interrupt dump \
+         (GT merges exchanged data before its sigend dump): {doc}"
+    );
+}

--- a/riperf3/src/client.rs
+++ b/riperf3/src/client.rs
@@ -404,10 +404,21 @@ impl Client {
                 s = protocol::recv_state(&mut ctrl) => s?,
                 msg = wait_interrupt(interrupt.as_mut()) => {
                     let _ = protocol::send_state(&mut ctrl, TestState::ClientTerminate).await;
+                    // r1 item 5: a test that never STARTED reports a zero
+                    // window (GT's pre-data dump says 0/0/0), not the
+                    // requested -t default measured_secs still holds.
+                    let dump_secs = if test_start_millis > 0 {
+                        measured_secs
+                    } else {
+                        0.0
+                    };
                     self.print_results(
                         &streams,
                         cpu_start.as_ref(),
-                        None,
+                        // r1 item 7: post-ExchangeResults interrupts keep the
+                        // peer halves GT would show (its sigend dump merges
+                        // already-exchanged data); None only pre-exchange.
+                        server_results.as_ref(),
                         blksize,
                         &interval_data,
                         &StartMeta {
@@ -418,14 +429,14 @@ impl Client {
                             tcp_mss_default: control_mss,
                             start_time_millis: test_start_millis,
                         },
-                        measured_secs,
+                        dump_secs,
                         Some(&msg),
                     );
                     return Ok(self.build_results(
                         &streams,
                         cpu_start.as_ref(),
                         blksize,
-                        measured_secs,
+                        dump_secs,
                     ));
                 }
             };

--- a/riperf3/src/client.rs
+++ b/riperf3/src/client.rs
@@ -388,7 +388,47 @@ impl Client {
 
         // ---- State machine: react to server-driven transitions ----
         loop {
-            let state = protocol::recv_state(&mut ctrl).await?;
+            // #231: iperf_catch_sigend is armed for the WHOLE run, so the
+            // central state wait polls the interrupt watch like the
+            // TEST_RUNNING selects — covering the setup phases AND the
+            // post-test ExchangeResults/DisplayResults waits, which
+            // previously ignored a signal until the control read returned
+            // (against a wedged server: forever, with only the CLI's #211
+            // second-signal hard exit as the way out). iperf_got_sigend's
+            // client arm has NO phase gate: it dumps the accumulated stats
+            // from any phase (empty rows pre-data), tells the peer via
+            // CLIENT_TERMINATE, and exits signal-normal — the same shape as
+            // the run_test arm. recv_state is a single 1-byte read, so the
+            // select is cancel-safe.
+            let state = tokio::select! {
+                s = protocol::recv_state(&mut ctrl) => s?,
+                msg = wait_interrupt(interrupt.as_mut()) => {
+                    let _ = protocol::send_state(&mut ctrl, TestState::ClientTerminate).await;
+                    self.print_results(
+                        &streams,
+                        cpu_start.as_ref(),
+                        None,
+                        blksize,
+                        &interval_data,
+                        &StartMeta {
+                            cookie: String::from_utf8_lossy(
+                                &cookie[..protocol::COOKIE_SIZE - 1],
+                            )
+                            .into_owned(),
+                            tcp_mss_default: control_mss,
+                            start_time_millis: test_start_millis,
+                        },
+                        measured_secs,
+                        Some(&msg),
+                    );
+                    return Ok(self.build_results(
+                        &streams,
+                        cpu_start.as_ref(),
+                        blksize,
+                        measured_secs,
+                    ));
+                }
+            };
 
             match state {
                 TestState::ParamExchange => {

--- a/riperf3/tests/integration.rs
+++ b/riperf3/tests/integration.rs
@@ -1770,6 +1770,53 @@ mod unimplemented_flags {
     }
 
     #[tokio::test]
+    async fn interrupt_honored_in_setup_phase_wait() {
+        // #231: iperf_catch_sigend is armed for the WHOLE run — a client
+        // whose interrupt watch fires while it waits on the control channel
+        // between states (here: a mock that accepts + reads the cookie, then
+        // goes silent pre-ParamExchange) must dump and return promptly,
+        // exactly like the TEST_RUNNING arm. Pre-#231 the central recv_state
+        // wait never polled the watch and run() blocked until the read
+        // returned.
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind mock");
+        let port = listener.local_addr().unwrap().port();
+        let mock = tokio::spawn(async move {
+            if let Ok((mut sock, _)) = listener.accept().await {
+                use tokio::io::AsyncReadExt;
+                let mut cookie = [0u8; 37];
+                let _ = sock.read_exact(&mut cookie).await;
+                // Silent hold, outliving the test body.
+                tokio::time::sleep(Duration::from_secs(20)).await;
+            }
+        });
+
+        let (tx, rx) = tokio::sync::watch::channel::<Option<String>>(None);
+        let client = ClientBuilder::new("127.0.0.1")
+            .port(Some(port))
+            .duration(5)
+            .interrupt(rx)
+            .build()
+            .unwrap();
+        let run = tokio::spawn(async move { client.run().await });
+        tokio::time::sleep(Duration::from_millis(400)).await;
+        tx.send(Some(
+            "interrupt - the client has terminated by signal Terminated(15)".into(),
+        ))
+        .unwrap();
+
+        let res = tokio::time::timeout(Duration::from_secs(3), run)
+            .await
+            .expect("the interrupt must be honored in the setup-phase wait (#231)")
+            .expect("join");
+        // GT dumps + returns normally (iperf_got_sigend's client arm has no
+        // phase gate); the signal-normal EXIT is the CLI's business.
+        assert!(res.is_ok(), "{res:?}");
+        mock.abort();
+    }
+
+    #[tokio::test]
     async fn server_max_duration() {
         // #230: --server-max-duration is an UPFRONT param-exchange check in
         // iperf3 (iperf_api.c:2666), not a timer — a -t 10 request against


### PR DESCRIPTION
> **GT** = ground truth: the pinned reference **iperf 3.21**, built from source at commit `d39cf41526626b4e5a130f115d931cd6cbdffc19`, that riperf3's wire/behavior faithfulness is captured from and verified against (source-line citations like `iperf_api.c:4288` refer to that tree).

Fixes #231.

## The gap

`iperf_catch_sigend` covers iperf3's whole client run. riperf3's #223 work armed `wait_interrupt` only in the three TEST_RUNNING end-condition selects — a signal landing in any other wait (the state waits between phases, or the post-test ExchangeResults/DisplayResults reads) was ignored until the control read returned. Against a wedged server: forever, with only the CLI's #211 second-signal hard exit (no dump) or its 5 s dump-window fallback (also no dump) as ways out.

## The fix

The client's **central `recv_state` wait** — the single site every state transition goes through — is now a select over the watch, reusing the run_test interrupt arm's shape: best-effort `CLIENT_TERMINATE`, dump the accumulated stats, return Ok, signal-normal exit stays the caller's. GT's `iperf_got_sigend` client arm has **no phase gate** (r1 verified the source: iperf_api.c:5151-5152) — pre-data the dump renders a **zero-second** window (r1 item 5) and a post-exchange interrupt keeps the already-exchanged peer halves like GT's merged dump (r1 item 7). `recv_state` is a 1-byte single-read, cancel-safe in a select (r1 traced both interleavings of the byte-vs-interrupt race: no lost signal — the watch latches — and no protocol corruption).

## Tests (red-first)

- Lib: a mock that accepts + reads the cookie then goes silent; firing the watch must unblock `run()` (red: 3 s timeout; green: 0.4 s).
- CLI: SIGTERM while parked in the setup wait, pinned on **promptness** — the #211 fallback produces the identical exit shape at exactly the 5 s window (red measured 5.016 s / r1's mutation re-measured 5.0098 s) — plus the dump block and the signal-normal line/exit-0. r1 flake-tested both 2-core-pinned and under load: stable.

## Residue (disclosed, out of scope — r1 items 6/8 + mutation c)

- Waits OUTSIDE the state loop stay interrupt-blind: the pre-loop connect/cookie write, the CreateStreams arm's internals (incl. the UDP connect handshake's up-to-30 s timeout), and the bulk `recv_results` read. CLI users are bounded by the 5 s fallback; lib consumers are not. Same follow-up family.
- The server's IperfDone wait ignores a CLIENT_TERMINATE state byte (`Ok(_) => continue`) where GT dumps + reports — pre-existing server code this PR merely makes reachable.
- The pre-data dump's Retr column/`retransmits` key divergence (GT pins by mode, we pin by data presence) — pre-existing print-path logic, text-parity-batch territory.
- The arm's CLIENT_TERMINATE send is untestable without a racy real-server fixture (r1 mutation c) — recorded as accepted coverage.

