### PR TITLE
fix(error): mirror GT's perr-class trailing ': ' on the SERVER_ERROR relay (#248)

### DIFF
--- a/riperf3/src/error.rs
+++ b/riperf3/src/error.rs
@@ -81,32 +81,47 @@ pub enum RiperfError {
 /// iperf3 servers relay stale/live errno from the bitrate and
 /// cleanup_server sites). Rendered via io::Error, whose "(os error N)"
 /// suffix is the convention riperf3's raw os errors already carry (#151).
-/// CONSCIOUS DEVIATION: iperf_strerror's perr codes emit a dangling ": "
-/// even at errno==0 (live: "server test duration expired: ") — an artifact
-/// we do not mirror. Unknown codes use iperf3's literal "int_errno=%d"
-/// fallback (iperf_error.c default case).
+/// PERR SUFFIX (#248): iperf_strerror's perr-class codes emit a dangling ": "
+/// even at errno==0 (live: "server test duration expired: "). Mirrored per-code
+/// from the d39cf41 iperf_error.c switch — 160 and the int_errno default are
+/// perr=1 (they get the suffix); 27/37/120 are perr=0 (snprintf-only, stay
+/// bare). Unknown codes use iperf3's literal "int_errno=%d" fallback (the
+/// default case, which is perr=1).
 pub(crate) fn iperf3_strerror(i_errno: u32, os_errno: u32) -> String {
-    let base = match i_errno {
-        // IETOTALRATE — the --server-bitrate-limit breach
-        27 => "total required bandwidth is larger than server limit".to_string(),
+    // `perr` is iperf_error.c's per-code flag: when set, GT dangles a trailing
+    // ": " even at errno==0.
+    let (base, perr) = match i_errno {
+        // IETOTALRATE — the --server-bitrate-limit breach (perr=0)
+        27 => (
+            "total required bandwidth is larger than server limit".to_string(),
+            false,
+        ),
         // IEMAXSERVERTESTDURATIONEXCEEDED — the upfront param-exchange
         // reject modern iperf3 servers send for over-limit or unbounded
         // requests. riperf3's own upfront check is #230, but a real iperf3
-        // server can relay this TODAY, so the client must render it.
-        37 => {
-            "client's requested duration exceeds the server's maximum permitted limit".to_string()
-        }
-        // IESERVERTERM — a server relaying its own terminate as an error
-        120 => "the server has terminated".to_string(),
-        // IESERVERTESTDURATIONEXPIRED — the --server-max-duration timer
-        160 => "server test duration expired".to_string(),
-        other => format!("int_errno={other}"),
+        // server can relay this TODAY, so the client must render it. (perr=0)
+        37 => (
+            "client's requested duration exceeds the server's maximum permitted limit".to_string(),
+            false,
+        ),
+        // IESERVERTERM — a server relaying its own terminate as an error (perr=0)
+        120 => ("the server has terminated".to_string(), false),
+        // IESERVERTESTDURATIONEXPIRED — the --server-max-duration timer (perr=1)
+        160 => ("server test duration expired".to_string(), true),
+        // iperf3's default case is perr=1.
+        other => (format!("int_errno={other}"), true),
     };
     if os_errno > 0 {
+        // Unchanged r1 decision (#248 out of scope): append ", errno: <strerror>"
+        // for any code at errno>0. Unreachable from a riperf3 server, which
+        // always relays errno 0.
         format!(
             "{base}, errno: {}",
             std::io::Error::from_raw_os_error(os_errno as i32)
         )
+    } else if perr {
+        // GT's dangling ": " for the perr-class codes at errno==0 (#248).
+        format!("{base}: ")
     } else {
         base
     }
@@ -124,17 +139,20 @@ mod strerror_tests {
             "total required bandwidth is larger than server limit"
         );
         assert_eq!(iperf3_strerror(120, 0), "the server has terminated");
-        assert_eq!(iperf3_strerror(160, 0), "server test duration expired");
+        // #248: 160 is perr=1, so GT dangles a trailing ": " even at errno==0;
+        // 27/120 above are perr=0 and stay bare.
+        assert_eq!(iperf3_strerror(160, 0), "server test duration expired: ");
     }
 
     /// The errno append is UNCONDITIONAL on errno > 0 for every code
     /// (iperf_client_api.c:403-404 — the r1 review corrected the earlier
-    /// perr-gated model with a live probe); errno == 0 appends nothing (the
-    /// dangling-": " iperf_strerror artifact is a documented conscious
-    /// deviation). Unknown codes fall back to iperf3's literal int_errno=%d.
+    /// perr-gated model with a live probe). At errno == 0, perr-class codes
+    /// (160 and the int_errno default) get GT's dangling ": " (#248); perr=0
+    /// codes (27/37/120) stay bare. Unknown codes fall back to int_errno=%d.
     #[test]
     fn errno_append_and_fallback() {
-        assert_eq!(iperf3_strerror(9999, 0), "int_errno=9999");
+        // #248: the int_errno default is perr=1 → trailing ": " at errno==0.
+        assert_eq!(iperf3_strerror(9999, 0), "int_errno=9999: ");
         for (code, base) in [
             (160u32, "server test duration expired"),
             (

--- a/riperf3/src/protocol.rs
+++ b/riperf3/src/protocol.rs
@@ -1667,6 +1667,47 @@ mod protocol_error_tests {
         let _ = server_task.await;
     }
 
+    /// #248: a SERVER_ERROR(160) — the --server-max-duration timer relay — is
+    /// adopted as iperf_strerror(160), which is perr-class, so GT (and now
+    /// riperf3) dangles a trailing ": ". The fast end-to-end pin for the suffix
+    /// (the real watchdog fires at duration+omit+40s, too slow to drive live).
+    #[tokio::test]
+    async fn client_handles_server_error_duration_expired() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        let server_task = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let mut cookie = [0u8; 37];
+            tokio::io::AsyncReadExt::read_exact(&mut stream, &mut cookie)
+                .await
+                .unwrap();
+            protocol::send_state(&mut stream, TestState::ServerError)
+                .await
+                .unwrap();
+            tokio::io::AsyncWriteExt::write_all(
+                &mut stream,
+                &[160u32.to_be_bytes(), 0u32.to_be_bytes()].concat(),
+            )
+            .await
+            .unwrap();
+        });
+
+        let client = crate::ClientBuilder::new("127.0.0.1")
+            .port(Some(addr.port()))
+            .duration(1)
+            .build()
+            .unwrap();
+        let result = client.run().await;
+        let err = result.expect_err("client should error on ServerError");
+        assert_eq!(
+            err.to_string(),
+            "server test duration expired: ",
+            "the client adopts the relayed perr-class strerror(160) with GT's dangling ': ' (#248): {err:?}"
+        );
+        let _ = server_task.await;
+    }
+
     /// A SERVER_ERROR whose payload never arrives (peer died mid-relay, or a
     /// pre-payload sender): still an error, never a hang or a panic.
     #[tokio::test]


### PR DESCRIPTION
Closes #248.

## What
GT's `iperf_strerror` dangles a trailing `": "` even at errno==0 for its **perr-class** codes (live: `server test duration expired: `) — an artifact riperf3 had consciously not mirrored. The d39cf41 `iperf_error.c` audit shows it's **per-code, not blanket**:

| code | iperf3 name | perr | errno==0 render |
|---|---|---|---|
| 160 | IESERVERTESTDURATIONEXPIRED | 1 | `server test duration expired: ` |
| default | (int_errno=N) | 1 | `int_errno=N: ` |
| 27 | IETOTALRATE | 0 | `total required bandwidth is larger than server limit` (bare) |
| 37 | IEMAXSERVERTESTDURATIONEXCEEDED | 0 | `…maximum permitted limit` (bare) |
| 120 | IESERVERTERM | 0 | `the server has terminated` (bare) |

## Change
`iperf3_strerror` now carries a per-code `perr` flag and appends `"{base}: "` at errno==0 for the perr-class codes only. The `errno>0` branch (`", errno: <strerror>"`, the r1 live-verified unconditional append — unreachable from a riperf3 server, which always relays errno 0) is **unchanged**.

## Guardrails (unaffected)
27/37/120 stay bare, so the code-27 exact pins (`protocol.rs`, `integration.rs`, `self_terminate` `BITRATE_MSG`) and the code-37 `MAXDUR_MSG` pins are untouched. The server's *local* 160 line (`server.rs` `SELF_TERM_DURATION_MSG` — a different string, `"… - test is terminated by the server"`) is also unaffected.

## Tests (red-first)
- `error.rs` unit pins: `iperf3_strerror(160,0)` → `"server test duration expired: "`, `iperf3_strerror(9999,0)` → `"int_errno=9999: "`; 27/37/120 asserted bare.
- A fast end-to-end protocol test (`client_handles_server_error_duration_expired`) relays `SERVER_ERROR(160)` and asserts the client adopts `"server test duration expired: "` — the real `--server-max-duration` watchdog fires at duration+omit+40s (too slow to drive live; the existing watchdog test deliberately wedges the client).

## Verification
`cargo test --workspace`, clippy `-D warnings`, fmt, lib rustdoc `-D warnings`, `xcheck` 7/7. Per-PR compat smoke (52/52) + two cold-review rounds gate the merge.
