### PR TITLE
refactor: RunStage enum (#286) + by-value report-collection drain (#287)

### DIFF
--- a/riperf3-cli/tests/get_server_output.rs
+++ b/riperf3-cli/tests/get_server_output.rs
@@ -154,7 +154,7 @@ fn json_client_gets_server_output_json() {
         Duration::from_secs(20),
         "client",
     );
-    let _ = server.0.wait();
+    let server_own = collect_stdout(server);
 
     let v: Value =
         serde_json::from_str(&out).unwrap_or_else(|e| panic!("client -J invalid ({e}): {out}"));
@@ -166,6 +166,23 @@ fn json_client_gets_server_output_json() {
     for k in ["start", "intervals", "end"] {
         assert!(sj.get(k).is_some(), "server_output_json missing {k}: {out}");
     }
+
+    // r1 F2 (#297): the server's OWN stdout doc is the SAME single build the
+    // attachment rode (ReportSource::Built is reused, never rebuilt) — a
+    // double build would empty this copy's intervals while the attachment
+    // stays populated. Previously this pipe was captured but never read.
+    let sv: Value = serde_json::from_str(&server_own)
+        .unwrap_or_else(|e| panic!("server -J invalid ({e}): {server_own}"));
+    let own_n = sv["intervals"].as_array().map(Vec::len).unwrap_or(0);
+    assert!(
+        own_n > 0,
+        "the -J server's own doc lost its intervals (double-build class): {server_own}"
+    );
+    assert_eq!(
+        Some(own_n),
+        sj["intervals"].as_array().map(Vec::len),
+        "the attachment and the server's own doc are the same single build"
+    );
 }
 
 /// Without the flag nothing changes: no Server output section, no keys.

--- a/riperf3-cli/tests/get_server_output.rs
+++ b/riperf3-cli/tests/get_server_output.rs
@@ -138,7 +138,7 @@ fn json_client_gets_server_output_text() {
 fn json_client_gets_server_output_json() {
     let port = free_port();
     let ps = port.to_string();
-    let mut server = spawn_server_capturing(&["-J"], &ps);
+    let server = spawn_server_capturing(&["-J"], &ps);
 
     let out = run_capturing(
         &[

--- a/riperf3/src/client.rs
+++ b/riperf3/src/client.rs
@@ -346,8 +346,7 @@ impl Client {
             server_results: None,
             final_report: None,
             measured_secs: self.duration as f64,
-            test_start_millis: 0,
-            connect_time_millis: 0,
+            stage: RunStage::PreTestStart { connect_millis: 0 },
             prev_state: TestState::IperfStart,
         };
         // Signal `done` on every exit path (incl. early `?` returns) so a UDP
@@ -412,7 +411,7 @@ impl Client {
                     // #261: a relay arriving before TestStart is the upfront
                     // refusal (code 37 et al.) — the dump takes GT's minimal
                     // shape; after TestStart it keeps its late fields.
-                    let reached = ctx.test_start_millis > 0;
+                    let reached = ctx.stage.started();
                     return Err(self.on_server_error_relay(&mut ctx, reached).await);
                 }
 
@@ -591,7 +590,11 @@ impl Client {
             ctx.cpu_start.as_ref(),
             server_results,
             ctx.blksize,
-            &ctx.interval_data,
+            // The ONE drain of the reporter's collections (#287): emit_results
+            // is the single dump site, and every terminal path runs it at most
+            // once. Downstream builders take the value, so nothing can
+            // silently re-drain.
+            crate::reporter::CollectedIntervals::drain(&ctx.interval_data),
             &ctx.start_meta(reached_test_start),
             secs,
             error,
@@ -607,7 +610,7 @@ impl Client {
         // r1 item 5: a test that never STARTED reports a zero
         // window (GT's pre-data dump says 0/0/0), not the
         // requested -t default measured_secs still holds.
-        let dump_secs = if ctx.test_start_millis > 0 {
+        let dump_secs = if ctx.stage.started() {
             ctx.measured_secs
         } else {
             0.0
@@ -629,10 +632,17 @@ impl Client {
         // (e.g. code 37) arrives on the NEXT state read, after this
         // stamp, so the refusal document carries this real wall-clock
         // rather than epoch-0.
-        ctx.connect_time_millis = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .map(|d| d.as_millis() as u64)
-            .unwrap_or(0);
+        // Stage no-regress guard (#286): a tolerant re-received ParamExchange
+        // after TestStart must not demote the stage (the old code merely
+        // re-stamped a by-then-unread connect clock).
+        if !ctx.stage.started() {
+            ctx.stage = RunStage::PreTestStart {
+                connect_millis: std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .map(|d| d.as_millis() as u64)
+                    .unwrap_or(0),
+            };
+        }
         // #222: iperf3's connect text block — printed HERE,
         // after the param exchange (GT's on_connect timing, r2
         // item 5: a failed exchange prints no banner). The
@@ -726,10 +736,12 @@ impl Client {
         // All streams are set up — release the UDP senders.
         ctx.start.store(true, Ordering::Relaxed);
         ctx.cpu_start = Some(CpuSnapshot::now());
-        ctx.test_start_millis = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .map(|d| d.as_millis() as u64)
-            .unwrap_or(0);
+        ctx.stage = RunStage::Started {
+            start_millis: std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_millis() as u64)
+                .unwrap_or(0),
+        };
 
         // --json-stream: emit the `start` event now, before the reporter
         // streams any `interval` events (faithful event order, #62).
@@ -738,7 +750,6 @@ impl Client {
                 &ctx.streams,
                 ctx.cpu_start.as_ref(),
                 ctx.blksize,
-                &ctx.interval_data,
                 &ctx.start_meta(true),
             );
         }
@@ -1661,7 +1672,7 @@ impl Client {
         cpu_start: Option<&CpuSnapshot>,
         remote_cpu: Option<&TestResultsJson>,
         blksize: usize,
-        interval_data: &Arc<Mutex<crate::reporter::CollectedIntervals>>,
+        collected: crate::reporter::CollectedIntervals,
         start_meta: &StartMeta,
         test_duration: f64,
         error: Option<&str>,
@@ -1710,7 +1721,7 @@ impl Client {
                 cpu_start,
                 remote_cpu,
                 blksize,
-                interval_data,
+                collected,
                 start_meta,
                 test_duration,
             );
@@ -1724,7 +1735,7 @@ impl Client {
                 cpu_start,
                 remote_cpu,
                 blksize,
-                interval_data,
+                collected,
                 start_meta,
                 test_duration,
                 error,
@@ -1744,7 +1755,7 @@ impl Client {
                 cpu_start,
                 remote_cpu,
                 blksize,
-                interval_data,
+                collected,
                 start_meta,
                 test_duration,
             );
@@ -1958,7 +1969,7 @@ impl Client {
         cpu_start: Option<&CpuSnapshot>,
         remote_cpu: Option<&TestResultsJson>,
         blksize: usize,
-        interval_data: &Arc<Mutex<crate::reporter::CollectedIntervals>>,
+        collected: crate::reporter::CollectedIntervals,
         start_meta: &StartMeta,
         test_duration: f64,
     ) -> crate::json_report::ReportInput {
@@ -1966,15 +1977,10 @@ impl Client {
             CpuUtilization, ReportInput, StreamReport, TcpEndExtras, UdpStreamStats,
         };
 
-        // Take the interval samples + per-stream extremes the reporter collected.
-        // Its task has been joined by now (run_test awaits it), so this is final.
-        let (collected_intervals, extremes) = match interval_data.lock() {
-            Ok(mut g) => (
-                std::mem::take(&mut g.intervals),
-                std::mem::take(&mut g.extremes),
-            ),
-            Err(_) => (Vec::new(), Vec::new()),
-        };
+        // The interval samples + per-stream extremes the reporter collected,
+        // handed in BY VALUE from the single drain point (#287) — a second
+        // build has nothing to drain, structurally.
+        let (collected_intervals, extremes) = (collected.intervals, collected.extremes);
 
         let cpu_end = CpuSnapshot::now();
         let cpu_util = cpu_start
@@ -2158,16 +2164,11 @@ impl Client {
             // riperf3's single --gsro flag drives both GSO and GRO.
             gso: i32::from(self.gsro),
             gro: i32::from(self.gsro),
-            // #261: on a run that reached TestStart use that wall-clock; on the
-            // upfront-refusal path TestStart was never reached (start wall-clock
-            // is 0), so fall back to the connect-time wall-clock — GT stamps
-            // start.timestamp at on_connect (after the param exchange, BEFORE the
-            // refusal arrives), never epoch-0.
-            start_time_millis: if start_meta.start_time_millis > 0 {
-                start_meta.start_time_millis
-            } else {
-                start_meta.connect_time_millis
-            },
+            // #261/#286: the stage's wall-clock — TestStart's once started; on
+            // the upfront-refusal path the connect-time clock (GT stamps
+            // start.timestamp at on_connect, after the param exchange, BEFORE
+            // the refusal arrives — never epoch-0 on a real run).
+            start_time_millis: start_meta.stage.timestamp_millis(),
             extra_data: self.extra_data.clone(),
             // --get-server-output (#33): the server's returned output rides
             // the -J report tail — only when WE requested it (iperf3 gates on
@@ -2195,7 +2196,7 @@ impl Client {
         cpu_start: Option<&CpuSnapshot>,
         remote_cpu: Option<&TestResultsJson>,
         blksize: usize,
-        interval_data: &Arc<Mutex<crate::reporter::CollectedIntervals>>,
+        collected: crate::reporter::CollectedIntervals,
         start_meta: &StartMeta,
         test_duration: f64,
         error: Option<&str>,
@@ -2205,7 +2206,7 @@ impl Client {
             cpu_start,
             remote_cpu,
             blksize,
-            interval_data,
+            collected,
             start_meta,
             test_duration,
         );
@@ -2225,17 +2226,18 @@ impl Client {
         streams: &[DataStream],
         cpu_start: Option<&CpuSnapshot>,
         blksize: usize,
-        interval_data: &Arc<Mutex<crate::reporter::CollectedIntervals>>,
         start_meta: &StartMeta,
     ) {
         // The `start` event carries no summary window, so the elapsed value is
-        // unused here; pass the nominal duration.
+        // unused here; pass the nominal duration. Nothing is collected yet at
+        // TestStart (the reporter spawns after this event), so the builder
+        // gets explicit empty collections (#287).
         let input = self.build_report_input(
             streams,
             cpu_start,
             None,
             blksize,
-            interval_data,
+            crate::reporter::CollectedIntervals::default(),
             start_meta,
             self.duration as f64,
         );
@@ -2254,7 +2256,7 @@ impl Client {
         cpu_start: Option<&CpuSnapshot>,
         remote_cpu: Option<&TestResultsJson>,
         blksize: usize,
-        interval_data: &Arc<Mutex<crate::reporter::CollectedIntervals>>,
+        collected: crate::reporter::CollectedIntervals,
         start_meta: &StartMeta,
         test_duration: f64,
     ) -> crate::json_report::Report {
@@ -2263,7 +2265,7 @@ impl Client {
             cpu_start,
             remote_cpu,
             blksize,
-            interval_data,
+            collected,
             start_meta,
             test_duration,
         );
@@ -2289,23 +2291,64 @@ enum EndCondition {
 }
 
 /// Start-of-test metadata for the `-J` `start` block (#36 PR3), captured in
-/// `run()` where the cookie / control-MSS / start wall-clock are known.
+/// `run()` where the cookie / control-MSS / stage wall-clock are known.
 struct StartMeta {
     cookie: String,
     tcp_mss_default: u32,
-    /// Wall-clock at TestStart, ms since the Unix epoch. 0 until the TestStart
-    /// arm stamps it — its being > 0 is also the "reached TestStart" signal (#261).
-    start_time_millis: u64,
-    /// Wall-clock at on_connect (right after the param exchange), ms since the
-    /// Unix epoch (#261). GT stamps `start.timestamp` here; on an upfront refusal
-    /// (rejection before TestStart) it is the only real wall-clock the document
-    /// has, so the refusal path uses it for the timestamp instead of epoch-0.
-    connect_time_millis: u64,
+    /// How far the run progressed and the wall-clock that goes with it (#286).
+    stage: RunStage,
     /// #261: false ONLY on the upfront server-refusal path — drives the
     /// stage-gated omission of the late `start` fields and the bare `end: {}`.
     /// True on every other path (success, sigend interrupt, SERVER_TERMINATE),
-    /// which all render the full report structure like GT.
+    /// which all render the full report structure like GT. Kept EXPLICIT
+    /// (not derived from `stage`): a pre-TestStart sigend interrupt and the
+    /// refusal are the same stage but take different shapes — GT's interrupt
+    /// dump shows the full structure with 0/0/0, not the minimal refusal doc.
     reached_test_start: bool,
+}
+
+/// How far the client's run has progressed, carrying the authoritative
+/// wall-clock for the `-J` `start.timestamp` at that point (#286 — the
+/// single-value replacement for the old `test_start_millis` /
+/// `connect_time_millis` / start-is-zero tri-state). GT stamps
+/// `start.timestamp` at on_connect (the end of its PARAM_EXCHANGE case,
+/// iperf_api.c:338) and the TestStart processing then re-stamps it, so the
+/// timestamp a dump carries is exactly the stage's clock.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RunStage {
+    /// The param exchange has not completed: no real wall-clock yet (a dump
+    /// from here — e.g. an interrupt during the first state wait — carries
+    /// epoch-0, as before).
+    PreTestStart {
+        /// Wall-clock at on_connect, ms since the Unix epoch; 0 until the
+        /// ParamExchange arm stamps it (#261). On an upfront refusal this is
+        /// the only real wall-clock the document has.
+        connect_millis: u64,
+    },
+    /// TestStart was processed: the test ran (or is running).
+    Started {
+        /// Wall-clock at TestStart, ms since the Unix epoch (#36 PR3).
+        start_millis: u64,
+    },
+}
+
+impl RunStage {
+    /// The test reached TestStart. Replaces the old `test_start_millis > 0`
+    /// sentinel probes (#286).
+    fn started(&self) -> bool {
+        matches!(self, RunStage::Started { .. })
+    }
+
+    /// The wall-clock the `-J` `start.timestamp` carries for a dump made at
+    /// this stage — the TestStart clock once started, else the on_connect
+    /// clock (#261's refusal-timestamp rule, previously the
+    /// `if start > 0 { start } else { connect }` fallback).
+    fn timestamp_millis(&self) -> u64 {
+        match *self {
+            RunStage::PreTestStart { connect_millis } => connect_millis,
+            RunStage::Started { start_millis } => start_millis,
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -2357,12 +2400,10 @@ struct RunCtx {
     /// Authoritative test duration captured from run_test: `-t` for a duration
     /// run, the measured elapsed for `-n`/`-k`. Drives the summary window (#103).
     measured_secs: f64,
-    /// Wall-clock at TestStart, for the `-J` start.timestamp (#36 PR3).
-    test_start_millis: u64,
-    /// Wall-clock at on_connect (set at the end of the ParamExchange arm,
-    /// GT's on_connect timing) — the timestamp the `-J` document carries on an
-    /// upfront refusal that never reaches TestStart (#261).
-    connect_time_millis: u64,
+    /// How far the run has progressed + the `-J` start.timestamp wall-clock
+    /// for a dump made now (#286): the ParamExchange arm stamps the connect
+    /// clock (GT's on_connect timing), the TestStart arm advances to Started.
+    stage: RunStage,
     /// #145: AUDITABILITY ONLY — the last state this side processed, kept so
     /// an unexpected byte can be diagnosed against the transition table.
     /// Seeded at IperfStart (the first state the client legally receives is
@@ -2375,13 +2416,12 @@ impl RunCtx {
     /// Assemble the `StartMeta` for a report dump from the run's captured
     /// state — the one construction site (#289). `reached_test_start` is the
     /// caller's call: true everywhere except the upfront server-refusal path
-    /// (#261). #286 tracks collapsing the underlying tri-state itself.
+    /// (#261, see the field doc on StartMeta).
     fn start_meta(&self, reached_test_start: bool) -> StartMeta {
         StartMeta {
             cookie: String::from_utf8_lossy(&self.cookie[..protocol::COOKIE_SIZE - 1]).into_owned(),
             tcp_mss_default: self.control_mss,
-            start_time_millis: self.test_start_millis,
-            connect_time_millis: self.connect_time_millis,
+            stage: self.stage,
             reached_test_start,
         }
     }
@@ -3211,6 +3251,46 @@ impl ClientBuilder {
 
 #[cfg(test)]
 mod tests {
+    mod run_stage {
+        use crate::client::RunStage;
+
+        /// #286: the stage enum's two contracts — `started()` replaces the old
+        /// `test_start_millis > 0` sentinel probes, and `timestamp_millis()`
+        /// replaces the `if start > 0 { start } else { connect }` fallback
+        /// (#261's refusal-timestamp rule).
+        #[test]
+        fn started_and_timestamp_follow_the_stage() {
+            let fresh = RunStage::PreTestStart { connect_millis: 0 };
+            assert!(!fresh.started());
+            assert_eq!(
+                fresh.timestamp_millis(),
+                0,
+                "no clock before the param exchange — a dump here carries \
+                 epoch-0, as before #286"
+            );
+
+            let connected = RunStage::PreTestStart {
+                connect_millis: 1_700_000_000_123,
+            };
+            assert!(!connected.started(), "the refusal window is pre-start");
+            assert_eq!(
+                connected.timestamp_millis(),
+                1_700_000_000_123,
+                "the refusal document carries the on_connect wall-clock (#261)"
+            );
+
+            let started = RunStage::Started {
+                start_millis: 1_700_000_000_456,
+            };
+            assert!(started.started());
+            assert_eq!(
+                started.timestamp_millis(),
+                1_700_000_000_456,
+                "once started, the TestStart wall-clock wins"
+            );
+        }
+    }
+
     mod stream_report_retransmits_quadrants {
         use crate::client::stream_report_retransmits;
 

--- a/riperf3/src/reporter.rs
+++ b/riperf3/src/reporter.rs
@@ -568,6 +568,22 @@ pub struct CollectedIntervals {
     pub extremes: Vec<StreamExtremes>,
 }
 
+impl CollectedIntervals {
+    /// Drain the shared collector — the single ownership-transfer point from
+    /// the reporter to the report builder (#287). Every builder downstream
+    /// takes the collections BY VALUE, so a second build has nothing to drain
+    /// and the old "must be built exactly once" comment-invariant is now
+    /// structural. Callers drain only after the reporter task is joined, so
+    /// the take is final; a poisoned lock yields empty collections (the old
+    /// in-builder fallback).
+    pub(crate) fn drain(shared: &Mutex<Self>) -> Self {
+        shared
+            .lock()
+            .map(|mut g| std::mem::take(&mut *g))
+            .unwrap_or_default()
+    }
+}
+
 /// End-of-test signal from the test driver to the interval reporter (#55).
 ///
 /// The reporter's periodic ticks fall on idealized boundaries, but a run can end

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -211,6 +211,16 @@ struct EndState {
     test_duration: f64,
 }
 
+/// Where the test's rich report stands after `finish_server_output` (#287):
+/// either already built (the JSON-mode --get-server-output pre-exchange build,
+/// #33 — the drained collections are inside) or still pending, carrying the
+/// drained collections to the single post-exchange build. Exactly one build
+/// happens either way, by construction.
+enum ReportSource {
+    Built(Box<crate::json_report::Report>),
+    Pending(crate::reporter::CollectedIntervals),
+}
+
 // ---------------------------------------------------------------------------
 // Server
 // ---------------------------------------------------------------------------
@@ -508,9 +518,16 @@ impl Server {
         // monolith's counter read order.
         let result_streams = self.build_result_streams(&ctx, &end);
 
+        // The ONE drain of the reporter's collections (#287): the reporter was
+        // joined in shutdown_and_flush, so the take is final. From here the
+        // collections move by value — into the pre-exchange build (JSON-mode
+        // --get-server-output) or through `ReportSource::Pending` to the
+        // single post-exchange build below.
+        let collected = crate::reporter::CollectedIntervals::drain(&ctx.interval_data);
+
         // ---- --get-server-output finish + ExchangeResults / IperfDone ----
-        let (server_output_text, server_output_json, prebuilt_report) =
-            self.finish_server_output(&mut ctx, &end);
+        let (server_output_text, server_output_json, report_source) =
+            self.finish_server_output(&mut ctx, &end, collected);
         let was_captured = server_output_text.is_some();
         self.exchange_results_phase(
             &mut ctx,
@@ -521,12 +538,15 @@ impl Server {
         )
         .await?;
 
-        // #137: build the rich report ONCE — handle_one_test returns it (run
-        // discards it; run_once hands it back to the library caller). build_report
-        // drains the collected intervals via mem::take, so it must be built
-        // exactly once; reuse the pre-exchange build when --get-server-output
-        // already attached it (#33).
-        let report = prebuilt_report.unwrap_or_else(|| self.build_ctx_report(&ctx, &end));
+        // #137/#287: the report is built exactly ONCE per test, by
+        // construction — the collections moved either into the pre-exchange
+        // --get-server-output build (#33) or arrive here for the single
+        // post-exchange build. handle_one_test returns it (run discards it;
+        // run_once hands it back to the library caller).
+        let report = match report_source {
+            ReportSource::Built(report) => *report,
+            ReportSource::Pending(collected) => self.build_ctx_report(&ctx, &end, collected),
+        };
 
         self.emit_final_output(&ctx, &end, &report, was_captured);
 
@@ -1007,7 +1027,6 @@ impl Server {
                 &ctx.accepted_host,
                 ctx.accepted_port,
                 ctx.test_start_millis,
-                &ctx.interval_data,
             );
         }
 
@@ -1333,17 +1352,16 @@ impl Server {
     /// --get-server-output (#33): finish the diverted text (render the final
     /// summaries into the capture first, so the client sees the complete
     /// report), or attach the full -J report for a JSON-mode server. Returns
-    /// `(server_output_text, server_output_json, prebuilt_report)`.
+    /// `(server_output_text, server_output_json, report_source)` — the drained
+    /// collections go in and come back either inside the pre-built report or
+    /// untouched for the single post-exchange build (#287).
     fn finish_server_output(
         &self,
         ctx: &mut TestRunCtx,
         end: &EndState,
-    ) -> (
-        Option<String>,
-        Option<serde_json::Value>,
-        Option<crate::json_report::Report>,
-    ) {
-        let mut prebuilt_report: Option<crate::json_report::Report> = None;
+        collected: crate::reporter::CollectedIntervals,
+    ) -> (Option<String>, Option<serde_json::Value>, ReportSource) {
+        let mut report_source = ReportSource::Pending(collected);
         let (server_output_text, server_output_json) = if let Some(capture) = ctx.capture.take() {
             let summaries = Self::text_summaries(&ctx.streams, end.test_duration, &ctx.cfg);
             let with_retr = summaries.iter().any(|s| s.retransmits.is_some());
@@ -1388,22 +1406,31 @@ impl Server {
             // (discard_json = json_stream && ... && !(server && get_server_output),
             // iperf_api.c:3900) — without this a real iperf3 client
             // requesting output silently got none (#168).
-            let report = self.build_ctx_report(ctx, end);
+            let ReportSource::Pending(collected) = report_source else {
+                unreachable!("report_source is Pending until this single build");
+            };
+            let report = self.build_ctx_report(ctx, end, collected);
             let value = serde_json::to_value(&report).ok();
-            prebuilt_report = Some(report);
+            report_source = ReportSource::Built(Box::new(report));
             (None, value)
         } else {
             (None, None)
         };
-        (server_output_text, server_output_json, prebuilt_report)
+        (server_output_text, server_output_json, report_source)
     }
 
-    /// The one `build_report` plumbing site for the pipeline (#289):
-    /// build_report drains the collected intervals via mem::take, so it must
-    /// be built exactly once per test — the pre-exchange --get-server-output
-    /// build is reused as `prebuilt_report` (#33/#137). #287 tracks making
-    /// that invariant structural.
-    fn build_ctx_report(&self, ctx: &TestRunCtx, end: &EndState) -> crate::json_report::Report {
+    /// The one `build_report` plumbing site for the pipeline (#289). The
+    /// drained collections arrive BY VALUE and move into the report, so the
+    /// old "must be built exactly once" comment-invariant is structural
+    /// (#287): the pre-exchange --get-server-output build consumes them into
+    /// `ReportSource::Built` (#33/#137), else they ride `Pending` to the
+    /// single post-exchange build.
+    fn build_ctx_report(
+        &self,
+        ctx: &TestRunCtx,
+        end: &EndState,
+        collected: crate::reporter::CollectedIntervals,
+    ) -> crate::json_report::Report {
         self.build_report(
             &ctx.streams,
             &ctx.cfg,
@@ -1414,7 +1441,7 @@ impl Server {
             &ctx.accepted_host,
             ctx.accepted_port,
             ctx.test_start_millis,
-            &ctx.interval_data,
+            collected,
             end.report_error.as_deref(),
         )
     }
@@ -2067,22 +2094,18 @@ impl Server {
         accepted_host: &str,
         accepted_port: u16,
         start_time_millis: u64,
-        interval_data: &Arc<Mutex<crate::reporter::CollectedIntervals>>,
+        collected: crate::reporter::CollectedIntervals,
         error: Option<&str>,
     ) -> crate::json_report::ReportInput {
         use crate::json_report::{
             CpuUtilization, ReportInput, StreamReport, TcpEndExtras, UdpStreamStats,
         };
 
-        // Take the interval samples + per-stream TCP_INFO extremes the reporter
-        // collected (its task is joined by now, so this is final).
-        let (collected_intervals, extremes) = match interval_data.lock() {
-            Ok(mut g) => (
-                std::mem::take(&mut g.intervals),
-                std::mem::take(&mut g.extremes),
-            ),
-            Err(_) => (Vec::new(), Vec::new()),
-        };
+        // The interval samples + per-stream TCP_INFO extremes the reporter
+        // collected, handed in BY VALUE from the single drain point in
+        // handle_one_test (#287) — a second build has nothing to drain,
+        // structurally.
+        let (collected_intervals, extremes) = (collected.intervals, collected.extremes);
 
         let is_udp = matches!(cfg.protocol, TransportProtocol::Udp);
 
@@ -2262,7 +2285,7 @@ impl Server {
         accepted_host: &str,
         accepted_port: u16,
         start_time_millis: u64,
-        interval_data: &Arc<Mutex<crate::reporter::CollectedIntervals>>,
+        collected: crate::reporter::CollectedIntervals,
         error: Option<&str>,
     ) -> crate::json_report::Report {
         self.build_report_input(
@@ -2275,7 +2298,7 @@ impl Server {
             accepted_host,
             accepted_port,
             start_time_millis,
-            interval_data,
+            collected,
             error,
         )
         .build()
@@ -2323,9 +2346,9 @@ impl Server {
 
     /// `--json-stream`: emit the server's `end` event (#62). The interval events
     /// were already streamed live by the reporter.
-    // Takes the already-built `Report` (#137: handle_one_test builds it once and
-    // returns it) so the report isn't reassembled — build_report_input drains the
-    // collected intervals via mem::take, so a second build would lose them.
+    // Takes the already-built `Report` (#137: handle_one_test builds it once
+    // and returns it) so the report isn't reassembled — the collected
+    // intervals moved into it by value at build time (#287).
     fn emit_json_stream_end(&self, report: &crate::json_report::Report) {
         crate::reporter::emit_json_stream_line(&crate::json_report::json_stream_event(
             "end",
@@ -2351,8 +2374,9 @@ impl Server {
         accepted_host: &str,
         accepted_port: u16,
         start_time_millis: u64,
-        interval_data: &Arc<Mutex<crate::reporter::CollectedIntervals>>,
     ) {
+        // Nothing is collected yet at TestStart (the reporter spawns after
+        // this event), so the builder gets explicit empty collections (#287).
         let input = self.build_report_input(
             streams,
             cfg,
@@ -2363,7 +2387,7 @@ impl Server {
             accepted_host,
             accepted_port,
             start_time_millis,
-            interval_data,
+            crate::reporter::CollectedIntervals::default(),
             None,
         );
         crate::reporter::emit_json_stream_line(&crate::json_report::json_stream_event(

--- a/riperf3/tests/integration.rs
+++ b/riperf3/tests/integration.rs
@@ -2412,6 +2412,20 @@ mod client_run_return_value {
             cpu.is_finite() && cpu >= 0.0,
             "cpu host_total not a sane non-negative number: {cpu}"
         );
+        // r1 F1 (#297): the started run's -J timestamp is the TestStart
+        // wall-clock (RunStage::Started) — a stage regression to epoch-0 or a
+        // misfiring connect-clock fallback shows here as a non-now value.
+        // (Previously only a unit pin guarded this; a mutation zeroing the
+        // Started stamp survived every integration test.)
+        let now_secs = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        let ts = report.start.timestamp.timesecs;
+        assert!(
+            now_secs.abs_diff(ts) < 300,
+            "start.timestamp.timesecs must be the real TestStart wall-clock: {ts} vs now {now_secs}"
+        );
         // intervals is built from the reporter's collected samples, which
         // build_report_input drains via mem::take — a non-empty array here guards
         // the #137 build-once invariant at the LIB layer (a double build would


### PR DESCRIPTION
Closes #286. Closes #287.

## What

Two behavior-preserving structural fixes from the 0.8.0 post-release review, on the surface #289 reshaped:

**#286 — RunStage enum.** The client's run-progress tri-state (`test_start_millis` / `connect_time_millis` / the `reached` derivations) collapses into one `RunStage` value on `RunCtx`: `PreTestStart { connect_millis }` | `Started { start_millis }`. `started()` replaces the `test_start_millis > 0` sentinel probes (the ServerError arm, the interrupt dump-window rule); `timestamp_millis()` replaces `build_report_input`'s start-else-connect fallback (#261's refusal-timestamp rule). `reached_test_start` deliberately stays an explicit per-dump parameter — a pre-TestStart sigend interrupt and the upfront refusal are the same *stage* but take different GT shapes (#261), so it is not derivable from the stage.

**#287 — build-once by construction.** `CollectedIntervals::drain` is now the single ownership-transfer point from the reporter; every builder downstream takes the collections **by value**, so a second build has nothing to drain — the "must be built exactly once" comment invariant is structural. Client: the drain lives in `emit_results`, the single dump site. Server: `handle_one_test` drains once post-flush and a `ReportSource::{Built, Pending}` enum carries the collections either inside the pre-exchange `--get-server-output` build (#33) or through to the single post-exchange build. The pre-test `--json-stream` start events pass explicit empty collections instead of (harmlessly) draining the shared collector.

## Notes for review

- One deliberate edge divergence (#286): with a pathological clock (`SystemTime` before the epoch), the old code's `start > 0` probe would have mis-shaped a post-TestStart dump as a refusal; `started()` is now true regardless of the clock value. More correct, unreachable in practice.
- New ParamExchange stage no-regress guard: a tolerantly re-received ParamExchange after TestStart no longer has state to clobber (old code re-stamped an unread clock; new code would otherwise demote the stage).
- Both `ReportInput` and all touched plumbing are `pub(crate)` — no public-surface change (SemVer CI concurs).

## Evidence

- Full workspace suite: 26 binaries, 639 tests, 0 failures (incl. the #261 refusal-shape pins and the build-once `report.intervals` guards on both roles).
- New unit pin: `run_stage::started_and_timestamp_follow_the_stage`.
- Per-PR compat smoke to run before merge.
