### PR TITLE
fix(json): faithful client -J upfront-refusal document (#261)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,9 @@ release tags.
 
 The architecture-and-API release the 0.7.x faithfulness train deferred. Per the
 SemVer 0.x convention, this minor bump carries breaking **library API** changes
-(below); the wire protocol, CLI flags, and `-J`/text output are unchanged — the
-faithful iperf3 drop-in behavior is preserved.
+(below). The wire protocol and CLI flags are unchanged. The success-path `-J`/
+text output is byte-identical; the only `-J` change is on the upfront-refusal
+path, which is now byte-faithful to iperf3 (#261).
 
 ### Breaking
 
@@ -31,6 +32,16 @@ faithful iperf3 drop-in behavior is preserved.
 - **`TestResultsJson` / `StreamResultJson` are no longer re-exported** from the
   crate root (#137): they are the internal control-channel exchange model. The
   public result type is now `Report`.
+- **Several `Report` fields are now `Option`** (#261), so a refusal document can
+  faithfully omit the fields the test never produced (matching iperf3): on
+  `Start`, `sock_bufsize` / `sndbuf_actual` / `rcvbuf_actual` (`u64` →
+  `Option<u64>`) and `test_start` (`TestStart` → `Option<TestStart>`); on `End`,
+  `sum_sent` / `sum_received` (`SumSide` → `Option<SumSide>`) and
+  `cpu_utilization_percent` (`CpuUtilization` → `Option<CpuUtilization>`).
+  On a run that reached TestStart (every success and every mid-test interrupt)
+  these are always `Some`, so the serialized success/partial output is unchanged.
+  Migration: where you read `report.end.sum_sent.bytes`, use
+  `report.end.sum_sent.as_ref().unwrap().bytes` (or pattern-match the `Option`).
 
 ### Added
 
@@ -46,6 +57,26 @@ faithful iperf3 drop-in behavior is preserved.
   documented why the UDP data path deliberately uses `spawn_blocking` with
   blocking sockets — SO_SNDBUF backpressure, the sendmmsg batch path, the winsock
   demux constraint (#146). No behavior change.
+
+### Fixed
+
+- **The client `-J` upfront-refusal document is now byte-faithful to iperf3**
+  (#261). On a server rejection that arrives before TestStart (e.g. code 37,
+  `--server-max-duration`), iperf3 populates `Report` fields by how far the test
+  progressed: it omits `start.sock_bufsize` / `sndbuf_actual` / `rcvbuf_actual` /
+  `test_start`, emits a bare `end: {}`, and carries the real on-connect
+  wall-clock timestamp. riperf3 previously emitted those fields with epoch-0 /
+  zero placeholders; it now matches iperf3's shape. A mid-test interrupt or
+  SERVER_TERMINATE still carries its (partial) late fields, since those paths
+  reached TestStart.
+
+  Deliberate deviation: on this path iperf3 emits the `"error"` key **twice** (a
+  `SERVER ERROR - <msg>` variant and the bare `<msg>`) — an upstream defect from
+  two code paths writing the same cJSON key, filed as
+  [esnet/iperf#2051](https://github.com/esnet/iperf/issues/2051). riperf3 emits a
+  single clean `"error"` key holding the bare message, which is what a conformant
+  last-wins parser of iperf3's malformed document resolves to. (Precedent: the
+  recorded `(os error N)` connect-failure suffix deviation, #151.)
 
 ## [0.7.4] - 2026-06-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,10 @@ Architecture-and-API release. Wire protocol and CLI flags unchanged; success-pat
 
 - Client `-J` upfront-refusal document is now byte-faithful to iperf3 (#261): omits the
   unreached `start`/`end` fields, emits `end: {}`, real on-connect timestamp (was epoch-0).
-  Emits one clean `"error"` key vs iperf3's duplicate-key defect ([esnet/iperf#2051](https://github.com/esnet/iperf/issues/2051)).
+- Deliberate deviation from iperf3 (#261): where iperf3 emits the `"error"` key **twice**
+  on a relayed refusal (an upstream defect, [esnet/iperf#2051](https://github.com/esnet/iperf/issues/2051)),
+  riperf3 emits a single clean `"error"` key — the bare message a conformant last-wins
+  parser resolves to.
 
 ## [0.7.4] - 2026-06-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,70 +13,36 @@ release tags.
 
 ## [0.8.0] - unreleased
 
-The architecture-and-API release the 0.7.x faithfulness train deferred. Per the
-SemVer 0.x convention, this minor bump carries breaking **library API** changes
-(below). The wire protocol and CLI flags are unchanged. The success-path `-J`/
-text output is byte-identical; the only `-J` change is on the upfront-refusal
-path, which is now byte-faithful to iperf3 (#261).
+Architecture-and-API release. Wire protocol and CLI flags unchanged; success-path
+`-J`/text output byte-identical. Breaking changes are library-API only.
 
 ### Breaking
 
-- **`Client::run` now returns `riperf3::Report`** (#137) — the rich
-  iperf3-schema report, the same object `-J`/`--json` serializes — instead of
-  the lean control-channel `TestResultsJson`. Library consumers get start
-  metadata, interval arrays, per-direction aggregates, and richer end summaries
-  directly. Migration: total bytes
-  `result.streams.iter().map(|s| s.bytes).sum()` → `result.end.sum_sent.bytes`
-  (forward) / `result.end.sum_received.bytes` (reverse); CPU
+- `Client::run` returns `riperf3::Report` (the rich `-J`-schema report) instead of
+  `TestResultsJson` (#137). Migration: `result.streams.iter().map(|s| s.bytes).sum()`
+  → `result.end.sum_sent.bytes` (fwd) / `.sum_received.bytes` (rev);
   `result.cpu_util_total` → `result.end.cpu_utilization_percent.host_total`.
-- **`TestResultsJson` / `StreamResultJson` are no longer re-exported** from the
-  crate root (#137): they are the internal control-channel exchange model. The
-  public result type is now `Report`.
-- **Several `Report` fields are now `Option`** (#261), so a refusal document can
-  faithfully omit the fields the test never produced (matching iperf3): on
-  `Start`, `sock_bufsize` / `sndbuf_actual` / `rcvbuf_actual` (`u64` →
-  `Option<u64>`) and `test_start` (`TestStart` → `Option<TestStart>`); on `End`,
-  `sum_sent` / `sum_received` (`SumSide` → `Option<SumSide>`) and
-  `cpu_utilization_percent` (`CpuUtilization` → `Option<CpuUtilization>`).
-  On a run that reached TestStart (every success and every mid-test interrupt)
-  these are always `Some`, so the serialized success/partial output is unchanged.
-  Migration: where you read `report.end.sum_sent.bytes`, use
-  `report.end.sum_sent.as_ref().unwrap().bytes` (or pattern-match the `Option`).
+- `TestResultsJson` / `StreamResultJson` no longer re-exported from the crate root (#137).
+- Seven `Report` fields are now `Option` so a refusal document can omit what the test
+  never produced (#261): `Start::{sock_bufsize, sndbuf_actual, rcvbuf_actual, test_start}`,
+  `End::{sum_sent, sum_received, cpu_utilization_percent}`. Always `Some` once a run
+  reaches TestStart, so success output is unchanged. Migration: `…sum_sent.as_ref().unwrap()`.
 
 ### Added
 
-- **`Server::run_once() -> Result<Report>`** (#137) — serves exactly one test and
-  returns its rich report, the server-side analog of `Client::run`.
-  `Server::run` remains the long-lived accept loop (`Result<()>`).
-- **`riperf3::json_report` is a documented public module** (#137); its top-level
-  `Report` is re-exported at the crate root.
+- `Server::run_once() -> Result<Report>`: serve one test and return its report (#137).
+- `riperf3::json_report` is public; `Report` re-exported at the crate root (#137).
 
 ### Changed
 
-- Removed the unwired `#[allow(dead_code)]` async UDP sender/receiver variants and
-  documented why the UDP data path deliberately uses `spawn_blocking` with
-  blocking sockets — SO_SNDBUF backpressure, the sendmmsg batch path, the winsock
-  demux constraint (#146). No behavior change.
+- Removed the dead async UDP sender/receiver variants; documented the deliberate
+  `spawn_blocking`/blocking-socket UDP design (#146).
 
 ### Fixed
 
-- **The client `-J` upfront-refusal document is now byte-faithful to iperf3**
-  (#261). On a server rejection that arrives before TestStart (e.g. code 37,
-  `--server-max-duration`), iperf3 populates `Report` fields by how far the test
-  progressed: it omits `start.sock_bufsize` / `sndbuf_actual` / `rcvbuf_actual` /
-  `test_start`, emits a bare `end: {}`, and carries the real on-connect
-  wall-clock timestamp. riperf3 previously emitted those fields with epoch-0 /
-  zero placeholders; it now matches iperf3's shape. A mid-test interrupt or
-  SERVER_TERMINATE still carries its (partial) late fields, since those paths
-  reached TestStart.
-
-  Deliberate deviation: on this path iperf3 emits the `"error"` key **twice** (a
-  `SERVER ERROR - <msg>` variant and the bare `<msg>`) — an upstream defect from
-  two code paths writing the same cJSON key, filed as
-  [esnet/iperf#2051](https://github.com/esnet/iperf/issues/2051). riperf3 emits a
-  single clean `"error"` key holding the bare message, which is what a conformant
-  last-wins parser of iperf3's malformed document resolves to. (Precedent: the
-  recorded `(os error N)` connect-failure suffix deviation, #151.)
+- Client `-J` upfront-refusal document is now byte-faithful to iperf3 (#261): omits the
+  unreached `start`/`end` fields, emits `end: {}`, real on-connect timestamp (was epoch-0).
+  Emits one clean `"error"` key vs iperf3's duplicate-key defect ([esnet/iperf#2051](https://github.com/esnet/iperf/issues/2051)).
 
 ## [0.7.4] - 2026-06-12
 

--- a/riperf3-cli/tests/self_terminate.rs
+++ b/riperf3-cli/tests/self_terminate.rs
@@ -420,6 +420,53 @@ fn upfront_reject_json_doc_shapes() {
         Some(MAXDUR_MSG),
         "client doc adopts the relayed strerror: {doc}"
     );
+    // #261: the client's refusal doc is byte-faithful to GT's. The test never
+    // reached TestStart, so GT OMITS the late start fields and emits `end: {}` —
+    // while keeping the early metadata (timestamp/cookie/connecting_to). The
+    // start.timestamp carries the REAL on_connect wall-clock, NOT epoch-0.
+    let cstart = doc["start"].as_object().expect("client start object");
+    for present in [
+        "connected",
+        "version",
+        "system_info",
+        "timestamp",
+        "connecting_to",
+        "cookie",
+    ] {
+        assert!(
+            cstart.contains_key(present),
+            "#261 client refusal start keeps {present}: {doc}"
+        );
+    }
+    for absent in [
+        "sock_bufsize",
+        "sndbuf_actual",
+        "rcvbuf_actual",
+        "test_start",
+    ] {
+        assert!(
+            !cstart.contains_key(absent),
+            "#261 client refusal start must OMIT {absent} (GT shape): {doc}"
+        );
+    }
+    assert_eq!(
+        doc["end"].as_object().map(serde_json::Map::len),
+        Some(0),
+        "#261 client refusal end must be the bare `end: {{}}`: {doc}"
+    );
+    assert_ne!(
+        doc["start"]["timestamp"]["timesecs"],
+        serde_json::json!(0),
+        "#261 refusal timestamp must be the real connect wall-clock, not epoch-0: {doc}"
+    );
+    // Exactly ONE `error` key (single clean key, not GT's #2051 duplicate) —
+    // checked against the raw bytes, since the parsed Value de-duplicates.
+    assert_eq!(
+        client.stdout.matches("\"error\"").count(),
+        1,
+        "#261 exactly one error key in the client doc: {out}",
+        out = client.stdout
+    );
 
     // Server skeleton doc.
     assert!(serr.trim().is_empty(), "server -J stderr empty: {serr}");

--- a/riperf3/src/client.rs
+++ b/riperf3/src/client.rs
@@ -438,6 +438,10 @@ impl Client {
         let mut measured_secs = self.duration as f64;
         // Wall-clock at TestStart, for the `-J` start.timestamp (#36 PR3).
         let mut test_start_millis = 0u64;
+        // Wall-clock at on_connect (set at the end of the ParamExchange arm,
+        // GT's on_connect timing) — the timestamp the `-J` document carries on an
+        // upfront refusal that never reaches TestStart (#261).
+        let mut connect_time_millis = 0u64;
 
         // #145: AUDITABILITY ONLY — the last state this side processed, threaded
         // through the dispatch loop so an unexpected byte can be diagnosed against
@@ -489,6 +493,8 @@ impl Client {
                             .into_owned(),
                             tcp_mss_default: control_mss,
                             start_time_millis: test_start_millis,
+                            connect_time_millis,
+                            reached_test_start: true,
                         },
                         dump_secs,
                         Some(&msg),
@@ -501,6 +507,17 @@ impl Client {
                 TestState::ParamExchange => {
                     let params = self.build_params(blksize);
                     protocol::send_params(&mut ctrl, &params).await?;
+                    // #261: stamp the on_connect wall-clock HERE — GT runs
+                    // on_connect at the end of its PARAM_EXCHANGE case
+                    // (iperf_client_api.c:338, after iperf_exchange_parameters),
+                    // which sets start.timestamp. A subsequent upfront refusal
+                    // (e.g. code 37) arrives on the NEXT state read, after this
+                    // stamp, so the refusal document carries this real wall-clock
+                    // rather than epoch-0.
+                    connect_time_millis = std::time::SystemTime::now()
+                        .duration_since(std::time::UNIX_EPOCH)
+                        .map(|d| d.as_millis() as u64)
+                        .unwrap_or(0);
                     // #222: iperf3's connect text block — printed HERE,
                     // after the param exchange (GT's on_connect timing, r2
                     // item 5: a failed exchange prints no banner). The
@@ -611,6 +628,8 @@ impl Client {
                                 .into_owned(),
                                 tcp_mss_default: control_mss,
                                 start_time_millis: test_start_millis,
+                                connect_time_millis,
+                                reached_test_start: true,
                             },
                         );
                     }
@@ -650,6 +669,8 @@ impl Client {
                                     .into_owned(),
                                     tcp_mss_default: control_mss,
                                     start_time_millis: test_start_millis,
+                                    connect_time_millis,
+                                    reached_test_start: true,
                                 },
                                 measured_secs,
                                 Some("the server has terminated"),
@@ -679,6 +700,8 @@ impl Client {
                                     .into_owned(),
                                     tcp_mss_default: control_mss,
                                     start_time_millis: test_start_millis,
+                                    connect_time_millis,
+                                    reached_test_start: true,
                                 },
                                 measured_secs,
                                 Some(&msg),
@@ -713,6 +736,8 @@ impl Client {
                                         .into_owned(),
                                         tcp_mss_default: control_mss,
                                         start_time_millis: test_start_millis,
+                                        connect_time_millis,
+                                        reached_test_start: true,
                                     },
                                     measured_secs,
                                     Some(&msg),
@@ -754,6 +779,10 @@ impl Client {
                                 .into_owned(),
                                 tcp_mss_default: control_mss,
                                 start_time_millis: test_start_millis,
+                                connect_time_millis,
+                                // #261: the success path always reached TestStart —
+                                // full report structure, late fields present.
+                                reached_test_start: true,
                             },
                             measured_secs,
                             None,
@@ -796,6 +825,13 @@ impl Client {
                                 .into_owned(),
                                 tcp_mss_default: control_mss,
                                 start_time_millis: test_start_millis,
+                                connect_time_millis,
+                                // #261: a SERVER_ERROR relay before TestStart is
+                                // the upfront refusal (code 37 et al.) — emit GT's
+                                // minimal doc (`end: {}`, late start fields
+                                // omitted). The mid-test ControlEvent variant is
+                                // always past TestStart, so this stays true there.
+                                reached_test_start: test_start_millis > 0,
                             },
                             measured_secs,
                             Some(&msg),
@@ -824,6 +860,8 @@ impl Client {
                                 .into_owned(),
                             tcp_mss_default: control_mss,
                             start_time_millis: test_start_millis,
+                            connect_time_millis,
+                            reached_test_start: true,
                         },
                         measured_secs,
                         Some("the server has terminated"),
@@ -2134,14 +2172,39 @@ impl Client {
             // sndbuf/rcvbuf_actual are the kernel's actual sizes on a data socket.
             // .max(0): the public builder accepts an i32 window; clamp so a
             // negative can't wrap to a huge u64 (the CLI path is already >= 0).
-            sock_bufsize: self.window.map(|w| w.max(0) as u64).unwrap_or(0),
-            sndbuf_actual: streams.first().and_then(|s| s.sndbuf_actual).unwrap_or(0),
-            rcvbuf_actual: streams.first().and_then(|s| s.rcvbuf_actual).unwrap_or(0),
+            // #261: `Some(..)` on a run that set up streams (build() gates them
+            // out on the upfront-refusal path via `reached_test_start`); a
+            // success run always carries them, so the shape is unchanged. A
+            // missing kernel readback still yields `Some(0)` on a real run, like
+            // iperf3.
+            sock_bufsize: Some(self.window.map(|w| w.max(0) as u64).unwrap_or(0)),
+            sndbuf_actual: Some(streams.first().and_then(|s| s.sndbuf_actual).unwrap_or(0)),
+            rcvbuf_actual: Some(streams.first().and_then(|s| s.rcvbuf_actual).unwrap_or(0)),
+            // #261: false ONLY on the upfront server-refusal path (a SERVER_ERROR
+            // relay that arrives before stream setup, e.g. code 37) — there GT's
+            // client errexits through json_top, which never populated json_end, so
+            // the late `start` fields are omitted and `end` is `{}`. EVERY other
+            // path (success and the sigend/SERVER_TERMINATE dumps) renders the
+            // full structure — GT's interrupt dump shows 0/0/0 pre-data, NOT an
+            // empty end — so the flag is true and the partial document keeps its
+            // late fields. The flag is threaded explicitly via StartMeta because
+            // the refusal and a pre-data interrupt BOTH happen before TestStart
+            // and so are indistinguishable by the start wall-clock alone.
+            reached_test_start: start_meta.reached_test_start,
             interval: self.interval.unwrap_or(1.0),
             // riperf3's single --gsro flag drives both GSO and GRO.
             gso: i32::from(self.gsro),
             gro: i32::from(self.gsro),
-            start_time_millis: start_meta.start_time_millis,
+            // #261: on a run that reached TestStart use that wall-clock; on the
+            // upfront-refusal path TestStart was never reached (start wall-clock
+            // is 0), so fall back to the connect-time wall-clock — GT stamps
+            // start.timestamp at on_connect (after the param exchange, BEFORE the
+            // refusal arrives), never epoch-0.
+            start_time_millis: if start_meta.start_time_millis > 0 {
+                start_meta.start_time_millis
+            } else {
+                start_meta.connect_time_millis
+            },
             extra_data: self.extra_data.clone(),
             // --get-server-output (#33): the server's returned output rides
             // the -J report tail — only when WE requested it (iperf3 gates on
@@ -2267,7 +2330,19 @@ enum EndCondition {
 struct StartMeta {
     cookie: String,
     tcp_mss_default: u32,
+    /// Wall-clock at TestStart, ms since the Unix epoch. 0 until the TestStart
+    /// arm stamps it — its being > 0 is also the "reached TestStart" signal (#261).
     start_time_millis: u64,
+    /// Wall-clock at on_connect (right after the param exchange), ms since the
+    /// Unix epoch (#261). GT stamps `start.timestamp` here; on an upfront refusal
+    /// (rejection before TestStart) it is the only real wall-clock the document
+    /// has, so the refusal path uses it for the timestamp instead of epoch-0.
+    connect_time_millis: u64,
+    /// #261: false ONLY on the upfront server-refusal path — drives the
+    /// stage-gated omission of the late `start` fields and the bare `end: {}`.
+    /// True on every other path (success, sigend interrupt, SERVER_TERMINATE),
+    /// which all render the full report structure like GT.
+    reached_test_start: bool,
 }
 
 // ---------------------------------------------------------------------------

--- a/riperf3/src/json_report.rs
+++ b/riperf3/src/json_report.rs
@@ -239,10 +239,21 @@ pub struct Start {
     pub tcp_mss_default: Option<u32>,
     pub target_bitrate: u64,
     pub fq_rate: u64,
-    pub sock_bufsize: u64,
-    pub sndbuf_actual: u64,
-    pub rcvbuf_actual: u64,
-    pub test_start: TestStart,
+    // #261: these four are populated only once the test reaches stream-setup /
+    // TestStart. On an upfront refusal (server-side rejection BEFORE TestStart,
+    // e.g. --server-max-duration / code 37) the client never sets up streams, so
+    // GT (iperf 3.21) OMITS them entirely — the document carries the early start
+    // metadata (timestamp, cookie, connecting_to) and an empty `end`. `Option` +
+    // skip-if-none reproduces that: `Some(..)` on a run that reached TestStart
+    // (every success and every mid-test interrupt), `None` on the refusal path.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sock_bufsize: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sndbuf_actual: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rcvbuf_actual: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub test_start: Option<TestStart>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -397,14 +408,27 @@ pub struct IntervalSum {
 #[derive(Debug, Clone, Serialize)]
 #[non_exhaustive]
 pub struct End {
+    // #261: a run that reached TestStart always has ≥1 stream, so on success/
+    // partial this serializes unchanged; on an upfront refusal it is empty and
+    // omitted, contributing to GT's bare `end: {}` (which carries no `streams`
+    // key either).
+    #[serde(skip_serializing_if = "Vec::is_empty")]
     pub streams: Vec<EndStream>,
     /// UDP only: the datagram aggregate iperf3 emits as `sum` — BEFORE the
     /// sent/received pair in its key order (GT 3.21, fwd and bidir alike;
     /// the old field position serialized it after, a raw-diff divergence).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub sum: Option<SumSide>,
-    pub sum_sent: SumSide,
-    pub sum_received: SumSide,
+    // #261: the summary aggregates and CPU figure exist only once the test
+    // reached TestStart. On an upfront refusal GT emits `end: {}` — every key
+    // omitted. With these three as `Option` + skip-if-none, an `End` whose
+    // optional fields are all `None` serializes as `{}`, matching GT byte-for-
+    // byte. A run that reached TestStart (success, mid-test interrupt) sets them
+    // `Some(..)`, so the success/partial shape is unchanged.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sum_sent: Option<SumSide>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sum_received: Option<SumSide>,
     /// UDP bidir only (#214): the reverse-direction datagram aggregate,
     /// between the forward pair and the reverse pair, like iperf3.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -414,7 +438,8 @@ pub struct End {
     pub sum_sent_bidir_reverse: Option<SumSide>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub sum_received_bidir_reverse: Option<SumSide>,
-    pub cpu_utilization_percent: CpuUtilization,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cpu_utilization_percent: Option<CpuUtilization>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub sender_tcp_congestion: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -661,9 +686,19 @@ pub struct ReportInput {
     /// emitted as `start.tcp_mss` and suppresses `tcp_mss_default` (iperf3 parity).
     pub mss: Option<u32>,
     pub fq_rate: u64,
-    pub sock_bufsize: u64,
-    pub sndbuf_actual: u64,
-    pub rcvbuf_actual: u64,
+    /// Socket buffer sizes (`start.sock_bufsize` / `sndbuf_actual` /
+    /// `rcvbuf_actual`). `None` on a path that never set up data sockets (the
+    /// upfront-refusal path), so `build()` omits them like GT (#261).
+    pub sock_bufsize: Option<u64>,
+    pub sndbuf_actual: Option<u64>,
+    pub rcvbuf_actual: Option<u64>,
+    /// True once the test reached stream-setup / TestStart (#261). Drives the
+    /// stage-gated `start.test_start` and the `end` summary aggregates: GT
+    /// populates them only by how far the test progressed, and OMITS them on an
+    /// upfront refusal (server rejection before TestStart, e.g. code 37). A
+    /// mid-test interrupt or SERVER_TERMINATE DID reach TestStart, so it stays
+    /// `true` there — the partial document keeps the late fields it has.
+    pub reached_test_start: bool,
     pub interval: f64,
     pub gso: i32,
     pub gro: i32,
@@ -1170,15 +1205,22 @@ impl ReportInput {
             (self.congestion_used.clone(), self.congestion_used.clone())
         };
 
+        // #261: stage-gate the `end` summary aggregates on whether the test
+        // reached TestStart. On an upfront refusal (never reached it) every
+        // optional field is None and `streams` is empty, so `End` serializes as
+        // GT's bare `end: {}`. A run that reached TestStart (success, mid-test
+        // interrupt, SERVER_TERMINATE) keeps them — the partial document carries
+        // the late fields it has, unchanged from before.
+        let reached = self.reached_test_start;
         let end = End {
             streams: end_streams,
-            sum_sent,
-            sum_received,
+            sum_sent: reached.then_some(sum_sent),
+            sum_received: reached.then_some(sum_received),
             sum,
             sum_bidir_reverse,
             sum_sent_bidir_reverse,
             sum_received_bidir_reverse,
-            cpu_utilization_percent: self.cpu.clone(),
+            cpu_utilization_percent: reached.then(|| self.cpu.clone()),
             sender_tcp_congestion: cong_sender,
             receiver_tcp_congestion: cong_receiver,
         };
@@ -1231,10 +1273,15 @@ impl ReportInput {
                 tcp_mss_default,
                 target_bitrate: self.target_bitrate,
                 fq_rate: self.fq_rate,
-                sock_bufsize: self.sock_bufsize,
-                sndbuf_actual: self.sndbuf_actual,
-                rcvbuf_actual: self.rcvbuf_actual,
-                test_start: TestStart {
+                // #261: the socket buffers and `test_start` block are populated
+                // only once the test reached stream-setup / TestStart. On the
+                // upfront-refusal path `reached` is false → all omitted (the
+                // buffer fields are also `None` at the source there); GT does the
+                // same, so the refusal `start` carries only the early metadata.
+                sock_bufsize: reached.then_some(self.sock_bufsize).flatten(),
+                sndbuf_actual: reached.then_some(self.sndbuf_actual).flatten(),
+                rcvbuf_actual: reached.then_some(self.rcvbuf_actual).flatten(),
+                test_start: reached.then(|| TestStart {
                     protocol: if is_udp { "UDP" } else { "TCP" }.to_string(),
                     num_streams: self.num_streams,
                     blksize: self.blksize,
@@ -1257,12 +1304,22 @@ impl ReportInput {
                     interval: self.interval,
                     gso: self.gso,
                     gro: self.gro,
-                },
+                }),
             },
             intervals: self.intervals.clone(),
             end,
             extra_data: self.extra_data.clone(),
             server_output_text: self.server_output_text.clone(),
+            // #261 DELIBERATE DEVIATION: riperf3 emits a SINGLE `"error"` key
+            // holding the bare strerror message. GT (iperf 3.21) emits the
+            // `"error"` key TWICE on a client-side refusal — once as
+            // `SERVER ERROR - <msg>` and once as the bare `<msg>` — because two
+            // code paths both `cJSON_AddStringToObject(json, "error", ...)` the
+            // same key (an upstream defect we filed as esnet/iperf#2051). A
+            // duplicate object key is undefined in JSON; a conformant last-wins
+            // parser of GT's document resolves to the bare message, which is what
+            // riperf3 emits — so we are faithful to the *parsed* result while
+            // declining to reproduce the malformed wire bytes.
             error: self.error.clone(),
             server_output_json: self.server_output_json.clone(),
         }
@@ -1673,9 +1730,10 @@ mod tests {
             tcp_mss_default: 1448,
             mss: None,
             fq_rate: 0,
-            sock_bufsize: 0,
-            sndbuf_actual: 16384,
-            rcvbuf_actual: 87380,
+            sock_bufsize: Some(0),
+            sndbuf_actual: Some(16384),
+            rcvbuf_actual: Some(87380),
+            reached_test_start: true,
             interval: 1.0,
             gso: 0,
             gro: 0,
@@ -2540,6 +2598,139 @@ mod tests {
         ] {
             assert!(v["end"].get(k).is_some(), "end.{k} missing");
         }
+    }
+
+    /// #261: a run that reached TestStart (`reached_test_start = true`) carries
+    /// the full late shape — the four `start` late fields AND the `end` summary
+    /// aggregates are all present (`Some`). This is the SUCCESS-path invariant:
+    /// the Option-ification must NEVER drop a field from a real run.
+    #[test]
+    fn success_run_keeps_all_late_fields() {
+        let mut input = base_input();
+        input.streams = vec![tcp_stream(1, true, 10, 10)];
+        assert!(input.reached_test_start, "base_input models a real run");
+        let report = input.build();
+        // start late fields: typed Option, all Some.
+        assert!(report.start.sock_bufsize.is_some(), "sock_bufsize");
+        assert!(report.start.sndbuf_actual.is_some(), "sndbuf_actual");
+        assert!(report.start.rcvbuf_actual.is_some(), "rcvbuf_actual");
+        assert!(report.start.test_start.is_some(), "test_start");
+        // end summaries: typed Option, all Some.
+        assert!(report.end.sum_sent.is_some(), "sum_sent");
+        assert!(report.end.sum_received.is_some(), "sum_received");
+        assert!(
+            report.end.cpu_utilization_percent.is_some(),
+            "cpu_utilization_percent"
+        );
+        assert!(!report.end.streams.is_empty(), "streams");
+        // And the serialized shape still emits every late key.
+        let v = serde_json::to_value(&report).unwrap();
+        for k in [
+            "sock_bufsize",
+            "sndbuf_actual",
+            "rcvbuf_actual",
+            "test_start",
+        ] {
+            assert!(v["start"].get(k).is_some(), "serialized start.{k} dropped");
+        }
+        for k in [
+            "streams",
+            "sum_sent",
+            "sum_received",
+            "cpu_utilization_percent",
+        ] {
+            assert!(v["end"].get(k).is_some(), "serialized end.{k} dropped");
+        }
+    }
+
+    /// #261: the GT-faithful upfront-REFUSAL shape. When the test never reached
+    /// TestStart (`reached_test_start = false`, as on a code-37 server rejection
+    /// that arrives before stream setup), GT OMITS the late `start` fields and
+    /// emits a bare `end: {}` — but still carries the early start metadata
+    /// (timestamp/cookie/connecting_to) and the bare error message. Pinned
+    /// against the live GT capture (iperf 3.21 @ d39cf41).
+    #[test]
+    fn refusal_omits_late_fields_and_empty_end() {
+        let mut input = base_input();
+        // The refusal path: error set BEFORE TestStart, no streams, the late
+        // buffer inputs are None, and a REAL connect-time wall-clock (not 0).
+        input.error =
+            Some("client's requested duration exceeds the server's maximum permitted limit".into());
+        input.reached_test_start = false;
+        input.streams = vec![];
+        input.sock_bufsize = None;
+        input.sndbuf_actual = None;
+        input.rcvbuf_actual = None;
+        // No data streams were ever created, so the client never read back a
+        // congestion algorithm — the *_tcp_congestion keys are naturally absent
+        // on the real refusal path (driven by stream presence, not the gate).
+        input.congestion_used = None;
+        // base_input's start_time_millis stands in for the connect-time stamp the
+        // client passes on this path (non-zero — never epoch-0).
+        let v = serde_json::to_value(input.build()).unwrap();
+
+        // start: the EARLY metadata survives …
+        let start = v["start"].as_object().expect("start object");
+        for present in [
+            "connected",
+            "version",
+            "system_info",
+            "timestamp",
+            "connecting_to",
+        ] {
+            assert!(
+                start.contains_key(present),
+                "refusal start keeps {present}: {v}"
+            );
+        }
+        // … but the four late fields are OMITTED (GT's refusal shape).
+        for absent in [
+            "sock_bufsize",
+            "sndbuf_actual",
+            "rcvbuf_actual",
+            "test_start",
+        ] {
+            assert!(
+                !start.contains_key(absent),
+                "refusal start must omit {absent}: {v}"
+            );
+        }
+        // timestamp carries a REAL wall-clock — never epoch-0.
+        assert_ne!(v["start"]["timestamp"]["timesecs"], serde_json::json!(0));
+        assert_ne!(
+            v["start"]["timestamp"]["timemillisecs"],
+            serde_json::json!(0)
+        );
+        assert_ne!(
+            v["start"]["timestamp"]["time"],
+            serde_json::json!("Thu, 01 Jan 1970 00:00:00 GMT"),
+            "refusal timestamp must not be the epoch: {v}"
+        );
+
+        // end is a bare, EMPTY object — no streams/sum_sent/sum_received/cpu keys.
+        assert_eq!(
+            v["end"].as_object().map(serde_json::Map::len),
+            Some(0),
+            "refusal end must serialize as the GT bare `end: {{}}`: {v}"
+        );
+
+        // intervals stays an empty array (the test never ran).
+        assert_eq!(v["intervals"].as_array().map(Vec::len), Some(0));
+
+        // exactly ONE `error` key holding the bare message (NOT GT's duplicate;
+        // esnet/iperf#2051) — verified at the raw-bytes level since serde_json's
+        // Value would silently de-duplicate object keys.
+        let raw = serde_json::to_string(&input.build()).unwrap();
+        assert_eq!(
+            raw.matches("\"error\"").count(),
+            1,
+            "exactly one error key (single clean key, not GT's #2051 duplicate): {raw}"
+        );
+        assert_eq!(
+            v["error"].as_str(),
+            Some("client's requested duration exceeds the server's maximum permitted limit"),
+            "the bare strerror, what a last-wins parser of GT's doc resolves to: {v}"
+        );
     }
 
     #[test]

--- a/riperf3/src/json_report.rs
+++ b/riperf3/src/json_report.rs
@@ -2744,39 +2744,45 @@ mod tests {
 
     #[test]
     fn udp_refusal_also_emits_bare_end() {
-        // Round-1 cold-review catch: the UDP aggregates (`sum` + the bidir trio)
-        // are Some(zeros) on a UDP refusal, so unless they too are gated on
+        // The UDP `end` aggregates (`sum` + the `sum_*_bidir_reverse` trio) are
+        // Some(zeros) on a UDP refusal, so unless they too are gated on
         // reached_test_start, `end` leaks `{"sum": {...}}` instead of GT's bare
         // `{}`. The TCP refusal test above never exercised this (TCP leaves those
-        // None), which is how it slipped the suite.
-        let mut input = base_input();
-        input.protocol = TransportProtocol::Udp;
-        input.error =
-            Some("client's requested duration exceeds the server's maximum permitted limit".into());
-        input.reached_test_start = false;
-        input.streams = vec![];
-        input.sock_bufsize = None;
-        input.sndbuf_actual = None;
-        input.rcvbuf_actual = None;
-        input.congestion_used = None;
-        let v = serde_json::to_value(input.build()).unwrap();
-        assert_eq!(
-            v["end"].as_object().map(serde_json::Map::len),
-            Some(0),
-            "UDP refusal end must serialize as GT's bare `end: {{}}` (no leaked `sum`): {v}"
-        );
-        // the late start fields are omitted on UDP too.
-        let start = v["start"].as_object().expect("start object");
-        for absent in [
-            "sock_bufsize",
-            "sndbuf_actual",
-            "rcvbuf_actual",
-            "test_start",
-        ] {
-            assert!(
-                !start.contains_key(absent),
-                "UDP refusal start must omit {absent}: {v}"
+        // None). Cover both bidir settings so all four aggregate gates are pinned:
+        // !bidir exercises `sum` (round-1 catch); bidir exercises the trio
+        // (round-2 catch — reverting any trio gate otherwise ships green).
+        for bidir in [false, true] {
+            let mut input = base_input();
+            input.protocol = TransportProtocol::Udp;
+            input.bidir = bidir;
+            input.error = Some(
+                "client's requested duration exceeds the server's maximum permitted limit".into(),
             );
+            input.reached_test_start = false;
+            input.streams = vec![];
+            input.sock_bufsize = None;
+            input.sndbuf_actual = None;
+            input.rcvbuf_actual = None;
+            input.congestion_used = None;
+            let v = serde_json::to_value(input.build()).unwrap();
+            assert_eq!(
+                v["end"].as_object().map(serde_json::Map::len),
+                Some(0),
+                "UDP refusal (bidir={bidir}) end must be GT's bare `end: {{}}` (no leaked aggregate): {v}"
+            );
+            // the late start fields are omitted on UDP too.
+            let start = v["start"].as_object().expect("start object");
+            for absent in [
+                "sock_bufsize",
+                "sndbuf_actual",
+                "rcvbuf_actual",
+                "test_start",
+            ] {
+                assert!(
+                    !start.contains_key(absent),
+                    "UDP refusal start must omit {absent}: {v}"
+                );
+            }
         }
     }
 

--- a/riperf3/src/json_report.rs
+++ b/riperf3/src/json_report.rs
@@ -1208,18 +1208,20 @@ impl ReportInput {
         // #261: stage-gate the `end` summary aggregates on whether the test
         // reached TestStart. On an upfront refusal (never reached it) every
         // optional field is None and `streams` is empty, so `End` serializes as
-        // GT's bare `end: {}`. A run that reached TestStart (success, mid-test
-        // interrupt, SERVER_TERMINATE) keeps them — the partial document carries
-        // the late fields it has, unchanged from before.
+        // GT's bare `end: {}`. This must cover the UDP aggregates too (`sum` and
+        // the bidir trio are `Some(zeros)` on a UDP refusal) or a UDP refusal
+        // leaks `end: {"sum": {...}}`. A run that reached TestStart (success,
+        // mid-test interrupt, SERVER_TERMINATE) keeps them — the partial document
+        // carries the late fields it has, unchanged from before.
         let reached = self.reached_test_start;
         let end = End {
             streams: end_streams,
             sum_sent: reached.then_some(sum_sent),
             sum_received: reached.then_some(sum_received),
-            sum,
-            sum_bidir_reverse,
-            sum_sent_bidir_reverse,
-            sum_received_bidir_reverse,
+            sum: reached.then_some(sum).flatten(),
+            sum_bidir_reverse: reached.then_some(sum_bidir_reverse).flatten(),
+            sum_sent_bidir_reverse: reached.then_some(sum_sent_bidir_reverse).flatten(),
+            sum_received_bidir_reverse: reached.then_some(sum_received_bidir_reverse).flatten(),
             cpu_utilization_percent: reached.then(|| self.cpu.clone()),
             sender_tcp_congestion: cong_sender,
             receiver_tcp_congestion: cong_receiver,
@@ -1278,6 +1280,13 @@ impl ReportInput {
                 // upfront-refusal path `reached` is false → all omitted (the
                 // buffer fields are also `None` at the source there); GT does the
                 // same, so the refusal `start` carries only the early metadata.
+                // NOTE: GT stages these at two distinct points — the buffers at
+                // CREATE_STREAMS (iperf_tcp.c) and `test_start` at TEST_START
+                // (iperf_api.c) — whereas this one `reached` flag flips at
+                // TestStart. A SERVER_ERROR arriving in the CreateStreams..
+                // TestStart window would diverge, but that window is unreachable
+                // against a riperf3 server (its only top-level SERVER_ERROR is the
+                // param-exchange refusal, before CreateStreams).
                 sock_bufsize: reached.then_some(self.sock_bufsize).flatten(),
                 sndbuf_actual: reached.then_some(self.sndbuf_actual).flatten(),
                 rcvbuf_actual: reached.then_some(self.rcvbuf_actual).flatten(),
@@ -2731,6 +2740,44 @@ mod tests {
             Some("client's requested duration exceeds the server's maximum permitted limit"),
             "the bare strerror, what a last-wins parser of GT's doc resolves to: {v}"
         );
+    }
+
+    #[test]
+    fn udp_refusal_also_emits_bare_end() {
+        // Round-1 cold-review catch: the UDP aggregates (`sum` + the bidir trio)
+        // are Some(zeros) on a UDP refusal, so unless they too are gated on
+        // reached_test_start, `end` leaks `{"sum": {...}}` instead of GT's bare
+        // `{}`. The TCP refusal test above never exercised this (TCP leaves those
+        // None), which is how it slipped the suite.
+        let mut input = base_input();
+        input.protocol = TransportProtocol::Udp;
+        input.error =
+            Some("client's requested duration exceeds the server's maximum permitted limit".into());
+        input.reached_test_start = false;
+        input.streams = vec![];
+        input.sock_bufsize = None;
+        input.sndbuf_actual = None;
+        input.rcvbuf_actual = None;
+        input.congestion_used = None;
+        let v = serde_json::to_value(input.build()).unwrap();
+        assert_eq!(
+            v["end"].as_object().map(serde_json::Map::len),
+            Some(0),
+            "UDP refusal end must serialize as GT's bare `end: {{}}` (no leaked `sum`): {v}"
+        );
+        // the late start fields are omitted on UDP too.
+        let start = v["start"].as_object().expect("start object");
+        for absent in [
+            "sock_bufsize",
+            "sndbuf_actual",
+            "rcvbuf_actual",
+            "test_start",
+        ] {
+            assert!(
+                !start.contains_key(absent),
+                "UDP refusal start must omit {absent}: {v}"
+            );
+        }
     }
 
     #[test]

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -1967,9 +1967,14 @@ impl Server {
             tcp_mss_default: 0,
             mss: cfg.mss.filter(|&m| m > 0).map(|m| m as u32),
             fq_rate: params.fqrate.unwrap_or(0),
-            sock_bufsize: cfg.window.map(|w| w.max(0) as u64).unwrap_or(0),
-            sndbuf_actual: streams.first().and_then(|s| s.sndbuf_actual).unwrap_or(0),
-            rcvbuf_actual: streams.first().and_then(|s| s.rcvbuf_actual).unwrap_or(0),
+            sock_bufsize: Some(cfg.window.map(|w| w.max(0) as u64).unwrap_or(0)),
+            sndbuf_actual: Some(streams.first().and_then(|s| s.sndbuf_actual).unwrap_or(0)),
+            rcvbuf_actual: Some(streams.first().and_then(|s| s.rcvbuf_actual).unwrap_or(0)),
+            // #261: the server only ever assembles a full report on a run that
+            // reached TestStart — its upfront refusal renders the skeleton via
+            // json_report::error_document, not build(). So the late fields are
+            // always present here; the stage-gate is a no-op on this path.
+            reached_test_start: true,
             // The server reports at its 1s default; it has no -i.
             interval: 1.0,
             // GSO/GRO are client-side knobs, not exchanged; iperf3's server emits 0.

--- a/riperf3/tests/integration.rs
+++ b/riperf3/tests/integration.rs
@@ -397,7 +397,7 @@ async fn tcp_reverse_bytes_limit_terminates() {
     // rate the 100ms end-condition poll overshoots the target (a pre-existing
     // characteristic shared with forward `-n`), so this guards termination +
     // floor, not an exact byte count.
-    let transferred: u64 = res.end.sum_sent.bytes;
+    let transferred: u64 = res.end.sum_sent.as_ref().unwrap().bytes;
     assert!(
         transferred >= target,
         "transferred {transferred} < requested {target}"
@@ -433,7 +433,7 @@ async fn tcp_reverse_blocks_limit_terminates() {
     let result = tokio::time::timeout(Duration::from_secs(15), client.run()).await;
     assert!(result.is_ok(), "-R -k hung — issue #60 regression");
     let res = result.unwrap().expect("-R -k errored");
-    let transferred: u64 = res.end.sum_sent.bytes;
+    let transferred: u64 = res.end.sum_sent.as_ref().unwrap().bytes;
     assert!(
         transferred >= blocks * blksize as u64,
         "transferred {transferred} < requested {blocks} blocks"
@@ -470,7 +470,7 @@ async fn tcp_byte_limit_overshoot_bounded_forward() {
         .await
         .expect("client hung")
         .expect("client errored");
-    let bytes: u64 = result.end.sum_received.bytes;
+    let bytes: u64 = result.end.sum_received.as_ref().unwrap().bytes;
     assert!(
         bytes > target / 2,
         "transferred {bytes} far below target {target}"
@@ -505,7 +505,7 @@ async fn tcp_byte_limit_overshoot_bounded_reverse() {
         .await
         .expect("client hung")
         .expect("client errored");
-    let bytes: u64 = result.end.sum_sent.bytes;
+    let bytes: u64 = result.end.sum_sent.as_ref().unwrap().bytes;
     assert!(
         bytes > target / 2,
         "transferred {bytes} far below target {target}"
@@ -548,7 +548,7 @@ async fn tcp_bitrate_is_paced() {
         .expect("client hung")
         .expect("client errored");
     // run() returns the rich report; forward → server received ≈ what we sent.
-    let bytes: u64 = result.end.sum_received.bytes;
+    let bytes: u64 = result.end.sum_received.as_ref().unwrap().bytes;
     let achieved = bytes * 8 / secs;
     // Unpaced this is line rate (tens of Gbit/s, >100x target). Paced lands near
     // target; allow a generous band for burst/timing slack.
@@ -591,7 +591,7 @@ async fn tcp_low_bitrate_no_overshoot() {
         .await
         .expect("client hung")
         .expect("client errored");
-    let bytes: u64 = result.end.sum_received.bytes;
+    let bytes: u64 = result.end.sum_received.as_ref().unwrap().bytes;
     let budget = (target / 8 * secs) as f64; // 250 KB
     let bound = budget * 1.25 + (128 * 1024) as f64;
     assert!(
@@ -623,7 +623,7 @@ async fn tcp_unlimited_is_not_paced() {
         .await
         .expect("client hung")
         .expect("client errored");
-    let bytes: u64 = result.end.sum_received.bytes;
+    let bytes: u64 = result.end.sum_received.as_ref().unwrap().bytes;
     // A 200 Mbit cap would yield ~25 MB in 1 s; unthrottled loopback moves far
     // more. >200 MB confirms pacing didn't leak into the rate-0 path.
     assert!(
@@ -661,7 +661,7 @@ async fn tcp_bitrate_reverse_is_paced() {
         .expect("client hung")
         .expect("client errored");
     // Reverse: the server sends; its reported bytes ≈ what it paced out.
-    let bytes: u64 = result.end.sum_sent.bytes;
+    let bytes: u64 = result.end.sum_sent.as_ref().unwrap().bytes;
     let achieved = bytes * 8 / secs;
     assert!(
         achieved < target * 2,
@@ -2386,14 +2386,14 @@ mod client_run_return_value {
             "expected at least one stream in report.end"
         );
         assert!(
-            report.end.sum_sent.bytes > 0,
+            report.end.sum_sent.as_ref().unwrap().bytes > 0,
             "expected non-zero sent bytes, got {}",
-            report.end.sum_sent.bytes
+            report.end.sum_sent.as_ref().unwrap().bytes
         );
         assert!(
-            report.end.sum_received.bytes > 0,
+            report.end.sum_received.as_ref().unwrap().bytes > 0,
             "expected non-zero received bytes, got {}",
-            report.end.sum_received.bytes
+            report.end.sum_received.as_ref().unwrap().bytes
         );
         // start metadata is populated …
         assert!(
@@ -2402,7 +2402,12 @@ mod client_run_return_value {
             report.start.version
         );
         // … and the host CPU figure is a sane number.
-        let cpu = report.end.cpu_utilization_percent.host_total;
+        let cpu = report
+            .end
+            .cpu_utilization_percent
+            .as_ref()
+            .unwrap()
+            .host_total;
         assert!(
             cpu.is_finite() && cpu >= 0.0,
             "cpu host_total not a sane non-negative number: {cpu}"
@@ -2454,9 +2459,9 @@ mod client_run_return_value {
         );
         // Forward run: the server is the receiver, so its received aggregate moved.
         assert!(
-            report.end.sum_received.bytes > 0,
+            report.end.sum_received.as_ref().unwrap().bytes > 0,
             "server expected non-zero received bytes, got {}",
-            report.end.sum_received.bytes
+            report.end.sum_received.as_ref().unwrap().bytes
         );
         // Guards the build-once invariant on the server path too (#137).
         assert!(


### PR DESCRIPTION
Closes #261. Makes the client `-J` upfront-refusal document byte-faithful to iperf 3.21.

## What
On a server refusal that arrives before TestStart (e.g. code 37, `--server-max-duration`), iperf3 populates `Report` fields by how far the test progressed: it omits `start.sock_bufsize`/`sndbuf_actual`/`rcvbuf_actual`/`test_start`, emits a bare `end: {}`, and carries the real on-connect timestamp. riperf3 emitted an epoch-0 timestamp, zero-placeholder buffer/`test_start` fields, and a populated `end`. Now matched.

## How (semver-breaking — 0.8.0 absorbs it)
- 7 `Report` fields → `Option` + `skip_serializing_if`, gated on a new `StartMeta.reached_test_start`: `Start::{sock_bufsize, sndbuf_actual, rcvbuf_actual, test_start}`, `End::{sum_sent, sum_received, cpu_utilization_percent}`. The UDP `end` aggregates (`sum` + the `sum_*_bidir_reverse` trio) are gated the same way.
- Timestamp: a new `connect_time_millis` (stamped at PARAM_EXCHANGE, where iperf3's `on_connect` runs) is the fallback when TestStart wasn't reached.
- Success/partial output is byte-identical — every field is `Some` once a run reaches TestStart (success, mid-test interrupt, SERVER_TERMINATE).

## Deliberate deviation from iperf3
iperf3 emits the `"error"` key **twice** on a relayed refusal (a duplicate-key defect from two cJSON writes; filed upstream as esnet/iperf#2051). riperf3 emits a single clean `"error"` — the bare message a conformant last-wins parser of iperf3's doc resolves to. Text-mode output keeps the `SERVER ERROR -` prefix, matching iperf3's text output.

## Verification
- **2 cold-agent review rounds.** R1 found + fixed a UDP `end: {"sum": ...}` leak (the UDP aggregates were ungated). R2 confirmed field-by-field byte-faithfulness across TCP / UDP / UDP-bidir + `--json-stream`, and flagged a bidir-aggregate test-coverage gap, now closed (the refusal test is parametrized over `bidir`, mutation-verified non-vacuous).
- `cargo fmt`/`clippy -D warnings`/`test --workspace` (636) /rustdoc `-D warnings`/`xcheck` 7/7; **compat 52/52 no-drift**.
- `cargo-semver-checks`: the field retypes are the expected, accepted 0.8.0 break.

Out of scope, filed for 0.8.1: #281 (the pre-TestStart interrupt-dump arm emits late fields where iperf3 omits them).
