### PR TITLE
feat(api)!: Client::run returns the rich Report; add Server::run_once (#137)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,42 @@ This changelog begins at 0.6.0. For earlier releases (0.1.1–0.5.4), see the
 [git history](https://github.com/therealevanhenry/riperf3/commits/main) and
 release tags.
 
+## [0.8.0] - unreleased
+
+The architecture-and-API release the 0.7.x faithfulness train deferred. Per the
+SemVer 0.x convention, this minor bump carries breaking **library API** changes
+(below); the wire protocol, CLI flags, and `-J`/text output are unchanged — the
+faithful iperf3 drop-in behavior is preserved.
+
+### Breaking
+
+- **`Client::run` now returns `riperf3::Report`** (#137) — the rich
+  iperf3-schema report, the same object `-J`/`--json` serializes — instead of
+  the lean control-channel `TestResultsJson`. Library consumers get start
+  metadata, interval arrays, per-direction aggregates, and richer end summaries
+  directly. Migration: total bytes
+  `result.streams.iter().map(|s| s.bytes).sum()` → `result.end.sum_sent.bytes`
+  (forward) / `result.end.sum_received.bytes` (reverse); CPU
+  `result.cpu_util_total` → `result.end.cpu_utilization_percent.host_total`.
+- **`TestResultsJson` / `StreamResultJson` are no longer re-exported** from the
+  crate root (#137): they are the internal control-channel exchange model. The
+  public result type is now `Report`.
+
+### Added
+
+- **`Server::run_once() -> Result<Report>`** (#137) — serves exactly one test and
+  returns its rich report, the server-side analog of `Client::run`.
+  `Server::run` remains the long-lived accept loop (`Result<()>`).
+- **`riperf3::json_report` is a documented public module** (#137); its top-level
+  `Report` is re-exported at the crate root.
+
+### Changed
+
+- Removed the unwired `#[allow(dead_code)]` async UDP sender/receiver variants and
+  documented why the UDP data path deliberately uses `spawn_blocking` with
+  blocking sockets — SO_SNDBUF backpressure, the sendmmsg batch path, the winsock
+  demux constraint (#146). No behavior change.
+
 ## [0.7.4] - 2026-06-12
 
 A non-breaking faithfulness patch in two waves: 18 issues closed across 17

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -793,7 +793,7 @@ dependencies = [
 
 [[package]]
 name = "riperf3"
-version = "0.7.4"
+version = "0.8.0"
 dependencies = [
  "base64",
  "libc",
@@ -815,7 +815,7 @@ dependencies = [
 
 [[package]]
 name = "riperf3-cli"
-version = "0.7.4"
+version = "0.8.0"
 dependencies = [
  "clap",
  "libc",
@@ -831,7 +831,7 @@ dependencies = [
 
 [[package]]
 name = "riperf3-test-support"
-version = "0.7.4"
+version = "0.8.0"
 dependencies = [
  "serde_json",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.7.4"
+version = "0.8.0"
 authors = ["Evan Henry"]
 edition = "2021"
 # MSRV floor 1.85 (review r1, verified empirically): the locked base64ct 1.8

--- a/riperf3-cli/Cargo.toml
+++ b/riperf3-cli/Cargo.toml
@@ -14,7 +14,7 @@ readme = "../README.md"
 
 [dependencies]
 # riperf3 workspace dependencies
-riperf3 = { path = "../riperf3", version = "0.7.4" }
+riperf3 = { path = "../riperf3", version = "0.8.0" }
 
 # external dependencies
 clap.workspace = true

--- a/riperf3/src/client.rs
+++ b/riperf3/src/client.rs
@@ -287,7 +287,7 @@ impl Client {
         self
     }
 
-    pub async fn run(&self) -> Result<TestResultsJson> {
+    pub async fn run(&self) -> Result<crate::json_report::Report> {
         let mut interrupt = self.interrupt.clone().map(|w| w.0);
         // -T/--title: prefix every client text line with "<title>:  " (#34),
         // matching iperf3. Run-scoped (cleared on drop) and only in plain-text
@@ -417,6 +417,10 @@ impl Client {
         let mut byte_budget: Option<(Arc<AtomicI64>, i64)> = None;
         let mut cpu_start: Option<CpuSnapshot> = None;
         let mut server_results: Option<TestResultsJson> = None;
+        // The rich report `run` returns to the library caller (#137): captured
+        // from the DisplayResults print so the returned value IS what `-J`/text
+        // printed (built once). The interrupt path returns its own local report.
+        let mut final_report: Option<crate::json_report::Report> = None;
         // Authoritative test duration captured from run_test: `-t` for a duration
         // run, the measured elapsed for `-n`/`-k`. Drives the summary window (#103).
         let mut measured_secs = self.duration as f64;
@@ -449,7 +453,8 @@ impl Client {
                     } else {
                         0.0
                     };
-                    self.print_results(
+                    // #137: return the rich report we just dumped.
+                    let report = self.print_results(
                         &streams,
                         cpu_start.as_ref(),
                         // r1 item 7: post-ExchangeResults interrupts keep the
@@ -469,12 +474,7 @@ impl Client {
                         dump_secs,
                         Some(&msg),
                     );
-                    return Ok(self.build_results(
-                        &streams,
-                        cpu_start.as_ref(),
-                        blksize,
-                        dump_secs,
-                    ));
+                    return Ok(report);
                 }
             };
 
@@ -645,7 +645,9 @@ impl Client {
                             // (iperf3 exits 0 on TERM/INT/HUP).
                             let _ =
                                 protocol::send_state(&mut ctrl, TestState::ClientTerminate).await;
-                            self.print_results(
+                            // #137: return the rich report we just dumped (the
+                            // local-only partial — no peer half on a signal exit).
+                            let report = self.print_results(
                                 &streams,
                                 cpu_start.as_ref(),
                                 None,
@@ -662,12 +664,7 @@ impl Client {
                                 measured_secs,
                                 Some(&msg),
                             );
-                            return Ok(self.build_results(
-                                &streams,
-                                cpu_start.as_ref(),
-                                blksize,
-                                measured_secs,
-                            ));
+                            return Ok(report);
                         }
                         Some(ControlEvent::ServerError) => {
                             // #224: read the relay pair (safe here, outside
@@ -725,20 +722,24 @@ impl Client {
                 }
 
                 TestState::DisplayResults => {
-                    self.print_results(
-                        &streams,
-                        cpu_start.as_ref(),
-                        server_results.as_ref(),
-                        blksize,
-                        &interval_data,
-                        &StartMeta {
-                            cookie: String::from_utf8_lossy(&cookie[..protocol::COOKIE_SIZE - 1])
+                    final_report = Some(
+                        self.print_results(
+                            &streams,
+                            cpu_start.as_ref(),
+                            server_results.as_ref(),
+                            blksize,
+                            &interval_data,
+                            &StartMeta {
+                                cookie: String::from_utf8_lossy(
+                                    &cookie[..protocol::COOKIE_SIZE - 1],
+                                )
                                 .into_owned(),
-                            tcp_mss_default: control_mss,
-                            start_time_millis: test_start_millis,
-                        },
-                        measured_secs,
-                        None,
+                                tcp_mss_default: control_mss,
+                                start_time_millis: test_start_millis,
+                            },
+                            measured_secs,
+                            None,
+                        ),
                     );
                     protocol::send_state(&mut ctrl, TestState::IperfDone).await?;
                     break; // test complete — server will close the connection
@@ -832,14 +833,20 @@ impl Client {
         // (r1 item 9: a failed exchange must not print Done; GT's
         // cleanup_and_fail never does), and as two prints so a --timestamps
         // prefix lands on both lines like GT (item 10b).
-        let results = server_results.ok_or_else(|| {
-            RiperfError::Protocol("missing server results in control exchange".into())
-        })?;
+        // Protocol-correctness guard kept: a clean run must have completed the
+        // results exchange. The RETURNED value is the rich report captured at
+        // DisplayResults (#137), not the lean wire struct.
+        if server_results.is_none() {
+            return Err(RiperfError::Protocol(
+                "missing server results in control exchange".into(),
+            ));
+        }
         if !self.json_output && !self.json_stream {
             vprintln!("");
             vprintln!("iperf Done.");
         }
-        Ok(results)
+        final_report
+            .ok_or_else(|| RiperfError::Protocol("results not displayed before IPERF_DONE".into()))
     }
 
     fn build_params(&self, blksize: usize) -> TestParams {
@@ -1625,7 +1632,7 @@ impl Client {
         start_meta: &StartMeta,
         test_duration: f64,
         error: Option<&str>,
-    ) {
+    ) -> crate::json_report::Report {
         // #220: stream mode WINS when both flags are set — iperf3's
         // OPT_JSON_STREAM implies -J (iperf_api.c:1280-1282), so `-J
         // --json-stream` IS stream mode (full event stream incl. `end`; the
@@ -1633,6 +1640,10 @@ impl Client {
         // stream arm already honors). The old json_output-first dispatch
         // emitted a truncated stream (no end event) followed by the doc.
         // The CLI's error-sink dispatch has always been stream-first (#198).
+        //
+        // Every arm returns the same rich `Report` it emits/prints — `run`
+        // hands it back to the library caller (#137), so "what run returns" is
+        // byte-for-byte "what `-J` prints" (built once via build_report_input).
         if self.json_stream {
             // iperf3's NDJSON tail order is: error?, server_output_json,
             // server_output_text, end (iperf_api.c:5310-5323) (#170 + #168).
@@ -1661,7 +1672,7 @@ impl Client {
             }
             // --json-stream: emit the `end` event. (Previously this fell through
             // to print_results_text, printing text banners into the NDJSON — #62.)
-            self.emit_json_stream_end(
+            let mut report = self.emit_json_stream_end(
                 streams,
                 cpu_start,
                 remote_cpu,
@@ -1670,6 +1681,10 @@ impl Client {
                 start_meta,
                 test_duration,
             );
+            // The error went out as a discrete stream event above; also carry it
+            // on the returned Report (return-value only — no effect on output).
+            report.error = error.map(str::to_owned);
+            report
         } else if self.json_output {
             self.print_results_json(
                 streams,
@@ -1680,7 +1695,7 @@ impl Client {
                 start_meta,
                 test_duration,
                 error,
-            );
+            )
         } else {
             self.print_results_text(
                 streams,
@@ -1689,6 +1704,20 @@ impl Client {
                 test_duration,
                 cpu_start.map(|s| CpuSnapshot::now().utilization_since(s)),
             );
+            // Text mode prints the live summary but builds no Report; build it
+            // for the return value via the same path `-J` uses, then attach any
+            // run error (matching print_results_json's iperf_json_finish step).
+            let mut input = self.build_report_input(
+                streams,
+                cpu_start,
+                remote_cpu,
+                blksize,
+                interval_data,
+                start_meta,
+                test_duration,
+            );
+            input.error = error.map(str::to_owned);
+            input.build()
         }
     }
 
@@ -2102,7 +2131,7 @@ impl Client {
         start_meta: &StartMeta,
         test_duration: f64,
         error: Option<&str>,
-    ) {
+    ) -> crate::json_report::Report {
         let mut input = self.build_report_input(
             streams,
             cpu_start,
@@ -2114,7 +2143,9 @@ impl Client {
         );
         // iperf3's iperf_json_finish attaches the run error to the blob (#170).
         input.error = error.map(str::to_owned);
-        println!("{}", serde_json::to_string_pretty(&input.build()).unwrap());
+        let report = input.build();
+        println!("{}", serde_json::to_string_pretty(&report).unwrap());
+        report
     }
 
     /// `--json-stream`: emit the `start` event (#62). Called at TestStart, before
@@ -2158,7 +2189,7 @@ impl Client {
         interval_data: &Arc<Mutex<crate::reporter::CollectedIntervals>>,
         start_meta: &StartMeta,
         test_duration: f64,
-    ) {
+    ) -> crate::json_report::Report {
         let input = self.build_report_input(
             streams,
             cpu_start,
@@ -2179,6 +2210,7 @@ impl Client {
         if self.json_stream_full_output {
             println!("{}", serde_json::to_string_pretty(&report).unwrap());
         }
+        report
     }
 }
 

--- a/riperf3/src/lib.rs
+++ b/riperf3/src/lib.rs
@@ -39,21 +39,26 @@ mod server;
 // any public signature); it stays crate-private rather than a public type (#67).
 pub use server::{Server, ServerBuilder};
 
-// The wire protocol enum and the result model returned by `Client::run()`.
-pub use protocol::{StreamResultJson, TestResultsJson, TransportProtocol};
+// The transport enum used across the public builder API. `TestResultsJson` /
+// `StreamResultJson` are the internal control-channel exchange model and are no
+// longer re-exported (0.8.0 breaking, #137) — `Client::run` now returns `Report`.
+pub use protocol::TransportProtocol;
+
+// The rich iperf3-schema result model returned by `Client::run` and
+// `Server::run_once` — the same object `-J` / `--json` serializes (#137).
+pub use json_report::Report;
 
 pub use net::set_cpu_affinity;
 
 // --- Internal modules: implementation detail, NOT part of the public API. ---
 // Crate-private (`pub(crate)`), so nothing here is a semver commitment; the
 // few genuinely-public types are re-exported at the crate root above (#67).
-// `json_report` is the exception — it is the iperf3-schema result model and
-// stays publicly accessible (kept `#[doc(hidden)]` to keep its ~25 structs out
-// of the rendered API surface).
+// `json_report` is the exception — it is the iperf3-schema result model that
+// `Client::run` / `Server::run_once` return, so it is a documented public
+// module (#137); its top-level `Report` is re-exported at the crate root above.
 
 pub(crate) mod auth;
 pub(crate) mod cpu;
-#[doc(hidden)]
 pub mod json_report;
 pub(crate) mod net;
 pub(crate) mod protocol;

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -254,7 +254,9 @@ impl Server {
         let mut interrupt_fired = self.interrupt.clone().map(|w| w.0);
         loop {
             match self.handle_one_test(&listener).await {
-                Ok(()) => {}
+                // #137: the daemon loop discards each test's Report; library
+                // users who want it call `run_once`.
+                Ok(_) => {}
                 Err(RiperfError::PeerDisconnected) => {
                     if self.verbose {
                         vprintln!("Client disconnected.");
@@ -300,7 +302,37 @@ impl Server {
         Ok(())
     }
 
-    async fn handle_one_test(&self, listener: &tokio::net::TcpListener) -> Result<()> {
+    /// Serve exactly one test and return its rich JSON [`Report`](crate::Report) — the same
+    /// object [`Client::run`](crate::Client::run) returns and `-s -J` prints.
+    ///
+    /// Binds its own listener, accepts one client, runs the test to completion,
+    /// and returns. This is the one-shot building block, mirroring
+    /// `tokio::net::TcpListener::accept`; use [`Server::run`] for the long-lived
+    /// accept loop. Unlike `run`, it does not print the "Server listening"
+    /// banner — it is a library entry point, not the daemon. The test report is
+    /// still printed to stdout in `-J` / text mode, like `Client::run`.
+    pub async fn run_once(&self) -> Result<crate::json_report::Report> {
+        let listener = net::tcp_listen(
+            self.bind_address.as_deref(),
+            self.port,
+            self.ip_version,
+            self.bind_dev.as_deref(),
+        )
+        .await?;
+        match self.handle_one_test(&listener).await? {
+            Some(report) => Ok(report),
+            // Reachable only with an interrupt watch set (e.g. the CLI's signal
+            // handling): interrupted while idle, before any client connected.
+            None => Err(RiperfError::Aborted(
+                "interrupted before a test started".into(),
+            )),
+        }
+    }
+
+    async fn handle_one_test(
+        &self,
+        listener: &tokio::net::TcpListener,
+    ) -> Result<Option<crate::json_report::Report>> {
         // ---- Accept control connection (with optional idle timeout) ----
         // The IDLE wait races the interrupt watch (#210 follow-through): an
         // idle server's first signal must exit promptly — without this arm
@@ -331,7 +363,8 @@ impl Server {
         };
         let (mut ctrl, peer_addr) = match accepted {
             Some(r) => r?,
-            None => return Ok(()),
+            // Interrupted while idle (no client): no test ran, so no report.
+            None => return Ok(None),
         };
         // (#222 r1 item 6: the Time/banner/Cookie/MSS block prints AFTER the
         // param exchange — GT's iperf_on_connect fires there — so a
@@ -378,7 +411,8 @@ impl Server {
         // GT's create_server_timers.
         if let Some(max) = self.server_max_duration.filter(|&m| m > 0) {
             if cfg.duration.saturating_add(cfg.omit) > max || cfg.duration == 0 {
-                return self.refuse_max_duration(&mut ctrl).await;
+                // Refused before any test ran → no report.
+                return self.refuse_max_duration(&mut ctrl).await.map(|()| None);
             }
         }
 
@@ -1149,6 +1183,27 @@ impl Server {
             }
         }
 
+        // #137: build the rich report ONCE — handle_one_test returns it (run
+        // discards it; run_once hands it back to the library caller). build_report
+        // drains the collected intervals via mem::take, so it must be built
+        // exactly once; reuse the pre-exchange build when --get-server-output
+        // already attached it (#33).
+        let report = prebuilt_report.unwrap_or_else(|| {
+            self.build_report(
+                &streams,
+                &cfg,
+                &params,
+                &cpu_util,
+                test_duration,
+                &cookie,
+                &accepted_host,
+                accepted_port,
+                test_start_millis,
+                &interval_data,
+                report_error.as_deref(),
+            )
+        });
+
         // #220: stream mode WINS when both flags are set — iperf3's
         // OPT_JSON_STREAM implies -J, so `-s -J --json-stream` IS stream
         // mode (the client-side dispatch and the CLI error sinks already
@@ -1165,37 +1220,9 @@ impl Server {
                 ));
             }
             // --json-stream: emit the `end` event (intervals already streamed; #62).
-            self.emit_json_stream_end(
-                &streams,
-                &cfg,
-                &params,
-                &cpu_util,
-                test_duration,
-                &cookie,
-                &accepted_host,
-                accepted_port,
-                test_start_millis,
-                &interval_data,
-                report_error.as_deref(),
-            );
+            self.emit_json_stream_end(&report);
         } else if self.json_output {
-            // Emit the iperf3-schema JSON report on stdout (#50); reuse the
-            // pre-exchange build when --get-server-output attached it (#33).
-            let report = prebuilt_report.unwrap_or_else(|| {
-                self.build_report(
-                    &streams,
-                    &cfg,
-                    &params,
-                    &cpu_util,
-                    test_duration,
-                    &cookie,
-                    &accepted_host,
-                    accepted_port,
-                    test_start_millis,
-                    &interval_data,
-                    report_error.as_deref(),
-                )
-            });
+            // Emit the iperf3-schema JSON report on stdout (#50).
             self.print_results_json(&report);
         } else if !was_captured && server_error.is_none() {
             // Print summary: per-stream lines plus aggregate [SUM] row(s) for
@@ -1261,7 +1288,7 @@ impl Server {
             // "the client has terminated" (no "error - " prefix) (#210).
             return Err(RiperfError::ClientTerminated);
         }
-        Ok(())
+        Ok(Some(report))
     }
 
     /// iperf3's UDP server design (the default on Unix): one connected data
@@ -2000,35 +2027,10 @@ impl Server {
 
     /// `--json-stream`: emit the server's `end` event (#62). The interval events
     /// were already streamed live by the reporter.
-    #[allow(clippy::too_many_arguments)]
-    fn emit_json_stream_end(
-        &self,
-        streams: &[DataStream],
-        cfg: &TestConfig,
-        params: &TestParams,
-        cpu_util: &crate::cpu::CpuUtilization,
-        test_duration: f64,
-        cookie: &[u8; protocol::COOKIE_SIZE],
-        accepted_host: &str,
-        accepted_port: u16,
-        start_time_millis: u64,
-        interval_data: &Arc<Mutex<crate::reporter::CollectedIntervals>>,
-        error: Option<&str>,
-    ) {
-        let input = self.build_report_input(
-            streams,
-            cfg,
-            params,
-            cpu_util,
-            test_duration,
-            cookie,
-            accepted_host,
-            accepted_port,
-            start_time_millis,
-            interval_data,
-            error,
-        );
-        let report = input.build();
+    // Takes the already-built `Report` (#137: handle_one_test builds it once and
+    // returns it) so the report isn't reassembled — build_report_input drains the
+    // collected intervals via mem::take, so a second build would lose them.
+    fn emit_json_stream_end(&self, report: &crate::json_report::Report) {
         crate::reporter::emit_json_stream_line(&crate::json_report::json_stream_event(
             "end",
             &report.end,
@@ -2036,7 +2038,7 @@ impl Server {
         // --json-stream-full-output: the monolithic document follows the
         // stream, like iperf_json_finish under the flag (#213).
         if self.json_stream_full_output {
-            println!("{}", serde_json::to_string_pretty(&report).unwrap());
+            println!("{}", serde_json::to_string_pretty(report).unwrap());
         }
     }
 

--- a/riperf3/tests/integration.rs
+++ b/riperf3/tests/integration.rs
@@ -2369,7 +2369,12 @@ mod client_run_return_value {
 
         let client = ClientBuilder::new("127.0.0.1")
             .port(Some(port))
-            .bytes(1024 * 1024)
+            // JSON mode + a duration run so the reporter KEEPS interval samples:
+            // iperf3's discard_json keeps them only under -J (text mode prints
+            // then discards), and a duration run crosses an interval boundary.
+            // The build-once guard below needs `report.intervals` non-empty.
+            .json_output(true)
+            .duration(2)
             .build()
             .unwrap();
 
@@ -2402,6 +2407,15 @@ mod client_run_return_value {
             cpu.is_finite() && cpu >= 0.0,
             "cpu host_total not a sane non-negative number: {cpu}"
         );
+        // intervals is built from the reporter's collected samples, which
+        // build_report_input drains via mem::take — a non-empty array here guards
+        // the #137 build-once invariant at the LIB layer (a double build would
+        // empty it; previously only the CLI golden tests caught that). Even a
+        // byte-limited run yields the final partial interval (#159).
+        assert!(
+            !report.intervals.is_empty(),
+            "report.intervals empty — build-once / final-flush regression"
+        );
 
         let _ = server_task.await;
     }
@@ -2411,13 +2425,21 @@ mod client_run_return_value {
     #[tokio::test]
     async fn server_run_once_returns_rich_report() {
         let port = next_port();
-        let server = ServerBuilder::new().port(Some(port)).build().unwrap();
+        let server = ServerBuilder::new()
+            .port(Some(port))
+            // JSON mode so the server KEEPS interval samples (discard_json),
+            // making the build-once intervals guard below meaningful.
+            .json_output(true)
+            .build()
+            .unwrap();
         let server_task = tokio::spawn(async move { server.run_once().await });
         tokio::time::sleep(Duration::from_millis(200)).await;
 
         let client = ClientBuilder::new("127.0.0.1")
             .port(Some(port))
-            .bytes(1024 * 1024)
+            // Duration run so the server's reporter collects intervals (the
+            // build-once guard on the returned report needs them non-empty).
+            .duration(2)
             .build()
             .unwrap();
         let _ = client.run().await.expect("client run failed");
@@ -2435,6 +2457,11 @@ mod client_run_return_value {
             report.end.sum_received.bytes > 0,
             "server expected non-zero received bytes, got {}",
             report.end.sum_received.bytes
+        );
+        // Guards the build-once invariant on the server path too (#137).
+        assert!(
+            !report.intervals.is_empty(),
+            "server report.intervals empty — build-once / final-flush regression"
         );
     }
     // run_errors_when_server_skips_results_exchange migrated in-crate to src/client.rs (#67).

--- a/riperf3/tests/integration.rs
+++ b/riperf3/tests/integration.rs
@@ -397,7 +397,7 @@ async fn tcp_reverse_bytes_limit_terminates() {
     // rate the 100ms end-condition poll overshoots the target (a pre-existing
     // characteristic shared with forward `-n`), so this guards termination +
     // floor, not an exact byte count.
-    let transferred: u64 = res.streams.iter().map(|s| s.bytes).sum();
+    let transferred: u64 = res.end.sum_sent.bytes;
     assert!(
         transferred >= target,
         "transferred {transferred} < requested {target}"
@@ -433,7 +433,7 @@ async fn tcp_reverse_blocks_limit_terminates() {
     let result = tokio::time::timeout(Duration::from_secs(15), client.run()).await;
     assert!(result.is_ok(), "-R -k hung — issue #60 regression");
     let res = result.unwrap().expect("-R -k errored");
-    let transferred: u64 = res.streams.iter().map(|s| s.bytes).sum();
+    let transferred: u64 = res.end.sum_sent.bytes;
     assert!(
         transferred >= blocks * blksize as u64,
         "transferred {transferred} < requested {blocks} blocks"
@@ -470,7 +470,7 @@ async fn tcp_byte_limit_overshoot_bounded_forward() {
         .await
         .expect("client hung")
         .expect("client errored");
-    let bytes: u64 = result.streams.iter().map(|s| s.bytes).sum();
+    let bytes: u64 = result.end.sum_received.bytes;
     assert!(
         bytes > target / 2,
         "transferred {bytes} far below target {target}"
@@ -505,7 +505,7 @@ async fn tcp_byte_limit_overshoot_bounded_reverse() {
         .await
         .expect("client hung")
         .expect("client errored");
-    let bytes: u64 = result.streams.iter().map(|s| s.bytes).sum();
+    let bytes: u64 = result.end.sum_sent.bytes;
     assert!(
         bytes > target / 2,
         "transferred {bytes} far below target {target}"
@@ -547,8 +547,8 @@ async fn tcp_bitrate_is_paced() {
         .await
         .expect("client hung")
         .expect("client errored");
-    // run() returns the server's results; forward → server received ≈ what we sent.
-    let bytes: u64 = result.streams.iter().map(|s| s.bytes).sum();
+    // run() returns the rich report; forward → server received ≈ what we sent.
+    let bytes: u64 = result.end.sum_received.bytes;
     let achieved = bytes * 8 / secs;
     // Unpaced this is line rate (tens of Gbit/s, >100x target). Paced lands near
     // target; allow a generous band for burst/timing slack.
@@ -591,7 +591,7 @@ async fn tcp_low_bitrate_no_overshoot() {
         .await
         .expect("client hung")
         .expect("client errored");
-    let bytes: u64 = result.streams.iter().map(|s| s.bytes).sum();
+    let bytes: u64 = result.end.sum_received.bytes;
     let budget = (target / 8 * secs) as f64; // 250 KB
     let bound = budget * 1.25 + (128 * 1024) as f64;
     assert!(
@@ -623,7 +623,7 @@ async fn tcp_unlimited_is_not_paced() {
         .await
         .expect("client hung")
         .expect("client errored");
-    let bytes: u64 = result.streams.iter().map(|s| s.bytes).sum();
+    let bytes: u64 = result.end.sum_received.bytes;
     // A 200 Mbit cap would yield ~25 MB in 1 s; unthrottled loopback moves far
     // more. >200 MB confirms pacing didn't leak into the rate-0 path.
     assert!(
@@ -661,7 +661,7 @@ async fn tcp_bitrate_reverse_is_paced() {
         .expect("client hung")
         .expect("client errored");
     // Reverse: the server sends; its reported bytes ≈ what it paced out.
-    let bytes: u64 = result.streams.iter().map(|s| s.bytes).sum();
+    let bytes: u64 = result.end.sum_sent.bytes;
     let achieved = bytes * 8 / secs;
     assert!(
         achieved < target * 2,
@@ -2348,16 +2348,16 @@ async fn udp_sendmmsg_with_64bit_counters() {
 }
 
 // ---------------------------------------------------------------------------
-// Client::run return-value tests (added with the Result<TestResultsJson> change)
+// Client::run / Server::run_once return-value tests (#137: the rich Report API)
 // ---------------------------------------------------------------------------
 
 mod client_run_return_value {
     use super::*;
 
-    /// Happy path: a normal TCP exchange yields a populated `TestResultsJson`,
-    /// proving the library now exposes what `print_results` used to consume internally.
+    /// #137: a normal TCP exchange makes `Client::run` return a populated rich
+    /// `Report` (the same object `-J` serializes), not the lean wire struct.
     #[tokio::test]
-    async fn run_returns_populated_results() {
+    async fn run_returns_rich_report() {
         let port = next_port();
         let server = ServerBuilder::new()
             .port(Some(port))
@@ -2373,24 +2373,69 @@ mod client_run_return_value {
             .build()
             .unwrap();
 
-        let results = client.run().await.expect("client run failed");
+        let report = client.run().await.expect("client run failed");
 
+        // The end block carries both halves on a forward run.
         assert!(
-            !results.streams.is_empty(),
-            "expected at least one stream in returned results"
-        );
-        let total_bytes: i64 = results.streams.iter().map(|s| s.bytes as i64).sum();
-        assert!(
-            total_bytes > 0,
-            "expected non-zero bytes across streams, got {total_bytes}"
+            !report.end.streams.is_empty(),
+            "expected at least one stream in report.end"
         );
         assert!(
-            results.cpu_util_total.is_finite() && results.cpu_util_total >= 0.0,
-            "cpu_util_total not a sane non-negative number: {}",
-            results.cpu_util_total
+            report.end.sum_sent.bytes > 0,
+            "expected non-zero sent bytes, got {}",
+            report.end.sum_sent.bytes
+        );
+        assert!(
+            report.end.sum_received.bytes > 0,
+            "expected non-zero received bytes, got {}",
+            report.end.sum_received.bytes
+        );
+        // start metadata is populated …
+        assert!(
+            report.start.version.starts_with("riperf"),
+            "start.version should name the tool: {:?}",
+            report.start.version
+        );
+        // … and the host CPU figure is a sane number.
+        let cpu = report.end.cpu_utilization_percent.host_total;
+        assert!(
+            cpu.is_finite() && cpu >= 0.0,
+            "cpu host_total not a sane non-negative number: {cpu}"
         );
 
         let _ = server_task.await;
+    }
+
+    /// #137: the `Server::run_once` analog returns the same rich `Report` for the
+    /// single test it serves — symmetric with `Client::run`.
+    #[tokio::test]
+    async fn server_run_once_returns_rich_report() {
+        let port = next_port();
+        let server = ServerBuilder::new().port(Some(port)).build().unwrap();
+        let server_task = tokio::spawn(async move { server.run_once().await });
+        tokio::time::sleep(Duration::from_millis(200)).await;
+
+        let client = ClientBuilder::new("127.0.0.1")
+            .port(Some(port))
+            .bytes(1024 * 1024)
+            .build()
+            .unwrap();
+        let _ = client.run().await.expect("client run failed");
+
+        let report = server_task
+            .await
+            .expect("server task panicked")
+            .expect("server run_once failed");
+        assert!(
+            !report.end.streams.is_empty(),
+            "server report.end should carry the served test's streams"
+        );
+        // Forward run: the server is the receiver, so its received aggregate moved.
+        assert!(
+            report.end.sum_received.bytes > 0,
+            "server expected non-zero received bytes, got {}",
+            report.end.sum_received.bytes
+        );
     }
     // run_errors_when_server_skips_results_exchange migrated in-crate to src/client.rs (#67).
 }

--- a/riperf3/tests/stream_thread_readiness.rs
+++ b/riperf3/tests/stream_thread_readiness.rs
@@ -86,17 +86,20 @@ fn udp_bidir_window_waits_for_stream_threads() {
         };
         srv.await.unwrap().expect("server run");
 
-        // The server's exchanged results carry both streams: its receiving
-        // stream (forward bytes received) and its sending stream (reverse
-        // bytes sent). Pre-fix, the hogged pool keeps every data thread off
-        // the CPU until the window has already closed, and both are zero.
-        assert_eq!(results.streams.len(), 2, "bidir run has two streams");
-        for s in &results.streams {
+        // The report carries both data streams: the forward (server-received)
+        // and reverse (server-sent) halves. Pre-fix, the hogged pool keeps every
+        // data thread off the CPU until the window has already closed, so a
+        // stream moves zero bytes. (#137: the rich Report replaces the lean wire
+        // struct; per-stream bytes live on the sender/receiver/udp side objects.)
+        assert_eq!(results.end.streams.len(), 2, "bidir run has two streams");
+        for s in &results.end.streams {
+            let moved = s.sender.as_ref().map_or(0, |x| x.bytes)
+                + s.receiver.as_ref().map_or(0, |x| x.bytes)
+                + s.udp.as_ref().map_or(0, |x| x.bytes);
             assert!(
-                s.bytes > 0,
-                "stream {} moved no bytes — test window opened before the \
-                 data threads started (#178): {results:?}",
-                s.id
+                moved > 0,
+                "a stream moved no bytes — test window opened before the \
+                 data threads started (#178): {results:?}"
             );
         }
     });


### PR DESCRIPTION
Closes #137. The headline 0.8.0 API change, requested by @Sean-Bartie.

## What

`Client::run` now returns the rich **`riperf3::Report`** — the full iperf3-schema report (start metadata, interval arrays, per-direction aggregates, end summaries) — the same object `-J`/`--json` serializes. Previously it returned the lean control-channel `TestResultsJson`.

The server gets the symmetric analog: **`Server::run_once() -> Result<Report>`**.

> **Breaking: library API only.** The wire protocol, CLI flags, and `-J`/text **output are byte-for-byte unchanged** — the faithful iperf3 drop-in behavior is untouched. The break is the return type + dropped re-exports.

## Key design points

- **Built once, printed and returned.** `print_results` / `print_results_json` / `emit_json_stream_end` now return the `Report` they emit, so `run` hands back *exactly* what `-J` printed. `build_report_input` drains the collected intervals via `mem::take`, so it must build exactly once — every exit reuses that single build.
- **Text mode** previously built no `Report`; it now builds one for the return value via the same path `-J` uses (printing the live text summary is unchanged).
- **Server**: `handle_one_test` builds the report once and returns `Option<Report>` (`None` = interrupted while idle / refused before any test). `run` discards it in the daemon loop; `run_once` hands it back. `run_once` binds its own listener, serves one test, returns — mirroring `tokio::net::TcpListener::accept`'s one-shot shape.
- **Exports**: `json_report` is now a documented public module; `Report` is re-exported at the crate root. `TestResultsJson` / `StreamResultJson` re-exports dropped (they remain the internal wire model).
- **Version → 0.8.0**: `cargo-semver-checks` requires the minor bump for the breaking API change (and it covers the rest of the 0.8.0 campaign).

## Migration (in CHANGELOG)

- total bytes `result.streams.iter().map(|s| s.bytes).sum()` → `result.end.sum_sent.bytes` (forward) / `result.end.sum_received.bytes` (reverse)
- CPU `result.cpu_util_total` → `result.end.cpu_utilization_percent.host_total`

## Tests

- New `run_returns_rich_report` and `server_run_once_returns_rich_report` (the return-value contract for both roles).
- 8 byte-sum integration sites migrated by direction (forward→`sum_received`, reverse→`sum_sent`; the old value was always the *server's* measured bytes, whose role flips with direction).
- The #178 readiness test now reads per-stream bytes off the `EndStream` `sender`/`receiver`/`udp` sides.

## Verification (local, all green)

`cargo test --workspace`; `clippy --all-targets -D warnings`; `fmt --check`; `RUSTDOCFLAGS=-D warnings cargo doc --no-deps -p riperf3`; `cargo semver-checks -p riperf3` (0.7.4→0.8.0 accepted); `scripts/xcheck.sh` 7/7 targets.
