### PR TITLE
refactor(streams): single source of truth for DataStream + socket capture (#144)

### DIFF
--- a/riperf3/src/client.rs
+++ b/riperf3/src/client.rs
@@ -8,7 +8,7 @@ use crate::cpu::CpuSnapshot;
 use crate::error::{ConfigError, Result, RiperfError};
 use crate::net;
 use crate::protocol::{self, TestParams, TestResultsJson, TestState, TransportProtocol};
-use crate::stream::{self, DataStream, StreamCounters, UdpRecvStats};
+use crate::stream::{self, DataStream, StreamCounters, StreamMeta, UdpRecvStats};
 use crate::utils::*;
 
 // ---------------------------------------------------------------------------
@@ -1034,16 +1034,17 @@ impl Client {
                     #[cfg(not(unix))]
                     let raw_fd: Option<i32> = None;
 
-                    // Capture the real socket addresses before the stream moves
+                    // Capture the real socket addresses + realized buffers and
+                    // run the #97 window-clamp check, before the stream moves
                     // into its task, for the `-J` start.connected block (#36).
-                    let local_addr = data_stream.local_addr().ok();
-                    let peer_addr = data_stream.peer_addr().ok();
-                    let sock = socket2::SockRef::from(&data_stream);
-                    let sndbuf_actual = sock.send_buffer_size().ok().map(|v| v as u64);
-                    let rcvbuf_actual = sock.recv_buffer_size().ok().map(|v| v as u64);
-                    // #97: abort if the kernel clamped -w below the request, like
-                    // iperf3 (IESETBUF2). Before the stream moves into its task.
-                    net::check_socket_window(self.window, sndbuf_actual, rcvbuf_actual)?;
+                    // TCP applied -w earlier in configure_tcp_stream_full, so
+                    // apply_window is false here (#144).
+                    let (local_addr, peer_addr, sndbuf_actual, rcvbuf_actual) =
+                        net::capture_stream_meta(
+                            socket2::SockRef::from(&data_stream),
+                            self.window,
+                            false,
+                        )?;
                     // #37: the congestion algorithm actually in effect (the kernel
                     // default when -C is unset), for `congestion_used`.
                     let congestion_used = net::tcp_congestion_used(&data_stream);
@@ -1118,19 +1119,21 @@ impl Client {
                         })
                     };
 
-                    streams.push(DataStream {
-                        id: stream_id,
-                        is_sender,
-                        counters,
-                        udp_recv_stats: None,
+                    streams.push(DataStream::from_meta(
+                        StreamMeta {
+                            id: stream_id,
+                            is_sender,
+                            counters,
+                            raw_fd,
+                            local_addr,
+                            peer_addr,
+                            sndbuf_actual,
+                            rcvbuf_actual,
+                            congestion_used,
+                        },
                         task,
-                        raw_fd,
-                        local_addr,
-                        peer_addr,
-                        sndbuf_actual,
-                        rcvbuf_actual,
-                        congestion_used,
-                    });
+                        None,
+                    ));
                 }
             }
             TransportProtocol::Udp => {
@@ -1180,19 +1183,18 @@ impl Client {
                     let is_sender = i < send_count;
                     let counters = Arc::new(StreamCounters::new());
 
-                    // Capture real addresses for the `-J` start.connected block
-                    // (#36) before the socket moves into its task.
-                    let local_addr = udp_sock.local_addr().ok();
-                    let peer_addr = udp_sock.peer_addr().ok();
-                    let sock = socket2::SockRef::from(&udp_sock);
-                    // Honor -w/--window on the UDP socket too (#59); iperf3 applies
-                    // it to UDP via iperf_udp_buffercheck. Set before the read-back
-                    // so sndbuf_actual/rcvbuf_actual report the realized size.
-                    net::apply_socket_window(&sock, self.window);
-                    let sndbuf_actual = sock.send_buffer_size().ok().map(|v| v as u64);
-                    let rcvbuf_actual = sock.recv_buffer_size().ok().map(|v| v as u64);
-                    // #97: abort if -w was clamped below the request (iperf3 IESETBUF2).
-                    net::check_socket_window(self.window, sndbuf_actual, rcvbuf_actual)?;
+                    // Capture real addresses + realized buffers and run the #97
+                    // window-clamp check for the `-J` start.connected block (#36)
+                    // before the socket moves into its task. apply_window=true:
+                    // honor -w/--window on the UDP socket too (#59); iperf3
+                    // applies it to UDP via iperf_udp_buffercheck, before the
+                    // read-back, so sndbuf/rcvbuf report the realized size (#144).
+                    let (local_addr, peer_addr, sndbuf_actual, rcvbuf_actual) =
+                        net::capture_stream_meta(
+                            socket2::SockRef::from(&udp_sock),
+                            self.window,
+                            true,
+                        )?;
 
                     // Convert tokio UdpSocket to std for blocking I/O
                     let std_sock = udp_sock.into_std().map_err(RiperfError::Io)?;
@@ -1234,35 +1236,39 @@ impl Client {
                         let task = thread_gate.spawn(move || {
                             stream::run_udp_receiver_blocking(std_sock, c, sc, bs, d, u64bit)
                         });
-                        streams.push(DataStream {
+                        streams.push(DataStream::from_meta(
+                            StreamMeta {
+                                id: stream_id,
+                                is_sender,
+                                counters,
+                                raw_fd: None,
+                                local_addr,
+                                peer_addr,
+                                sndbuf_actual,
+                                rcvbuf_actual,
+                                congestion_used: None,
+                            },
+                            task,
+                            Some(stats),
+                        ));
+                        continue;
+                    };
+
+                    streams.push(DataStream::from_meta(
+                        StreamMeta {
                             id: stream_id,
                             is_sender,
                             counters,
-                            udp_recv_stats: Some(stats),
-                            task,
                             raw_fd: None,
                             local_addr,
                             peer_addr,
                             sndbuf_actual,
                             rcvbuf_actual,
                             congestion_used: None,
-                        });
-                        continue;
-                    };
-
-                    streams.push(DataStream {
-                        id: stream_id,
-                        is_sender,
-                        counters,
-                        udp_recv_stats: None,
+                        },
                         task,
-                        raw_fd: None,
-                        local_addr,
-                        peer_addr,
-                        sndbuf_actual,
-                        rcvbuf_actual,
-                        congestion_used: None,
-                    });
+                        None,
+                    ));
                 }
                 // #178: hold CreateStreams until every data thread is running
                 // (parked at its start gate). This gates the CLIENT's side

--- a/riperf3/src/net.rs
+++ b/riperf3/src/net.rs
@@ -405,6 +405,41 @@ pub(crate) fn check_socket_window(
     Ok(())
 }
 
+/// Capture a data stream's local/peer addr + realized SO_SNDBUF/SO_RCVBUF and
+/// enforce the #97 window-clamp check, in one place so no create-streams path
+/// forgets the check. `apply_window` applies the window first (UDP applies it
+/// here; TCP applied it earlier in `configure_tcp_stream_full`). The aggregate
+/// demux site sizes its recv buffer uniquely and stays inline; every regular
+/// (per-stream-socket) site routes through here so the capture + clamp check is
+/// a single source of truth.
+///
+/// Addresses come from the same socket via `SockRef`; `as_socket()` yields the
+/// identical `std::net::SocketAddr` the data socket's own `local_addr()` does
+/// (verified for IPv4 and IPv6 against `TcpStream::local_addr()`), so a stream
+/// whose socket is not AF_INET/AF_INET6 — which a TCP/UDP data socket never is —
+/// is the only case that would differ, and there it would yield `None`.
+#[allow(clippy::type_complexity)]
+pub(crate) fn capture_stream_meta(
+    sock: socket2::SockRef,
+    window: Option<i32>,
+    apply_window: bool,
+) -> Result<(
+    Option<SocketAddr>,
+    Option<SocketAddr>,
+    Option<u64>,
+    Option<u64>,
+)> {
+    if apply_window {
+        apply_socket_window(&sock, window);
+    }
+    let local_addr = sock.local_addr().ok().and_then(|a| a.as_socket());
+    let peer_addr = sock.peer_addr().ok().and_then(|a| a.as_socket());
+    let sndbuf_actual = sock.send_buffer_size().ok().map(|v| v as u64);
+    let rcvbuf_actual = sock.recv_buffer_size().ok().map(|v| v as u64);
+    check_socket_window(window, sndbuf_actual, rcvbuf_actual)?;
+    Ok((local_addr, peer_addr, sndbuf_actual, rcvbuf_actual))
+}
+
 /// Read the TCP congestion-control algorithm actually in effect on a connected
 /// stream, via `getsockopt(TCP_CONGESTION)`, for the `congestion_used` report
 /// (#37). Returns the algorithm name (e.g. "cubic", "bbr"); iperf3 reports the

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -5,7 +5,7 @@ use crate::cpu::CpuSnapshot;
 use crate::error::{ConfigError, Result, RiperfError};
 use crate::net;
 use crate::protocol::{self, TestParams, TestResultsJson, TestState, TransportProtocol};
-use crate::stream::{self, DataStream, StreamCounters, UdpRecvStats};
+use crate::stream::{self, DataStream, StreamCounters, StreamMeta, UdpRecvStats};
 use crate::utils::*;
 
 /// Shared test configuration derived from the client's parameter JSON.
@@ -602,16 +602,17 @@ impl Server {
                     let raw_fd: Option<i32> = None;
                     let fp = self.file.as_ref().map(std::path::PathBuf::from);
 
-                    // Real socket addresses + kernel buffer sizes for the server's
-                    // `-J` `connected[]` / `sndbuf_actual` / `rcvbuf_actual` (#50),
-                    // captured before the stream moves into its task.
-                    let local_addr = data_stream.local_addr().ok();
-                    let peer_addr_s = data_stream.peer_addr().ok();
-                    let sock = socket2::SockRef::from(&data_stream);
-                    let sndbuf_actual = sock.send_buffer_size().ok().map(|v| v as u64);
-                    let rcvbuf_actual = sock.recv_buffer_size().ok().map(|v| v as u64);
-                    // #97: abort if the kernel clamped -w below the request (iperf3 IESETBUF2).
-                    net::check_socket_window(cfg.window, sndbuf_actual, rcvbuf_actual)?;
+                    // Real socket addresses + kernel buffer sizes + the #97
+                    // window-clamp check for the server's `-J` `connected[]` /
+                    // `sndbuf_actual` / `rcvbuf_actual` (#50), captured before the
+                    // stream moves into its task. TCP applied -w earlier in
+                    // configure_tcp_stream_full, so apply_window is false (#144).
+                    let (local_addr, peer_addr_s, sndbuf_actual, rcvbuf_actual) =
+                        net::capture_stream_meta(
+                            socket2::SockRef::from(&data_stream),
+                            cfg.window,
+                            false,
+                        )?;
                     // #37: congestion algorithm actually in effect on this stream.
                     let congestion_used = net::tcp_congestion_used(&data_stream);
 
@@ -639,19 +640,21 @@ impl Server {
                         })
                     };
 
-                    streams.push(DataStream {
-                        id: stream_id,
-                        is_sender,
-                        counters,
-                        udp_recv_stats: None,
+                    streams.push(DataStream::from_meta(
+                        StreamMeta {
+                            id: stream_id,
+                            is_sender,
+                            counters,
+                            raw_fd,
+                            local_addr,
+                            peer_addr: peer_addr_s,
+                            sndbuf_actual,
+                            rcvbuf_actual,
+                            congestion_used,
+                        },
                         task,
-                        raw_fd,
-                        local_addr,
-                        peer_addr: peer_addr_s,
-                        sndbuf_actual,
-                        rcvbuf_actual,
-                        congestion_used,
-                    });
+                        None,
+                    ));
                 }
             }
             TransportProtocol::Udp => {
@@ -1355,31 +1358,22 @@ impl Server {
             let is_sender = i >= recv_count;
             let counters = Arc::new(StreamCounters::new());
 
-            // Socket addresses + buffer sizes for the `-J` blob (#50),
-            // captured before the socket is converted to std + moved.
-            let local_addr = data_sock.local_addr().ok();
-            let peer_addr_s = data_sock.peer_addr().ok();
-            let (sndbuf_actual, rcvbuf_actual) = {
-                let sock = socket2::SockRef::from(&data_sock);
-                // Honor -w/--window on the server's UDP data socket too
-                // (#59) so reverse/bidir UDP matches iperf3; set before the
-                // read-back below.
-                net::apply_socket_window(&sock, cfg.window);
-                (
-                    sock.send_buffer_size().ok().map(|v| v as u64),
-                    sock.recv_buffer_size().ok().map(|v| v as u64),
-                )
-            };
             // iperf3 runs iperf_common_sockopts (IP_TOS/IPV6_TCLASS) on UDP
             // stream sockets on BOTH roles — it matters for reverse/bidir,
             // where the server marks egress. Fatal like every other set_tos
             // site (#45). The TCP accept loop has had this since #45; the
-            // UDP paths never did (#154).
+            // UDP paths never did (#154). IP_TOS is independent of SO_SND/RCVBUF,
+            // so setting it before the window-apply/capture below is equivalent.
             if cfg.tos != 0 {
                 net::set_tos(&data_sock, cfg.tos as u32)?;
             }
-            // #97: abort if -w was clamped below the request (iperf3 IESETBUF2).
-            net::check_socket_window(cfg.window, sndbuf_actual, rcvbuf_actual)?;
+            // Socket addresses + buffer sizes + the #97 window-clamp check for
+            // the `-J` blob (#50), captured before the socket is converted to
+            // std + moved. apply_window=true: honor -w/--window on the server's
+            // UDP data socket too (#59) so reverse/bidir UDP matches iperf3,
+            // before the read-back (#144).
+            let (local_addr, peer_addr_s, sndbuf_actual, rcvbuf_actual) =
+                net::capture_stream_meta(socket2::SockRef::from(&data_sock), cfg.window, true)?;
 
             let std_sock = data_sock.into_std().map_err(RiperfError::Io)?;
 
@@ -1400,19 +1394,21 @@ impl Server {
                         std_sock, c, bs, d, rate, pt, bu, uw, u64bit, st, md,
                     )
                 });
-                streams.push(DataStream {
-                    id: stream_id,
-                    is_sender,
-                    counters,
-                    udp_recv_stats: None,
+                streams.push(DataStream::from_meta(
+                    StreamMeta {
+                        id: stream_id,
+                        is_sender,
+                        counters,
+                        raw_fd: None,
+                        local_addr,
+                        peer_addr: peer_addr_s,
+                        sndbuf_actual,
+                        rcvbuf_actual,
+                        congestion_used: None,
+                    },
                     task,
-                    raw_fd: None,
-                    local_addr,
-                    peer_addr: peer_addr_s,
-                    sndbuf_actual,
-                    rcvbuf_actual,
-                    congestion_used: None,
-                });
+                    None,
+                ));
             } else {
                 let c = counters.clone();
                 let d = done.clone();
@@ -1423,19 +1419,21 @@ impl Server {
                 let task = thread_gate.spawn(move || {
                     stream::run_udp_receiver_blocking(std_sock, c, stats_clone, bs, d, u64bit)
                 });
-                streams.push(DataStream {
-                    id: stream_id,
-                    is_sender,
-                    counters,
-                    udp_recv_stats: Some(stats),
+                streams.push(DataStream::from_meta(
+                    StreamMeta {
+                        id: stream_id,
+                        is_sender,
+                        counters,
+                        raw_fd: None,
+                        local_addr,
+                        peer_addr: peer_addr_s,
+                        sndbuf_actual,
+                        rcvbuf_actual,
+                        congestion_used: None,
+                    },
                     task,
-                    raw_fd: None,
-                    local_addr,
-                    peer_addr: peer_addr_s,
-                    sndbuf_actual,
-                    rcvbuf_actual,
-                    congestion_used: None,
-                });
+                    Some(stats),
+                ));
             }
         }
         // #178: hold TestStart (sent by the caller right after this returns)
@@ -1643,19 +1641,21 @@ impl Server {
                         md,
                     )
                 });
-                streams.push(DataStream {
-                    id: stream_id,
-                    is_sender,
-                    counters,
-                    udp_recv_stats: None,
+                streams.push(DataStream::from_meta(
+                    StreamMeta {
+                        id: stream_id,
+                        is_sender,
+                        counters,
+                        raw_fd: None,
+                        local_addr,
+                        peer_addr: Some(client_addr),
+                        sndbuf_actual,
+                        rcvbuf_actual,
+                        congestion_used: None,
+                    },
                     task,
-                    raw_fd: None,
-                    local_addr,
-                    peer_addr: Some(client_addr),
-                    sndbuf_actual,
-                    rcvbuf_actual,
-                    congestion_used: None,
-                });
+                    None,
+                ));
             } else {
                 let stats = Arc::new(Mutex::new(UdpRecvStats::new()));
                 routes.insert(
@@ -1669,19 +1669,21 @@ impl Server {
                 // below; give each a resolved placeholder task so the per-stream
                 // join at teardown stays uniform. The real handle is `demux_handle`.
                 let task = tokio::spawn(async { Ok::<(), RiperfError>(()) });
-                streams.push(DataStream {
-                    id: stream_id,
-                    is_sender,
-                    counters,
-                    udp_recv_stats: Some(stats),
+                streams.push(DataStream::from_meta(
+                    StreamMeta {
+                        id: stream_id,
+                        is_sender,
+                        counters,
+                        raw_fd: None,
+                        local_addr,
+                        peer_addr: Some(client_addr),
+                        sndbuf_actual,
+                        rcvbuf_actual,
+                        congestion_used: None,
+                    },
                     task,
-                    raw_fd: None,
-                    local_addr,
-                    peer_addr: Some(client_addr),
-                    sndbuf_actual,
-                    rcvbuf_actual,
-                    congestion_used: None,
-                });
+                    Some(stats),
+                ));
             }
         }
 

--- a/riperf3/src/stream.rs
+++ b/riperf3/src/stream.rs
@@ -427,7 +427,50 @@ pub struct DataStream {
     pub congestion_used: Option<String>,
 }
 
+/// The non-task, non-stats fields a create-streams path captures per stream
+/// before the socket moves into its data task. Bundling them into one struct
+/// gives the `DataStream` field set a single source of truth: adding a future
+/// field becomes one compiler-enforced change across every caller, instead of
+/// the #25-class "fixed one create-streams branch, forgot the other" drift.
+/// The `task` and `udp_recv_stats` stay out — they're computed per branch
+/// (the spawn shape and the receiver-only jitter mutex diverge by role) and
+/// are passed alongside the meta to `DataStream::from_meta`.
+pub(crate) struct StreamMeta {
+    pub id: i32,
+    pub is_sender: bool,
+    pub counters: Arc<StreamCounters>,
+    pub raw_fd: Option<i32>,
+    pub local_addr: Option<std::net::SocketAddr>,
+    pub peer_addr: Option<std::net::SocketAddr>,
+    pub sndbuf_actual: Option<u64>,
+    pub rcvbuf_actual: Option<u64>,
+    pub congestion_used: Option<String>,
+}
+
 impl DataStream {
+    /// Assemble a `DataStream` from its captured `StreamMeta` plus the two
+    /// per-branch values: the spawned `task` and the receiver-only
+    /// `udp_recv_stats` (UDP receivers pass `Some`; everyone else `None`).
+    pub(crate) fn from_meta(
+        meta: StreamMeta,
+        task: JoinHandle<Result<()>>,
+        udp_recv_stats: Option<Arc<Mutex<UdpRecvStats>>>,
+    ) -> Self {
+        DataStream {
+            id: meta.id,
+            is_sender: meta.is_sender,
+            counters: meta.counters,
+            udp_recv_stats,
+            task,
+            raw_fd: meta.raw_fd,
+            local_addr: meta.local_addr,
+            peer_addr: meta.peer_addr,
+            sndbuf_actual: meta.sndbuf_actual,
+            rcvbuf_actual: meta.rcvbuf_actual,
+            congestion_used: meta.congestion_used,
+        }
+    }
+
     /// The omit-adjusted lifetime retransmit total to render/exchange for a TCP
     /// sending stream, or `None` for a receiver, a UDP stream, or a platform
     /// without TCP_INFO retransmits (Windows) — where iperf3 omits the `Retr`
@@ -1757,6 +1800,67 @@ pub fn run_udp_receiver_blocking(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // #144: DataStream::from_meta must move every captured field through
+    // unchanged and attach the two per-branch values (task + udp_recv_stats).
+    // This is the round-trip guard that makes the bundled StreamMeta a safe
+    // single source of truth for the create-streams paths.
+    #[tokio::test]
+    async fn from_meta_round_trips_every_field() {
+        let counters = Arc::new(StreamCounters::new());
+        let local: std::net::SocketAddr = "127.0.0.1:5201".parse().unwrap();
+        let peer: std::net::SocketAddr = "10.0.0.2:40000".parse().unwrap();
+        let meta = StreamMeta {
+            id: 7,
+            is_sender: true,
+            counters: counters.clone(),
+            raw_fd: Some(42),
+            local_addr: Some(local),
+            peer_addr: Some(peer),
+            sndbuf_actual: Some(212_992),
+            rcvbuf_actual: Some(131_072),
+            congestion_used: Some("bbr".to_string()),
+        };
+        let stats = Arc::new(Mutex::new(UdpRecvStats::new()));
+        let task = tokio::spawn(async { Ok(()) });
+        let ds = DataStream::from_meta(meta, task, Some(stats.clone()));
+
+        assert_eq!(ds.id, 7);
+        assert!(ds.is_sender);
+        assert!(Arc::ptr_eq(&ds.counters, &counters));
+        assert_eq!(ds.raw_fd, Some(42));
+        assert_eq!(ds.local_addr, Some(local));
+        assert_eq!(ds.peer_addr, Some(peer));
+        assert_eq!(ds.sndbuf_actual, Some(212_992));
+        assert_eq!(ds.rcvbuf_actual, Some(131_072));
+        assert_eq!(ds.congestion_used.as_deref(), Some("bbr"));
+        assert!(ds.udp_recv_stats.is_some());
+        ds.task.abort();
+
+        // The None udp_recv_stats branch (TCP / UDP sender) round-trips too.
+        let meta2 = StreamMeta {
+            id: 1,
+            is_sender: false,
+            counters: Arc::new(StreamCounters::new()),
+            raw_fd: None,
+            local_addr: None,
+            peer_addr: None,
+            sndbuf_actual: None,
+            rcvbuf_actual: None,
+            congestion_used: None,
+        };
+        let ds2 = DataStream::from_meta(meta2, tokio::spawn(async { Ok(()) }), None);
+        assert_eq!(ds2.id, 1);
+        assert!(!ds2.is_sender);
+        assert!(ds2.raw_fd.is_none());
+        assert!(ds2.local_addr.is_none());
+        assert!(ds2.peer_addr.is_none());
+        assert!(ds2.sndbuf_actual.is_none());
+        assert!(ds2.rcvbuf_actual.is_none());
+        assert!(ds2.congestion_used.is_none());
+        assert!(ds2.udp_recv_stats.is_none());
+        ds2.task.abort();
+    }
 
     // #185: the paced UDP batch is sized to ~one pacing quantum of send budget,
     // not a fixed packet count. A low rate over a large datagram must drop to a


### PR DESCRIPTION
Closes #144.

## What
A conservative refactor giving the per-stream data-stream setup a single source of truth, to prevent the #25-class "fixed one create-streams branch, forgot the other" drift. **No behavior change** — wire/CLI/`-J` output untouched.

## Two extractions
- **`StreamMeta` + `DataStream::from_meta`** (stream.rs): the 9 captured per-stream fields bundle into `StreamMeta`; `from_meta(meta, task, udp_recv_stats)` assembles the `DataStream`. All **8 production literals** (3 client, 5 server) route through it — adding a future `DataStream` field is now one compiler-enforced change across every caller instead of 8 hand-edited literals.
- **`net::capture_stream_meta(SockRef, window, apply_window)`** (net.rs): local/peer addr + realized `SO_SNDBUF`/`SO_RCVBUF` + the #97 window-clamp check, in one place so no path can forget the check. The **4 regular** per-stream-socket sites route through it (TCP `apply_window=false` — window already applied in `configure_tcp_stream_full`; UDP `true`). The **aggregate-sized UDP demux** site stays inline (it sizes its recv buffer to per-stream × recv_count — structurally unique). `SockRef::local_addr().as_socket()` was verified byte-identical to the prior `TcpStream/UdpSocket::local_addr()` for IPv4/IPv6.

## Deliberately NOT folded (avoids reintroducing coupling)
The divergent connect/accept/UDP-handshake/demux heads, the client-only option set (`set_dont_fragment`/`fq_rate`/timeouts/flowlabel), the zerocopy spawn gate, the sendmmsg choice, and the inverted `is_sender` index (client `i<send_count` vs server `i>=recv_count`) all stay role-specific. The 4 `bytes/blksize` derivation sites are left for #256.

## Verification
`cargo test --workspace` (new `from_meta` round-trip unit test), clippy `-D warnings`, fmt, lib rustdoc `-D warnings`, `xcheck` 7/7 targets. Per-PR compat smoke (52/52) on the sandbox fleet + two cold-review rounds gate the merge.
