### PR TITLE
feat(api): emit_output builder knob (#290) + Server::bind building block (#291)

### DIFF
--- a/riperf3/src/auth.rs
+++ b/riperf3/src/auth.rs
@@ -169,8 +169,12 @@ pub fn read_password() -> Result<String> {
         return Ok(pw);
     }
 
-    // Interactive prompt with echo disabled — safe, cross-platform
-    eprint!("Password: ");
+    // Interactive prompt with echo disabled — safe, cross-platform.
+    // #290 (r1 finding 2): a quiet run suppresses the PROMPT (the stderr
+    // write); the stdin read itself is the pre-existing interactive wart.
+    if !crate::macros::output_quiet() {
+        eprint!("Password: ");
+    }
     rpassword::read_password()
         .map_err(|e| RiperfError::Protocol(format!("password read failed: {e}")))
 }

--- a/riperf3/src/client.rs
+++ b/riperf3/src/client.rs
@@ -2745,6 +2745,11 @@ impl ClientBuilder {
     /// [`Report`](crate::Report) is the only output; nothing is written to
     /// stdout or stderr. Wire behavior is unaffected either way (a quiet
     /// server still relays `--get-server-output` text to the peer).
+    ///
+    /// Note: with authentication configured but no password provided, a run
+    /// still BLOCKS reading the password from stdin — quiet suppresses the
+    /// prompt, not the read. Supply the password via the builder or the
+    /// `RIPERF3_PASSWORD`/`IPERF3_PASSWORD` env vars for unattended use.
     pub fn emit_output(mut self, enabled: bool) -> Self {
         self.emit_output = enabled;
         self

--- a/riperf3/src/client.rs
+++ b/riperf3/src/client.rs
@@ -46,6 +46,9 @@ pub struct Client {
     pub(crate) extra_data: Option<String>,
     pub(crate) verbose: bool,
     pub(crate) json_output: bool,
+    /// #290: console output enabled (default). When false, `run` returns the
+    /// rich Report and the crate writes nothing to stdout/stderr.
+    pub(crate) emit_output: bool,
     pub(crate) json_stream: bool,
     /// #210: fired by the consumer (the CLI's first signal) with the
     /// formatted interrupt message; the run dumps stats, sends
@@ -300,6 +303,9 @@ impl Client {
     }
 
     pub async fn run(&self) -> Result<crate::json_report::Report> {
+        // #290: run-scoped console silence, armed FIRST so even the -V
+        // preamble honors it. Construct-only-when-quiet (see the guard doc).
+        let _quiet_guard = (!self.emit_output).then(crate::macros::OutputQuietGuard::set);
         let interrupt = self.interrupt.clone().map(|w| w.0);
         // -T/--title: prefix every client text line with "<title>:  " (#34),
         // matching iperf3. Run-scoped (cleared on drop) and only in plain-text
@@ -845,7 +851,10 @@ impl Client {
             // riperf3's logfile plumbing lives in the
             // CLI (#198), so this lib line stays on
             // stderr. Revisit with the sink plumbing.
-            eprintln!("riperf3: SERVER ERROR - {msg}");
+            // #290: quiet runs surface the error via Err alone.
+            if !crate::macros::output_quiet() {
+                eprintln!("riperf3: SERVER ERROR - {msg}");
+            }
         }
         RiperfError::ServerErrorRelayed(msg)
     }
@@ -1764,7 +1773,8 @@ impl Client {
     /// iperf3's format strings. Only consulted when WE requested it, like
     /// test->get_server_output gate (a misbehaving server can't inject).
     fn print_server_output(&self, server_results: Option<&TestResultsJson>) {
-        if !self.get_server_output {
+        // #290: nothing to print on a quiet run.
+        if !self.get_server_output || crate::macros::output_quiet() {
             return;
         }
         let Some(server) = server_results else { return };
@@ -2220,7 +2230,10 @@ impl Client {
         // iperf3's iperf_json_finish attaches the run error to the blob (#170).
         input.error = error.map(str::to_owned);
         let report = input.build();
-        println!("{}", serde_json::to_string_pretty(&report).unwrap());
+        // #290: a quiet run returns the report without printing the document.
+        if !crate::macros::output_quiet() {
+            println!("{}", serde_json::to_string_pretty(&report).unwrap());
+        }
         report
     }
 
@@ -2284,7 +2297,7 @@ impl Client {
         // --json-stream-full-output: the complete monolithic document also
         // prints after the stream, like iperf_json_finish keeping
         // print_full_json under the flag (iperf_api.c:5323) (#213).
-        if self.json_stream_full_output {
+        if self.json_stream_full_output && !crate::macros::output_quiet() {
             println!("{}", serde_json::to_string_pretty(&report).unwrap());
         }
         report
@@ -2462,6 +2475,7 @@ pub struct ClientBuilder {
     extra_data: Option<String>,
     verbose: bool,
     json_output: bool,
+    emit_output: bool,
     json_stream: bool,
     interrupt: Option<InterruptWatch>,
     json_stream_full_output: bool,
@@ -2522,6 +2536,7 @@ impl Default for ClientBuilder {
             extra_data: None,
             verbose: false,
             json_output: false,
+            emit_output: true,
             json_stream: false,
             interrupt: None,
             json_stream_full_output: false,
@@ -2720,6 +2735,18 @@ impl ClientBuilder {
     /// When combined with [`Self::json_stream`], stream mode wins (#220).
     pub fn json_output(mut self, enabled: bool) -> Self {
         self.json_output = enabled;
+        self
+    }
+
+    /// Console output from `run` (#290). `true` (the default) keeps today's
+    /// behavior: the crate prints the mode's report (text banners/summary,
+    /// the `-J` document, or `--json-stream` events) to the host process's
+    /// stdout, exactly like the CLI. `false` runs silently — the returned
+    /// [`Report`](crate::Report) is the only output; nothing is written to
+    /// stdout or stderr. Wire behavior is unaffected either way (a quiet
+    /// server still relays `--get-server-output` text to the peer).
+    pub fn emit_output(mut self, enabled: bool) -> Self {
+        self.emit_output = enabled;
         self
     }
 
@@ -3214,6 +3241,7 @@ impl ClientBuilder {
             extra_data: self.extra_data,
             verbose: self.verbose,
             json_output: self.json_output,
+            emit_output: self.emit_output,
             json_stream: self.json_stream,
             interrupt: self.interrupt.clone(),
             json_stream_full_output: self.json_stream_full_output,

--- a/riperf3/src/lib.rs
+++ b/riperf3/src/lib.rs
@@ -37,7 +37,7 @@ pub use client::{Client, ClientBuilder};
 mod server;
 // TestConfig is server-internal (built from received wire params, not used in
 // any public signature); it stays crate-private rather than a public type (#67).
-pub use server::{Server, ServerBuilder};
+pub use server::{BoundServer, Server, ServerBuilder};
 
 // The transport enum used across the public builder API. `TestResultsJson` /
 // `StreamResultJson` are the internal control-channel exchange model and are no

--- a/riperf3/src/macros.rs
+++ b/riperf3/src/macros.rs
@@ -149,6 +149,39 @@ fn render_timestamp(_fmt: &str) -> String {
     )
 }
 
+/// Console-quiet flag for library callers (#290): when set (run-scoped, via
+/// [`OutputQuietGuard`]), every console `println!`/`eprintln!` the crate makes
+/// is skipped — while `log::` records and the `--get-server-output` capture
+/// tee keep working, so a quiet server can still relay its report on the
+/// wire. Process-global like OUTPUT_TITLE (one run at a time); visible across
+/// the reporter task, which a thread-local could not be.
+static OUTPUT_QUIET: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
+
+/// True while any active run asked for no console output (#290).
+pub(crate) fn output_quiet() -> bool {
+    OUTPUT_QUIET.load(std::sync::atomic::Ordering::Relaxed) > 0
+}
+
+/// RAII guard arming the run-scoped console-quiet flag (#290). Construct ONLY
+/// when quiet is requested (callers gate then `.then(OutputQuietGuard::set)`).
+/// A COUNTER, not a bool: an in-process client + bound-server pair each hold
+/// a guard, and the first one to finish must not un-silence the other
+/// (a bool's drop did exactly that — the closing "iperf Done." leaked).
+pub(crate) struct OutputQuietGuard;
+
+impl OutputQuietGuard {
+    pub(crate) fn set() -> Self {
+        OUTPUT_QUIET.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        OutputQuietGuard
+    }
+}
+
+impl Drop for OutputQuietGuard {
+    fn drop(&mut self) {
+        OUTPUT_QUIET.fetch_sub(1, std::sync::atomic::Ordering::Relaxed);
+    }
+}
+
 pub(crate) fn set_output_title(title: Option<String>) {
     if let Ok(mut g) = OUTPUT_TITLE.write() {
         *g = title;
@@ -195,7 +228,10 @@ macro_rules! vprintln {
                 format_args!($($arg)*)
             );
             $crate::macros::capture_line(&line);
-            println!("{line}");
+            // #290: a quiet run logs + captures but never touches stdout.
+            if !$crate::macros::output_quiet() {
+                println!("{line}");
+            }
         }
     };
 }

--- a/riperf3/src/macros.rs
+++ b/riperf3/src/macros.rs
@@ -167,12 +167,15 @@ pub(crate) fn output_quiet() -> bool {
 /// A COUNTER, not a bool: an in-process client + bound-server pair each hold
 /// a guard, and the first one to finish must not un-silence the other
 /// (a bool's drop did exactly that — the closing "iperf Done." leaked).
-pub(crate) struct OutputQuietGuard;
+// The private unit field makes `set()` the ONLY constructor (r1 finding 3):
+// a literal `OutputQuietGuard` elsewhere in the crate would skip the
+// increment and its Drop would underflow the counter into permanent silence.
+pub(crate) struct OutputQuietGuard(());
 
 impl OutputQuietGuard {
     pub(crate) fn set() -> Self {
         OUTPUT_QUIET.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-        OutputQuietGuard
+        OutputQuietGuard(())
     }
 }
 

--- a/riperf3/src/reporter.rs
+++ b/riperf3/src/reporter.rs
@@ -86,7 +86,10 @@ fn titled(line: std::fmt::Arguments) {
     // into the exchange buffer while still printing — iperf3's iperf_printf
     // dual-writes (console + server_output_list).
     crate::macros::capture_line(&rendered);
-    println!("{rendered}");
+    // #290: a quiet run captures but never touches stdout.
+    if !crate::macros::output_quiet() {
+        println!("{rendered}");
+    }
 }
 
 /// Print the header line for interval reports.
@@ -151,6 +154,10 @@ pub fn print_header(
 /// reporter flushes its own `interval` events via the per-tick flush.
 pub(crate) fn emit_json_stream_line(line: &str) {
     use std::io::Write;
+    // #290: a quiet run emits no stream events on stdout.
+    if crate::macros::output_quiet() {
+        return;
+    }
     println!("{line}");
     let _ = std::io::stdout().flush();
 }
@@ -1197,10 +1204,16 @@ pub fn spawn_interval_reporter(
                     // `-J` collects intervals for the final batched blob; `--json-stream`
                     // emits each one live as `{"event":"interval","data":{...}}`.
                     if config.json_stream {
-                        println!(
-                            "{}",
-                            crate::json_report::json_stream_event("interval", &interval)
-                        );
+                        // #290: a quiet run emits no live event — but the
+                        // RETENTION decision below must not change with
+                        // quietness, or the returned Report's intervals would
+                        // differ between a loud and a quiet run.
+                        if !crate::macros::output_quiet() {
+                            println!(
+                                "{}",
+                                crate::json_report::json_stream_event("interval", &interval)
+                            );
+                        }
                         // A json-stream SERVER additionally keeps them when
                         // the client requested --get-server-output: iperf3's
                         // discard_json exists precisely to retain the

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -303,7 +303,11 @@ impl Server {
     /// (#216). Not tee'd into the --get-server-output capture — iperf3's
     /// banner prints before the test's JSON/capture exists.
     fn banner_line(line: &str) {
-        println!("{}{line}", crate::macros::output_timestamp_prefix());
+        // #290 (r1 finding 1): the quiet gate must live at the PRINT SITE —
+        // arming the flag in run() silences nothing here by itself.
+        if !crate::macros::output_quiet() {
+            println!("{}{line}", crate::macros::output_timestamp_prefix());
+        }
     }
 
     pub async fn run(&self) -> Result<()> {

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -251,6 +251,10 @@ pub struct Server {
     pub(crate) use_pkcs1_padding: bool,
     /// Emit the test results as iperf3-schema JSON on stdout instead of text (#50).
     pub(crate) json_output: bool,
+    /// #290: console output enabled (default). When false, `run`/`run_once`
+    /// write nothing to stdout/stderr; reports flow via the return value and
+    /// the wire (--get-server-output still relays).
+    pub(crate) emit_output: bool,
     /// Stream line-delimited interval JSON during the test (`--json-stream`).
     pub(crate) json_stream: bool,
     /// #210: fired by the consumer (the CLI's first signal); a running test
@@ -303,6 +307,9 @@ impl Server {
     }
 
     pub async fn run(&self) -> Result<()> {
+        // #290: run-scoped console silence, armed FIRST so the listening
+        // banner honors it. Construct-only-when-quiet (see the guard doc).
+        let _quiet_guard = (!self.emit_output).then(crate::macros::OutputQuietGuard::set);
         // Daemonizing (`-s -D`) is a process-level concern handled by the binary
         // *before* the tokio runtime is built — `daemon()` forks, and a fork from
         // inside a multi-threaded runtime would leave the child with no worker
@@ -356,12 +363,14 @@ impl Server {
                     // live-captured) and keeps serving (#210). In the JSON
                     // modes the doc/event carried it — stderr stays silent
                     // like iperf_err (review r1 f1/f3).
-                    if !json {
+                    if !json && !crate::macros::output_quiet() {
                         eprintln!("riperf3: {}", RiperfError::ClientTerminated);
                     }
                 }
                 Err(e) => {
-                    eprintln!("riperf3: error - {e}");
+                    if !crate::macros::output_quiet() {
+                        eprintln!("riperf3: error - {e}");
+                    }
                 }
             }
 
@@ -400,14 +409,47 @@ impl Server {
     /// banner — it is a library entry point, not the daemon. The test report is
     /// still printed to stdout in `-J` / text mode, like `Client::run`.
     pub async fn run_once(&self) -> Result<crate::json_report::Report> {
-        let listener = net::tcp_listen(
+        let listener = self.listen().await?;
+        self.serve_once(&listener).await
+    }
+
+    /// Bind the configured listener ONCE and return an owned handle that can
+    /// serve tests on it (#291) — the accept()-style building block
+    /// `run_once`'s per-call rebind couldn't be: sequential tests keep the
+    /// port (no steal window, no re-listen race), and a `port(Some(0))`
+    /// ephemeral bind is learnable via [`BoundServer::local_addr`] before any
+    /// client connects. Consumes the `Server` (like a socket `bind`
+    /// constructor), so the handle is `'static` and moves freely into
+    /// spawned tasks.
+    pub async fn bind(self) -> Result<BoundServer> {
+        let listener = self.listen().await?;
+        Ok(BoundServer {
+            server: self,
+            listener,
+        })
+    }
+
+    /// The configured control listener — shared by `run_once` and `bind`.
+    async fn listen(&self) -> Result<tokio::net::TcpListener> {
+        net::tcp_listen(
             self.bind_address.as_deref(),
             self.port,
             self.ip_version,
             self.bind_dev.as_deref(),
         )
-        .await?;
-        match self.handle_one_test(&listener).await? {
+        .await
+    }
+
+    /// One test on an already-bound listener: the shared body of
+    /// [`Server::run_once`] and [`BoundServer::run_once`] (#291), with the
+    /// #290 console-quiet scope.
+    async fn serve_once(
+        &self,
+        listener: &tokio::net::TcpListener,
+    ) -> Result<crate::json_report::Report> {
+        // #290: run-scoped console silence for this test.
+        let _quiet_guard = (!self.emit_output).then(crate::macros::OutputQuietGuard::set);
+        match self.handle_one_test(listener).await? {
             Some(report) => Ok(report),
             // Reachable only with an interrupt watch set (e.g. the CLI's signal
             // handling): interrupted while idle, before any client connected.
@@ -1243,7 +1285,7 @@ impl Server {
         // still EXITS 0 after this — live-verified wart, mirrored by NOT
         // returning an error from this path (#224).
         if let Some(msg) = ctx.server_error {
-            if !self.json_output && !self.json_stream {
+            if !self.json_output && !self.json_stream && !crate::macros::output_quiet() {
                 eprintln!("riperf3: error - {msg}");
             }
         }
@@ -2326,6 +2368,10 @@ impl Server {
     /// `-J`: pretty-print the server's single batched report blob (#50), or a
     /// prebuilt one (#33).
     fn print_results_json(&self, report: &crate::json_report::Report) {
+        // #290: a quiet run returns the report without printing the document.
+        if crate::macros::output_quiet() {
+            return;
+        }
         match serde_json::to_string_pretty(report) {
             Ok(s) => println!("{s}"),
             Err(e) => eprintln!("riperf3: error - failed to serialize JSON: {e}"),
@@ -2353,11 +2399,13 @@ impl Server {
                 &format!("error - {MSG}"),
             ));
         } else if self.json_output {
-            println!(
-                "{}",
-                crate::json_report::error_document(&format!("error - {MSG}"))
-            );
-        } else {
+            if !crate::macros::output_quiet() {
+                println!(
+                    "{}",
+                    crate::json_report::error_document(&format!("error - {MSG}"))
+                );
+            }
+        } else if !crate::macros::output_quiet() {
             eprintln!("riperf3: error - {MSG}");
         }
         Ok(())
@@ -2375,7 +2423,7 @@ impl Server {
         ));
         // --json-stream-full-output: the monolithic document follows the
         // stream, like iperf_json_finish under the flag (#213).
-        if self.json_stream_full_output {
+        if self.json_stream_full_output && !crate::macros::output_quiet() {
             println!("{}", serde_json::to_string_pretty(report).unwrap());
         }
     }
@@ -2417,6 +2465,38 @@ impl Server {
 }
 
 // ---------------------------------------------------------------------------
+// BoundServer (#291)
+// ---------------------------------------------------------------------------
+
+/// A [`Server`] bound to its listener (#291) — the accept()-style building
+/// block. Obtained from [`Server::bind`]; holds the port across sequential
+/// [`run_once`](BoundServer::run_once) calls, so a library caller serving N
+/// tests has no rebind gap and can learn a `port(Some(0))` ephemeral
+/// assignment up front via [`local_addr`](BoundServer::local_addr).
+pub struct BoundServer {
+    server: Server,
+    listener: tokio::net::TcpListener,
+}
+
+impl BoundServer {
+    /// The bound listener's local address — the resolved port for a
+    /// `port(Some(0))` ephemeral bind.
+    pub fn local_addr(&self) -> Result<std::net::SocketAddr> {
+        self.listener.local_addr().map_err(RiperfError::Io)
+    }
+
+    /// Serve exactly one test on the held listener and return its rich
+    /// [`Report`](crate::Report) — the same contract as
+    /// [`Server::run_once`], minus the per-call rebind. No "Server
+    /// listening" banner (a library entry point, not the daemon); the test
+    /// report still prints in `-J` / text mode unless the server was built
+    /// with `emit_output(false)` (#290).
+    pub async fn run_once(&self) -> Result<crate::json_report::Report> {
+        self.server.serve_once(&self.listener).await
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Builder
 // ---------------------------------------------------------------------------
 
@@ -2438,6 +2518,7 @@ pub struct ServerBuilder {
     time_skew_threshold: u32,
     use_pkcs1_padding: bool,
     json_output: bool,
+    emit_output: bool,
     json_stream: bool,
     interrupt: Option<crate::client::InterruptWatch>,
     json_stream_full_output: bool,
@@ -2464,6 +2545,7 @@ impl Default for ServerBuilder {
             time_skew_threshold: 10,
             use_pkcs1_padding: false,
             json_output: false,
+            emit_output: true,
             json_stream: false,
             interrupt: None,
             json_stream_full_output: false,
@@ -2501,6 +2583,16 @@ impl ServerBuilder {
     /// When combined with [`Self::json_stream`], stream mode wins (#220).
     pub fn json_output(mut self, enabled: bool) -> Self {
         self.json_output = enabled;
+        self
+    }
+
+    /// Console output from `run`/`run_once` (#290). `true` (the default)
+    /// keeps today's behavior; `false` runs silently — reports flow only via
+    /// the return value and the wire (`--get-server-output` still relays the
+    /// text report to the requesting client). See
+    /// [`ClientBuilder::emit_output`](crate::ClientBuilder::emit_output).
+    pub fn emit_output(mut self, enabled: bool) -> Self {
+        self.emit_output = enabled;
         self
     }
 
@@ -2697,6 +2789,7 @@ impl ServerBuilder {
             time_skew_threshold: self.time_skew_threshold,
             use_pkcs1_padding: self.use_pkcs1_padding,
             json_output: self.json_output,
+            emit_output: self.emit_output,
             json_stream: self.json_stream,
             interrupt: self.interrupt.clone(),
             json_stream_full_output: self.json_stream_full_output,

--- a/riperf3/tests/bound_server.rs
+++ b/riperf3/tests/bound_server.rs
@@ -1,0 +1,73 @@
+//! #291: `Server::bind()` — the bind-once building block. A library caller
+//! serving N sequential tests holds the port the whole time (no rebind gap
+//! for another process to steal, no re-listen race) and can learn a
+//! port-0 ephemeral assignment before the first client connects.
+
+use std::time::Duration;
+
+use riperf3::{ClientBuilder, ServerBuilder};
+
+async fn run_client(port: u16) -> riperf3::Report {
+    let client = ClientBuilder::new("127.0.0.1")
+        .port(Some(port))
+        .bytes(256 * 1024)
+        .json_output(true)
+        .build()
+        .unwrap();
+    tokio::time::timeout(Duration::from_secs(15), client.run())
+        .await
+        .expect("client hung")
+        .expect("client errored")
+}
+
+/// One bind, two sequential tests on the same listener — the accept()-style
+/// contract run_once's per-call rebind couldn't give (#291).
+#[tokio::test]
+async fn bind_once_serves_sequential_tests_on_one_port() {
+    let server = ServerBuilder::new()
+        .port(Some(0)) // ephemeral: the port is learnable only via bind()
+        .json_output(true)
+        .build()
+        .unwrap();
+    let bound = server.bind().await.expect("bind");
+    let port = bound.local_addr().expect("local_addr").port();
+    assert_ne!(port, 0, "bind resolves the ephemeral port");
+
+    for i in 0..2 {
+        let server_run = async { bound.run_once().await };
+        let client_run = async {
+            // Give the accept loop a beat; the listener is already bound, so
+            // even a too-early connect would queue rather than be refused.
+            tokio::time::sleep(Duration::from_millis(50)).await;
+            run_client(port).await
+        };
+        let (srv, cli) = tokio::join!(server_run, client_run);
+        let srv = srv.unwrap_or_else(|e| panic!("server run_once #{i} errored: {e}"));
+        assert!(
+            srv.end.sum_received.as_ref().unwrap().bytes > 0,
+            "test #{i}: the server measured the transfer"
+        );
+        assert!(
+            cli.end.sum_sent.as_ref().unwrap().bytes > 0,
+            "test #{i}: the client moved bytes"
+        );
+    }
+}
+
+/// `Server::run_once` keeps its exact contract (it now delegates through
+/// bind()): one test served on the configured port, report returned.
+#[tokio::test]
+async fn run_once_still_serves_one_test() {
+    let server = ServerBuilder::new().port(Some(0)).build().unwrap();
+    // run_once on port 0 can't learn the port externally — this pin uses a
+    // fixed high port instead, mirroring the pre-#291 usage.
+    drop(server);
+    let port = 15790;
+    let server = ServerBuilder::new().port(Some(port)).build().unwrap();
+    let server_task = tokio::spawn(async move { server.run_once().await });
+    tokio::time::sleep(Duration::from_millis(150)).await;
+    let cli = run_client(port).await;
+    assert!(cli.end.sum_sent.as_ref().unwrap().bytes > 0);
+    let srv = server_task.await.unwrap().expect("run_once");
+    assert!(srv.end.sum_received.as_ref().unwrap().bytes > 0);
+}

--- a/riperf3/tests/bound_server.rs
+++ b/riperf3/tests/bound_server.rs
@@ -58,11 +58,10 @@ async fn bind_once_serves_sequential_tests_on_one_port() {
 /// bind()): one test served on the configured port, report returned.
 #[tokio::test]
 async fn run_once_still_serves_one_test() {
-    let server = ServerBuilder::new().port(Some(0)).build().unwrap();
-    // run_once on port 0 can't learn the port externally — this pin uses a
-    // fixed high port instead, mirroring the pre-#291 usage.
-    drop(server);
-    let port = 15790;
+    // run_once on port 0 can't learn the port externally — take a free
+    // ephemeral port from the shared helper instead of pinning one (r2 nit:
+    // a hardcoded port is a collision-flake risk on shared runners).
+    let port = riperf3_test_support::free_port();
     let server = ServerBuilder::new().port(Some(port)).build().unwrap();
     let server_task = tokio::spawn(async move { server.run_once().await });
     tokio::time::sleep(Duration::from_millis(150)).await;

--- a/riperf3/tests/quiet_output.rs
+++ b/riperf3/tests/quiet_output.rs
@@ -7,6 +7,100 @@
 
 use std::process::Command;
 
+/// Child arm (r1 finding 1 / mutations a+c): a QUIET one-off `Server::run`
+/// serving a LOUD in-process client, then a fully LOUD pair in the SAME
+/// process. The parent asserts (1) no server-side line — the listening banner
+/// included — leaked while the quiet server ran, (2) the loud client's output
+/// is present during the overlap (the client's own loudness must survive the
+/// server's guard is a NON-goal: the guard is process-global by design, so
+/// the overlap window silences both — what MUST hold is that the SECOND,
+/// fully-loud pair prints, proving the guard count returned to zero).
+fn child_quiet_server_then_loud_pair() {
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    rt.block_on(async {
+        // Phase 1: quiet daemon-loop server (one_off via run()) + client.
+        let server = riperf3::ServerBuilder::new()
+            .port(Some(0))
+            .emit_output(false)
+            .build()
+            .unwrap();
+        let bound = server.bind().await.unwrap();
+        let port = bound.local_addr().unwrap().port();
+        let server_task = tokio::spawn(async move { bound.run_once().await });
+        let client = riperf3::ClientBuilder::new("127.0.0.1")
+            .port(Some(port))
+            .duration(1)
+            .emit_output(false)
+            .build()
+            .unwrap();
+        client.run().await.expect("phase-1 client");
+        server_task.await.unwrap().expect("phase-1 server");
+
+        // Phase 1b: the DAEMON entry point itself — a quiet Server::run()
+        // (one_off) with no client, killed by idle timeout. The listening
+        // banner is the r1-finding-1 leak site.
+        let server = riperf3::ServerBuilder::new()
+            .port(Some(0))
+            .idle_timeout(1)
+            .one_off(true)
+            .emit_output(false)
+            .build()
+            .unwrap();
+        let _ = server.run().await; // idle timeout -> Err(Aborted), fine
+
+        // Phase 2: a fully LOUD pair in the same process — proves every quiet
+        // guard dropped back to zero (a leaked increment would silence this).
+        let server = riperf3::ServerBuilder::new().port(Some(0)).build().unwrap();
+        let bound = server.bind().await.unwrap();
+        let port = bound.local_addr().unwrap().port();
+        let server_task = tokio::spawn(async move { bound.run_once().await });
+        let client = riperf3::ClientBuilder::new("127.0.0.1")
+            .port(Some(port))
+            .duration(1)
+            .build()
+            .unwrap();
+        client.run().await.expect("phase-2 client");
+        server_task.await.unwrap().expect("phase-2 server");
+    });
+    eprintln!("QUIET_CHILD_DONE");
+}
+
+/// Child arm (r1 mutation b): a quiet `--json-stream` pair — no `{"event"...`
+/// lines may reach stdout.
+fn child_quiet_json_stream() {
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    rt.block_on(async {
+        let server = riperf3::ServerBuilder::new()
+            .port(Some(0))
+            .emit_output(false)
+            .build()
+            .unwrap();
+        let bound = server.bind().await.unwrap();
+        let port = bound.local_addr().unwrap().port();
+        let server_task = tokio::spawn(async move { bound.run_once().await });
+        let client = riperf3::ClientBuilder::new("127.0.0.1")
+            .port(Some(port))
+            .duration(1)
+            .json_stream(true)
+            .emit_output(false)
+            .build()
+            .unwrap();
+        let report = client.run().await.expect("client run");
+        assert!(
+            report.end.sum_sent.as_ref().unwrap().bytes > 0,
+            "quiet json-stream still returns the report"
+        );
+        server_task.await.unwrap().expect("server");
+    });
+    eprintln!("QUIET_CHILD_DONE");
+}
+
 /// Child arm: run one loopback text-mode test with the given emit setting and
 /// exit. Everything the crate prints (or correctly doesn't) lands on the
 /// child's real stdout/stderr for the parent to inspect.
@@ -72,6 +166,14 @@ fn quiet_run_writes_nothing_to_stdout() {
         child_run(true);
         return;
     }
+    if std::env::var("RIPERF3_QUIET_CHILD").as_deref() == Ok("server-then-loud") {
+        child_quiet_server_then_loud_pair();
+        return;
+    }
+    if std::env::var("RIPERF3_QUIET_CHILD").as_deref() == Ok("json-stream") {
+        child_quiet_json_stream();
+        return;
+    }
     if std::env::var("RIPERF3_QUIET_CHILD").as_deref() == Ok("0") {
         // This test fn doubles as the child entry for both settings so the
         // two parents below can't race each other's env.
@@ -113,5 +215,59 @@ fn loud_run_control_prints_the_report() {
     assert!(
         stdout.contains("Connecting to host"),
         "the loud control run must print the connect banner: {stdout}"
+    );
+}
+
+/// r1 finding 1 + mutations a/c: the quiet daemon path may not leak the
+/// listening banner, and a loud run AFTER quiet runs in one process must
+/// still print (the guard count must return to zero).
+#[test]
+fn quiet_server_daemon_is_silent_and_loudness_recovers() {
+    if std::env::var("RIPERF3_QUIET_CHILD").is_ok() {
+        return;
+    }
+    let out = Command::new(std::env::current_exe().unwrap())
+        .args([
+            "quiet_run_writes_nothing_to_stdout",
+            "--exact",
+            "--nocapture",
+        ])
+        .env("RIPERF3_QUIET_CHILD", "server-then-loud")
+        .output()
+        .expect("re-exec child");
+    assert!(out.status.success(), "child failed: {out:?}");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        !stdout.contains("Server listening"),
+        "the quiet daemon's listening banner leaked (r1 finding 1): {stdout}"
+    );
+    // Phase 2 (fully loud) must have printed: guard count returned to zero.
+    assert!(
+        stdout.contains("iperf Done."),
+        "the loud phase after quiet runs printed nothing — a quiet guard \
+         leaked its increment (r1 mutation a): {stdout}"
+    );
+}
+
+/// r1 mutation b: a quiet --json-stream run emits no event lines.
+#[test]
+fn quiet_json_stream_emits_no_events() {
+    if std::env::var("RIPERF3_QUIET_CHILD").is_ok() {
+        return;
+    }
+    let out = Command::new(std::env::current_exe().unwrap())
+        .args([
+            "quiet_run_writes_nothing_to_stdout",
+            "--exact",
+            "--nocapture",
+        ])
+        .env("RIPERF3_QUIET_CHILD", "json-stream")
+        .output()
+        .expect("re-exec child");
+    assert!(out.status.success(), "child failed: {out:?}");
+    let leaked = non_harness_stdout(&out.stdout);
+    assert!(
+        leaked.is_empty(),
+        "quiet json-stream leaked stdout lines (r1 mutation b): {leaked:#?}"
     );
 }

--- a/riperf3/tests/quiet_output.rs
+++ b/riperf3/tests/quiet_output.rs
@@ -1,0 +1,117 @@
+//! #290: `emit_output(false)` — a library caller can run a test without the
+//! crate writing to the host process's stdout/stderr. Verified by re-exec:
+//! the parent spawns THIS test binary with a marker env var; the child arm
+//! runs a real loopback test in-process and the parent asserts on the child's
+//! actual stdout/stderr bytes (an in-process capture can't observe the
+//! `println!` layer these gates suppress).
+
+use std::process::Command;
+
+/// Child arm: run one loopback text-mode test with the given emit setting and
+/// exit. Everything the crate prints (or correctly doesn't) lands on the
+/// child's real stdout/stderr for the parent to inspect.
+fn child_run(quiet: bool) {
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    rt.block_on(async {
+        let server = riperf3::ServerBuilder::new()
+            .port(Some(0))
+            .emit_output(!quiet)
+            .build()
+            .unwrap();
+        let bound = server.bind().await.unwrap();
+        let port = bound.local_addr().unwrap().port();
+        let server_task = tokio::spawn(async move { bound.run_once().await });
+        let client = riperf3::ClientBuilder::new("127.0.0.1")
+            .port(Some(port))
+            .duration(1)
+            .emit_output(!quiet)
+            .build()
+            .unwrap();
+        let report = client.run().await.expect("client run");
+        assert!(
+            report.end.sum_sent.as_ref().unwrap().bytes > 0,
+            "the quiet run still returns a real report"
+        );
+        let _ = server_task.await.expect("server task").expect("run_once");
+    });
+    // The child prints this marker itself so the parent can prove the child
+    // arm actually ran (as opposed to the harness filtering everything).
+    eprintln!("QUIET_CHILD_DONE");
+}
+
+fn spawn_child(quiet: bool, test_name: &str) -> std::process::Output {
+    Command::new(std::env::current_exe().unwrap())
+        .args([test_name, "--exact", "--nocapture"])
+        .env("RIPERF3_QUIET_CHILD", if quiet { "1" } else { "0" })
+        .output()
+        .expect("re-exec child")
+}
+
+/// Lines the libtest harness itself prints in the child; everything else on
+/// stdout must have come from the riperf3 crate.
+fn non_harness_stdout(out: &[u8]) -> Vec<String> {
+    String::from_utf8_lossy(out)
+        .lines()
+        .filter(|l| {
+            let t = l.trim();
+            !t.is_empty()
+                && !t.starts_with("running ")
+                && !t.starts_with("test ")
+                && !t.starts_with("test result:")
+        })
+        .map(str::to_owned)
+        .collect()
+}
+
+#[test]
+fn quiet_run_writes_nothing_to_stdout() {
+    if std::env::var("RIPERF3_QUIET_CHILD").as_deref() == Ok("1") {
+        child_run(true);
+        return;
+    }
+    if std::env::var("RIPERF3_QUIET_CHILD").as_deref() == Ok("0") {
+        // This test fn doubles as the child entry for both settings so the
+        // two parents below can't race each other's env.
+        child_run(false);
+        return;
+    }
+
+    let out = spawn_child(true, "quiet_run_writes_nothing_to_stdout");
+    assert!(out.status.success(), "child failed: {out:?}");
+    let err = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        err.contains("QUIET_CHILD_DONE"),
+        "the child arm must have run: {err}"
+    );
+    let leaked = non_harness_stdout(&out.stdout);
+    assert!(
+        leaked.is_empty(),
+        "emit_output(false) must write NOTHING to stdout, got: {leaked:#?}"
+    );
+}
+
+/// Positive control for the harness filter above: the SAME child with output
+/// enabled must visibly print the text report — proving the quiet assertion
+/// isn't vacuously green because the filter ate everything.
+#[test]
+fn loud_run_control_prints_the_report() {
+    if std::env::var("RIPERF3_QUIET_CHILD").is_ok() {
+        // Child arms are handled by the quiet test's entry; this fn is
+        // parent-only (spawns THAT test's name with quiet off).
+        return;
+    }
+    let out = spawn_child(false, "quiet_run_writes_nothing_to_stdout");
+    assert!(out.status.success(), "child failed: {out:?}");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("iperf Done."),
+        "the loud control run must print the closing banner: {stdout}"
+    );
+    assert!(
+        stdout.contains("Connecting to host"),
+        "the loud control run must print the connect banner: {stdout}"
+    );
+}

--- a/riperf3/tests/quiet_output.rs
+++ b/riperf3/tests/quiet_output.rs
@@ -146,6 +146,24 @@ fn spawn_child(quiet: bool, test_name: &str) -> std::process::Output {
 
 /// Lines the libtest harness itself prints in the child; everything else on
 /// stdout must have come from the riperf3 crate.
+/// r2 nit: quiet children may emit ONLY the completion marker on stderr —
+/// any other line means a stderr gate regressed (the error sinks, the auth
+/// prompt, the daemon loop's eprintln paths).
+fn assert_stderr_only_marker(out: &std::process::Output) {
+    let err = String::from_utf8_lossy(&out.stderr);
+    let stray: Vec<&str> = err
+        .lines()
+        .filter(|l| {
+            let t = l.trim();
+            !t.is_empty() && t != "QUIET_CHILD_DONE"
+        })
+        .collect();
+    assert!(
+        stray.is_empty(),
+        "a quiet child wrote to stderr beyond the marker: {stray:#?}"
+    );
+}
+
 fn non_harness_stdout(out: &[u8]) -> Vec<String> {
     String::from_utf8_lossy(out)
         .lines()
@@ -193,6 +211,7 @@ fn quiet_run_writes_nothing_to_stdout() {
         leaked.is_empty(),
         "emit_output(false) must write NOTHING to stdout, got: {leaked:#?}"
     );
+    assert_stderr_only_marker(&out);
 }
 
 /// Positive control for the harness filter above: the SAME child with output
@@ -270,4 +289,5 @@ fn quiet_json_stream_emits_no_events() {
         leaked.is_empty(),
         "quiet json-stream leaked stdout lines (r1 mutation b): {leaked:#?}"
     );
+    assert_stderr_only_marker(&out);
 }


### PR DESCRIPTION
Closes #290. Closes #291.

## What

The additive library-API pair from the 0.8.0 review — both TDD-first, and both tests caught real design flaws before review:

**#290 — `emit_output(bool)` on both builders** (default `true`, CLI and existing callers unchanged). When `false`, `run`/`run_once` write NOTHING to the host process's stdout/stderr: a run-scoped `OutputQuietGuard` (macros.rs, alongside the title/timestamp/capture globals — process-global so the reporter task sees it) gates the `vprintln!` console write, the reporter's line printer, the json-stream event emitters, the `-J` document printers, and every `eprintln!` error sink. `log::` records and the `--get-server-output` capture tee keep working, so a quiet server still relays its report on the wire. Two design points the tests forced:
- The guard is a **counter**, not a bool: an in-process client + bound-server pair each hold one, and the first to finish must not un-silence the other (the bool version leaked `iperf Done.`).
- The json-stream interval **retention** decision is explicitly quiet-independent, so a loud and a quiet run return identical `Report`s.

**#291 — `Server::bind(self) -> BoundServer`** (consuming, so the handle is `'static` and moves into spawned tasks — the borrowing version failed `tokio::spawn` in the first test draft). Binds the configured listener once; `BoundServer::run_once` serves sequential tests on the held port (no rebind gap, no re-listen race); `local_addr()` resolves `port(Some(0))` ephemeral binds up front. `Server::run_once` keeps its exact contract via the shared `serve_once` body.

## Tests

- `quiet_output.rs`: re-exec harness — the child's REAL stdout is asserted byte-empty (an in-process capture can't observe the `println!` layer), with a loud positive control proving the harness filter isn't vacuous.
- `bound_server.rs`: one bind, two sequential tests on one ephemeral port; plus the `run_once` contract pin.
- Full workspace: 28 binaries, 644 tests, 0 failures.

## Notes

- Additive only; SemVer CI green. #294 (0.9.0) tracks whether the *default* should flip to quiet.
- Per-PR compat smoke to run before merge.
