### PR TITLE
fix(reporter): final partial interval reports the sender's final TCP_INFO (#245)

### DIFF
--- a/riperf3/src/reporter.rs
+++ b/riperf3/src/reporter.rs
@@ -909,10 +909,33 @@ pub fn spawn_interval_reporter(
                                         Some(info.pmtu),
                                         Some(info.reorder),
                                     )
-                                } else if let Some(s) = last_tcp[i] {
-                                    // Final-interval fallback (#55): the socket closed as
-                                    // the run ended, so a fresh read failed. Reuse the
-                                    // last sample's cwnd/rtt; no new retransmit count is
+                                } else if let Some(s) = stream
+                                    .counters
+                                    .final_tcp_sample()
+                                    .map(|info| TcpSample {
+                                        snd_cwnd: info.snd_cwnd,
+                                        snd_wnd: info.snd_wnd,
+                                        rtt: info.rtt,
+                                        rttvar: info.rttvar,
+                                        pmtu: info.pmtu,
+                                        reorder: info.reorder,
+                                    })
+                                    .or(last_tcp[i])
+                                {
+                                    // Final-interval fallback (#55/#245): the socket
+                                    // closed as the run ended, so a fresh read failed.
+                                    // PREFER the sender's genuinely-final snapshot
+                                    // (#245) — captured by snapshot_final_retransmits
+                                    // while the socket was still open, the LIVE
+                                    // cwnd/snd_wnd/rtt iperf3 reports by keeping its
+                                    // sockets open through the end exchange — and fall
+                                    // back to the previous interval's cached sample
+                                    // (#55) when no final snapshot exists. SAFE mid-run:
+                                    // final_tcp_sample is None until the sender exits
+                                    // (set AFTER the periodic ticks stop), so a transient
+                                    // read failure during the run still falls through to
+                                    // last_tcp[i] exactly as before — only the post-`done`
+                                    // final flush sees Some. No new retransmit count is
                                     // measurable for the sub-interval, so report 0.
                                     (
                                         Some(0),
@@ -1904,6 +1927,235 @@ mod interval_reporter_tests {
             "final interval must be a sub-interval partial; start={} end={} dur={dur}",
             last.sum.start,
             last.sum.end
+        );
+    }
+
+    /// #245: when the final partial interval's TCP_INFO read hits a CLOSED fd
+    /// (the sender dropped its socket on `done`, the #159 order), the fallback
+    /// must report the sender's GENUINELY-FINAL snapshot — captured by
+    /// `snapshot_final_retransmits` while the socket was still open — not blank
+    /// and not the previous interval's stale sample. Here the live read always
+    /// fails (`raw_fd = Some(-1)`), so `last_tcp` is never populated; pre-fix the
+    /// final interval's snd_cwnd/rtt would be `None`. The fix surfaces the stashed
+    /// final sample. Gated to platforms that read TCP_INFO at all (the reporter's
+    /// `has_retransmits` requires it) and to unix (raw fds).
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn final_partial_prefers_sender_final_tcp_sample() {
+        use crate::reporter::{CollectedIntervals, IntervalStreamRef};
+        use crate::stream::StreamCounters;
+        use crate::tcp_info::{has_retransmit_info, TcpInfoSnapshot};
+        use std::sync::Mutex;
+        use std::time::Duration;
+
+        // The reporter only reads TCP_INFO where the platform provides it; on
+        // others has_retransmits is false and there's nothing to exercise.
+        if !has_retransmit_info() {
+            return;
+        }
+
+        let interval = 0.5_f64;
+        let counters = Arc::new(StreamCounters::new());
+        let done = Arc::new(AtomicBool::new(false));
+        let collector = Arc::new(Mutex::new(CollectedIntervals::default()));
+
+        // The sender's genuinely-final snapshot, with values no fresh loopback
+        // connection would produce — proves the final interval carries THESE.
+        counters.set_final_tcp_sample(TcpInfoSnapshot {
+            total_retransmits: 0,
+            snd_cwnd: 424_242_424,
+            snd_wnd: 31_337,
+            rtt: 271_828,
+            rttvar: 161_803,
+            snd_mss: 1_448,
+            pmtu: 1_492,
+            reorder: 5,
+        });
+
+        let stream_ref = IntervalStreamRef {
+            id: 1,
+            is_sender: true,
+            counters: counters.clone(),
+            udp_recv_stats: None,
+            // An invalid fd: get_tcp_info fails on every tick AND the final
+            // flush, so last_tcp stays None and only the stashed final sample
+            // can fill the final interval (the closed-socket end state of #159).
+            raw_fd: Some(-1),
+        };
+        let config = IntervalReporterConfig {
+            interval_secs: interval,
+            protocol: TransportProtocol::Tcp,
+            format_char: 'a',
+            omit_secs: 0,
+            forceflush: false,
+            json_stream: false,
+            print: false,
+            blksize: 128 * 1024,
+            keep_intervals: false,
+            bidir: false,
+            is_server: false,
+        };
+        let reporter_end = Arc::new(ReporterEnd::new());
+        let report_start = std::time::Instant::now();
+        let handle = spawn_interval_reporter(
+            config,
+            vec![stream_ref],
+            done.clone(),
+            reporter_end.clone(),
+            Some(collector.clone()),
+            None,
+            None,
+        )
+        .expect("reporter spawns for a positive interval");
+
+        // One full interval, then a partial second that ends mid-interval.
+        counters.record_sent(1000);
+        tokio::time::sleep(Duration::from_millis(650)).await; // tick @0.5
+        counters.record_sent(500);
+        tokio::time::sleep(Duration::from_millis(120)).await;
+        done.store(true, Ordering::Relaxed);
+        reporter_end.finish(report_start.elapsed().as_secs_f64());
+        let _ = handle.await;
+
+        let g = collector.lock().unwrap();
+        let n = g.intervals.len();
+        assert!(n >= 1, "expected at least one collected interval");
+        let last = &g.intervals[n - 1];
+        assert_eq!(
+            last.sum.bytes, 500,
+            "final partial carries the residual bytes (#55 invariant intact)"
+        );
+        let s = last
+            .streams
+            .first()
+            .expect("the final interval has a per-stream entry");
+        assert_eq!(
+            s.snd_cwnd,
+            Some(424_242_424),
+            "final interval must report the sender's genuinely-final cwnd (#245), \
+             not None (pre-fix the closed fd left it blank)"
+        );
+        assert_eq!(
+            s.rtt,
+            Some(271_828),
+            "final interval must report the sender's genuinely-final rtt (#245)"
+        );
+    }
+
+    /// #245: the genuinely-final snapshot must WIN over the previous interval's
+    /// cached `last_tcp` sample (the #55 fallback). A real loopback socket feeds
+    /// the periodic tick a real `last_tcp`; then the socket is dropped and a
+    /// distinct final snapshot is stashed. The closed-fd final flush must emit
+    /// the stashed values, not the real loopback ones — pre-fix it took the
+    /// stale `last_tcp`.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn final_partial_overrides_cached_last_tcp_with_final_sample() {
+        use crate::reporter::{CollectedIntervals, IntervalStreamRef};
+        use crate::stream::StreamCounters;
+        use crate::tcp_info::{has_retransmit_info, TcpInfoSnapshot};
+        use std::os::unix::io::AsRawFd;
+        use std::sync::Mutex;
+        use std::time::Duration;
+
+        if !has_retransmit_info() {
+            return;
+        }
+
+        // A real connected loopback pair so the periodic tick reads a real,
+        // small cwnd into `last_tcp` (kept distinct from the sentinel below).
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let client_join =
+            tokio::spawn(async move { tokio::net::TcpStream::connect(addr).await.unwrap() });
+        let (server_stream, _) = listener.accept().await.unwrap();
+        let client_stream = client_join.await.unwrap();
+        let fd = server_stream.as_raw_fd();
+
+        let interval = 0.5_f64;
+        let counters = Arc::new(StreamCounters::new());
+        let done = Arc::new(AtomicBool::new(false));
+        let collector = Arc::new(Mutex::new(CollectedIntervals::default()));
+
+        let stream_ref = IntervalStreamRef {
+            id: 1,
+            is_sender: true,
+            counters: counters.clone(),
+            udp_recv_stats: None,
+            raw_fd: Some(fd),
+        };
+        let config = IntervalReporterConfig {
+            interval_secs: interval,
+            protocol: TransportProtocol::Tcp,
+            format_char: 'a',
+            omit_secs: 0,
+            forceflush: false,
+            json_stream: false,
+            print: false,
+            blksize: 128 * 1024,
+            keep_intervals: false,
+            bidir: false,
+            is_server: false,
+        };
+        let reporter_end = Arc::new(ReporterEnd::new());
+        let report_start = std::time::Instant::now();
+        let handle = spawn_interval_reporter(
+            config,
+            vec![stream_ref],
+            done.clone(),
+            reporter_end.clone(),
+            Some(collector.clone()),
+            None,
+            None,
+        )
+        .expect("reporter spawns for a positive interval");
+
+        // One full interval: the tick reads the live socket → last_tcp set to a
+        // real (small) cwnd.
+        counters.record_sent(1000);
+        tokio::time::sleep(Duration::from_millis(650)).await; // tick @0.5
+
+        // Now the sender "exits": stash a sentinel final snapshot and CLOSE the
+        // socket so the final flush's live read fails (the #159 end state).
+        counters.set_final_tcp_sample(TcpInfoSnapshot {
+            total_retransmits: 0,
+            snd_cwnd: 424_242_424, // impossibly large for a fresh loopback cwnd
+            snd_wnd: 31_337,
+            rtt: 271_828,
+            rttvar: 161_803,
+            snd_mss: 1_448,
+            pmtu: 1_492,
+            reorder: 5,
+        });
+        drop(server_stream);
+        drop(client_stream);
+
+        counters.record_sent(500);
+        tokio::time::sleep(Duration::from_millis(120)).await;
+        done.store(true, Ordering::Relaxed);
+        reporter_end.finish(report_start.elapsed().as_secs_f64());
+        let _ = handle.await;
+
+        let g = collector.lock().unwrap();
+        let n = g.intervals.len();
+        assert!(n >= 1, "expected at least one collected interval");
+        let last = &g.intervals[n - 1];
+        let s = last
+            .streams
+            .first()
+            .expect("the final interval has a per-stream entry");
+        // The sentinel, not the real loopback cwnd captured into last_tcp.
+        assert_eq!(
+            s.snd_cwnd,
+            Some(424_242_424),
+            "final interval must PREFER the sender's final snapshot over the \
+             cached last_tcp sample (#245); got {:?}",
+            s.snd_cwnd
+        );
+        assert_eq!(
+            s.rtt,
+            Some(271_828),
+            "final rtt must be the final sample (#245)"
         );
     }
 

--- a/riperf3/src/stream.rs
+++ b/riperf3/src/stream.rs
@@ -46,6 +46,16 @@ pub struct StreamCounters {
     /// stream_prev_total_retrans the same way, so the exchanged total covers
     /// the post-omit window only. -1 = no boundary crossed.
     omit_retransmits: AtomicI64,
+    /// #245: the sender task's genuinely-final TCP_INFO snapshot (cwnd / snd_wnd
+    /// / rtt / rttvar / pmtu / reorder), captured by `snapshot_final_retransmits`
+    /// while the socket is still open, just before the sender drops it. The #159
+    /// stop→grace→flush order means the reporter's final partial-interval read
+    /// then hits a CLOSED fd; with this stashed the closed-fd fallback can report
+    /// the LIVE final sample instead of the previous interval's cached one (the
+    /// #55 stale fallback). `None` = not captured (receiver, UDP, non-unix, or no
+    /// platform support). Set ONCE per stream at sender exit, read ONCE at the
+    /// final flush — never contended, never on the hot path, so a plain Mutex.
+    final_tcp_sample: Mutex<Option<crate::tcp_info::TcpInfoSnapshot>>,
 }
 
 impl Default for StreamCounters {
@@ -65,6 +75,7 @@ impl StreamCounters {
             bytes_received_omit: AtomicU64::new(0),
             final_retransmits: AtomicI64::new(-1),
             omit_retransmits: AtomicI64::new(-1),
+            final_tcp_sample: Mutex::new(None),
         }
     }
 
@@ -102,6 +113,22 @@ impl StreamCounters {
     /// The snapshotted end-of-test retransmit total, or -1 if never captured.
     pub fn final_retransmits(&self) -> i64 {
         self.final_retransmits.load(Ordering::Relaxed)
+    }
+
+    /// Store the sender's genuinely-final TCP_INFO snapshot (#245; sender task
+    /// only, captured while the socket is still open just before it is dropped).
+    pub fn set_final_tcp_sample(&self, info: crate::tcp_info::TcpInfoSnapshot) {
+        if let Ok(mut g) = self.final_tcp_sample.lock() {
+            *g = Some(info);
+        }
+    }
+
+    /// The sender's genuinely-final TCP_INFO snapshot, or `None` if never
+    /// captured (#245). A poisoned lock also yields `None` — the closed-fd
+    /// fallback then degrades to the previous interval's cached sample, never
+    /// panics.
+    pub fn final_tcp_sample(&self) -> Option<crate::tcp_info::TcpInfoSnapshot> {
+        self.final_tcp_sample.lock().ok().and_then(|g| *g)
     }
 
     /// Record the omit-boundary retransmit baseline (#171; reporter boundary
@@ -535,6 +562,12 @@ fn snapshot_final_retransmits(stream: &TcpStream, counters: &StreamCounters) {
         use std::os::unix::io::AsRawFd;
         if let Some(info) = crate::tcp_info::get_tcp_info(stream.as_raw_fd()) {
             counters.set_final_retransmits(info.total_retransmits as i64);
+            // #245: stash the WHOLE final snapshot too (cwnd/snd_wnd/rtt/...),
+            // read here while the socket is still open. The reporter's final
+            // partial-interval read hits the closed fd post-#159; this lets its
+            // fallback report the live final sample instead of the previous
+            // interval's stale one (#55).
+            counters.set_final_tcp_sample(info);
         }
     }
     #[cfg(not(unix))]
@@ -2055,6 +2088,40 @@ mod tests {
         assert_eq!(c.bytes_received(), 125);
         assert_eq!(c.take_received_interval(), 125);
         assert_eq!(c.take_received_interval(), 0);
+    }
+
+    /// #245: the final TCP_INFO snapshot stash round-trips. Default is `None`
+    /// (no socket read yet — receiver/UDP/non-unix stay here, so the reporter's
+    /// closed-fd fallback keeps the #55 cached-sample behavior); after the sender
+    /// stashes its genuinely-final sample, the reporter reads back exactly those
+    /// values.
+    #[test]
+    fn final_tcp_sample_round_trip() {
+        let c = StreamCounters::new();
+        assert!(
+            c.final_tcp_sample().is_none(),
+            "no final sample captured yet → None (keeps the #55 fallback)"
+        );
+
+        let snap = crate::tcp_info::TcpInfoSnapshot {
+            total_retransmits: 7,
+            snd_cwnd: 123_456,
+            snd_wnd: 65_535,
+            rtt: 4_321,
+            rttvar: 99,
+            snd_mss: 1_448,
+            pmtu: 1_500,
+            reorder: 3,
+        };
+        c.set_final_tcp_sample(snap);
+
+        let got = c.final_tcp_sample().expect("captured sample reads back");
+        assert_eq!(got.snd_cwnd, 123_456);
+        assert_eq!(got.snd_wnd, 65_535);
+        assert_eq!(got.rtt, 4_321);
+        assert_eq!(got.rttvar, 99);
+        assert_eq!(got.pmtu, 1_500);
+        assert_eq!(got.reorder, 3);
     }
 
     /// Regression: verify that interval swap-and-reset does NOT

--- a/riperf3/src/tcp_info.rs
+++ b/riperf3/src/tcp_info.rs
@@ -1,5 +1,5 @@
 /// Subset of TCP connection metrics from the kernel's `TCP_INFO` socket option.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Copy, Default)]
 pub struct TcpInfoSnapshot {
     /// Cumulative retransmissions over the connection lifetime.
     pub total_retransmits: u32,


### PR DESCRIPTION
Closes #245.

## What
The final partial interval's TCP_INFO (cwnd/snd_wnd/rtt) was stale: the TCP sender drops its `TcpStream` when its loop exits on `done`, so under the #159 stop→grace→flush order the reporter's final read hits a **closed fd** and took the #55 fallback — the *previous* interval's cached sample. iperf3 keeps its sockets open through the end exchange and reads live there. This surfaces the sender's **genuinely-final** snapshot instead.

## Fix — option (a), purely additive (no lifecycle/ordering change)
`snapshot_final_retransmits` already reads TCP_INFO once, just before the sender drops the socket (it's how #156 stashes the final retransmit count). Extend it to stash the **full** snapshot on `StreamCounters.final_tcp_sample`, and have the reporter's closed-fd fallback prefer it over `last_tcp[i]`.

- `tcp_info.rs`: `TcpInfoSnapshot` derives `Copy`.
- `stream.rs`: `StreamCounters.final_tcp_sample` (set once at sender exit; poison-safe get/set); `snapshot_final_retransmits` stashes the full snapshot. Non-unix is a no-op → `None` → unchanged.
- `reporter.rs`: the #55 closed-fd fallback prefers `final_tcp_sample()`, else `last_tcp[i]`.

**Safe mid-run:** `final_tcp_sample` is `None` until the sender exits (set *after* the periodic ticks stop), so a transient read failure during the run still falls through to `last_tcp[i]` exactly as before — only the post-`done` final flush sees `Some`. The `done`→sleep→`finish` ordering and the sender lifecycle are untouched.

No wire-format change — only which (already-valid) cwnd/snd_wnd/rtt the final sub-interval reports.

## Tests (red-first)
- `final_partial_prefers_sender_final_tcp_sample` — closed fd (`raw_fd=Some(-1)`), `last_tcp` never populated; the final interval reports the stashed snapshot (pre-fix: `None`).
- `final_partial_overrides_cached_last_tcp_with_final_sample` — a real loopback tick populates `last_tcp`, then the socket drops and a distinct sentinel is stashed; the final flush emits the sentinel (proving preference over the cached sample).
- `final_tcp_sample_round_trip` — `StreamCounters` set/get.

## Verification
`cargo test --workspace`, clippy `-D warnings`, fmt, lib rustdoc `-D warnings`, `xcheck` 7/7. Per-PR compat smoke (52/52) + two cold-review rounds gate the merge.
