### PR TITLE
fix(json): GT-staged start fields + full-zeros interrupt end (#281)

### DIFF
--- a/riperf3-cli/tests/signal_terminate.rs
+++ b/riperf3-cli/tests/signal_terminate.rs
@@ -399,6 +399,16 @@ fn pre_data_interrupt_dump_reports_a_zero_window() {
         doc["end"]["cpu_utilization_percent"].is_object(),
         "interrupt end keeps the cpu figure: {doc}"
     );
+    // #281 r1 F1: the stream-less TCP forward dump carries GT's role-level
+    // `sum_sent.retransmits: 0` (platform-gated exactly like GT: present
+    // where TCP_INFO retransmits exist — the Linux/FreeBSD CI legs — absent
+    // elsewhere, e.g. the Windows native leg).
+    #[cfg(any(target_os = "linux", target_os = "freebsd"))]
+    assert_eq!(
+        doc["end"]["sum_sent"]["retransmits"].as_i64(),
+        Some(0),
+        "stream-less TCP forward dump carries retransmits: 0 (GT): {doc}"
+    );
 }
 
 /// #281: the POST-param-exchange / pre-TestStart interrupt window (GT stage 1
@@ -483,6 +493,16 @@ fn post_exchange_prestart_interrupt_dump_takes_gt_stage1_shape() {
             "zero window: {doc}"
         );
     }
+    // #281 r1 F1: the stream-less TCP forward dump carries GT's role-level
+    // `sum_sent.retransmits: 0` (platform-gated exactly like GT: present
+    // where TCP_INFO retransmits exist — the Linux/FreeBSD CI legs — absent
+    // elsewhere, e.g. the Windows native leg).
+    #[cfg(any(target_os = "linux", target_os = "freebsd"))]
+    assert_eq!(
+        doc["end"]["sum_sent"]["retransmits"].as_i64(),
+        Some(0),
+        "stream-less TCP forward dump carries retransmits: 0 (GT): {doc}"
+    );
 }
 
 /// #231 r2 pin (mutation B): an interrupt AFTER ExchangeResults keeps the

--- a/riperf3-cli/tests/signal_terminate.rs
+++ b/riperf3-cli/tests/signal_terminate.rs
@@ -361,6 +361,128 @@ fn pre_data_interrupt_dump_reports_a_zero_window() {
              requested -t: {doc}"
         );
     }
+    // #281 (GT captures on the issue): a PRE-ParamExchange interrupt doc
+    // carries ONLY connected/version/system_info in `start` — GT stages the
+    // rest at on_connect (post-param-exchange) and TestStart respectively.
+    let start = doc["start"].as_object().expect("start object");
+    for present in ["connected", "version", "system_info"] {
+        assert!(
+            start.contains_key(present),
+            "pre-PE interrupt start keeps {present}: {doc}"
+        );
+    }
+    for absent in [
+        "timestamp",
+        "connecting_to",
+        "cookie",
+        "tcp_mss_default",
+        "target_bitrate",
+        "fq_rate",
+        "sock_bufsize",
+        "sndbuf_actual",
+        "rcvbuf_actual",
+        "test_start",
+    ] {
+        assert!(
+            !start.contains_key(absent),
+            "pre-PE interrupt start must omit {absent} (GT stage 0): {doc}"
+        );
+    }
+    // The interrupt end is the FULL zero structure — including a PRESENT
+    // (empty) streams key — NOT the refusal's bare `end: {{}}` (#261/#281).
+    assert_eq!(
+        doc["end"]["streams"].as_array().map(Vec::len),
+        Some(0),
+        "interrupt end carries streams: [] (GT), not an omitted key: {doc}"
+    );
+    assert!(
+        doc["end"]["cpu_utilization_percent"].is_object(),
+        "interrupt end keeps the cpu figure: {doc}"
+    );
+}
+
+/// #281: the POST-param-exchange / pre-TestStart interrupt window (GT stage 1
+/// — the second capture on the issue). The mock completes the param exchange
+/// (cookie → ParamExchange → params read) then stalls; the SIGTERM dump must
+/// carry the on_connect metadata (real timestamp, cookie, connecting_to,
+/// tcp_mss_default, target_bitrate, fq_rate) while still omitting the four
+/// TestStart-stage fields, with the same full-zeros end incl. streams: [].
+#[test]
+fn post_exchange_prestart_interrupt_dump_takes_gt_stage1_shape() {
+    use std::io::Write;
+
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind mock");
+    let port = listener.local_addr().unwrap().port().to_string();
+    let _mock = std::thread::spawn(move || {
+        if let Ok((mut s, _)) = listener.accept() {
+            let mut cookie = [0u8; 37];
+            let _ = s.read_exact(&mut cookie);
+            let _ = s.write_all(&[9u8]); // ParamExchange
+            let mut len = [0u8; 4];
+            if s.read_exact(&mut len).is_ok() {
+                let n = u32::from_be_bytes(len) as usize;
+                let mut params = vec![0u8; n];
+                let _ = s.read_exact(&mut params);
+            }
+            std::thread::sleep(Duration::from_secs(15)); // stall pre-TestStart
+        }
+    });
+
+    let client = spawn(&["-c", "127.0.0.1", "-p", &port, "-t", "5", "-J"]);
+    std::thread::sleep(Duration::from_millis(900));
+    unsafe {
+        libc::kill(client.0.id() as i32, libc::SIGTERM);
+    }
+    let (cout, _cerr, ccode) =
+        wait_with_output_bounded(client, Duration::from_secs(8), "client -J post-PE");
+    assert_eq!(ccode, 0);
+    let doc: serde_json::Value =
+        serde_json::from_str(cout.trim()).unwrap_or_else(|e| panic!("one -J doc ({e}): {cout}"));
+
+    let start = doc["start"].as_object().expect("start object");
+    for present in [
+        "connected",
+        "version",
+        "system_info",
+        "timestamp",
+        "connecting_to",
+        "cookie",
+        "target_bitrate",
+        "fq_rate",
+    ] {
+        assert!(
+            start.contains_key(present),
+            "post-PE interrupt start keeps {present} (GT stage 1): {doc}"
+        );
+    }
+    for absent in [
+        "sock_bufsize",
+        "sndbuf_actual",
+        "rcvbuf_actual",
+        "test_start",
+    ] {
+        assert!(
+            !start.contains_key(absent),
+            "post-PE interrupt start must omit {absent} (GT stage 1): {doc}"
+        );
+    }
+    assert_ne!(
+        doc["start"]["timestamp"]["timesecs"],
+        serde_json::json!(0),
+        "the stage-1 timestamp is the real on_connect wall-clock: {doc}"
+    );
+    assert_eq!(
+        doc["end"]["streams"].as_array().map(Vec::len),
+        Some(0),
+        "interrupt end carries streams: []: {doc}"
+    );
+    for key in ["sum_sent", "sum_received"] {
+        assert_eq!(
+            doc["end"][key]["seconds"].as_f64(),
+            Some(0.0),
+            "zero window: {doc}"
+        );
+    }
 }
 
 /// #231 r2 pin (mutation B): an interrupt AFTER ExchangeResults keeps the

--- a/riperf3-cli/tests/signal_terminate.rs
+++ b/riperf3-cli/tests/signal_terminate.rs
@@ -401,9 +401,9 @@ fn pre_data_interrupt_dump_reports_a_zero_window() {
     );
     // #281 r1 F1: the stream-less TCP forward dump carries GT's role-level
     // `sum_sent.retransmits: 0` (platform-gated exactly like GT: present
-    // where TCP_INFO retransmits exist — the Linux/FreeBSD CI legs — absent
-    // elsewhere, e.g. the Windows native leg).
-    #[cfg(any(target_os = "linux", target_os = "freebsd"))]
+    // where TCP_INFO retransmits exist — the Linux/FreeBSD/macOS CI legs —
+    // absent elsewhere, e.g. the Windows native leg).
+    #[cfg(any(target_os = "linux", target_os = "freebsd", target_os = "macos"))]
     assert_eq!(
         doc["end"]["sum_sent"]["retransmits"].as_i64(),
         Some(0),
@@ -495,9 +495,9 @@ fn post_exchange_prestart_interrupt_dump_takes_gt_stage1_shape() {
     }
     // #281 r1 F1: the stream-less TCP forward dump carries GT's role-level
     // `sum_sent.retransmits: 0` (platform-gated exactly like GT: present
-    // where TCP_INFO retransmits exist — the Linux/FreeBSD CI legs — absent
-    // elsewhere, e.g. the Windows native leg).
-    #[cfg(any(target_os = "linux", target_os = "freebsd"))]
+    // where TCP_INFO retransmits exist — the Linux/FreeBSD/macOS CI legs —
+    // absent elsewhere, e.g. the Windows native leg).
+    #[cfg(any(target_os = "linux", target_os = "freebsd", target_os = "macos"))]
     assert_eq!(
         doc["end"]["sum_sent"]["retransmits"].as_i64(),
         Some(0),

--- a/riperf3/src/client.rs
+++ b/riperf3/src/client.rs
@@ -415,10 +415,10 @@ impl Client {
                 }
                 TestState::ServerError => {
                     // #261: a relay arriving before TestStart is the upfront
-                    // refusal (code 37 et al.) — the dump takes GT's minimal
-                    // shape; after TestStart it keeps its late fields.
-                    let reached = ctx.stage.started();
-                    return Err(self.on_server_error_relay(&mut ctx, reached).await);
+                    // refusal (code 37 et al.) — its `end` is GT's bare {}.
+                    // After TestStart the dump keeps the full structure.
+                    let bare_end = !ctx.stage.started();
+                    return Err(self.on_server_error_relay(&mut ctx, bare_end).await);
                 }
 
                 // iperf_handle_message_client handles SERVER_TERMINATE in
@@ -581,13 +581,13 @@ impl Client {
 
     /// Render/emit the run's results from the context state — the one
     /// `render_results` plumbing site for every dump the dispatch loop makes
-    /// (#289). `server_results`/`reached`/`error` are per-dump; everything
-    /// else comes from the context.
+    /// (#289). `server_results`/`bare_end`/`error` are per-dump; everything
+    /// else (including the #281 start-stage) comes from the context.
     fn emit_results(
         &self,
         ctx: &RunCtx,
         server_results: Option<&TestResultsJson>,
-        reached_test_start: bool,
+        bare_end: bool,
         secs: f64,
         error: Option<&str>,
     ) -> crate::json_report::Report {
@@ -601,7 +601,7 @@ impl Client {
             // once. Downstream builders take the value, so nothing can
             // silently re-drain.
             crate::reporter::CollectedIntervals::drain(&ctx.interval_data),
-            &ctx.start_meta(reached_test_start),
+            &ctx.start_meta(bare_end),
             secs,
             error,
         )
@@ -625,7 +625,13 @@ impl Client {
         // r1 item 7: post-ExchangeResults interrupts keep the
         // peer halves GT would show (its sigend dump merges
         // already-exchanged data); None only pre-exchange.
-        self.emit_results(ctx, ctx.server_results.as_ref(), true, dump_secs, Some(msg))
+        self.emit_results(
+            ctx,
+            ctx.server_results.as_ref(),
+            false,
+            dump_secs,
+            Some(msg),
+        )
     }
 
     async fn on_param_exchange(&self, ctx: &mut RunCtx) -> Result<()> {
@@ -756,7 +762,7 @@ impl Client {
                 &ctx.streams,
                 ctx.cpu_start.as_ref(),
                 ctx.blksize,
-                &ctx.start_meta(true),
+                &ctx.start_meta(false),
             );
         }
     }
@@ -789,13 +795,13 @@ impl Client {
                 let _ = protocol::send_state(&mut ctx.ctrl, TestState::ClientTerminate).await;
                 // #137: return the rich report we just dumped (the
                 // local-only partial — no peer half on a signal exit).
-                let report = self.emit_results(ctx, None, true, ctx.measured_secs, Some(&msg));
+                let report = self.emit_results(ctx, None, false, ctx.measured_secs, Some(&msg));
                 return Ok(StepFlow::Return(Box::new(report)));
             }
             Some(ControlEvent::ServerError) => {
                 // Mid-test the run is always past TestStart, so the dump
                 // keeps the full report structure (#261).
-                return Err(self.on_server_error_relay(ctx, true).await);
+                return Err(self.on_server_error_relay(ctx, false).await);
             }
             Some(ControlEvent::Closed) | None => {}
         }
@@ -812,12 +818,11 @@ impl Client {
     }
 
     async fn on_display_results(&self, ctx: &mut RunCtx) -> Result<StepFlow> {
-        // #261: the success path always reached TestStart —
-        // full report structure, late fields present.
+        // The success path: full report structure (stage is Started).
         let report = self.emit_results(
             ctx,
             ctx.server_results.as_ref(),
-            true,
+            false,
             ctx.measured_secs,
             None,
         );
@@ -831,20 +836,16 @@ impl Client {
     /// receipt line only (iperf_err's shape; no summary dump — that is
     /// SERVER_TERMINATE's). JSON sinks: render the full document/events with
     /// the error inside, like iperf3's json_top; the CLI suppresses its
-    /// generic re-render. `reached_test_start` is the caller's: a relay
-    /// before TestStart is the upfront refusal (code 37 et al.) — emit GT's
-    /// minimal doc (`end: {}`, late start fields omitted) (#261).
-    async fn on_server_error_relay(
-        &self,
-        ctx: &mut RunCtx,
-        reached_test_start: bool,
-    ) -> RiperfError {
+    /// generic re-render. `bare_end` is the caller's: a relay before
+    /// TestStart is the upfront refusal (code 37 et al.) — emit GT's minimal
+    /// doc (`end: {}`; the late start fields already gate on the stage) (#261).
+    async fn on_server_error_relay(&self, ctx: &mut RunCtx, bare_end: bool) -> RiperfError {
         let msg = match protocol::read_server_error_payload(&mut ctx.ctrl).await {
             Some((i_errno, os_errno)) => crate::error::iperf3_strerror(i_errno, os_errno),
             None => "server error".to_string(),
         };
         if self.json_output || self.json_stream {
-            self.emit_results(ctx, None, reached_test_start, ctx.measured_secs, Some(&msg));
+            self.emit_results(ctx, None, bare_end, ctx.measured_secs, Some(&msg));
         } else {
             // KNOWN CORNER (r1 n5): with --logfile set,
             // iperf_err writes this line to the logfile;
@@ -869,7 +870,7 @@ impl Client {
         self.emit_results(
             ctx,
             None,
-            true,
+            false,
             ctx.measured_secs,
             Some("the server has terminated"),
         );
@@ -2149,7 +2150,7 @@ impl Client {
             // .max(0): the public builder accepts an i32 window; clamp so a
             // negative can't wrap to a huge u64 (the CLI path is already >= 0).
             // #261: `Some(..)` on a run that set up streams (build() gates them
-            // out on the upfront-refusal path via `reached_test_start`); a
+            // out on the upfront-refusal path via the stage gate, #281); a
             // success run always carries them, so the shape is unchanged. A
             // missing kernel readback still yields `Some(0)` on a real run, like
             // iperf3.
@@ -2166,17 +2167,24 @@ impl Client {
                     .and_then(|s| s.meta.sock.rcvbuf_actual)
                     .unwrap_or(0),
             ),
-            // #261: false ONLY on the upfront server-refusal path (a SERVER_ERROR
-            // relay that arrives before stream setup, e.g. code 37) — there GT's
-            // client errexits through json_top, which never populated json_end, so
-            // the late `start` fields are omitted and `end` is `{}`. EVERY other
-            // path (success and the sigend/SERVER_TERMINATE dumps) renders the
-            // full structure — GT's interrupt dump shows 0/0/0 pre-data, NOT an
-            // empty end — so the flag is true and the partial document keeps its
-            // late fields. The flag is threaded explicitly via StartMeta because
-            // the refusal and a pre-data interrupt BOTH happen before TestStart
-            // and so are indistinguishable by the start wall-clock alone.
-            reached_test_start: start_meta.reached_test_start,
+            // #281: the start-stage derives from the run stage — Connecting
+            // (pre-ParamExchange: no wall-clock stamped), Connected (on_connect
+            // done), or Started — so interrupt dumps take GT's staged shapes
+            // with no per-arm threading.
+            start_stage: match start_meta.stage {
+                RunStage::Started { .. } => crate::json_report::StartStage::Started,
+                RunStage::PreTestStart { connect_millis: 0 } => {
+                    crate::json_report::StartStage::Connecting
+                }
+                RunStage::PreTestStart { .. } => crate::json_report::StartStage::Connected,
+            },
+            // #261: true ONLY on the upfront server-refusal path (a SERVER_ERROR
+            // relay before stream setup, e.g. code 37) — GT's client errexits
+            // through json_top with json_end never populated, so `end` is `{}`.
+            // Interrupt dumps are NOT bare (#281: GT renders zeroed sums +
+            // streams: []), which is why the flag stays explicit on StartMeta:
+            // the refusal and a pre-data interrupt share a stage but differ here.
+            bare_end: start_meta.bare_end,
             interval: self.interval.unwrap_or(1.0),
             // riperf3's single --gsro flag drives both GSO and GRO.
             gso: i32::from(self.gsro),
@@ -2317,14 +2325,13 @@ struct StartMeta {
     tcp_mss_default: u32,
     /// How far the run progressed and the wall-clock that goes with it (#286).
     stage: RunStage,
-    /// #261: false ONLY on the upfront server-refusal path — drives the
-    /// stage-gated omission of the late `start` fields and the bare `end: {}`.
-    /// True on every other path (success, sigend interrupt, SERVER_TERMINATE),
-    /// which all render the full report structure like GT. Kept EXPLICIT
-    /// (not derived from `stage`): a pre-TestStart sigend interrupt and the
-    /// refusal are the same stage but take different shapes — GT's interrupt
-    /// dump shows the full structure with 0/0/0, not the minimal refusal doc.
-    reached_test_start: bool,
+    /// #261/#281: true ONLY on the upfront server-refusal path — the `end`
+    /// object serializes bare (`{}`). Every other dump (success, sigend
+    /// interrupt, SERVER_TERMINATE) keeps the full end structure; the late
+    /// `start` fields gate on the STAGE, not this flag. Kept EXPLICIT: a
+    /// pre-TestStart sigend interrupt and the refusal share a stage but GT
+    /// gives the interrupt zeroed sums + `streams: []` and the refusal `{}`.
+    bare_end: bool,
 }
 
 /// How far the client's run has progressed, carrying the authoritative
@@ -2434,15 +2441,15 @@ struct RunCtx {
 
 impl RunCtx {
     /// Assemble the `StartMeta` for a report dump from the run's captured
-    /// state — the one construction site (#289). `reached_test_start` is the
+    /// state — the one construction site (#289). `bare_end` is the
     /// caller's call: true everywhere except the upfront server-refusal path
     /// (#261, see the field doc on StartMeta).
-    fn start_meta(&self, reached_test_start: bool) -> StartMeta {
+    fn start_meta(&self, bare_end: bool) -> StartMeta {
         StartMeta {
             cookie: String::from_utf8_lossy(&self.cookie[..protocol::COOKIE_SIZE - 1]).into_owned(),
             tcp_mss_default: self.control_mss,
             stage: self.stage,
-            reached_test_start,
+            bare_end,
         }
     }
 }

--- a/riperf3/src/json_report.rs
+++ b/riperf3/src/json_report.rs
@@ -952,21 +952,11 @@ impl ReportInput {
         let blk = self.blksize.max(1) as u64;
         // iperf3's `stream_must_be_sender` for the aggregate `sender` flag.
         let fwd_sender = !self.reverse;
-        // #281 r1 F1: on a STREAM-LESS dump (pre-TestStart interrupt) GT still
-        // prints `sum_sent.retransmits: 0` when the local side would be a
-        // retransmit-capable TCP sender — its sender_has_retransmits is a
-        // role-level flag set before any stream exists (iperf_api.c:637; the
-        // receiving role sets 0 at :639, so a reverse client OMITS the key —
-        // both live-verified on the issue). Runs WITH streams keep the
-        // stream-derived figure untouched.
-        let retransmits = self.sender_retransmits().or_else(|| {
-            (self.streams.is_empty()
-                && !is_udp
-                && !self.reverse
-                && !self.is_server
-                && crate::tcp_info::has_retransmit_info())
-            .then_some(0)
-        });
+        // #281 r1 F1 / #300 r2 F1: the role-level stream-less fallback — see
+        // stream_less_sender_retransmits. Runs WITH streams are untouched.
+        let retransmits = self
+            .sender_retransmits()
+            .or_else(|| self.stream_less_sender_retransmits());
 
         let mut sum = None;
         let mut sum_bidir_reverse = None;
@@ -1233,7 +1223,14 @@ impl ReportInput {
                 Some(self.tcp_sum(rev_sent, false, self.retransmits_for(Some(false))));
             sum_received_bidir_reverse = Some(self.tcp_sum(local_recv, false, None));
             (
-                self.tcp_sum(local_sent, true, self.retransmits_for(Some(true))),
+                // #300 r2 F1: the bidir forward pass takes the same role-level
+                // stream-less fallback — GT's flag covers bidir senders too.
+                self.tcp_sum(
+                    local_sent,
+                    true,
+                    self.retransmits_for(Some(true))
+                        .or_else(|| self.stream_less_sender_retransmits()),
+                ),
                 self.tcp_sum(fwd_recv, true, None),
             )
         } else if is_udp {
@@ -1673,6 +1670,22 @@ impl ReportInput {
     /// fallback), replacing the old `local_sent / blksize` aggregate at the
     /// UDP-sender sites. Equal to `local_sent / blksize` bit-for-bit for a
     /// full-block-only sender.
+    /// #281/#300 r2 F1: GT's role-level `sender_has_retransmits` on a
+    /// STREAM-LESS dump — set for any SENDING mode (forward AND bidir,
+    /// check_sender_has_retransmits iperf_api.c:634-639) on retransmit-capable
+    /// TCP, so GT prints `sum_sent.retransmits: 0` before any stream exists;
+    /// a reverse client's flag is 0 pre-exchange, so the key is omitted
+    /// (both live-verified on the issue). None whenever streams exist — the
+    /// stream-derived figures always win.
+    fn stream_less_sender_retransmits(&self) -> Option<i64> {
+        (self.streams.is_empty()
+            && !matches!(self.protocol, TransportProtocol::Udp)
+            && !self.reverse
+            && !self.is_server
+            && crate::tcp_info::has_retransmit_info())
+        .then_some(0)
+    }
+
     fn local_sent_packets(&self) -> i64 {
         self.streams
             .iter()
@@ -2959,6 +2972,51 @@ mod tests {
             );
         } else {
             assert!(v["end"]["sum_sent"].get("retransmits").is_none());
+        }
+    }
+
+    /// #300 r2 F1+F2: the role-level stream-less retransmits rule per
+    /// direction — GT's check_sender_has_retransmits (iperf_api.c:634-639)
+    /// sets the flag for any SENDING mode (forward AND bidir; live captures
+    /// on the issue), while a reverse client's flag is 0 pre-exchange so the
+    /// key is OMITTED. Pins both polarities so neither gate can silently
+    /// drop (r2 mutation A survived without the reverse pin).
+    #[test]
+    fn stream_less_retransmits_follows_the_gt_role_rule() {
+        if !crate::tcp_info::has_retransmit_info() {
+            return;
+        }
+        let shapes = [
+            (false, false, true, "forward client emits retransmits: 0"),
+            (true, false, false, "reverse client omits the key"),
+            (
+                false,
+                true,
+                true,
+                "bidir client emits retransmits: 0 (r2 F1)",
+            ),
+        ];
+        for (reverse, bidir, present, why) in shapes {
+            let mut input = base_input();
+            input.error = Some("interrupt".into());
+            input.start_stage = StartStage::Connected;
+            input.streams = vec![];
+            input.reverse = reverse;
+            input.bidir = bidir;
+            input.congestion_used = None;
+            let v = serde_json::to_value(input.build()).unwrap();
+            assert_eq!(
+                v["end"]["sum_sent"].get("retransmits").is_some(),
+                present,
+                "{why}: {v}"
+            );
+            if present {
+                assert_eq!(
+                    v["end"]["sum_sent"]["retransmits"].as_i64(),
+                    Some(0),
+                    "{why}: {v}"
+                );
+            }
         }
     }
 

--- a/riperf3/src/json_report.rs
+++ b/riperf3/src/json_report.rs
@@ -213,9 +213,28 @@ pub(crate) fn json_stream_event<T: Serialize>(event: &'static str, data: &T) -> 
 // start{}
 // ---------------------------------------------------------------------------
 
-#[derive(Debug, Clone, Serialize)]
+/// How far the run progressed when the document was built (#281) — drives
+/// which `start` fields serialize, mirroring GT's three staging points:
+/// pre-ParamExchange (connected/version/system_info only), on_connect
+/// (+ timestamp/connecting_to/cookie/mss/target_bitrate/fq_rate), and
+/// TestStart (+ the four #261 late fields). `pub(crate)`: stage flags are
+/// build inputs, not schema.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum StartStage {
+    Connecting,
+    Connected,
+    Started,
+}
+
+// Serialize is HAND-WRITTEN (below) so the GT stage gating can omit fields
+// that are bare (non-Option) in the frozen 0.8.0 schema — timestamp, cookie,
+// target_bitrate, fq_rate — without the 0.9.0 break Option-ifying them would
+// be (#281). Field order in the impl matches declaration order exactly.
+#[derive(Debug, Clone)]
 #[non_exhaustive]
 pub struct Start {
+    /// #281: the GT staging point this document was built at.
+    pub(crate) stage: StartStage,
     pub connected: Vec<Connection>,
     pub version: String,
     pub system_info: String,
@@ -225,17 +244,13 @@ pub struct Start {
     // present, and they share the `{host, port}` shape. They sit in the same slot
     // (right after `timestamp`), so a single struct serializes both roles in
     // iperf3's order.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub connecting_to: Option<ConnectingTo>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub accepted_connection: Option<ConnectingTo>,
     pub cookie: String,
     // iperf3 emits exactly one of these, and only for TCP (iperf_api.c:1021):
     // `tcp_mss` when `-M`/`--set-mss` was given, else `tcp_mss_default` (the
     // control-socket MSS). UDP emits neither.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub tcp_mss: Option<u32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub tcp_mss_default: Option<u32>,
     pub target_bitrate: u64,
     pub fq_rate: u64,
@@ -243,17 +258,58 @@ pub struct Start {
     // TestStart. On an upfront refusal (server-side rejection BEFORE TestStart,
     // e.g. --server-max-duration / code 37) the client never sets up streams, so
     // GT (iperf 3.21) OMITS them entirely — the document carries the early start
-    // metadata (timestamp, cookie, connecting_to) and an empty `end`. `Option` +
-    // skip-if-none reproduces that: `Some(..)` on a run that reached TestStart
-    // (every success and every mid-test interrupt), `None` on the refusal path.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    // metadata (timestamp, cookie, connecting_to) and an empty `end`. Gated by
+    // `stage == Started` in the manual Serialize impl (#261/#281).
     pub sock_bufsize: Option<u64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub sndbuf_actual: Option<u64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub rcvbuf_actual: Option<u64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub test_start: Option<TestStart>,
+}
+
+impl Serialize for Start {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        use serde::ser::SerializeMap;
+        let mut m = serializer.serialize_map(None)?;
+        // GT stage 0 — always present, from the very first dump on.
+        m.serialize_entry("connected", &self.connected)?;
+        m.serialize_entry("version", &self.version)?;
+        m.serialize_entry("system_info", &self.system_info)?;
+        if self.stage != StartStage::Connecting {
+            // GT stage 1 — stamped at on_connect (end of PARAM_EXCHANGE).
+            m.serialize_entry("timestamp", &self.timestamp)?;
+            if let Some(v) = &self.connecting_to {
+                m.serialize_entry("connecting_to", v)?;
+            }
+            if let Some(v) = &self.accepted_connection {
+                m.serialize_entry("accepted_connection", v)?;
+            }
+            m.serialize_entry("cookie", &self.cookie)?;
+            if let Some(v) = &self.tcp_mss {
+                m.serialize_entry("tcp_mss", v)?;
+            }
+            if let Some(v) = &self.tcp_mss_default {
+                m.serialize_entry("tcp_mss_default", v)?;
+            }
+            m.serialize_entry("target_bitrate", &self.target_bitrate)?;
+            m.serialize_entry("fq_rate", &self.fq_rate)?;
+        }
+        if self.stage == StartStage::Started {
+            // GT stage 2 — the #261 late fields, stamped at TestStart.
+            if let Some(v) = &self.sock_bufsize {
+                m.serialize_entry("sock_bufsize", v)?;
+            }
+            if let Some(v) = &self.sndbuf_actual {
+                m.serialize_entry("sndbuf_actual", v)?;
+            }
+            if let Some(v) = &self.rcvbuf_actual {
+                m.serialize_entry("rcvbuf_actual", v)?;
+            }
+            if let Some(v) = &self.test_start {
+                m.serialize_entry("test_start", v)?;
+            }
+        }
+        m.end()
+    }
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -405,45 +461,76 @@ pub struct IntervalSum {
 // end{}
 // ---------------------------------------------------------------------------
 
-#[derive(Debug, Clone, Serialize)]
+// Serialize is HAND-WRITTEN (below): the refusal's bare `end: {}` (#261) and
+// the pre-TestStart interrupt's full-zeros end WITH a present `streams: []`
+// key (#281 — GT emits the key empty there) can't both be expressed by a
+// fixed per-field skip. Field order in the impl matches declaration order.
+#[derive(Debug, Clone)]
 #[non_exhaustive]
 pub struct End {
-    // #261: a run that reached TestStart always has ≥1 stream, so on success/
-    // partial this serializes unchanged; on an upfront refusal it is empty and
-    // omitted, contributing to GT's bare `end: {}` (which carries no `streams`
-    // key either).
-    #[serde(skip_serializing_if = "Vec::is_empty")]
+    /// #261/#281: true ONLY on the upfront-refusal path — the whole object
+    /// serializes as GT's bare `{}`. Every other dump (success, mid-test or
+    /// pre-TestStart interrupt, SERVER_TERMINATE) renders the full structure,
+    /// including `streams: []` when no stream ever existed.
+    pub(crate) bare: bool,
     pub streams: Vec<EndStream>,
     /// UDP only: the datagram aggregate iperf3 emits as `sum` — BEFORE the
     /// sent/received pair in its key order (GT 3.21, fwd and bidir alike;
     /// the old field position serialized it after, a raw-diff divergence).
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub sum: Option<SumSide>,
-    // #261: the summary aggregates and CPU figure exist only once the test
-    // reached TestStart. On an upfront refusal GT emits `end: {}` — every key
-    // omitted. With these three as `Option` + skip-if-none, an `End` whose
-    // optional fields are all `None` serializes as `{}`, matching GT byte-for-
-    // byte. A run that reached TestStart (success, mid-test interrupt) sets them
-    // `Some(..)`, so the success/partial shape is unchanged.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub sum_sent: Option<SumSide>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub sum_received: Option<SumSide>,
     /// UDP bidir only (#214): the reverse-direction datagram aggregate,
     /// between the forward pair and the reverse pair, like iperf3.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub sum_bidir_reverse: Option<SumSide>,
     /// Bidir only: the reverse-direction aggregates.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub sum_sent_bidir_reverse: Option<SumSide>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub sum_received_bidir_reverse: Option<SumSide>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub cpu_utilization_percent: Option<CpuUtilization>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub sender_tcp_congestion: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub receiver_tcp_congestion: Option<String>,
+}
+
+impl Serialize for End {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        use serde::ser::SerializeMap;
+        let mut m = serializer.serialize_map(None)?;
+        if self.bare {
+            // The refusal's bare `end: {}` (#261) — no keys at all.
+            return m.end();
+        }
+        // `streams` is UNCONDITIONAL — GT emits `[]` on a stream-less
+        // interrupt dump (#281); only the bare refusal omits the key.
+        m.serialize_entry("streams", &self.streams)?;
+        if let Some(v) = &self.sum {
+            m.serialize_entry("sum", v)?;
+        }
+        if let Some(v) = &self.sum_sent {
+            m.serialize_entry("sum_sent", v)?;
+        }
+        if let Some(v) = &self.sum_received {
+            m.serialize_entry("sum_received", v)?;
+        }
+        if let Some(v) = &self.sum_bidir_reverse {
+            m.serialize_entry("sum_bidir_reverse", v)?;
+        }
+        if let Some(v) = &self.sum_sent_bidir_reverse {
+            m.serialize_entry("sum_sent_bidir_reverse", v)?;
+        }
+        if let Some(v) = &self.sum_received_bidir_reverse {
+            m.serialize_entry("sum_received_bidir_reverse", v)?;
+        }
+        if let Some(v) = &self.cpu_utilization_percent {
+            m.serialize_entry("cpu_utilization_percent", v)?;
+        }
+        if let Some(v) = &self.sender_tcp_congestion {
+            m.serialize_entry("sender_tcp_congestion", v)?;
+        }
+        if let Some(v) = &self.receiver_tcp_congestion {
+            m.serialize_entry("receiver_tcp_congestion", v)?;
+        }
+        m.end()
+    }
 }
 
 /// One `end.streams[]` entry. iperf3 nests the per-direction stats: TCP carries
@@ -701,13 +788,15 @@ pub(crate) struct ReportInput {
     pub sock_bufsize: Option<u64>,
     pub sndbuf_actual: Option<u64>,
     pub rcvbuf_actual: Option<u64>,
-    /// True once the test reached stream-setup / TestStart (#261). Drives the
-    /// stage-gated `start.test_start` and the `end` summary aggregates: GT
-    /// populates them only by how far the test progressed, and OMITS them on an
-    /// upfront refusal (server rejection before TestStart, e.g. code 37). A
-    /// mid-test interrupt or SERVER_TERMINATE DID reach TestStart, so it stays
-    /// `true` there — the partial document keeps the late fields it has.
-    pub reached_test_start: bool,
+    /// How far the run progressed when this document is built (#281): drives
+    /// the three-stage `start` field gating (see [`StartStage`]). The client
+    /// derives it from its run stage; the server always builds at `Started`.
+    pub start_stage: StartStage,
+    /// True ONLY on the upfront server-refusal path (#261): the `end` object
+    /// serializes bare (`{}`). Interrupt dumps — mid-test OR pre-TestStart —
+    /// keep the full end structure (GT emits zeroed sums + `streams: []`
+    /// there, #281).
+    pub bare_end: bool,
     pub interval: f64,
     pub gso: i32,
     pub gro: i32,
@@ -783,6 +872,8 @@ impl ReportInput {
     pub(crate) fn build(&self) -> Report {
         let dur = self.duration;
         let is_udp = matches!(self.protocol, TransportProtocol::Udp);
+        // #281: the TestStart-stage gate for the four late `start` fields.
+        let started = self.start_stage == StartStage::Started;
 
         let connected: Vec<Connection> = self
             .streams
@@ -1229,24 +1320,21 @@ impl ReportInput {
             (self.congestion_used.clone(), self.congestion_used.clone())
         };
 
-        // #261: stage-gate the `end` summary aggregates on whether the test
-        // reached TestStart. On an upfront refusal (never reached it) every
-        // optional field is None and `streams` is empty, so `End` serializes as
-        // GT's bare `end: {}`. This must cover the UDP aggregates too (`sum` and
-        // the bidir trio are `Some(zeros)` on a UDP refusal) or a UDP refusal
-        // leaks `end: {"sum": {...}}`. A run that reached TestStart (success,
-        // mid-test interrupt, SERVER_TERMINATE) keeps them — the partial document
-        // carries the late fields it has, unchanged from before.
-        let reached = self.reached_test_start;
+        // #261/#281: the refusal's `end` is bare `{}` (every key omitted, the
+        // manual Serialize short-circuits on `bare`); every OTHER dump keeps
+        // the full structure — a pre-TestStart interrupt renders zeroed sums
+        // and a present `streams: []`, exactly GT's sigend shape.
+        let keep = !self.bare_end;
         let end = End {
+            bare: self.bare_end,
             streams: end_streams,
-            sum_sent: reached.then_some(sum_sent),
-            sum_received: reached.then_some(sum_received),
-            sum: reached.then_some(sum).flatten(),
-            sum_bidir_reverse: reached.then_some(sum_bidir_reverse).flatten(),
-            sum_sent_bidir_reverse: reached.then_some(sum_sent_bidir_reverse).flatten(),
-            sum_received_bidir_reverse: reached.then_some(sum_received_bidir_reverse).flatten(),
-            cpu_utilization_percent: reached.then(|| self.cpu.clone()),
+            sum_sent: keep.then_some(sum_sent),
+            sum_received: keep.then_some(sum_received),
+            sum: keep.then_some(sum).flatten(),
+            sum_bidir_reverse: keep.then_some(sum_bidir_reverse).flatten(),
+            sum_sent_bidir_reverse: keep.then_some(sum_sent_bidir_reverse).flatten(),
+            sum_received_bidir_reverse: keep.then_some(sum_received_bidir_reverse).flatten(),
+            cpu_utilization_percent: keep.then(|| self.cpu.clone()),
             sender_tcp_congestion: cong_sender,
             receiver_tcp_congestion: cong_receiver,
         };
@@ -1284,6 +1372,7 @@ impl ReportInput {
         };
         Report {
             start: Start {
+                stage: self.start_stage,
                 connected,
                 version: self.version.clone(),
                 system_info: self.system_info.clone(),
@@ -1299,22 +1388,21 @@ impl ReportInput {
                 tcp_mss_default,
                 target_bitrate: self.target_bitrate,
                 fq_rate: self.fq_rate,
-                // #261: the socket buffers and `test_start` block are populated
-                // only once the test reached stream-setup / TestStart. On the
-                // upfront-refusal path `reached` is false → all omitted (the
-                // buffer fields are also `None` at the source there); GT does the
-                // same, so the refusal `start` carries only the early metadata.
+                // #261/#281: the socket buffers and `test_start` block are
+                // populated only once the test reached stream-setup /
+                // TestStart — the manual Serialize also gates them on
+                // `stage == Started`, so both the refusal AND the
+                // pre-TestStart interrupt omit them, like GT.
                 // NOTE: GT stages these at two distinct points — the buffers at
                 // CREATE_STREAMS (iperf_tcp.c) and `test_start` at TEST_START
-                // (iperf_api.c) — whereas this one `reached` flag flips at
-                // TestStart. A SERVER_ERROR arriving in the CreateStreams..
-                // TestStart window would diverge, but that window is unreachable
-                // against a riperf3 server (its only top-level SERVER_ERROR is the
-                // param-exchange refusal, before CreateStreams).
-                sock_bufsize: reached.then_some(self.sock_bufsize).flatten(),
-                sndbuf_actual: reached.then_some(self.sndbuf_actual).flatten(),
-                rcvbuf_actual: reached.then_some(self.rcvbuf_actual).flatten(),
-                test_start: reached.then(|| TestStart {
+                // (iperf_api.c) — whereas this stage flips at TestStart. A
+                // dump landing in the CreateStreams..TestStart window would
+                // diverge, but that window is unreachable against a riperf3
+                // server for refusals, and vanishingly narrow for interrupts.
+                sock_bufsize: started.then_some(self.sock_bufsize).flatten(),
+                sndbuf_actual: started.then_some(self.sndbuf_actual).flatten(),
+                rcvbuf_actual: started.then_some(self.rcvbuf_actual).flatten(),
+                test_start: started.then(|| TestStart {
                     protocol: if is_udp { "UDP" } else { "TCP" }.to_string(),
                     num_streams: self.num_streams,
                     blksize: self.blksize,
@@ -1792,7 +1880,8 @@ mod tests {
             sock_bufsize: Some(0),
             sndbuf_actual: Some(16384),
             rcvbuf_actual: Some(87380),
-            reached_test_start: true,
+            start_stage: StartStage::Started,
+            bare_end: false,
             interval: 1.0,
             gso: 0,
             gro: 0,
@@ -2674,7 +2763,11 @@ mod tests {
     fn success_run_keeps_all_late_fields() {
         let mut input = base_input();
         input.streams = vec![tcp_stream(1, true, 10, 10)];
-        assert!(input.reached_test_start, "base_input models a real run");
+        assert_eq!(
+            input.start_stage,
+            StartStage::Started,
+            "base_input models a real run"
+        );
         let report = input.build();
         // start late fields: typed Option, all Some.
         assert!(report.start.sock_bufsize.is_some(), "sock_bufsize");
@@ -2722,7 +2815,8 @@ mod tests {
         // buffer inputs are None, and a REAL connect-time wall-clock (not 0).
         input.error =
             Some("client's requested duration exceeds the server's maximum permitted limit".into());
-        input.reached_test_start = false;
+        input.start_stage = StartStage::Connected;
+        input.bare_end = true;
         input.streams = vec![];
         input.sock_bufsize = None;
         input.sndbuf_actual = None;
@@ -2799,6 +2893,75 @@ mod tests {
         );
     }
 
+    /// #281: the pre-TestStart INTERRUPT shape (GT capture on the issue) —
+    /// stage Connected, NOT bare: the late `start` fields are omitted while
+    /// the on_connect metadata stays, and `end` is the FULL zero structure
+    /// with a PRESENT `streams: []` key (the refusal's bare `{}` would be
+    /// wrong here).
+    #[test]
+    fn prestart_interrupt_keeps_full_end_with_empty_streams() {
+        let mut input = base_input();
+        input.error = Some("interrupt - the client has terminated by signal".into());
+        input.start_stage = StartStage::Connected;
+        input.bare_end = false;
+        input.streams = vec![];
+        input.congestion_used = None;
+        // The real pre-start dump passes a ZERO window (r1 item 5) — model it.
+        input.elapsed = 0.0;
+        let v = serde_json::to_value(input.build()).unwrap();
+
+        let start = v["start"].as_object().expect("start object");
+        for present in ["connected", "version", "system_info", "timestamp", "cookie"] {
+            assert!(start.contains_key(present), "keeps {present}: {v}");
+        }
+        for absent in [
+            "sock_bufsize",
+            "sndbuf_actual",
+            "rcvbuf_actual",
+            "test_start",
+        ] {
+            assert!(!start.contains_key(absent), "omits {absent}: {v}");
+        }
+        assert_eq!(
+            v["end"]["streams"].as_array().map(Vec::len),
+            Some(0),
+            "the interrupt end carries streams: [] (GT), not an omitted key: {v}"
+        );
+        for key in ["sum_sent", "sum_received", "cpu_utilization_percent"] {
+            assert!(
+                v["end"].get(key).is_some(),
+                "the interrupt end keeps {key} (zeroed), unlike the refusal: {v}"
+            );
+        }
+        assert_eq!(v["end"]["sum_sent"]["seconds"].as_f64(), Some(0.0));
+    }
+
+    /// #281: the pre-ParamExchange shape (GT stage 0, second capture on the
+    /// issue) — `start` carries ONLY connected/version/system_info; even the
+    /// timestamp and cookie are absent, because GT stamps them at on_connect.
+    #[test]
+    fn connecting_stage_start_carries_only_the_earliest_metadata() {
+        let mut input = base_input();
+        input.error = Some("interrupt - the client has terminated by signal".into());
+        input.start_stage = StartStage::Connecting;
+        input.bare_end = false;
+        input.streams = vec![];
+        input.congestion_used = None;
+        let v = serde_json::to_value(input.build()).unwrap();
+
+        // serde_json::Value re-orders keys alphabetically, so assert the SET
+        // here; the on-wire order is the manual impl's entry order.
+        let start = v["start"].as_object().expect("start object");
+        let mut keys: Vec<_> = start.keys().map(String::as_str).collect();
+        keys.sort_unstable();
+        assert_eq!(
+            keys,
+            ["connected", "system_info", "version"],
+            "GT stage 0 is exactly these three: {v}"
+        );
+        assert_eq!(v["end"]["streams"].as_array().map(Vec::len), Some(0));
+    }
+
     #[test]
     fn udp_refusal_also_emits_bare_end() {
         // The UDP `end` aggregates (`sum` + the `sum_*_bidir_reverse` trio) are
@@ -2815,7 +2978,8 @@ mod tests {
             input.error = Some(
                 "client's requested duration exceeds the server's maximum permitted limit".into(),
             );
-            input.reached_test_start = false;
+            input.start_stage = StartStage::Connected;
+            input.bare_end = true;
             input.streams = vec![];
             input.sock_bufsize = None;
             input.sndbuf_actual = None;

--- a/riperf3/src/json_report.rs
+++ b/riperf3/src/json_report.rs
@@ -952,7 +952,21 @@ impl ReportInput {
         let blk = self.blksize.max(1) as u64;
         // iperf3's `stream_must_be_sender` for the aggregate `sender` flag.
         let fwd_sender = !self.reverse;
-        let retransmits = self.sender_retransmits();
+        // #281 r1 F1: on a STREAM-LESS dump (pre-TestStart interrupt) GT still
+        // prints `sum_sent.retransmits: 0` when the local side would be a
+        // retransmit-capable TCP sender — its sender_has_retransmits is a
+        // role-level flag set before any stream exists (iperf_api.c:637; the
+        // receiving role sets 0 at :639, so a reverse client OMITS the key —
+        // both live-verified on the issue). Runs WITH streams keep the
+        // stream-derived figure untouched.
+        let retransmits = self.sender_retransmits().or_else(|| {
+            (self.streams.is_empty()
+                && !is_udp
+                && !self.reverse
+                && !self.is_server
+                && crate::tcp_info::has_retransmit_info())
+            .then_some(0)
+        });
 
         let mut sum = None;
         let mut sum_bidir_reverse = None;
@@ -2934,6 +2948,95 @@ mod tests {
             );
         }
         assert_eq!(v["end"]["sum_sent"]["seconds"].as_f64(), Some(0.0));
+        // #281 r1 F1: GT prints retransmits: 0 on the stream-less TCP dump
+        // when the local role is a retransmit-capable sender (and omits it
+        // on platforms without TCP_INFO retransmits, like GT).
+        if crate::tcp_info::has_retransmit_info() {
+            assert_eq!(
+                v["end"]["sum_sent"]["retransmits"].as_i64(),
+                Some(0),
+                "stream-less TCP forward dump carries retransmits: 0 (GT): {v}"
+            );
+        } else {
+            assert!(v["end"]["sum_sent"].get("retransmits").is_none());
+        }
+    }
+
+    /// #281 r1 F2: the hand-written Start/End serializers own the key ORDER
+    /// the derive used to guarantee — pin the raw on-wire sequences (the
+    /// Interval struct has the same style of pin). Parsed-Value asserts can't
+    /// see order; this reads the serialized string.
+    #[test]
+    fn manual_serializer_key_order_is_pinned() {
+        let mut input = base_input();
+        input.streams = vec![tcp_stream(1, true, 10, 10)];
+        let raw = serde_json::to_string(&input.build()).unwrap();
+
+        let keys = |obj: &str| -> Vec<String> {
+            // Top-level keys of the serialized sub-object `obj`, in on-wire
+            // order: a quoted token is a KEY iff it sits at depth 1 and the
+            // next non-quote char is ':'. String VALUES are skipped by the
+            // lookahead. (No escapes occur in these fixture keys/values.)
+            let from = raw.find(&format!("\"{obj}\":")).unwrap() + obj.len() + 3;
+            let bytes = raw.as_bytes();
+            let mut depth = 0i32;
+            let mut i = from;
+            let mut out = Vec::new();
+            while i < bytes.len() {
+                match bytes[i] {
+                    b'{' | b'[' => depth += 1,
+                    b'}' | b']' => {
+                        depth -= 1;
+                        if depth == 0 {
+                            break;
+                        }
+                    }
+                    b'"' => {
+                        let close = raw[i + 1..].find('"').unwrap() + i + 1;
+                        if depth == 1 && bytes.get(close + 1) == Some(&b':') {
+                            out.push(raw[i + 1..close].to_string());
+                        }
+                        i = close;
+                    }
+                    _ => {}
+                }
+                i += 1;
+            }
+            out
+        };
+        let start_keys = keys("start");
+        assert_eq!(
+            start_keys,
+            [
+                "connected",
+                "version",
+                "system_info",
+                "timestamp",
+                "connecting_to",
+                "cookie",
+                "tcp_mss_default",
+                "target_bitrate",
+                "fq_rate",
+                "sock_bufsize",
+                "sndbuf_actual",
+                "rcvbuf_actual",
+                "test_start"
+            ],
+            "start key order drifted from the frozen 0.8.0 wire shape: {raw}"
+        );
+        let end_keys = keys("end");
+        assert_eq!(
+            end_keys,
+            [
+                "streams",
+                "sum_sent",
+                "sum_received",
+                "cpu_utilization_percent",
+                "sender_tcp_congestion",
+                "receiver_tcp_congestion"
+            ],
+            "end key order drifted from the frozen 0.8.0 wire shape: {raw}"
+        );
     }
 
     /// #281: the pre-ParamExchange shape (GT stage 0, second capture on the

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -2311,11 +2311,11 @@ impl Server {
                     .and_then(|s| s.meta.sock.rcvbuf_actual)
                     .unwrap_or(0),
             ),
-            // #261: the server only ever assembles a full report on a run that
-            // reached TestStart — its upfront refusal renders the skeleton via
-            // json_report::error_document, not build(). So the late fields are
-            // always present here; the stage-gate is a no-op on this path.
-            reached_test_start: true,
+            // #261/#281: the server only ever assembles a full report on a run
+            // that reached TestStart — its upfront refusal renders the skeleton
+            // via json_report::error_document, not build(). Always Started/full.
+            start_stage: crate::json_report::StartStage::Started,
+            bare_end: false,
             // The server reports at its 1s default; it has no -i.
             interval: 1.0,
             // GSO/GRO are client-side knobs, not exchanged; iperf3's server emits 0.


### PR DESCRIPTION
Closes #281.

## What

Realigns the client's pre-TestStart interrupt `-J` documents to GT (iperf 3.21 @ d39cf41), per the two live captures on the issue — which overturned half the original hypothesis and expanded the other half:

1. **`start` has THREE GT staging points, not two.** A pre-ParamExchange dump carries ONLY `connected`/`version`/`system_info`; on_connect adds `timestamp`/`connecting_to`/`cookie`/`tcp_mss*`/`target_bitrate`/`fq_rate`; TestStart adds the four #261 late fields. riperf3 emitted everything (epoch-0 timestamp included) from any stage.
2. **The interrupt `end` is NOT the refusal's bare `{}`.** GT renders the full zero structure with a present `streams: []` key — riperf3 omitted the key entirely (a collateral effect of #261's `Vec::is_empty` skip).

## How

Hand-written `Serialize` impls for `Start` and `End` (field order preserved exactly), driven by `pub(crate)` build inputs — **no public schema change**, because `timestamp`/`cookie`/`target_bitrate`/`fq_rate` are bare fields in the frozen 0.8.0 schema and Option-ifying them would be the 0.9.0 break:

- `StartStage` (`Connecting`/`Connected`/`Started`) gates the three field groups. The client derives it from `RunStage` with no per-arm threading (`PreTestStart { connect_millis: 0 }` = Connecting); the server always builds `Started`.
- `End.bare` (refusal-only, #261) short-circuits to the bare `{}`; every other dump emits the full structure including an unconditional `streams` key.
- `StartMeta` threads `bare_end` (refusal) instead of `reached_test_start` — the late-field decision now lives on the stage, where it belongs.

## Evidence

- TDD: the rewritten `pre_data_interrupt_dump_reports_a_zero_window` (GT stage-0 shape) ran red against the old behavior first; new `post_exchange_prestart_interrupt_dump_takes_gt_stage1_shape` covers the on_connect window with a stall-mock; unit pins cover both stages plus the interrupt-vs-refusal end split.
- The #261 refusal pins and the success-path golden `-J` tests are untouched and green — the manual serializers reproduce the frozen byte shape (26 binaries, 643 tests, 0 failures).
- Faithfulness only; no wire change. Per-PR compat smoke before merge.
