### PR TITLE
ci: close cross-platform compile gaps + add a rustdoc gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,23 @@ jobs:
       - run: cargo clippy --all-targets -- -D warnings
       - run: cargo fmt --all -- --check
 
+  # Rustdoc gate for the published library API. -D warnings turns broken
+  # intra-doc links and malformed doc HTML into a build failure — cheap insurance
+  # for the public result model (Report and friends) that #137 documents.
+  #
+  # Lib-only (-p riperf3): riperf3-cli is a binary with no published rustdoc, and
+  # its doc comments are clap --help text where `<host>`-style angle brackets are
+  # intentional (they would trip rustdoc::invalid_html_tags).
+  docs:
+    name: Docs
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - run: RUSTDOCFLAGS="-D warnings" cargo doc --no-deps -p riperf3
+
   semver:
     name: SemVer
     runs-on: ubuntu-latest
@@ -72,10 +89,27 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     strategy:
+      # fail-fast off so one target's break doesn't mask another's (cf.
+      # native-test): a NetBSD-only and a Windows-only regression should both
+      # surface in one run.
+      fail-fast: false
       matrix:
+        # The platforms riperf3 cfg-gates for, kept in sync with the canonical
+        # set in scripts/xcheck.sh. `cargo check --target` type-checks per-target
+        # cfg code without linking or running — runtime divergence (winsock, the
+        # macOS tcp_connection path, FreeBSD sendmmsg) is covered by the
+        # native-test / freebsd-test jobs and the local VMs. These four targets
+        # have NO native runner anywhere, so the compile check is their ONLY CI
+        # coverage: NetBSD is the "other-Unix" canary (#78), Intel macOS exists
+        # because native-test's macos-latest is arm64, and ARM Linux is the
+        # container deploy target (Graviton / Apple-silicon).
         target:
           - x86_64-pc-windows-msvc
           - aarch64-apple-darwin
+          - x86_64-apple-darwin
+          - x86_64-unknown-netbsd
+          - aarch64-unknown-linux-gnu
+          - aarch64-unknown-linux-musl
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
## What

Audit + expansion of CI coverage. No runtime code changes — `.github/workflows/ci.yml` only.

### Gaps closed
The CI compile matrix didn't match the platforms riperf3 supports (per `scripts/xcheck.sh`, the canonical target set):

| Platform | Before | After |
|---|---|---|
| NetBSD (`x86_64-unknown-netbsd`) | no CI coverage — the #78 "other-Unix canary", local-only via `xcheck.sh` | cross-check |
| Intel macOS (`x86_64-apple-darwin`) | `native-test` is arm64; cross-check only did aarch64 | cross-check |
| ARM Linux (`aarch64` gnu + musl) | container deploy target (Graviton / Apple-silicon), zero checks | cross-check |

`cross-check` now mirrors `xcheck.sh`'s set, with `fail-fast: false` so one target's break doesn't mask another's. These four have no native runner anywhere, so `cargo check` is their only CI coverage; runtime divergence stays covered by the `native-test` / `freebsd-test` jobs.

### New gate
- **Docs** job: `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps -p riperf3`. Fails CI on broken intra-doc links / malformed doc HTML in the published library API — cheap insurance for the `Report` result model #137 documents. Lib-only (`-p riperf3`) because `riperf3-cli`'s doc comments are clap `--help` text where `<host>`-style angle brackets are intentional (they'd trip `rustdoc::invalid_html_tags`).

## Verification
All four new compile targets and the lib-only rustdoc pass on `main` locally:
- `cargo check --target {x86_64-unknown-netbsd, x86_64-apple-darwin, aarch64-unknown-linux-gnu, aarch64-unknown-linux-musl}` → ok
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps -p riperf3` → ok

The new jobs run on this PR — that is the live proof.

## Notes
New checks start **non-required**; promote them to required branch-protection checks once they've run clean (mirroring how macOS was promoted from informational in June 2026).
