### PR TITLE
feat: consume the peer's exchanged sent counts (remote_packets) (#235)

### DIFF
--- a/riperf3-cli/tests/udp_end_block_json.rs
+++ b/riperf3-cli/tests/udp_end_block_json.rs
@@ -146,3 +146,62 @@ fn udp_bidir_server_end_no_graft_zeros() {
         "but measured packets are real: {recv}"
     );
 }
+
+/// #235 r2 pin (mutation c): the attach NETS the peer's omitted baseline.
+/// Under -O the riperf3 server exchanges gross counts + a nonzero omitted
+/// baseline; the client's reverse sent figures must land on the NET count —
+/// which equals net bytes / blksize exactly for full-block riperf3 senders —
+/// where an un-netted attach reports the gross figure (larger by the omit
+/// window's datagrams).
+#[test]
+fn udp_reverse_omit_run_consumes_the_netted_exchanged_count() {
+    let _serial = common::udp_serial();
+    let ps = common::free_port().to_string();
+    let mut server = ChildGuard(
+        Command::new(env!("CARGO_BIN_EXE_riperf3"))
+            .args(["-s", "-1", "-p", &ps])
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("spawn server"),
+    );
+
+    let out = common::run_client_ok(
+        &[
+            "-c",
+            "127.0.0.1",
+            "-p",
+            &ps,
+            "-u",
+            "-R",
+            "-O",
+            "1",
+            "-t",
+            "1",
+            "-b",
+            "5M",
+            "-J",
+        ],
+        Duration::from_secs(40),
+        "client -u -R -O 1",
+    )
+    .stdout;
+    let _ = server.0.wait();
+
+    let v: serde_json::Value = serde_json::from_str(&out).expect("client doc parses");
+    let blksize = v["start"]["test_start"]["blksize"]
+        .as_i64()
+        .expect("blksize");
+    for key in ["sum", "sum_sent"] {
+        let bytes = v["end"][key]["bytes"].as_i64().expect("bytes");
+        let packets = v["end"][key]["packets"].as_i64().expect("packets");
+        assert_eq!(
+            packets,
+            bytes / blksize,
+            "{key}: the exchanged figure must be the NET count (net bytes/blk \
+             for a full-block riperf3 sender) — gross would exceed it by the \
+             omit window: {v}"
+        );
+        assert!(packets > 0, "{key}: a real transfer happened: {v}");
+    }
+}

--- a/riperf3/src/client.rs
+++ b/riperf3/src/client.rs
@@ -1925,11 +1925,14 @@ impl Client {
                     is_sender: s.is_sender,
                     local_bytes,
                     remote_bytes: server_stream.map(|x| x.bytes),
-                    // #235: the peer's exchanged SENT datagram count, net of
-                    // its omitted baseline — GT's peer_packet_count. Exact
-                    // where the bytes-derived figure loses the tail partial
-                    // datagram.
-                    remote_packets: server_stream.map(|x| x.packets - x.omitted_packets),
+                    // #235: the peer's exchanged SENT datagram count, net
+                    // of its omitted baseline — exact when the peer keeps
+                    // true counters (iperf3); riperf3 peers exchange
+                    // bytes-derived figures until #235's counter half.
+                    // saturating: the #24 sentinel-hardening posture for
+                    // adversarial gross/omitted pairs.
+                    remote_packets: server_stream
+                        .map(|x| x.packets.saturating_sub(x.omitted_packets)),
                     retransmits,
                     tcp_end,
                     udp,

--- a/riperf3/src/client.rs
+++ b/riperf3/src/client.rs
@@ -1925,6 +1925,11 @@ impl Client {
                     is_sender: s.is_sender,
                     local_bytes,
                     remote_bytes: server_stream.map(|x| x.bytes),
+                    // #235: the peer's exchanged SENT datagram count, net of
+                    // its omitted baseline — GT's peer_packet_count. Exact
+                    // where the bytes-derived figure loses the tail partial
+                    // datagram.
+                    remote_packets: server_stream.map(|x| x.packets - x.omitted_packets),
                     retransmits,
                     tcp_end,
                     udp,

--- a/riperf3/src/json_report.rs
+++ b/riperf3/src/json_report.rs
@@ -568,6 +568,13 @@ pub struct StreamReport {
     /// UDP receiver stats (jitter seconds, lost, total packets, out-of-order),
     /// from whichever side measured them. `None` for TCP.
     pub udp: Option<UdpStreamStats>,
+    /// The peer's exchanged per-stream SENT datagram count, net of its
+    /// omitted baseline (#235) — GT's `peer_packet_count` (parsed at
+    /// iperf_api.c:2942, consumed as the receiving side's sender count at
+    /// :4227). `None` when the peer never reported (terminated runs, odd
+    /// peers); consumers fall back to the bytes-derived figure, which is
+    /// off by the tail partial datagram.
+    pub remote_packets: Option<i64>,
 }
 
 #[derive(Debug, Clone, Copy, Default)]
@@ -967,7 +974,11 @@ impl ReportInput {
             // figure is absent (iperf_api.c ~4242, the same fallback the
             // single-direction arm already uses).
             let fwd_sent_packets = (local_sent / blk) as i64;
-            let rev_sent_packets = (rev_sent / blk) as i64;
+            // #235: the reverse (peer-sent) figure prefers the exchanged
+            // true counts; bytes-derived only as the fallback.
+            let rev_sent_packets = self
+                .exchanged_sent_packets(false)
+                .unwrap_or((rev_sent / blk) as i64);
             let sum_fwd_packets = if fwd_sent_packets > 0 {
                 fwd_sent_packets
             } else {
@@ -1058,7 +1069,12 @@ impl ReportInput {
             } else {
                 peer_recv
             };
-            let sent_packets = (sent_bytes / blk) as i64;
+            // #235: when the sent side is the PEER's (-R), prefer its
+            // exchanged true counts over the bytes-derived figure.
+            let sent_packets = (!fwd_sender)
+                .then(|| self.exchanged_sent_packets(false))
+                .flatten()
+                .unwrap_or((sent_bytes / blk) as i64);
             // iperf3's `sum` packet count falls back to the RECEIVER count
             // when the sender count is absent (iperf_api.c:4242, the
             // `packet_count = sender ? sender : receiver` running total) —
@@ -1285,7 +1301,12 @@ impl ReportInput {
                 // the pct has no such fallback in iperf3 (#238).
                 let bytes = s.remote_bytes.unwrap_or(s.local_bytes);
                 let blk = self.blksize.max(1) as u64;
-                if bytes > 0 {
+                if let Some(rp) = s.remote_packets.filter(|&p| p > 0) {
+                    // #235: the peer's exchanged TRUE sent count — exact
+                    // where bytes/blk loses the tail partial datagram
+                    // (GT's peer_packet_count, iperf_api.c:4227).
+                    (bytes, rp, true)
+                } else if bytes > 0 {
                     (bytes, (bytes / blk) as i64, true)
                 } else {
                     (bytes, u.packets, false)
@@ -1434,6 +1455,24 @@ impl ReportInput {
             lost_percent: None,
             sender,
         }
+    }
+
+    /// #235: the sum of the peers' exchanged per-stream SENT counts for one
+    /// direction, when EVERY stream of that direction reported one — GT's
+    /// sender_total_packets running total over peer_packet_count
+    /// (iperf_api.c:4227/4245). All-or-nothing: a partial set (unreachable
+    /// with real peers — results carry every stream or none) falls back to
+    /// the caller's bytes-derived figure, preserving the #170 terminated
+    /// and odd-peer graft rules unchanged.
+    fn exchanged_sent_packets(&self, want_sender: bool) -> Option<i64> {
+        let counts: Vec<Option<i64>> = self
+            .streams
+            .iter()
+            .filter(|s| s.is_sender == want_sender)
+            .map(|s| s.remote_packets.filter(|&p| p > 0))
+            .collect();
+        (!counts.is_empty() && counts.iter().all(Option::is_some))
+            .then(|| counts.into_iter().flatten().sum())
     }
 
     /// `pct_packets` is the lost_percent DENOMINATOR — iperf3 computes one
@@ -1729,6 +1768,7 @@ mod tests {
             remote_bytes: remote,
             retransmits: None,
             tcp_end: None,
+            remote_packets: None,
             udp: Some(UdpStreamStats {
                 jitter_secs,
                 lost_packets: lost,
@@ -1952,6 +1992,130 @@ mod tests {
         );
     }
 
+    #[allow(clippy::too_many_arguments)] // fixture mirror of udp_stream + one
+    fn udp_stream_rp(
+        id: i32,
+        is_sender: bool,
+        local: u64,
+        remote: Option<u64>,
+        remote_packets: Option<i64>,
+        jitter_secs: f64,
+        lost: i64,
+        packets: i64,
+    ) -> StreamReport {
+        let mut s = udp_stream(id, is_sender, local, remote, jitter_secs, lost, packets);
+        s.remote_packets = remote_packets;
+        s
+    }
+
+    /// #235: where the peer's exchanged SENT count is present, it wins over
+    /// the bytes-derived figure — which is off by the tail partial datagram
+    /// (GT: sender_packet_count = peer_packet_count for receiving streams,
+    /// iperf_api.c:4227, a true counter, never bytes/blksize).
+    #[test]
+    fn udp_receiving_entries_prefer_the_exchanged_sender_count() {
+        let blk = 131_072u64;
+        // The peer sent 100 datagrams: 99 full blocks + a 500-byte tail.
+        let sent_bytes = blk * 99 + 500;
+        let mut input = base_input();
+        input.protocol = TransportProtocol::Udp;
+        input.streams = vec![udp_stream_rp(
+            1,
+            false,
+            blk * 96,
+            Some(sent_bytes),
+            Some(100),
+            0.001,
+            4,
+            96,
+        )];
+        let v = serde_json::to_value(input.build()).unwrap();
+        let u = &v["end"]["streams"][0]["udp"];
+        assert_eq!(
+            u["packets"],
+            serde_json::json!(100i64),
+            "the exchanged count, not bytes/blk's 99: {u}"
+        );
+        assert!(
+            (u["lost_percent"].as_f64().unwrap() - 4.0).abs() < 1e-9,
+            "4/100 on the exchanged denominator: {u}"
+        );
+
+        // Absent (a terminated run / an odd peer): the derived figure stays.
+        let mut input = base_input();
+        input.protocol = TransportProtocol::Udp;
+        input.streams = vec![udp_stream_rp(
+            1,
+            false,
+            blk * 96,
+            Some(sent_bytes),
+            None,
+            0.001,
+            4,
+            96,
+        )];
+        let v = serde_json::to_value(input.build()).unwrap();
+        assert_eq!(
+            v["end"]["streams"][0]["udp"]["packets"],
+            serde_json::json!(99i64),
+            "bytes-derived fallback when the peer never reported: {v}"
+        );
+    }
+
+    /// #235, the aggregate analog: the reverse-direction sent figures sum
+    /// the per-stream exchanged counts (GT's sender_total_packets running
+    /// total over peer_packet_count) with the bytes-derived per-stream
+    /// fallback.
+    #[test]
+    fn udp_reverse_aggregates_sum_the_exchanged_counts() {
+        let blk = 131_072u64;
+        let tail = blk * 99 + 500; // 100 true datagrams, 99 derived
+
+        // Bidir: two receiving streams with exchanged counts.
+        let mut input = base_input();
+        input.protocol = TransportProtocol::Udp;
+        input.bidir = true;
+        input.num_streams = 2;
+        input.streams = vec![
+            udp_stream(1, true, blk * 100, Some(blk * 99), 0.001, 2, 99),
+            udp_stream(2, true, blk * 100, Some(blk * 99), 0.003, 2, 99),
+            udp_stream_rp(3, false, blk * 95, Some(tail), Some(100), 0.002, 4, 96),
+            udp_stream_rp(4, false, blk * 95, Some(tail), Some(100), 0.006, 4, 96),
+        ];
+        let v = serde_json::to_value(input.build()).unwrap();
+        let end = &v["end"];
+        for key in ["sum_bidir_reverse", "sum_sent_bidir_reverse"] {
+            assert_eq!(
+                end[key]["packets"],
+                serde_json::json!(200i64),
+                "{key} sums the exchanged 100s, not the derived 99s: {end}"
+            );
+        }
+
+        // Single-direction -R: same rule on sum/sum_sent.
+        let mut input = base_input();
+        input.protocol = TransportProtocol::Udp;
+        input.reverse = true;
+        input.streams = vec![udp_stream_rp(
+            1,
+            false,
+            blk * 96,
+            Some(tail),
+            Some(100),
+            0.001,
+            4,
+            96,
+        )];
+        let v = serde_json::to_value(input.build()).unwrap();
+        for key in ["sum", "sum_sent"] {
+            assert_eq!(
+                v["end"][key]["packets"],
+                serde_json::json!(100i64),
+                "-R {key} carries the exchanged count: {v}"
+            );
+        }
+    }
+
     fn tcp_stream(id: i32, is_sender: bool, local: u64, remote: u64) -> StreamReport {
         StreamReport {
             id,
@@ -1964,6 +2128,7 @@ mod tests {
             remote_bytes: Some(remote),
             retransmits: Some(3),
             tcp_end: None,
+            remote_packets: None,
             udp: None,
         }
     }

--- a/riperf3/src/json_report.rs
+++ b/riperf3/src/json_report.rs
@@ -568,12 +568,15 @@ pub struct StreamReport {
     /// UDP receiver stats (jitter seconds, lost, total packets, out-of-order),
     /// from whichever side measured them. `None` for TCP.
     pub udp: Option<UdpStreamStats>,
-    /// The peer's exchanged per-stream SENT datagram count, net of its
-    /// omitted baseline (#235) — GT's `peer_packet_count` (parsed at
-    /// iperf_api.c:2942, consumed as the receiving side's sender count at
-    /// :4227). `None` when the peer never reported (terminated runs, odd
-    /// peers); consumers fall back to the bytes-derived figure, which is
-    /// off by the tail partial datagram.
+    /// The peer's exchanged per-stream SENT datagram count, NETTED of the
+    /// peer's omitted baseline at attach time (#235) — GT keeps the
+    /// gross/omitted split (`peer_packet_count` is gross, iperf_api.c:2942/
+    /// 2948) and nets at consumption (:4245); a future per-stream omit
+    /// rework (#31/#214) will need a `remote_omitted_packets` sibling or a
+    /// shape change here. Exact when the peer keeps true counters (iperf3);
+    /// riperf3 peers exchange bytes-derived figures until #235's counter
+    /// half. `None` when the peer never reported (terminated runs, odd
+    /// peers); consumers fall back to the bytes-derived figure.
     pub remote_packets: Option<i64>,
 }
 
@@ -1302,9 +1305,14 @@ impl ReportInput {
                 let bytes = s.remote_bytes.unwrap_or(s.local_bytes);
                 let blk = self.blksize.max(1) as u64;
                 if let Some(rp) = s.remote_packets.filter(|&p| p > 0) {
-                    // #235: the peer's exchanged TRUE sent count — exact
-                    // where bytes/blk loses the tail partial datagram
-                    // (GT's peer_packet_count, iperf_api.c:4227).
+                    // #235: the peer's exchanged sent count — exact when the
+                    // peer keeps true counters (iperf3); our own senders
+                    // exchange bytes-derived figures until #235's counter
+                    // half. The >0 filter is load-bearing: a pre-#184
+                    // riperf3 server exchanges packets:0 with real bytes,
+                    // which must fall back, not zero the entry. (Per-stream
+                    // emission is iperf_api.c:4312; the netting nuance vs
+                    // GT's local-omit subtraction is #31/#214 scope.)
                     (bytes, rp, true)
                 } else if bytes > 0 {
                     (bytes, (bytes / blk) as i64, true)
@@ -2059,6 +2067,81 @@ mod tests {
             v["end"]["streams"][0]["udp"]["packets"],
             serde_json::json!(99i64),
             "bytes-derived fallback when the peer never reported: {v}"
+        );
+    }
+
+    /// r1 item 5c: the >0 filter is load-bearing — a pre-#184 riperf3
+    /// server exchanges packets:0 alongside real bytes, and a hostile peer
+    /// can send negatives; both must take the bytes-derived fallback, not
+    /// zero (or poison) the entry and the aggregates.
+    #[test]
+    fn udp_zero_or_negative_exchanged_counts_force_the_fallback() {
+        let blk = 131_072u64;
+        for bad in [Some(0i64), Some(-3i64)] {
+            // Per-stream entry.
+            let mut input = base_input();
+            input.protocol = TransportProtocol::Udp;
+            input.streams = vec![udp_stream_rp(
+                1,
+                false,
+                blk * 96,
+                Some(blk * 99),
+                bad,
+                0.001,
+                4,
+                96,
+            )];
+            let v = serde_json::to_value(input.build()).unwrap();
+            assert_eq!(
+                v["end"]["streams"][0]["udp"]["packets"],
+                serde_json::json!(99i64),
+                "exchanged {bad:?} must fall back to bytes/blk: {v}"
+            );
+
+            // -R aggregates.
+            let mut input = base_input();
+            input.protocol = TransportProtocol::Udp;
+            input.reverse = true;
+            input.streams = vec![udp_stream_rp(
+                1,
+                false,
+                blk * 96,
+                Some(blk * 99),
+                bad,
+                0.001,
+                4,
+                96,
+            )];
+            let v = serde_json::to_value(input.build()).unwrap();
+            assert_eq!(
+                v["end"]["sum_sent"]["packets"],
+                serde_json::json!(99i64),
+                "aggregates must not zero on exchanged {bad:?}: {v}"
+            );
+        }
+    }
+
+    /// r1 item 5b: the all-or-nothing aggregate rule — a MIXED set (one
+    /// stream reported, one didn't; unreachable from conforming peers but
+    /// the documented contract) falls back wholesale rather than summing a
+    /// partial.
+    #[test]
+    fn udp_mixed_exchanged_sets_fall_back_wholesale() {
+        let blk = 131_072u64;
+        let mut input = base_input();
+        input.protocol = TransportProtocol::Udp;
+        input.reverse = true;
+        input.num_streams = 2;
+        input.streams = vec![
+            udp_stream_rp(1, false, blk * 96, Some(blk * 99), Some(100), 0.001, 4, 96),
+            udp_stream_rp(2, false, blk * 96, Some(blk * 99), None, 0.001, 4, 96),
+        ];
+        let v = serde_json::to_value(input.build()).unwrap();
+        assert_eq!(
+            v["end"]["sum_sent"]["packets"],
+            serde_json::json!(198i64),
+            "mixed set -> wholesale bytes-derived fallback (99+99), never a \
+             partial 100+99 or 100+0 sum: {v}"
         );
     }
 

--- a/riperf3/src/json_report.rs
+++ b/riperf3/src/json_report.rs
@@ -577,10 +577,15 @@ pub struct StreamReport {
     /// gross/omitted split (`peer_packet_count` is gross, iperf_api.c:2942/
     /// 2948) and nets at consumption (:4245); a future per-stream omit
     /// rework (#31/#214) will need a `remote_omitted_packets` sibling or a
-    /// shape change here. Exact when the peer keeps true counters (iperf3);
-    /// riperf3 peers exchange bytes-derived figures until #235's counter
-    /// half. `None` when the peer never reported (terminated runs, odd
-    /// peers); consumers fall back to the bytes-derived figure.
+    /// shape change here. Set ONLY on streams this host received (a sent
+    /// stream's peer figure is the peer's RECEIVE counter — r2 item 1).
+    /// Exact when the peer keeps true counters (iperf3); riperf3 peers
+    /// exchange bytes-derived figures until #235's counter half. `None`
+    /// when the peer never reported (terminated runs) or for sent streams;
+    /// a 3.12-class peer omitting only `omitted_*` yields Some(gross) —
+    /// the #24 default-0 posture, NOT GT's all-omitted zeroing
+    /// (iperf_api.c:2945-2949), a documented faithfulness gap. Consumers
+    /// fall back to the bytes-derived figure on None/non-positive.
     pub remote_packets: Option<i64>,
 }
 
@@ -984,7 +989,9 @@ impl ReportInput {
             // single-direction arm already uses).
             let fwd_sent_packets = (local_sent / blk) as i64;
             // #235: the reverse (peer-sent) figure prefers the exchanged
-            // true counts; bytes-derived only as the fallback.
+            // true counts; bytes-derived only as the fallback. (GT's
+            // sum-class nets LOCAL omitted, :4243 — peer-netted here;
+            // identical at omit=0, ppm-scale under -O, #31/#214 scope.)
             let rev_sent_packets = self
                 .exchanged_sent_packets(false)
                 .unwrap_or((rev_sent / blk) as i64);
@@ -1084,7 +1091,8 @@ impl ReportInput {
                 peer_recv
             };
             // #235: when the sent side is the PEER's (-R), prefer its
-            // exchanged true counts over the bytes-derived figure.
+            // exchanged true counts over the bytes-derived figure (same
+            // local-vs-peer omit-netting hedge as the bidir arm).
             let sent_packets = (!fwd_sender)
                 .then(|| self.exchanged_sent_packets(false))
                 .flatten()

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -1838,6 +1838,9 @@ impl Server {
                     // The server never learns the peer's per-stream bytes; build()
                     // zeroes the un-measured side for is_server reports.
                     remote_bytes: None,
+                    // #235: never available server-side — the server prints
+                    // before the exchange (iperf_server_api.c:277 vs :280).
+                    remote_packets: None,
                     retransmits,
                     tcp_end,
                     udp,


### PR DESCRIPTION
> **GT** = ground truth: the pinned reference **iperf 3.21**, built from source at commit `d39cf41526626b4e5a130f115d931cd6cbdffc19`, that riperf3's wire/behavior faithfulness is captured from and verified against (source-line citations like `iperf_api.c:4288` refer to that tree).

Fixes #235 (the consume half — see scope note).

## What the triage question resolved to

"Check whether iperf3's results JSON already carries per-stream packets before adding plumbing" — it does, both directions, and riperf3's `StreamResultJson` already has the field. GT consumes it as the receiving side's sender count (`peer_packet_count`, iperf_api.c:2942 parse → :4227 consume → :4245 running total). riperf3 derived from bytes/blksize instead — off by the tail partial datagram whenever the true count isn't a full-block multiple.

## The change

`StreamReport.remote_packets` (the peer's exchanged per-stream sent count, net of its omitted baseline; `None` server-side — the server prints before the exchange — and on terminated runs), consumed at three sites with bytes-derived fallback:
- the per-stream client receiving arm
- the bidir reverse sent aggregates (`exchanged_sent_packets`, all-or-nothing so partial/odd-peer sets keep the #170 graft rules byte-identical)
- the single-direction `-R` sent aggregates

## Scope note — the deliberate split

This is the **consume** half. Our own UDP senders still exchange bytes-derived figures: true datagram counters touch the send hot path across the blocking/sendmmsg/async variants and the omit-baseline machinery, and deserve their own perf-gated change (the per-PR drift gate exists for exactly that class). Net effect today: riperf3-vs-**iperf3** runs consume iperf3's true counts end to end; riperf3↔riperf3 gains provenance, exactness arrives with the counter half. If the counter half should land in 0.7.4 too, say so — otherwise I'd file it against 0.8.0.

## Live + tests

Cross-tool full-block runs are byte-equal (iperf3 always sends full datagrams — it overshoots `-n` to the block boundary — so tail partials need `-F` diskfile or odd peers; that's why this residue is ppm-scale). Red-first fixtures: exchanged-100-beats-derived-99 per stream (denominator included) + fallback pin, bidir aggregates 200-not-198, `-R` sum/sum_sent 100-not-99. Gate clean.

