### PR TITLE
fix(tcp_info): per-platform-faithful snd_wnd via a signed (i64) chain (#161)

### DIFF
--- a/riperf3/src/json_report.rs
+++ b/riperf3/src/json_report.rs
@@ -327,8 +327,10 @@ pub struct IntervalStream {
     pub retransmits: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub snd_cwnd: Option<u64>,
+    // Signed so macOS can emit the faithful -1 (like iperf3's get_snd_wnd);
+    // non-negative values serialize identically to the old u64 (#161).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub snd_wnd: Option<u64>,
+    pub snd_wnd: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub rtt: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -456,8 +458,10 @@ pub struct TcpStreamSide {
     // emits when those are unavailable.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub max_snd_cwnd: Option<u64>,
+    // Signed i64 (the signed-max keeps macOS's -1 at 0); non-negative values
+    // serialize byte-identically to the old u64 (#161).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub max_snd_wnd: Option<u64>,
+    pub max_snd_wnd: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub max_rtt: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -594,8 +598,9 @@ pub struct StreamReport {
 pub struct TcpEndExtras {
     pub max_snd_cwnd: u64,
     /// Peak peer-advertised send window, where the platform reader captures
-    /// it (Linux UAPI mirror / FreeBSD) — iperf3's stream_max_snd_wnd (#161).
-    pub max_snd_wnd: u64,
+    /// it (Linux UAPI mirror / FreeBSD) — iperf3's stream_max_snd_wnd. Signed:
+    /// the signed-max accumulation keeps macOS's faithful -1 at 0 (#161).
+    pub max_snd_wnd: i64,
     pub max_rtt: u32,
     pub min_rtt: u32,
     pub mean_rtt: u32,

--- a/riperf3/src/reporter.rs
+++ b/riperf3/src/reporter.rs
@@ -521,7 +521,8 @@ pub struct IntervalReporterConfig {
 #[derive(Clone, Copy)]
 struct TcpSample {
     snd_cwnd: u64,
-    snd_wnd: u64,
+    /// Signed to carry macOS's faithful -1 (#161); Linux/FreeBSD non-negative.
+    snd_wnd: i64,
     rtt: u32,
     rttvar: u32,
     pmtu: u32,
@@ -534,7 +535,10 @@ struct TcpSample {
 pub struct StreamExtremes {
     pub stream_id: i32,
     pub max_snd_cwnd: u64,
-    pub max_snd_wnd: u64,
+    /// Signed i64 so the SIGNED max accumulation (`max(0i64, -1i64) == 0`)
+    /// keeps macOS's faithful -1 out of the peak; a u64 max would read -1 as
+    /// u64::MAX and inflate this catastrophically (#161).
+    pub max_snd_wnd: i64,
     pub max_rtt: u32,
     pub min_rtt: u32,
     pub reorder: u32,
@@ -1734,6 +1738,33 @@ mod tests {
         let line = format_summary_line(&s, 'm');
         assert!(line.contains(" 12 "), "Retr value should appear: {line}");
         assert!(line.ends_with("sender"));
+    }
+
+    // #161 (the load-bearing macOS-inflation guard, runs on every platform incl.
+    // Linux CI): the snd_wnd extremes accumulator is the EXACT expression the
+    // reporter runs (`e.max_snd_wnd = e.max_snd_wnd.max(info.snd_wnd)`) on i64
+    // operands. macOS's get_snd_wnd is a faithful -1; feeding that into the
+    // accumulator alongside the 0 start must yield max_snd_wnd == 0 (matching
+    // GT's macOS end), NOT u64::MAX / a huge number — which is precisely what
+    // an unsigned `(-1 as u64).max(0)` would have produced. This pins the
+    // signed-max contract that lets the faithful -1 flow without inflation.
+    #[test]
+    fn snd_wnd_signed_max_keeps_macos_minus_one_at_zero() {
+        let mut e = StreamExtremes::default();
+        assert_eq!(e.max_snd_wnd, 0i64, "extremes init to 0i64");
+        // The reporter's accumulator, verbatim, with macOS's -1.
+        let macos_snd_wnd: i64 = -1;
+        e.max_snd_wnd = e.max_snd_wnd.max(macos_snd_wnd);
+        assert_eq!(
+            e.max_snd_wnd, 0i64,
+            "signed max(0, -1) must be 0 — a u64 max would inflate to u64::MAX"
+        );
+        // A subsequent real (positive) sample still wins, unaffected.
+        e.max_snd_wnd = e.max_snd_wnd.max(1_500_000i64);
+        assert_eq!(e.max_snd_wnd, 1_500_000i64);
+        // And another -1 can't pull the established peak back down.
+        e.max_snd_wnd = e.max_snd_wnd.max(macos_snd_wnd);
+        assert_eq!(e.max_snd_wnd, 1_500_000i64);
     }
 }
 

--- a/riperf3/src/tcp_info.rs
+++ b/riperf3/src/tcp_info.rs
@@ -7,9 +7,10 @@ pub struct TcpInfoSnapshot {
     /// reader multiplies by mss; macOS and FreeBSD report bytes and are used
     /// raw, like iperf3 (#155).
     pub snd_cwnd: u64,
-    /// Send window advertised by the receiver, in bytes.
-    #[allow(dead_code)]
-    pub snd_wnd: u64,
+    /// Send window advertised by the receiver, in bytes. Signed so the macOS
+    /// reader can carry iperf3's faithful -1 (its `get_snd_wnd` returns -1
+    /// because the `HAVE_TCP_INFO_SND_WND` probe is dead on Apple) (#161).
+    pub snd_wnd: i64,
     /// Smoothed round-trip time in microseconds. On macOS the kernel's
     /// `tcpi_srtt` is MILLIseconds and is kept raw — iperf3 has the identical
     /// quirk (its APPLE `get_rtt` feeds tcpi_srtt into a usec-treated field),
@@ -151,9 +152,10 @@ pub fn get_tcp_info(fd: i32) -> Option<TcpInfoSnapshot> {
         // HAVE_TCP_INFO_SND_WND probe prefers linux/tcp.h, so Linux builds
         // emit the live value) (#161).
         snd_wnd: if field_filled(std::mem::offset_of!(LinuxTcpInfo, tcpi_snd_wnd)) {
-            info.tcpi_snd_wnd as u64
+            info.tcpi_snd_wnd as i64
         } else {
-            0
+            // Pre-5.4 short copy: iperf3 emits 0 where it can't read the field.
+            0i64
         },
         rtt: info.tcpi_rtt,
         rttvar: info.tcpi_rttvar,
@@ -258,9 +260,11 @@ pub fn get_tcp_info(fd: i32) -> Option<TcpInfoSnapshot> {
         // xnu has the live value, but iperf3's HAVE_TCP_INFO_SND_WND probe
         // checks struct tcp_info — absent on macOS — so its APPLE snd_wnd
         // branch is dead and get_snd_wnd returns -1. Emitting the real value
-        // here would diverge from every macOS iperf3 build; the faithful -1
-        // needs the 0.8.0 i64 report fields, so pin 0 until then (#161).
-        snd_wnd: 0,
+        // here would diverge from every macOS iperf3 build. The 0.8.0 i64
+        // report fields landed (#161), so emit the faithful -1; the signed max
+        // accumulation keeps it out of max_snd_wnd (max(0,-1)==0), matching
+        // GT's macOS max_snd_wnd:0.
+        snd_wnd: -1,
         rtt: info.tcpi_srtt,
         rttvar: info.tcpi_rttvar,
         snd_mss: info.tcpi_maxseg,
@@ -297,7 +301,7 @@ pub fn get_tcp_info(fd: i32) -> Option<TcpInfoSnapshot> {
         // FreeBSD's tcpi_snd_cwnd is BYTES (tcp_usrreq.c) and iperf3 uses it
         // raw — the old ×mss inflated the Cwnd column ~mss-fold (#155).
         snd_cwnd: info.tcpi_snd_cwnd as u64,
-        snd_wnd: info.tcpi_snd_wnd as u64,
+        snd_wnd: info.tcpi_snd_wnd as i64,
         rtt: info.tcpi_rtt,
         rttvar: info.tcpi_rttvar,
         snd_mss: info.tcpi_snd_mss,
@@ -437,6 +441,32 @@ mod tests {
             info.snd_cwnd >= info.snd_mss as u64 && info.snd_cwnd < (1 << 30),
             "snd_cwnd implausible: {}",
             info.snd_cwnd
+        );
+    }
+
+    // #161: macOS must emit the FAITHFUL -1 for snd_wnd. iperf3's
+    // HAVE_TCP_INFO_SND_WND probe checks `struct tcp_info` (absent on macOS),
+    // so its APPLE get_snd_wnd branch is dead and get_snd_wnd returns -1;
+    // riperf3's reader pins -1 to match. The signed-max accumulation then keeps
+    // it out of max_snd_wnd (max(0,-1)==0), so end emits max_snd_wnd:0 like GT.
+    // Validated by the macOS native CI job (can't run on Linux).
+    #[cfg(target_os = "macos")]
+    #[tokio::test]
+    async fn macos_snapshot_emits_faithful_minus_one_snd_wnd() {
+        use std::os::unix::io::AsRawFd;
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let client =
+            tokio::spawn(async move { tokio::net::TcpStream::connect(addr).await.unwrap() });
+        let (server_stream, _) = listener.accept().await.unwrap();
+        let _client_stream = client.await.unwrap();
+
+        let info = get_tcp_info(server_stream.as_raw_fd()).expect("TCP_CONNECTION_INFO");
+        assert_eq!(
+            info.snd_wnd, -1,
+            "macOS get_snd_wnd is faithfully -1 (the dead APPLE probe), got {}",
+            info.snd_wnd
         );
     }
 }


### PR DESCRIPTION
Closes #161. The last faithfulness item before #256.

## What
GT (iperf 3.21 @ d39cf41) emits `snd_wnd` differently per platform, and riperf3 had hardcoded macOS `snd_wnd: 0` because the report fields were unsigned:
- **macOS**: `get_snd_wnd()` returns **-1** (its `HAVE_TCP_INFO_SND_WND` probe checks `struct tcp_info`, absent on macOS → the APPLE branch is dead). The signed accumulation `temp.snd_wnd > stream_max_snd_wnd` keeps -1 out of the peak, so end `max_snd_wnd` stays **0**.
- **Linux/FreeBSD**: the real advertised window.

## Change — signed (i64) chain end-to-end
- `tcp_info.rs`: `TcpInfoSnapshot.snd_wnd` u64→**i64** (drop the now-stale `#[allow(dead_code)]`); macOS reader `0` → **`-1`**; Linux/FreeBSD read the real value `as i64`.
- `reporter.rs`: `TcpSample.snd_wnd` + `StreamExtremes.max_snd_wnd` → **i64**. **The load-bearing fix:** the extremes accumulator is now `i64::max`, so `max(0, -1) == 0` — a u64 max would read -1 as `u64::MAX` and catastrophically inflate the peak on macOS.
- `json_report.rs`: `IntervalStream.snd_wnd` → `Option<i64>`, `TcpStreamSide.max_snd_wnd` → `Option<i64>`, `TcpEndExtras.max_snd_wnd` → `i64` — matching the existing `retransmits`/`remote_packets` i64 -1-sentinel style.

## Faithfulness / blast radius
Linux/FreeBSD JSON is **byte-identical** (non-negative i64 serializes like u64). The **only** behavior change is macOS now emitting interval `snd_wnd: -1` / end `max_snd_wnd: 0`, matching GT. `snd_mss` keeps its `allow(dead_code)` (genuinely test-only). client.rs/server.rs needed no edits (the extremes flow i64→i64).

## Tests
- macOS test (`#[cfg(target_os="macos")]`, validated by the **macOS native CI** check) asserts `get_tcp_info().snd_wnd == -1`.
- A **Linux-CI** test runs the reporter's verbatim accumulator expression with `-1` and asserts `max_snd_wnd == 0` (the signed-max contract — the guard that would catch a u64 regression).
- Existing json_report `snd_wnd`/`max_snd_wnd` fixtures hold (non-negative literals infer i64; asserted JSON values unchanged).

## Verification
`cargo test --workspace`, clippy `-D warnings`, fmt, lib rustdoc `-D warnings`, **`xcheck` 7/7 (both darwin triples compile the `-1` reader)**. The macOS native-CI check runs the -1 path end-to-end. Per-PR compat smoke (52/52) + two cold-review rounds gate the merge.
