### PR TITLE
refactor: embed StreamMeta/SocketMeta in DataStream (#288) + review cleanups (#292)

### DIFF
--- a/riperf3-cli/tests/udp_demux.rs
+++ b/riperf3-cli/tests/udp_demux.rs
@@ -168,10 +168,12 @@ fn udp_demux_bidir_parallel_completes() {
     assert_all_streams_have_bytes(&report, 8, "bidir");
 }
 
-/// #288 (r1 mutation B): the demux server's `-J` `connected[]` must map each
-/// stream to the CLIENT's real source port (`peer_addr: Some(client_addr)` in
-/// the demux route table), with every local port being the shared demux
-/// socket's. A dropped/None peer_addr — or a stream/route mix-up — shows here.
+/// #288 (r1 mutation B, r2 finding 1): the demux server's `-J` `connected[]`
+/// must map each stream to the CLIENT's real source port
+/// (`peer_addr: Some(client_addr)` in the demux route table), with every
+/// local port being the shared demux socket's. BIDIR so ONE doc exercises
+/// BOTH SocketMeta literals — the sender branch and the receiver branch
+/// (r2 proved a forward-only pin leaves the sender literal mutation-silent).
 #[test]
 fn demux_server_connected_block_maps_streams_to_client_ports() {
     let _serial = udp_serial();
@@ -201,6 +203,7 @@ fn demux_server_connected_block_maps_streams_to_client_ports() {
                 "1",
                 "-P",
                 "2",
+                "--bidir",
                 "-J",
             ])
             .stdout(Stdio::piped())
@@ -251,7 +254,8 @@ fn demux_server_connected_block_maps_streams_to_client_ports() {
     let server_entries = sv["start"]["connected"]
         .as_array()
         .expect("server connected[]");
-    assert_eq!(server_entries.len(), 2, "one entry per stream: {sv}");
+    // -P 2 --bidir = 2 receiving + 2 sending streams on the server.
+    assert_eq!(server_entries.len(), 4, "one entry per stream: {sv}");
     let server_remote_ports: std::collections::BTreeSet<u64> = server_entries
         .iter()
         .map(|c| c["remote_port"].as_u64().expect("server remote_port"))

--- a/riperf3-cli/tests/udp_demux.rs
+++ b/riperf3-cli/tests/udp_demux.rs
@@ -36,12 +36,16 @@ fn free_port() -> u16 {
 }
 
 // Reaper guard + bounded wait now live in riperf3-test-support (#192).
-use common::{wait_bounded, ChildGuard};
+use common::{udp_serial, wait_bounded, ChildGuard};
 
 /// Run one UDP mode against a demux-forced one-off server and return the client's
 /// parsed `-J` report. `extra` carries the direction flag (`-R`, `--bidir`, or
 /// nothing for forward).
 fn run_demux_udp(extra: &[&str], who: &str) -> Value {
+    // #191-class: concurrent UDP-connect handshakes starve each other under
+    // load (this binary went from 3 to 4 UDP tests with the #288 pin, and the
+    // fourth tipped it over locally). Serialize within the binary.
+    let _serial = udp_serial();
     let bin = env!("CARGO_BIN_EXE_riperf3");
     let port = free_port();
     let port_s = port.to_string();
@@ -162,4 +166,105 @@ fn udp_demux_bidir_parallel_completes() {
     // The exact #80 case: 4 receiving + 4 sending streams over one server socket.
     let report = run_demux_udp(&["--bidir"], "bidir");
     assert_all_streams_have_bytes(&report, 8, "bidir");
+}
+
+/// #288 (r1 mutation B): the demux server's `-J` `connected[]` must map each
+/// stream to the CLIENT's real source port (`peer_addr: Some(client_addr)` in
+/// the demux route table), with every local port being the shared demux
+/// socket's. A dropped/None peer_addr — or a stream/route mix-up — shows here.
+#[test]
+fn demux_server_connected_block_maps_streams_to_client_ports() {
+    let _serial = udp_serial();
+    let bin = env!("CARGO_BIN_EXE_riperf3");
+    let port = free_port();
+    let port_s = port.to_string();
+
+    let server = Command::new(bin)
+        .args(["-s", "-1", "-p", &port_s, "-J"])
+        .env("RIPERF3_UDP_SERVER_DEMUX", "1")
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn server");
+    let mut server = ChildGuard(server);
+
+    let retry_deadline = Instant::now() + Duration::from_secs(10);
+    let out = loop {
+        let client = Command::new(bin)
+            .args([
+                "-c",
+                "127.0.0.1",
+                "-p",
+                &port_s,
+                "-u",
+                "-t",
+                "1",
+                "-P",
+                "2",
+                "-J",
+            ])
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .output()
+            .expect("run client");
+        // -J puts the refusal text in the stdout DOCUMENT, stderr empty
+        // (#198), so classify on BOTH — the stderr-only check silently
+        // never retried and failed on the first compile-load-delayed accept.
+        let combined = format!(
+            "{}{}",
+            String::from_utf8_lossy(&client.stdout),
+            String::from_utf8_lossy(&client.stderr)
+        );
+        if common::refused(&client.status, &combined) && Instant::now() < retry_deadline {
+            std::thread::sleep(Duration::from_millis(100));
+            continue;
+        }
+        assert!(client.status.success(), "client failed: {combined}");
+        break String::from_utf8_lossy(&client.stdout).into_owned();
+    };
+
+    // Server exits after the one test (-1); read its whole doc.
+    let deadline = Instant::now() + Duration::from_secs(10);
+    while server.0.try_wait().expect("try_wait").is_none() {
+        assert!(Instant::now() < deadline, "server did not exit");
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    let mut sdoc = String::new();
+    use std::io::Read;
+    server
+        .0
+        .stdout
+        .take()
+        .expect("piped")
+        .read_to_string(&mut sdoc)
+        .expect("read server doc");
+
+    let cv: Value = serde_json::from_str(&out).expect("client doc parses");
+    let sv: Value = serde_json::from_str(&sdoc).expect("server doc parses");
+
+    let client_local_ports: std::collections::BTreeSet<u64> = cv["start"]["connected"]
+        .as_array()
+        .expect("client connected[]")
+        .iter()
+        .map(|c| c["local_port"].as_u64().expect("client local_port"))
+        .collect();
+    let server_entries = sv["start"]["connected"]
+        .as_array()
+        .expect("server connected[]");
+    assert_eq!(server_entries.len(), 2, "one entry per stream: {sv}");
+    let server_remote_ports: std::collections::BTreeSet<u64> = server_entries
+        .iter()
+        .map(|c| c["remote_port"].as_u64().expect("server remote_port"))
+        .collect();
+    assert_eq!(
+        server_remote_ports, client_local_ports,
+        "each server stream maps to a real client source port: {sv}"
+    );
+    for c in server_entries {
+        assert_eq!(
+            c["local_port"].as_u64(),
+            Some(u64::from(port)),
+            "every demux stream shares the one server socket: {sv}"
+        );
+    }
 }

--- a/riperf3/src/client.rs
+++ b/riperf3/src/client.rs
@@ -148,13 +148,13 @@ fn transferred_bytes(streams: &[DataStream]) -> u64 {
     // warm-up bytes).
     let sent: u64 = streams
         .iter()
-        .filter(|s| s.is_sender)
-        .map(|s| s.counters.bytes_sent_net())
+        .filter(|s| s.meta.is_sender)
+        .map(|s| s.meta.counters.bytes_sent_net())
         .sum();
     let received: u64 = streams
         .iter()
-        .filter(|s| !s.is_sender)
-        .map(|s| s.counters.bytes_received())
+        .filter(|s| !s.meta.is_sender)
+        .map(|s| s.meta.counters.bytes_received())
         .sum();
     sent.max(received)
 }
@@ -574,7 +574,7 @@ impl Client {
     }
 
     /// Render/emit the run's results from the context state — the one
-    /// `print_results` plumbing site for every dump the dispatch loop makes
+    /// `render_results` plumbing site for every dump the dispatch loop makes
     /// (#289). `server_results`/`reached`/`error` are per-dump; everything
     /// else comes from the context.
     fn emit_results(
@@ -585,7 +585,7 @@ impl Client {
         secs: f64,
         error: Option<&str>,
     ) -> crate::json_report::Report {
-        self.print_results(
+        self.render_results(
             &ctx.streams,
             ctx.cpu_start.as_ref(),
             server_results,
@@ -697,10 +697,10 @@ impl Client {
         // mode (iperf3 prints it for every stream on connect).
         if !self.json_output && !self.json_stream {
             for s in &ctx.streams {
-                if let (Some(l), Some(p)) = (s.local_addr, s.peer_addr) {
+                if let (Some(l), Some(p)) = (s.meta.sock.local_addr, s.meta.sock.peer_addr) {
                     vprintln!(
                         "[{:3}] local {} port {} connected to {} port {}",
-                        s.id,
+                        s.meta.id,
                         l.ip().to_canonical(),
                         l.port(),
                         p.ip().to_canonical(),
@@ -1074,12 +1074,11 @@ impl Client {
                     // into its task, for the `-J` start.connected block (#36).
                     // TCP applied -w earlier in configure_tcp_stream_full, so
                     // apply_window is false here (#144).
-                    let (local_addr, peer_addr, sndbuf_actual, rcvbuf_actual) =
-                        net::capture_stream_meta(
-                            socket2::SockRef::from(&data_stream),
-                            self.window,
-                            false,
-                        )?;
+                    let sock = net::capture_stream_meta(
+                        socket2::SockRef::from(&data_stream),
+                        self.window,
+                        false,
+                    )?;
                     // #37: the congestion algorithm actually in effect (the kernel
                     // default when -C is unset), for `congestion_used`.
                     let congestion_used = net::tcp_congestion_used(&data_stream);
@@ -1154,21 +1153,18 @@ impl Client {
                         })
                     };
 
-                    streams.push(DataStream::from_meta(
-                        StreamMeta {
+                    streams.push(DataStream {
+                        meta: StreamMeta {
                             id: stream_id,
                             is_sender,
                             counters,
                             raw_fd,
-                            local_addr,
-                            peer_addr,
-                            sndbuf_actual,
-                            rcvbuf_actual,
+                            sock,
                             congestion_used,
                         },
                         task,
-                        None,
-                    ));
+                        udp_recv_stats: None,
+                    });
                 }
             }
             TransportProtocol::Udp => {
@@ -1224,12 +1220,11 @@ impl Client {
                     // honor -w/--window on the UDP socket too (#59); iperf3
                     // applies it to UDP via iperf_udp_buffercheck, before the
                     // read-back, so sndbuf/rcvbuf report the realized size (#144).
-                    let (local_addr, peer_addr, sndbuf_actual, rcvbuf_actual) =
-                        net::capture_stream_meta(
-                            socket2::SockRef::from(&udp_sock),
-                            self.window,
-                            true,
-                        )?;
+                    let sock = net::capture_stream_meta(
+                        socket2::SockRef::from(&udp_sock),
+                        self.window,
+                        true,
+                    )?;
 
                     // Convert tokio UdpSocket to std for blocking I/O
                     let std_sock = udp_sock.into_std().map_err(RiperfError::Io)?;
@@ -1271,39 +1266,33 @@ impl Client {
                         let task = thread_gate.spawn(move || {
                             stream::run_udp_receiver_blocking(std_sock, c, sc, bs, d, u64bit)
                         });
-                        streams.push(DataStream::from_meta(
-                            StreamMeta {
+                        streams.push(DataStream {
+                            meta: StreamMeta {
                                 id: stream_id,
                                 is_sender,
                                 counters,
                                 raw_fd: None,
-                                local_addr,
-                                peer_addr,
-                                sndbuf_actual,
-                                rcvbuf_actual,
+                                sock,
                                 congestion_used: None,
                             },
                             task,
-                            Some(stats),
-                        ));
+                            udp_recv_stats: Some(stats),
+                        });
                         continue;
                     };
 
-                    streams.push(DataStream::from_meta(
-                        StreamMeta {
+                    streams.push(DataStream {
+                        meta: StreamMeta {
                             id: stream_id,
                             is_sender,
                             counters,
                             raw_fd: None,
-                            local_addr,
-                            peer_addr,
-                            sndbuf_actual,
-                            rcvbuf_actual,
+                            sock,
                             congestion_used: None,
                         },
                         task,
-                        None,
-                    ));
+                        udp_recv_stats: None,
+                    });
                 }
                 // #178: hold CreateStreams until every data thread is running
                 // (parked at its start gate). This gates the CLIENT's side
@@ -1399,11 +1388,11 @@ impl Client {
             let stream_refs: Vec<_> = streams
                 .iter()
                 .map(|s| crate::reporter::IntervalStreamRef {
-                    id: s.id,
-                    is_sender: s.is_sender,
-                    counters: s.counters.clone(),
+                    id: s.meta.id,
+                    is_sender: s.meta.is_sender,
+                    counters: s.meta.counters.clone(),
                     udp_recv_stats: s.udp_recv_stats.clone(),
-                    raw_fd: s.raw_fd,
+                    raw_fd: s.meta.raw_fd,
                 })
                 .collect();
             crate::reporter::spawn_interval_reporter(
@@ -1581,10 +1570,10 @@ impl Client {
                 // Net (post-omit) bytes; packets/errors stay GROSS with the
                 // omitted_* baselines alongside — the reading side subtracts,
                 // exactly iperf3's exchange accounting (#31).
-                let bytes = if s.is_sender {
-                    s.counters.bytes_sent_net()
+                let bytes = if s.meta.is_sender {
+                    s.meta.counters.bytes_sent_net()
                 } else {
-                    s.counters.bytes_received_net()
+                    s.meta.counters.bytes_received_net()
                 };
 
                 let (jitter, errors, packets, omitted_errors, omitted_packets) =
@@ -1601,7 +1590,7 @@ impl Client {
                                 )
                             })
                             .unwrap_or((0.0, 0, 0, 0, 0))
-                    } else if s.is_sender && self.protocol == TransportProtocol::Udp {
+                    } else if s.meta.is_sender && self.protocol == TransportProtocol::Udp {
                         // iperf3's UDP sender counts every datagram it sends
                         // (iperf_udp.c `++sp->packet_count`) and exchanges
                         // that count unconditionally (iperf_api.c
@@ -1612,8 +1601,8 @@ impl Client {
                         // `bytes/blksize` derivation. Full-block-only senders
                         // keep this == the old value bit-for-bit (no
                         // compat-matrix drift).
-                        let gross = s.counters.datagrams_sent() as i64;
-                        let net = s.counters.datagrams_sent_net() as i64;
+                        let gross = s.meta.counters.datagrams_sent() as i64;
+                        let net = s.meta.counters.datagrams_sent_net() as i64;
                         (0.0, 0, gross, 0, gross - net)
                     } else {
                         (0.0, 0, 0, 0, 0)
@@ -1625,7 +1614,7 @@ impl Client {
                 let retransmits = s.sender_retransmits(is_udp_stream).unwrap_or(-1);
 
                 protocol::StreamResultJson {
-                    id: s.id,
+                    id: s.meta.id,
                     bytes,
                     retransmits,
                     jitter,
@@ -1650,7 +1639,7 @@ impl Client {
             // sender (check_sender_has_retransmits) — the PEER gates display
             // of our Retr column on it; 0 suppressed it cross-tool even where
             // riperf3 measures retransmits.
-            sender_has_retransmits: if streams.iter().any(|s| s.is_sender) {
+            sender_has_retransmits: if streams.iter().any(|s| s.meta.is_sender) {
                 i64::from(
                     self.protocol == TransportProtocol::Tcp
                         && crate::tcp_info::has_retransmit_info(),
@@ -1660,13 +1649,17 @@ impl Client {
             },
             // #37: the congestion algorithm actually in effect (read back at stream
             // creation); None for UDP / unsupported platforms.
-            congestion_used: streams.first().and_then(|s| s.congestion_used.clone()),
+            congestion_used: streams.first().and_then(|s| s.meta.congestion_used.clone()),
             streams: stream_results,
         }
     }
 
     #[allow(clippy::too_many_arguments)]
-    fn print_results(
+    /// Render the run's results for the active output mode AND return the
+    /// rich `Report` the run hands to the library caller (#137/#292): every
+    /// arm builds the same Report it emits — text mode builds one it never
+    /// prints (return-value only). Named for both halves of that contract.
+    fn render_results(
         &self,
         streams: &[DataStream],
         cpu_start: Option<&CpuSnapshot>,
@@ -1808,11 +1801,11 @@ impl Client {
             // Bidir tags every line with the STREAM's direction (#184).
             let role_tag = self
                 .bidir
-                .then_some(crate::reporter::bidir_role_tag(false, s.is_sender));
-            let bytes = if s.is_sender {
-                s.counters.bytes_sent_net()
+                .then_some(crate::reporter::bidir_role_tag(false, s.meta.is_sender));
+            let bytes = if s.meta.is_sender {
+                s.meta.counters.bytes_sent_net()
             } else {
-                s.counters.bytes_received_net()
+                s.meta.counters.bytes_received_net()
             };
 
             let (jitter, lost, total) = if let Some(ref udp_stats) = s.udp_recv_stats {
@@ -1836,18 +1829,18 @@ impl Client {
                 (
                     Some(0.0),
                     Some(0),
-                    Some(s.counters.datagrams_sent_net() as i64),
+                    Some(s.meta.counters.datagrams_sent_net() as i64),
                 )
             } else {
                 (None, None, None)
             };
 
             let local = crate::reporter::StreamSummary {
-                stream_id: s.id,
+                stream_id: s.meta.id,
                 start: 0.0,
                 end: test_duration,
                 bytes,
-                is_sender: s.is_sender,
+                is_sender: s.meta.is_sender,
                 // TCP sender lines carry the omit-adjusted retransmit total
                 // iperf3 prints (#184); receivers/UDP carry none.
                 retransmits: s.sender_retransmits(is_udp),
@@ -1863,11 +1856,11 @@ impl Client {
             // reported having them (#156 sender_has_retransmits).
             let peer_has_retr = server_results.is_some_and(|r| r.sender_has_retransmits == 1);
             let peer = server_results
-                .and_then(|r| r.streams.iter().find(|x| x.id == s.id))
+                .and_then(|r| r.streams.iter().find(|x| x.id == s.meta.id))
                 .map(|x| {
                     peer_half_summary(
                         x,
-                        s.is_sender,
+                        s.meta.is_sender,
                         is_udp,
                         peer_has_retr,
                         test_duration,
@@ -1885,11 +1878,11 @@ impl Client {
                 server_results
                     .is_none()
                     .then(|| crate::reporter::StreamSummary {
-                        stream_id: s.id,
+                        stream_id: s.meta.id,
                         start: 0.0,
                         end: test_duration,
                         bytes: 0,
-                        is_sender: !s.is_sender,
+                        is_sender: !s.meta.is_sender,
                         retransmits: None,
                         jitter: is_udp.then_some(0.0),
                         lost: is_udp.then_some(0),
@@ -1900,7 +1893,7 @@ impl Client {
 
             // iperf3 orders each pair sender-first.
             match peer {
-                Some(peer) if s.is_sender => summaries.extend([local, peer]),
+                Some(peer) if s.meta.is_sender => summaries.extend([local, peer]),
                 Some(peer) => summaries.extend([peer, local]),
                 None => summaries.push(local),
             }
@@ -1940,7 +1933,7 @@ impl Client {
                 }
             }
             if matches!(self.protocol, TransportProtocol::Tcp) {
-                let own = streams.iter().find_map(|s| s.congestion_used.clone());
+                let own = streams.iter().find_map(|s| s.meta.congestion_used.clone());
                 let peer = server_results.and_then(|r| r.congestion_used.clone());
                 let (snd, rcv) = if self.reverse {
                     (peer.clone(), own.clone())
@@ -1995,14 +1988,14 @@ impl Client {
         let stream_reports: Vec<StreamReport> = streams
             .iter()
             .map(|s| {
-                let local_bytes = if s.is_sender {
-                    s.counters.bytes_sent_net()
+                let local_bytes = if s.meta.is_sender {
+                    s.meta.counters.bytes_sent_net()
                 } else {
-                    s.counters.bytes_received_net()
+                    s.meta.counters.bytes_received_net()
                 };
                 // The peer's per-stream result is the opposite side of this stream.
                 let server_stream =
-                    remote_cpu.and_then(|r| r.streams.iter().find(|x| x.id == s.id));
+                    remote_cpu.and_then(|r| r.streams.iter().find(|x| x.id == s.meta.id));
 
                 // UDP datagram stats: from our local receiver if we measured
                 // them, else (any UDP sending stream) from the server's
@@ -2016,7 +2009,7 @@ impl Client {
                         packets: st.packet_count - st.omitted_packet_count,
                         out_of_order: st.outoforder_packets - st.omitted_outoforder_packets,
                     })
-                } else if is_udp && s.is_sender {
+                } else if is_udp && s.meta.is_sender {
                     // A sending stream's datagram stats are measured at the
                     // peer's receiver and live only in the results it returned
                     // — attach them to the sender entry, in bidir exactly as
@@ -2036,10 +2029,14 @@ impl Client {
                 // (matches iperf3); a no-op for the client's usual canonical
                 // addresses, correct if the client is bound to a dual-stack socket.
                 let (local_host, local_port) = s
+                    .meta
+                    .sock
                     .local_addr
                     .map(|a| (a.ip().to_canonical().to_string(), a.port()))
                     .unwrap_or_else(|| (self.host.clone(), 0));
                 let (remote_host, remote_port) = s
+                    .meta
+                    .sock
                     .peer_addr
                     .map(|a| (a.ip().to_canonical().to_string(), a.port()))
                     .unwrap_or_else(|| (self.host.clone(), self.port));
@@ -2048,7 +2045,7 @@ impl Client {
                 // across intervals (#36 PR2); only present for streams we sent.
                 let ext = extremes
                     .iter()
-                    .find(|e| e.stream_id == s.id && e.has_samples());
+                    .find(|e| e.stream_id == s.meta.id && e.has_samples());
                 let tcp_end = ext.map(|e| TcpEndExtras {
                     max_snd_cwnd: e.max_snd_cwnd,
                     max_snd_wnd: e.max_snd_wnd,
@@ -2059,19 +2056,19 @@ impl Client {
                 });
                 let retransmits = stream_report_retransmits(
                     is_udp,
-                    s.is_sender,
+                    s.meta.is_sender,
                     ext.and_then(|e| e.total_retransmits),
                     remote_cpu.is_some_and(|r| r.sender_has_retransmits == 1),
                     server_stream.map(|x| x.retransmits),
                 );
 
                 StreamReport {
-                    id: s.id,
+                    id: s.meta.id,
                     local_host,
                     local_port,
                     remote_host,
                     remote_port,
-                    is_sender: s.is_sender,
+                    is_sender: s.meta.is_sender,
                     local_bytes,
                     // #256/#283: the authoritative per-stream SENT datagram
                     // count, net of the `-O` omit baseline — the SAME source
@@ -2080,8 +2077,8 @@ impl Client {
                     // None for received streams (the -J keeps the peer/bytes
                     // path there). == local_bytes / blksize bit-for-bit for a
                     // full-block-only sender, so the -J stays byte-identical.
-                    datagrams_sent: (is_udp && s.is_sender)
-                        .then(|| s.counters.datagrams_sent_net()),
+                    datagrams_sent: (is_udp && s.meta.is_sender)
+                        .then(|| s.meta.counters.datagrams_sent_net()),
                     remote_bytes: server_stream.map(|x| x.bytes),
                     // #235: the peer's exchanged SENT datagram count, net
                     // of its omitted baseline — exact when the peer keeps
@@ -2130,7 +2127,7 @@ impl Client {
             // #37: the congestion algorithm actually in effect on the data socket,
             // read back via getsockopt(TCP_CONGESTION) at stream creation (the
             // kernel default when -C is unset). None for UDP / unsupported platforms.
-            congestion_used: streams.first().and_then(|s| s.congestion_used.clone()),
+            congestion_used: streams.first().and_then(|s| s.meta.congestion_used.clone()),
             cookie: start_meta.cookie.clone(),
             tcp_mss_default: start_meta.tcp_mss_default,
             // -M/--set-mss request: emitted as start.tcp_mss (TCP only), which
@@ -2147,8 +2144,18 @@ impl Client {
             // missing kernel readback still yields `Some(0)` on a real run, like
             // iperf3.
             sock_bufsize: Some(self.window.map(|w| w.max(0) as u64).unwrap_or(0)),
-            sndbuf_actual: Some(streams.first().and_then(|s| s.sndbuf_actual).unwrap_or(0)),
-            rcvbuf_actual: Some(streams.first().and_then(|s| s.rcvbuf_actual).unwrap_or(0)),
+            sndbuf_actual: Some(
+                streams
+                    .first()
+                    .and_then(|s| s.meta.sock.sndbuf_actual)
+                    .unwrap_or(0),
+            ),
+            rcvbuf_actual: Some(
+                streams
+                    .first()
+                    .and_then(|s| s.meta.sock.rcvbuf_actual)
+                    .unwrap_or(0),
+            ),
             // #261: false ONLY on the upfront server-refusal path (a SERVER_ERROR
             // relay that arrives before stream setup, e.g. code 37) — there GT's
             // client errexits through json_top, which never populated json_end, so
@@ -3464,17 +3471,21 @@ mod tests {
 
         let client = crate::ClientBuilder::new("127.0.0.1").build().unwrap();
         let ds = crate::stream::DataStream {
-            id: 1,
-            is_sender: true,
-            counters,
+            meta: crate::stream::StreamMeta {
+                id: 1,
+                is_sender: true,
+                counters,
+                raw_fd: None,
+                sock: crate::net::SocketMeta {
+                    local_addr: None,
+                    peer_addr: None,
+                    sndbuf_actual: None,
+                    rcvbuf_actual: None,
+                },
+                congestion_used: None,
+            },
             udp_recv_stats: None,
             task: tokio::spawn(async { Ok(()) }),
-            raw_fd: None,
-            local_addr: None,
-            peer_addr: None,
-            sndbuf_actual: None,
-            rcvbuf_actual: None,
-            congestion_used: None,
         };
         let results = client.build_results(std::slice::from_ref(&ds), None, 1.0);
         assert_eq!(results.sender_has_retransmits, 1);
@@ -3509,17 +3520,21 @@ mod tests {
         receiver.record_received(300);
 
         let mk = |is_sender: bool, counters: Arc<StreamCounters>| DataStream {
-            id: 1,
-            is_sender,
-            counters,
+            meta: crate::stream::StreamMeta {
+                id: 1,
+                is_sender,
+                counters,
+                raw_fd: None,
+                sock: crate::net::SocketMeta {
+                    local_addr: None,
+                    peer_addr: None,
+                    sndbuf_actual: None,
+                    rcvbuf_actual: None,
+                },
+                congestion_used: None,
+            },
             udp_recv_stats: None,
             task: tokio::spawn(async { Ok(()) }),
-            raw_fd: None,
-            local_addr: None,
-            peer_addr: None,
-            sndbuf_actual: None,
-            rcvbuf_actual: None,
-            congestion_used: None,
         };
         let streams = [mk(true, sender), mk(false, receiver)];
         assert_eq!(
@@ -3549,17 +3564,21 @@ mod tests {
         counters.set_omit_retransmits(5); // boundary baseline (warm-up retransmits)
         counters.set_final_retransmits(8); // connection-lifetime total at exit
         let ds = DataStream {
-            id: 1,
-            is_sender: true,
-            counters,
+            meta: crate::stream::StreamMeta {
+                id: 1,
+                is_sender: true,
+                counters,
+                raw_fd: None,
+                sock: crate::net::SocketMeta {
+                    local_addr: None,
+                    peer_addr: None,
+                    sndbuf_actual: None,
+                    rcvbuf_actual: None,
+                },
+                congestion_used: None,
+            },
             udp_recv_stats: None,
             task: tokio::spawn(async { Ok(()) }),
-            raw_fd: None,
-            local_addr: None,
-            peer_addr: None,
-            sndbuf_actual: None,
-            rcvbuf_actual: None,
-            congestion_used: None,
         };
         let client = crate::ClientBuilder::new("127.0.0.1").build().unwrap();
         let results = client.build_results(std::slice::from_ref(&ds), None, 1.0);

--- a/riperf3/src/net.rs
+++ b/riperf3/src/net.rs
@@ -418,17 +418,11 @@ pub(crate) fn check_socket_window(
 /// (verified for IPv4 and IPv6 against `TcpStream::local_addr()`), so a stream
 /// whose socket is not AF_INET/AF_INET6 — which a TCP/UDP data socket never is —
 /// is the only case that would differ, and there it would yield `None`.
-#[allow(clippy::type_complexity)]
 pub(crate) fn capture_stream_meta(
     sock: socket2::SockRef,
     window: Option<i32>,
     apply_window: bool,
-) -> Result<(
-    Option<SocketAddr>,
-    Option<SocketAddr>,
-    Option<u64>,
-    Option<u64>,
-)> {
+) -> Result<SocketMeta> {
     if apply_window {
         apply_socket_window(&sock, window);
     }
@@ -437,7 +431,26 @@ pub(crate) fn capture_stream_meta(
     let sndbuf_actual = sock.send_buffer_size().ok().map(|v| v as u64);
     let rcvbuf_actual = sock.recv_buffer_size().ok().map(|v| v as u64);
     check_socket_window(window, sndbuf_actual, rcvbuf_actual)?;
-    Ok((local_addr, peer_addr, sndbuf_actual, rcvbuf_actual))
+    Ok(SocketMeta {
+        local_addr,
+        peer_addr,
+        sndbuf_actual,
+        rcvbuf_actual,
+    })
+}
+
+/// What `capture_stream_meta` reads off a data socket at creation, named
+/// (#288 — was a clippy-allowed 4-tuple that every call site destructured and
+/// re-spread): the real addresses for the `-J` `start.connected` block (#36)
+/// and the realized SO_SNDBUF/SO_RCVBUF for `sndbuf_actual`/`rcvbuf_actual`
+/// (#36 PR3). Embedded whole into `StreamMeta`.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct SocketMeta {
+    /// `None` if unavailable.
+    pub local_addr: Option<SocketAddr>,
+    pub peer_addr: Option<SocketAddr>,
+    pub sndbuf_actual: Option<u64>,
+    pub rcvbuf_actual: Option<u64>,
 }
 
 /// Read the TCP congestion-control algorithm actually in effect on a connected

--- a/riperf3/src/net.rs
+++ b/riperf3/src/net.rs
@@ -1006,6 +1006,45 @@ pub async fn udp_bind_reusable(
 mod tests {
     use super::*;
 
+    /// #288 (r1 blocker): `capture_stream_meta` must map each socket property
+    /// to ITS OWN `SocketMeta` field. The struct literal is a hand-built copy
+    /// site (the class the deleted `from_meta` round-trip guarded), and a
+    /// sndbuf/rcvbuf transposition is invisible to every functional test —
+    /// `check_socket_window` runs on the untransposed locals, and UDP's
+    /// defaults are equal so only a TCP-style distinct pair can catch it.
+    /// Buffers are asserted against the socket's OWN getters (the kernel
+    /// doubles requested sizes on Linux), set explicitly DISTINCT first.
+    #[test]
+    fn capture_stream_meta_maps_every_field_to_its_own() {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        let client = std::net::TcpStream::connect(addr).unwrap();
+        let (server_side, _) = listener.accept().unwrap();
+
+        let sock = socket2::SockRef::from(&client);
+        sock.set_send_buffer_size(64 * 1024).unwrap();
+        sock.set_recv_buffer_size(256 * 1024).unwrap();
+        let snd = sock.send_buffer_size().unwrap() as u64;
+        let rcv = sock.recv_buffer_size().unwrap() as u64;
+        assert_ne!(snd, rcv, "the swap-detection premise: distinct sizes");
+
+        let meta = capture_stream_meta(socket2::SockRef::from(&client), None, false)
+            .expect("capture on a live socket");
+        assert_eq!(
+            meta.local_addr,
+            Some(client.local_addr().unwrap()),
+            "local_addr is THIS socket's own address"
+        );
+        assert_eq!(
+            meta.peer_addr,
+            Some(client.peer_addr().unwrap()),
+            "peer_addr is the remote's address"
+        );
+        assert_eq!(meta.sndbuf_actual, Some(snd), "sndbuf maps to SO_SNDBUF");
+        assert_eq!(meta.rcvbuf_actual, Some(rcv), "rcvbuf maps to SO_RCVBUF");
+        drop(server_side);
+    }
+
     /// #163: configure_udp_sender must be GROW-ONLY. The old unconditional
     /// set_send_buffer_size shrank SO_SNDBUF ~9-90x below the OS default at
     /// moderate batch×blksize products (worst at -b rate/1: one datagram!) —

--- a/riperf3/src/reporter.rs
+++ b/riperf3/src/reporter.rs
@@ -529,6 +529,21 @@ struct TcpSample {
     reorder: u32,
 }
 
+// One conversion site (#292): a future TcpSample field then fails to compile
+// here instead of silently defaulting at a hand-copy.
+impl From<crate::tcp_info::TcpInfoSnapshot> for TcpSample {
+    fn from(info: crate::tcp_info::TcpInfoSnapshot) -> Self {
+        TcpSample {
+            snd_cwnd: info.snd_cwnd,
+            snd_wnd: info.snd_wnd,
+            rtt: info.rtt,
+            rttvar: info.rttvar,
+            pmtu: info.pmtu,
+            reorder: info.reorder,
+        }
+    }
+}
+
 /// Per-stream sender-side TCP_INFO extremes accumulated across the run (#36 PR2),
 /// for the `end.streams[].sender` object. Only meaningful for TCP sender streams.
 #[derive(Debug, Default, Clone, Copy)]
@@ -912,14 +927,7 @@ pub fn spawn_interval_reporter(
                                         e.rtt_samples += 1;
                                     }
                                     e.total_retransmits = Some(info.total_retransmits);
-                                    last_tcp[i] = Some(TcpSample {
-                                        snd_cwnd: info.snd_cwnd,
-                                        snd_wnd: info.snd_wnd,
-                                        rtt: info.rtt,
-                                        rttvar: info.rttvar,
-                                        pmtu: info.pmtu,
-                                        reorder: info.reorder,
-                                    });
+                                    last_tcp[i] = Some(TcpSample::from(info));
                                     (
                                         Some(delta as i64),
                                         Some(info.snd_cwnd),
@@ -932,14 +940,7 @@ pub fn spawn_interval_reporter(
                                 } else if let Some(s) = stream
                                     .counters
                                     .final_tcp_sample()
-                                    .map(|info| TcpSample {
-                                        snd_cwnd: info.snd_cwnd,
-                                        snd_wnd: info.snd_wnd,
-                                        rtt: info.rtt,
-                                        rttvar: info.rttvar,
-                                        pmtu: info.pmtu,
-                                        reorder: info.reorder,
-                                    })
+                                    .map(TcpSample::from)
                                     .or(last_tcp[i])
                                 {
                                     // Final-interval fallback (#55/#245): the socket

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -836,12 +836,11 @@ impl Server {
                     // `sndbuf_actual` / `rcvbuf_actual` (#50), captured before the
                     // stream moves into its task. TCP applied -w earlier in
                     // configure_tcp_stream_full, so apply_window is false (#144).
-                    let (local_addr, peer_addr_s, sndbuf_actual, rcvbuf_actual) =
-                        net::capture_stream_meta(
-                            socket2::SockRef::from(&data_stream),
-                            ctx.cfg.window,
-                            false,
-                        )?;
+                    let sock = net::capture_stream_meta(
+                        socket2::SockRef::from(&data_stream),
+                        ctx.cfg.window,
+                        false,
+                    )?;
                     // #37: congestion algorithm actually in effect on this stream.
                     let congestion_used = net::tcp_congestion_used(&data_stream);
 
@@ -869,21 +868,18 @@ impl Server {
                         })
                     };
 
-                    ctx.streams.push(DataStream::from_meta(
-                        StreamMeta {
+                    ctx.streams.push(DataStream {
+                        meta: StreamMeta {
                             id: stream_id,
                             is_sender,
                             counters,
                             raw_fd,
-                            local_addr,
-                            peer_addr: peer_addr_s,
-                            sndbuf_actual,
-                            rcvbuf_actual,
+                            sock,
                             congestion_used,
                         },
                         task,
-                        None,
-                    ));
+                        udp_recv_stats: None,
+                    });
                 }
             }
             TransportProtocol::Udp => {
@@ -958,10 +954,10 @@ impl Server {
         // Starting Test parameter line, like the client side.
         if !self.json_output && !self.json_stream {
             for s in &ctx.streams {
-                if let (Some(l), Some(p)) = (s.local_addr, s.peer_addr) {
+                if let (Some(l), Some(p)) = (s.meta.sock.local_addr, s.meta.sock.peer_addr) {
                     vprintln!(
                         "[{:3}] local {} port {} connected to {} port {}",
-                        s.id,
+                        s.meta.id,
                         l.ip().to_canonical(),
                         l.port(),
                         p.ip().to_canonical(),
@@ -1039,11 +1035,11 @@ impl Server {
                 .streams
                 .iter()
                 .map(|s| crate::reporter::IntervalStreamRef {
-                    id: s.id,
-                    is_sender: s.is_sender,
-                    counters: s.counters.clone(),
+                    id: s.meta.id,
+                    is_sender: s.meta.is_sender,
+                    counters: s.meta.counters.clone(),
                     udp_recv_stats: s.udp_recv_stats.clone(),
-                    raw_fd: s.raw_fd,
+                    raw_fd: s.meta.raw_fd,
                 })
                 .collect();
             crate::reporter::spawn_interval_reporter(
@@ -1164,7 +1160,7 @@ impl Server {
                     let elapsed = test_start.elapsed().as_secs_f64();
                     if elapsed > 0.0 {
                         let total_bytes: u64 = ctx.streams.iter().map(|s| {
-                            s.counters.bytes_sent() + s.counters.bytes_received()
+                            s.meta.counters.bytes_sent() + s.meta.counters.bytes_received()
                         }).sum();
                         let bits_per_sec = total_bytes as f64 * 8.0 / elapsed;
                         if let Some(limit) = bitrate_limit {
@@ -1291,10 +1287,10 @@ impl Server {
     ) -> Vec<protocol::StreamResultJson> {
         let mut result_streams = Vec::new();
         for s in &ctx.streams {
-            let bytes = if s.is_sender {
-                s.counters.bytes_sent_net()
+            let bytes = if s.meta.is_sender {
+                s.meta.counters.bytes_sent_net()
             } else {
-                s.counters.bytes_received_net()
+                s.meta.counters.bytes_received_net()
             };
 
             let (jitter, errors, packets, omitted_errors, omitted_packets) =
@@ -1310,7 +1306,7 @@ impl Server {
                     } else {
                         (0.0, 0, 0, 0, 0)
                     }
-                } else if s.is_sender && matches!(ctx.cfg.protocol, TransportProtocol::Udp) {
+                } else if s.meta.is_sender && matches!(ctx.cfg.protocol, TransportProtocol::Udp) {
                     // iperf3's UDP sender counts every datagram it sends
                     // (iperf_udp.c `++sp->packet_count`) and exchanges that
                     // count unconditionally (iperf_api.c `"packets"`); the
@@ -1323,8 +1319,8 @@ impl Server {
                     // derivation. Full-block-only senders keep this == the old
                     // value bit-for-bit (no compat-matrix drift); making it
                     // authoritative just protects against a future short-send.
-                    let gross = s.counters.datagrams_sent() as i64;
-                    let net = s.counters.datagrams_sent_net() as i64;
+                    let gross = s.meta.counters.datagrams_sent() as i64;
+                    let net = s.meta.counters.datagrams_sent_net() as i64;
                     (0.0, 0, gross, 0, gross - net)
                 } else {
                     (0.0, 0, 0, 0, 0)
@@ -1334,7 +1330,7 @@ impl Server {
             let retransmits = s.sender_retransmits(is_udp_stream).unwrap_or(-1);
 
             result_streams.push(protocol::StreamResultJson {
-                id: s.id,
+                id: s.meta.id,
                 bytes,
                 retransmits,
                 jitter,
@@ -1378,7 +1374,7 @@ impl Server {
                 self.verbose,
                 ctx.cfg.protocol,
             );
-            if self.verbose && ctx.streams.iter().any(|s| s.is_sender) {
+            if self.verbose && ctx.streams.iter().any(|s| s.meta.is_sender) {
                 // GT gates the CPU line on the SENDING side (iperf_api.c:
                 // 4563): a -R server prints it, with ZERO remote figures —
                 // the peer's CPU is never exchanged to the server (#50).
@@ -1391,8 +1387,12 @@ impl Server {
                 );
             }
             if self.verbose && matches!(ctx.cfg.protocol, TransportProtocol::Tcp) {
-                if let Some(c) = ctx.streams.iter().find_map(|s| s.congestion_used.clone()) {
-                    if ctx.streams.iter().any(|s| s.is_sender) {
+                if let Some(c) = ctx
+                    .streams
+                    .iter()
+                    .find_map(|s| s.meta.congestion_used.clone())
+                {
+                    if ctx.streams.iter().any(|s| s.meta.is_sender) {
                         vprintln!("snd_tcp_congestion {c}");
                     } else {
                         vprintln!("rcv_tcp_congestion {c}");
@@ -1466,7 +1466,7 @@ impl Server {
                 cpu_util_system: end.cpu_util.host_system,
                 // #156: 1 when this side is a retransmit-capable TCP sender
                 // (reverse/bidir), like iperf3's check_sender_has_retransmits.
-                sender_has_retransmits: if ctx.streams.iter().any(|s| s.is_sender) {
+                sender_has_retransmits: if ctx.streams.iter().any(|s| s.meta.is_sender) {
                     i64::from(
                         matches!(ctx.cfg.protocol, TransportProtocol::Tcp)
                             && crate::tcp_info::has_retransmit_info(),
@@ -1476,7 +1476,10 @@ impl Server {
                 },
                 // #37: the congestion algorithm actually in effect (read back at stream
                 // creation); None for UDP / unsupported platforms.
-                congestion_used: ctx.streams.first().and_then(|s| s.congestion_used.clone()),
+                congestion_used: ctx
+                    .streams
+                    .first()
+                    .and_then(|s| s.meta.congestion_used.clone()),
                 server_output_text,
                 server_output_json,
                 streams: result_streams,
@@ -1574,7 +1577,7 @@ impl Server {
                 self.verbose,
                 ctx.cfg.protocol,
             );
-            if self.verbose && ctx.streams.iter().any(|s| s.is_sender) {
+            if self.verbose && ctx.streams.iter().any(|s| s.meta.is_sender) {
                 // GT gates the CPU line on the SENDING side (iperf_api.c:
                 // 4563): a -R server prints it, with ZERO remote figures —
                 // the peer's CPU is never exchanged to the server (#50).
@@ -1587,8 +1590,12 @@ impl Server {
                 );
             }
             if self.verbose && matches!(ctx.cfg.protocol, TransportProtocol::Tcp) {
-                if let Some(c) = ctx.streams.iter().find_map(|s| s.congestion_used.clone()) {
-                    let is_sender = ctx.streams.iter().any(|s| s.is_sender);
+                if let Some(c) = ctx
+                    .streams
+                    .iter()
+                    .find_map(|s| s.meta.congestion_used.clone())
+                {
+                    let is_sender = ctx.streams.iter().any(|s| s.meta.is_sender);
                     if is_sender {
                         vprintln!("snd_tcp_congestion {c}");
                     } else {
@@ -1677,7 +1684,7 @@ impl Server {
             // std + moved. apply_window=true: honor -w/--window on the server's
             // UDP data socket too (#59) so reverse/bidir UDP matches iperf3,
             // before the read-back (#144).
-            let (local_addr, peer_addr_s, sndbuf_actual, rcvbuf_actual) =
+            let sock =
                 net::capture_stream_meta(socket2::SockRef::from(&data_sock), cfg.window, true)?;
 
             let std_sock = data_sock.into_std().map_err(RiperfError::Io)?;
@@ -1699,21 +1706,18 @@ impl Server {
                         std_sock, c, bs, d, rate, pt, bu, uw, u64bit, st, md,
                     )
                 });
-                streams.push(DataStream::from_meta(
-                    StreamMeta {
+                streams.push(DataStream {
+                    meta: StreamMeta {
                         id: stream_id,
                         is_sender,
                         counters,
                         raw_fd: None,
-                        local_addr,
-                        peer_addr: peer_addr_s,
-                        sndbuf_actual,
-                        rcvbuf_actual,
+                        sock,
                         congestion_used: None,
                     },
                     task,
-                    None,
-                ));
+                    udp_recv_stats: None,
+                });
             } else {
                 let c = counters.clone();
                 let d = done.clone();
@@ -1724,21 +1728,18 @@ impl Server {
                 let task = thread_gate.spawn(move || {
                     stream::run_udp_receiver_blocking(std_sock, c, stats_clone, bs, d, u64bit)
                 });
-                streams.push(DataStream::from_meta(
-                    StreamMeta {
+                streams.push(DataStream {
+                    meta: StreamMeta {
                         id: stream_id,
                         is_sender,
                         counters,
                         raw_fd: None,
-                        local_addr,
-                        peer_addr: peer_addr_s,
-                        sndbuf_actual,
-                        rcvbuf_actual,
+                        sock,
                         congestion_used: None,
                     },
                     task,
-                    Some(stats),
-                ));
+                    udp_recv_stats: Some(stats),
+                });
             }
         }
         // #178: hold TestStart (sent by the caller right after this returns)
@@ -1946,21 +1947,23 @@ impl Server {
                         md,
                     )
                 });
-                streams.push(DataStream::from_meta(
-                    StreamMeta {
+                streams.push(DataStream {
+                    meta: StreamMeta {
                         id: stream_id,
                         is_sender,
                         counters,
                         raw_fd: None,
-                        local_addr,
-                        peer_addr: Some(client_addr),
-                        sndbuf_actual,
-                        rcvbuf_actual,
+                        sock: crate::net::SocketMeta {
+                            local_addr,
+                            peer_addr: Some(client_addr),
+                            sndbuf_actual,
+                            rcvbuf_actual,
+                        },
                         congestion_used: None,
                     },
                     task,
-                    None,
-                ));
+                    udp_recv_stats: None,
+                });
             } else {
                 let stats = Arc::new(Mutex::new(UdpRecvStats::new()));
                 routes.insert(
@@ -1974,21 +1977,23 @@ impl Server {
                 // below; give each a resolved placeholder task so the per-stream
                 // join at teardown stays uniform. The real handle is `demux_handle`.
                 let task = tokio::spawn(async { Ok::<(), RiperfError>(()) });
-                streams.push(DataStream::from_meta(
-                    StreamMeta {
+                streams.push(DataStream {
+                    meta: StreamMeta {
                         id: stream_id,
                         is_sender,
                         counters,
                         raw_fd: None,
-                        local_addr,
-                        peer_addr: Some(client_addr),
-                        sndbuf_actual,
-                        rcvbuf_actual,
+                        sock: crate::net::SocketMeta {
+                            local_addr,
+                            peer_addr: Some(client_addr),
+                            sndbuf_actual,
+                            rcvbuf_actual,
+                        },
                         congestion_used: None,
                     },
                     task,
-                    Some(stats),
-                ));
+                    udp_recv_stats: Some(stats),
+                });
             }
         }
 
@@ -2021,10 +2026,10 @@ impl Server {
         streams
             .iter()
             .map(|s| {
-                let bytes = if s.is_sender {
-                    s.counters.bytes_sent_net()
+                let bytes = if s.meta.is_sender {
+                    s.meta.counters.bytes_sent_net()
                 } else {
-                    s.counters.bytes_received_net()
+                    s.meta.counters.bytes_received_net()
                 };
 
                 let (jitter, lost, total) = if let Some(ref udp_stats) = s.udp_recv_stats {
@@ -2041,7 +2046,7 @@ impl Server {
                             )
                         })
                         .unwrap_or((None, None, None))
-                } else if is_udp && s.is_sender {
+                } else if is_udp && s.meta.is_sender {
                     // iperf3's sender line shows zero jitter/loss over the
                     // sent datagram count, not blank columns (#184). #256: the
                     // authoritative post-omit datagram count, not bytes/blksize
@@ -2049,18 +2054,18 @@ impl Server {
                     (
                         Some(0.0),
                         Some(0),
-                        Some(s.counters.datagrams_sent_net() as i64),
+                        Some(s.meta.counters.datagrams_sent_net() as i64),
                     )
                 } else {
                     (None, None, None)
                 };
 
                 crate::reporter::StreamSummary {
-                    stream_id: s.id,
+                    stream_id: s.meta.id,
                     start: 0.0,
                     end: test_duration,
                     bytes,
-                    is_sender: s.is_sender,
+                    is_sender: s.meta.is_sender,
                     // TCP sender lines carry the retransmit total (#184).
                     retransmits: s.sender_retransmits(is_udp),
                     jitter,
@@ -2069,7 +2074,7 @@ impl Server {
                     // Bidir tags every line with the stream's direction (#184).
                     role_tag: cfg
                         .bidir
-                        .then_some(crate::reporter::bidir_role_tag(true, s.is_sender)),
+                        .then_some(crate::reporter::bidir_role_tag(true, s.meta.is_sender)),
                 }
             })
             .collect()
@@ -2112,10 +2117,10 @@ impl Server {
         let stream_reports: Vec<StreamReport> = streams
             .iter()
             .map(|s| {
-                let local_bytes = if s.is_sender {
-                    s.counters.bytes_sent_net()
+                let local_bytes = if s.meta.is_sender {
+                    s.meta.counters.bytes_sent_net()
                 } else {
-                    s.counters.bytes_received_net()
+                    s.meta.counters.bytes_received_net()
                 };
 
                 // The server measures UDP loss/jitter on the streams it
@@ -2132,10 +2137,14 @@ impl Server {
                 // to_canonical(): unwrap IPv4-mapped IPv6 from the dual-stack
                 // listener to plain IPv4 in connected[], matching iperf3.
                 let (local_host, local_port) = s
+                    .meta
+                    .sock
                     .local_addr
                     .map(|a| (a.ip().to_canonical().to_string(), a.port()))
                     .unwrap_or_default();
                 let (remote_host, remote_port) = s
+                    .meta
+                    .sock
                     .peer_addr
                     .map(|a| (a.ip().to_canonical().to_string(), a.port()))
                     .unwrap_or_default();
@@ -2144,7 +2153,7 @@ impl Server {
                 // for streams the server sent (reverse / bidir).
                 let ext = extremes
                     .iter()
-                    .find(|e| e.stream_id == s.id && e.has_samples());
+                    .find(|e| e.stream_id == s.meta.id && e.has_samples());
                 let tcp_end = ext.map(|e| TcpEndExtras {
                     max_snd_cwnd: e.max_snd_cwnd,
                     max_snd_wnd: e.max_snd_wnd,
@@ -2157,7 +2166,7 @@ impl Server {
                 // reverse/bidir streams; a stream it received has no retransmit
                 // count (None → omitted), so it can't leak a 0 into sum_sent on a
                 // forward test (where iperf3's server emits no retransmits).
-                let retransmits = if is_udp || !s.is_sender {
+                let retransmits = if is_udp || !s.meta.is_sender {
                     None
                 } else {
                     ext.and_then(|e| e.total_retransmits)
@@ -2170,12 +2179,12 @@ impl Server {
                 };
 
                 StreamReport {
-                    id: s.id,
+                    id: s.meta.id,
                     local_host,
                     local_port,
                     remote_host,
                     remote_port,
-                    is_sender: s.is_sender,
+                    is_sender: s.meta.is_sender,
                     local_bytes,
                     // #256/#283: the authoritative per-stream SENT datagram
                     // count, net of the `-O` omit baseline — the SAME source
@@ -2184,8 +2193,8 @@ impl Server {
                     // (reverse/bidir); None for received streams. == local_bytes
                     // / blksize bit-for-bit for a full-block-only sender, so the
                     // -J stays byte-identical.
-                    datagrams_sent: (is_udp && s.is_sender)
-                        .then(|| s.counters.datagrams_sent_net()),
+                    datagrams_sent: (is_udp && s.meta.is_sender)
+                        .then(|| s.meta.counters.datagrams_sent_net()),
                     // The server never learns the peer's per-stream bytes; build()
                     // zeroes the un-measured side for is_server reports.
                     remote_bytes: None,
@@ -2236,7 +2245,7 @@ impl Server {
             // #37: the congestion algorithm actually in effect on the server's data
             // socket, read back via getsockopt(TCP_CONGESTION). None for UDP /
             // unsupported platforms.
-            congestion_used: streams.first().and_then(|s| s.congestion_used.clone()),
+            congestion_used: streams.first().and_then(|s| s.meta.congestion_used.clone()),
             cookie: String::from_utf8_lossy(&cookie[..protocol::COOKIE_SIZE - 1]).to_string(),
             // iperf3's server emits tcp_mss_default = 0 (it never reads the control
             // socket MSS); the requested -M (via params) still surfaces as tcp_mss.
@@ -2244,8 +2253,18 @@ impl Server {
             mss: cfg.mss.filter(|&m| m > 0).map(|m| m as u32),
             fq_rate: params.fqrate.unwrap_or(0),
             sock_bufsize: Some(cfg.window.map(|w| w.max(0) as u64).unwrap_or(0)),
-            sndbuf_actual: Some(streams.first().and_then(|s| s.sndbuf_actual).unwrap_or(0)),
-            rcvbuf_actual: Some(streams.first().and_then(|s| s.rcvbuf_actual).unwrap_or(0)),
+            sndbuf_actual: Some(
+                streams
+                    .first()
+                    .and_then(|s| s.meta.sock.sndbuf_actual)
+                    .unwrap_or(0),
+            ),
+            rcvbuf_actual: Some(
+                streams
+                    .first()
+                    .and_then(|s| s.meta.sock.rcvbuf_actual)
+                    .unwrap_or(0),
+            ),
             // #261: the server only ever assembles a full report on a run that
             // reached TestStart — its upfront refusal renders the skeleton via
             // json_report::error_document, not build(). So the late fields are

--- a/riperf3/src/stream.rs
+++ b/riperf3/src/stream.rs
@@ -70,7 +70,7 @@ pub struct StreamCounters {
     /// #55 stale fallback). `None` = not captured (receiver, UDP, non-unix, or no
     /// platform support). Set ONCE per stream at sender exit, read ONCE at the
     /// final flush — never contended, never on the hot path, so a plain Mutex.
-    final_tcp_sample: Mutex<Option<crate::tcp_info::TcpInfoSnapshot>>,
+    final_tcp_sample: std::sync::OnceLock<crate::tcp_info::TcpInfoSnapshot>,
 }
 
 impl Default for StreamCounters {
@@ -92,7 +92,7 @@ impl StreamCounters {
             datagrams_sent_omit: AtomicU64::new(0),
             final_retransmits: AtomicI64::new(-1),
             omit_retransmits: AtomicI64::new(-1),
-            final_tcp_sample: Mutex::new(None),
+            final_tcp_sample: std::sync::OnceLock::new(),
         }
     }
 
@@ -147,19 +147,19 @@ impl StreamCounters {
     }
 
     /// Store the sender's genuinely-final TCP_INFO snapshot (#245; sender task
-    /// only, captured while the socket is still open just before it is dropped).
+    /// only, captured while the socket is still open just before it is
+    /// dropped). `OnceLock` encodes the documented set-once contract in the
+    /// type (#292); a second call — which no path makes — would be ignored
+    /// rather than overwrite.
     pub fn set_final_tcp_sample(&self, info: crate::tcp_info::TcpInfoSnapshot) {
-        if let Ok(mut g) = self.final_tcp_sample.lock() {
-            *g = Some(info);
-        }
+        let _ = self.final_tcp_sample.set(info);
     }
 
     /// The sender's genuinely-final TCP_INFO snapshot, or `None` if never
-    /// captured (#245). A poisoned lock also yields `None` — the closed-fd
-    /// fallback then degrades to the previous interval's cached sample, never
-    /// panics.
+    /// captured (#245) — the closed-fd fallback then degrades to the previous
+    /// interval's cached sample.
     pub fn final_tcp_sample(&self) -> Option<crate::tcp_info::TcpInfoSnapshot> {
-        self.final_tcp_sample.lock().ok().and_then(|g| *g)
+        self.final_tcp_sample.get().copied()
     }
 
     /// Record the omit-boundary retransmit baseline (#171; reporter boundary
@@ -476,28 +476,14 @@ impl RateLimiter {
 
 /// A running data stream with its background task handle and shared state.
 pub struct DataStream {
-    /// Stream identifier (shown as `[ ID]` in output).
-    pub id: i32,
-    pub is_sender: bool,
-    pub counters: Arc<StreamCounters>,
+    /// Everything a create-streams path captured about this stream (#288 —
+    /// embedded, not flattened, so `from_meta`-style field copies can't
+    /// drift).
+    pub meta: StreamMeta,
     /// UDP-only: receiver-side jitter/loss stats behind a mutex.
     pub udp_recv_stats: Option<Arc<Mutex<UdpRecvStats>>>,
     /// The background send/recv task.
     pub task: JoinHandle<Result<()>>,
-    /// Raw TCP socket fd for TCP_INFO queries. `None` for UDP streams.
-    pub raw_fd: Option<i32>,
-    /// This stream's actual local/peer socket addresses, captured at creation
-    /// for the `-J` `start.connected` block (issue #36). `None` if unavailable.
-    pub local_addr: Option<std::net::SocketAddr>,
-    pub peer_addr: Option<std::net::SocketAddr>,
-    /// Actual SO_SNDBUF/SO_RCVBUF on this stream's socket, captured at creation
-    /// for the `-J` `start.sndbuf_actual`/`rcvbuf_actual` fields (#36 PR3).
-    pub sndbuf_actual: Option<u64>,
-    pub rcvbuf_actual: Option<u64>,
-    /// The TCP congestion-control algorithm actually in effect on this stream's
-    /// socket (read back via `getsockopt(TCP_CONGESTION)`), for the `congestion_used`
-    /// report field (#37). `None` for UDP and on platforms without TCP_CONGESTION.
-    pub congestion_used: Option<String>,
 }
 
 /// The non-task, non-stats fields a create-streams path captures per stream
@@ -509,41 +495,23 @@ pub struct DataStream {
 /// (the spawn shape and the receiver-only jitter mutex diverge by role) and
 /// are passed alongside the meta to `DataStream::from_meta`.
 pub(crate) struct StreamMeta {
+    /// Stream identifier (shown as `[ ID]` in output).
     pub id: i32,
     pub is_sender: bool,
     pub counters: Arc<StreamCounters>,
+    /// Raw TCP socket fd for TCP_INFO queries. `None` for UDP streams.
     pub raw_fd: Option<i32>,
-    pub local_addr: Option<std::net::SocketAddr>,
-    pub peer_addr: Option<std::net::SocketAddr>,
-    pub sndbuf_actual: Option<u64>,
-    pub rcvbuf_actual: Option<u64>,
+    /// The socket-level capture (#288): real addresses + realized buffer
+    /// sizes, taken whole from `net::capture_stream_meta`.
+    pub sock: crate::net::SocketMeta,
+    /// The TCP congestion-control algorithm actually in effect on this
+    /// stream's socket (read back via `getsockopt(TCP_CONGESTION)`), for the
+    /// `congestion_used` report field (#37). `None` for UDP and on platforms
+    /// without TCP_CONGESTION.
     pub congestion_used: Option<String>,
 }
 
 impl DataStream {
-    /// Assemble a `DataStream` from its captured `StreamMeta` plus the two
-    /// per-branch values: the spawned `task` and the receiver-only
-    /// `udp_recv_stats` (UDP receivers pass `Some`; everyone else `None`).
-    pub(crate) fn from_meta(
-        meta: StreamMeta,
-        task: JoinHandle<Result<()>>,
-        udp_recv_stats: Option<Arc<Mutex<UdpRecvStats>>>,
-    ) -> Self {
-        DataStream {
-            id: meta.id,
-            is_sender: meta.is_sender,
-            counters: meta.counters,
-            udp_recv_stats,
-            task,
-            raw_fd: meta.raw_fd,
-            local_addr: meta.local_addr,
-            peer_addr: meta.peer_addr,
-            sndbuf_actual: meta.sndbuf_actual,
-            rcvbuf_actual: meta.rcvbuf_actual,
-            congestion_used: meta.congestion_used,
-        }
-    }
-
     /// The omit-adjusted lifetime retransmit total to render/exchange for a TCP
     /// sending stream, or `None` for a receiver, a UDP stream, or a platform
     /// without TCP_INFO retransmits (Windows) — where iperf3 omits the `Retr`
@@ -553,19 +521,20 @@ impl DataStream {
     /// `iperf_reset_stats`. `Some(-1)` means info exists but the value was
     /// unavailable (iperf3's sentinel, rendered literally).
     pub(crate) fn sender_retransmits(&self, is_udp: bool) -> Option<i64> {
-        if !self.is_sender || is_udp || !crate::tcp_info::has_retransmit_info() {
+        if !self.meta.is_sender || is_udp || !crate::tcp_info::has_retransmit_info() {
             return None;
         }
-        let lifetime = match self.counters.final_retransmits() {
+        let lifetime = match self.meta.counters.final_retransmits() {
             n if n >= 0 => Some(n),
             _ => self
+                .meta
                 .raw_fd
                 .and_then(crate::tcp_info::get_tcp_info)
                 .map(|i| i.total_retransmits as i64),
         };
         Some(
             lifetime
-                .map(|t| self.counters.omit_adjusted_retransmits(t))
+                .map(|t| self.meta.counters.omit_adjusted_retransmits(t))
                 .unwrap_or(-1),
         )
     }
@@ -1895,67 +1864,6 @@ pub fn run_udp_receiver_blocking(
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    // #144: DataStream::from_meta must move every captured field through
-    // unchanged and attach the two per-branch values (task + udp_recv_stats).
-    // This is the round-trip guard that makes the bundled StreamMeta a safe
-    // single source of truth for the create-streams paths.
-    #[tokio::test]
-    async fn from_meta_round_trips_every_field() {
-        let counters = Arc::new(StreamCounters::new());
-        let local: std::net::SocketAddr = "127.0.0.1:5201".parse().unwrap();
-        let peer: std::net::SocketAddr = "10.0.0.2:40000".parse().unwrap();
-        let meta = StreamMeta {
-            id: 7,
-            is_sender: true,
-            counters: counters.clone(),
-            raw_fd: Some(42),
-            local_addr: Some(local),
-            peer_addr: Some(peer),
-            sndbuf_actual: Some(212_992),
-            rcvbuf_actual: Some(131_072),
-            congestion_used: Some("bbr".to_string()),
-        };
-        let stats = Arc::new(Mutex::new(UdpRecvStats::new()));
-        let task = tokio::spawn(async { Ok(()) });
-        let ds = DataStream::from_meta(meta, task, Some(stats.clone()));
-
-        assert_eq!(ds.id, 7);
-        assert!(ds.is_sender);
-        assert!(Arc::ptr_eq(&ds.counters, &counters));
-        assert_eq!(ds.raw_fd, Some(42));
-        assert_eq!(ds.local_addr, Some(local));
-        assert_eq!(ds.peer_addr, Some(peer));
-        assert_eq!(ds.sndbuf_actual, Some(212_992));
-        assert_eq!(ds.rcvbuf_actual, Some(131_072));
-        assert_eq!(ds.congestion_used.as_deref(), Some("bbr"));
-        assert!(ds.udp_recv_stats.is_some());
-        ds.task.abort();
-
-        // The None udp_recv_stats branch (TCP / UDP sender) round-trips too.
-        let meta2 = StreamMeta {
-            id: 1,
-            is_sender: false,
-            counters: Arc::new(StreamCounters::new()),
-            raw_fd: None,
-            local_addr: None,
-            peer_addr: None,
-            sndbuf_actual: None,
-            rcvbuf_actual: None,
-            congestion_used: None,
-        };
-        let ds2 = DataStream::from_meta(meta2, tokio::spawn(async { Ok(()) }), None);
-        assert_eq!(ds2.id, 1);
-        assert!(!ds2.is_sender);
-        assert!(ds2.raw_fd.is_none());
-        assert!(ds2.local_addr.is_none());
-        assert!(ds2.peer_addr.is_none());
-        assert!(ds2.sndbuf_actual.is_none());
-        assert!(ds2.rcvbuf_actual.is_none());
-        assert!(ds2.congestion_used.is_none());
-        assert!(ds2.udp_recv_stats.is_none());
-        ds2.task.abort();
-    }
 
     // #185: the paced UDP batch is sized to ~one pacing quantum of send budget,
     // not a fixed packet count. A low rate over a large datagram must drop to a

--- a/riperf3/src/stream.rs
+++ b/riperf3/src/stream.rs
@@ -493,7 +493,7 @@ pub struct DataStream {
 /// the #25-class "fixed one create-streams branch, forgot the other" drift.
 /// The `task` and `udp_recv_stats` stay out — they're computed per branch
 /// (the spawn shape and the receiver-only jitter mutex diverge by role) and
-/// are passed alongside the meta to `DataStream::from_meta`.
+/// are set directly on the `DataStream` literal alongside `meta` (#288).
 pub(crate) struct StreamMeta {
     /// Stream identifier (shown as `[ ID]` in output).
     pub id: i32,


### PR DESCRIPTION
Closes #288. Closes #292.

## What

**#288 — finish the #144 single-source-of-truth chain.** `net::capture_stream_meta` returns a named `SocketMeta` (was a clippy-allowed 4-tuple that all call sites destructured and re-spread); `StreamMeta` embeds it whole; `DataStream` embeds `StreamMeta` (`meta:` field) instead of flattening. `DataStream::from_meta` and its round-trip guard test are **deleted** — there is no field copy left to drift. A future captured field is one struct-field addition end to end. The access churn (`s.id` → `s.meta.id`, `s.local_addr` → `s.meta.sock.local_addr`) was applied mechanically from the compiler's span diagnostics.

**#292 — review cleanups.** `final_tcp_sample`: `Mutex<Option<T>>` → `OnceLock<T>` (the documented set-once/read-once contract in the type; drops the poisoned-lock caveat). `From<TcpInfoSnapshot> for TcpSample` replaces the two hand-copied 6-field maps in the reporter (a future field now fails to compile instead of silently defaulting). `print_results` → `render_results`, with rustdoc naming both halves of its post-#137 contract (renders for the active mode AND returns the `Report`; text mode builds one it never prints).

## Notes

- Behavior-preserving throughout; all crate-internal types.
- OnceLock nuance (documented at the site): a hypothetical second `set_final_tcp_sample` call would now be ignored rather than overwrite — no path makes one.
- Suite delta is −1: the deleted `from_meta_round_trips_every_field`, whose subject no longer exists.

## Evidence

- Full workspace suite: 26 binaries, 638 tests, 0 failures.
- Rebased on #297; per-PR compat smoke to run before merge.
