### PR TITLE
fix(compat): wording batch — banner test #N (#262), IECTRLCLOSE shape (#267), parameter-error class (#270)

### DIFF
--- a/riperf3-cli/src/main.rs
+++ b/riperf3-cli/src/main.rs
@@ -83,7 +83,11 @@ fn main() -> std::process::ExitCode {
     }
 
     if let Some(msg) = parse_class_rejection(&cli) {
-        eprintln!("riperf3: error - {msg}");
+        // #270: GT routes the parse-error class through 'parameter error - '
+        // with the usage trailer (live-probed for all three classes here:
+        // end-conditions, client-only, server-only).
+        eprintln!("riperf3: parameter error - {msg}");
+        print_usage_trailer();
         return std::process::ExitCode::FAILURE;
     }
 
@@ -109,6 +113,9 @@ fn main() -> std::process::ExitCode {
                     le,
                     riperf3::RiperfError::ServerTerminated
                         | riperf3::RiperfError::ServerErrorRelayed(_)
+                        // #267: the lib emits the populated ctrl-closed doc
+                        // (bare end{}) before returning this class.
+                        | riperf3::RiperfError::ControlSocketClosed
                 )
             });
             // --json-stream wins over -J when combined: iperf3's

--- a/riperf3-cli/tests/daemon.rs
+++ b/riperf3-cli/tests/daemon.rs
@@ -124,3 +124,47 @@ fn daemon_server_serves_a_client() {
     // line above) leaves the reaper armed so it reaps the leaked daemon.
     reaper.pid = None;
 }
+
+/// #262: GT's accept banner carries a per-test counter —
+/// "Server listening on <port> (test #N)" (iperf_server_api.c:137),
+/// N starting at 1 and incrementing for each serve round, so the
+/// re-printed banner between tests shows #2, #3, ...
+#[test]
+fn server_banner_numbers_each_test() {
+    let port = common::free_port();
+    let ps = port.to_string();
+    let mut server = common::ChildGuard(
+        Command::new(env!("CARGO_BIN_EXE_riperf3"))
+            .args(["-s", "-p", &ps])
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::null())
+            .spawn()
+            .expect("spawn server"),
+    );
+
+    for _ in 0..2 {
+        let _ = common::run_client(
+            &["-c", "127.0.0.1", "-p", &ps, "-t", "1"],
+            Duration::from_secs(20),
+            "client",
+        );
+    }
+    let _ = server.0.kill();
+    let mut out = String::new();
+    use std::io::Read;
+    server
+        .0
+        .stdout
+        .take()
+        .expect("piped")
+        .read_to_string(&mut out)
+        .expect("read server stdout");
+    assert!(
+        out.contains(&format!("Server listening on {port} (test #1)")),
+        "first banner numbered #1 (GT shape): {out}"
+    );
+    assert!(
+        out.contains(&format!("Server listening on {port} (test #2)")),
+        "the re-printed banner increments to #2: {out}"
+    );
+}

--- a/riperf3-cli/tests/daemon.rs
+++ b/riperf3-cli/tests/daemon.rs
@@ -168,3 +168,65 @@ fn server_banner_numbers_each_test() {
         "the re-printed banner increments to #2: {out}"
     );
 }
+
+/// #262 r1 F3: idle-timeout expiries are GT's silent rc==2 restart
+/// (iperf_server_api.c:133-135) — no banner re-print, no counter increment,
+/// no stderr line. A client arriving after idle rounds is still test #1,
+/// and the post-test re-print says #2.
+#[test]
+fn idle_restarts_do_not_advance_the_banner_counter() {
+    let port = common::free_port();
+    let ps = port.to_string();
+    let mut server = common::ChildGuard(
+        Command::new(env!("CARGO_BIN_EXE_riperf3"))
+            .args(["-s", "-p", &ps, "--idle-timeout", "1"])
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .spawn()
+            .expect("spawn server"),
+    );
+
+    // Sit through at least two idle expiries.
+    std::thread::sleep(Duration::from_millis(2600));
+    let _ = common::run_client(
+        &["-c", "127.0.0.1", "-p", &ps, "-t", "1"],
+        Duration::from_secs(20),
+        "client",
+    );
+    let _ = server.0.kill();
+    let mut out = String::new();
+    let mut err = String::new();
+    use std::io::Read;
+    server
+        .0
+        .stdout
+        .take()
+        .expect("piped")
+        .read_to_string(&mut out)
+        .expect("read");
+    server
+        .0
+        .stderr
+        .take()
+        .expect("piped")
+        .read_to_string(&mut err)
+        .expect("read");
+
+    assert!(
+        out.contains(&format!("Server listening on {port} (test #1)")),
+        "the post-idle test is STILL #1: {out}"
+    );
+    assert!(
+        !out.contains("(test #3)") && !out.contains("(test #4)"),
+        "idle rounds must not advance the counter: {out}"
+    );
+    assert_eq!(
+        out.matches("Server listening").count(),
+        2,
+        "banners: the initial one + the post-test re-print, none per idle round: {out}"
+    );
+    assert!(
+        !err.contains("idle timeout"),
+        "GT's idle restart is silent on stderr: {err}"
+    );
+}

--- a/riperf3-cli/tests/daemon.rs
+++ b/riperf3-cli/tests/daemon.rs
@@ -186,6 +186,21 @@ fn idle_restarts_do_not_advance_the_banner_counter() {
             .expect("spawn server"),
     );
 
+    // Accumulate stdout on a reader thread: the post-test banner re-print
+    // happens AFTER the client exits (the server still has to finish the
+    // round), so a kill right after run_client races it (review r2 f1).
+    let out_buf = std::sync::Arc::new(std::sync::Mutex::new(String::new()));
+    let reader = {
+        let buf = std::sync::Arc::clone(&out_buf);
+        let mut stdout = server.0.stdout.take().expect("piped");
+        std::thread::spawn(move || {
+            use std::io::Read;
+            let mut s = String::new();
+            stdout.read_to_string(&mut s).expect("read");
+            buf.lock().unwrap().push_str(&s);
+        })
+    };
+
     // Sit through at least two idle expiries.
     std::thread::sleep(Duration::from_millis(2600));
     let _ = common::run_client(
@@ -193,17 +208,20 @@ fn idle_restarts_do_not_advance_the_banner_counter() {
         Duration::from_secs(20),
         "client",
     );
+    // Bounded-wait for the post-test re-print before killing: exactly two
+    // banners is the pass state, so waiting for the second can't mask the
+    // idle-rounds-print bug (that overshoots to 3+ and still fails below).
+    let deadline = Instant::now() + Duration::from_secs(10);
+    while out_buf.lock().unwrap().matches("Server listening").count() < 2
+        && Instant::now() < deadline
+    {
+        std::thread::sleep(Duration::from_millis(50));
+    }
     let _ = server.0.kill();
-    let mut out = String::new();
+    reader.join().expect("reader thread");
+    let out = out_buf.lock().unwrap().clone();
     let mut err = String::new();
     use std::io::Read;
-    server
-        .0
-        .stdout
-        .take()
-        .expect("piped")
-        .read_to_string(&mut out)
-        .expect("read");
     server
         .0
         .stderr

--- a/riperf3-cli/tests/end_conditions.rs
+++ b/riperf3-cli/tests/end_conditions.rs
@@ -32,8 +32,14 @@ fn conflicting_end_conditions_exit_before_side_effects() {
     );
     let stderr = String::from_utf8_lossy(&out.stderr);
     assert!(
-        stderr.contains("only one test end condition (-t, -n, -k) may be specified"),
-        "stderr must carry iperf3's IEENDCONDITIONS text, got: {stderr}"
+        stderr.contains(
+            "parameter error - only one test end condition (-t, -n, -k) may be specified"
+        ),
+        "stderr must carry GT's parameter-error IEENDCONDITIONS shape (#270), got: {stderr}"
+    );
+    assert!(
+        stderr.contains("Usage:") && stderr.contains("--help"),
+        "the usage trailer rides the parameter-error class (#270): {stderr}"
     );
     assert!(
         !pidfile.exists(),

--- a/riperf3-cli/tests/error_format.rs
+++ b/riperf3-cli/tests/error_format.rs
@@ -190,8 +190,12 @@ fn parse_class_errors_stay_on_stderr_even_with_json() {
     );
     let stderr = String::from_utf8_lossy(&out.stderr);
     assert!(
-        stderr.contains("riperf3: error - ") && stderr.contains("client only"),
-        "the #65 rejection stays plain text on stderr: {stderr:?}"
+        stderr.contains("riperf3: parameter error - ") && stderr.contains("client only"),
+        "the #65 rejection uses GT's parameter-error wording (#270): {stderr:?}"
+    );
+    assert!(
+        stderr.contains("Usage:") && stderr.contains("--help"),
+        "the usage trailer rides the parameter-error class (#270): {stderr:?}"
     );
 }
 

--- a/riperf3-cli/tests/signal_terminate.rs
+++ b/riperf3-cli/tests/signal_terminate.rs
@@ -588,3 +588,63 @@ fn post_exchange_interrupt_dump_keeps_the_peer_halves() {
          (GT merges exchanged data before its sigend dump): {doc}"
     );
 }
+
+/// #267: an abruptly-lost control connection (server SIGKILLed mid-test) is
+/// GT's IECTRLCLOSE class — text prints exactly
+/// `error - control socket has closed unexpectedly` (no summary block), and
+/// the `-J` doc is the POPULATED-so-far document: full start (the test
+/// reached TestStart), collected intervals, and a bare `end: {}` (GT's
+/// errexit never fills json_end) — live-captured on the issue.
+#[test]
+fn killed_server_takes_gt_ctrl_closed_shape() {
+    // --- text mode ---
+    let port = free_port();
+    let ps = port.to_string();
+    let server = spawn(&["-s", "-1", "-p", &ps]);
+    std::thread::sleep(Duration::from_millis(300));
+    let client = spawn(&["-c", "127.0.0.1", "-p", &ps, "-t", "5"]);
+    std::thread::sleep(Duration::from_millis(1500));
+    unsafe { libc::kill(server.0.id() as i32, libc::SIGKILL) };
+    let (_, cerr, ccode) = wait_with_output_bounded(client, Duration::from_secs(10), "text client");
+    assert_eq!(ccode, 1, "GT exits 1 on IECTRLCLOSE");
+    assert!(
+        cerr.contains("error - control socket has closed unexpectedly"),
+        "GT's IECTRLCLOSE wording (#267): {cerr}"
+    );
+    assert!(
+        !cerr.contains("peer disconnected"),
+        "the old wording is gone: {cerr}"
+    );
+
+    // --- -J mode ---
+    let port = free_port();
+    let ps = port.to_string();
+    let server = spawn(&["-s", "-1", "-p", &ps]);
+    std::thread::sleep(Duration::from_millis(300));
+    let client = spawn(&["-c", "127.0.0.1", "-p", &ps, "-t", "5", "-J"]);
+    std::thread::sleep(Duration::from_millis(1500));
+    unsafe { libc::kill(server.0.id() as i32, libc::SIGKILL) };
+    let (cout, _cerr, ccode) =
+        wait_with_output_bounded(client, Duration::from_secs(10), "-J client");
+    assert_eq!(ccode, 1);
+    let doc: serde_json::Value =
+        serde_json::from_str(cout.trim()).unwrap_or_else(|e| panic!("one -J doc ({e}): {cout}"));
+    assert!(
+        doc["start"]["test_start"].is_object(),
+        "the populated start survives (GT errexit keeps json_top): {doc}"
+    );
+    assert!(
+        !doc["intervals"].as_array().unwrap().is_empty(),
+        "collected intervals survive: {doc}"
+    );
+    assert_eq!(
+        doc["end"].as_object().map(serde_json::Map::len),
+        Some(0),
+        "the errexit end is GT's bare `end: {{}}`: {doc}"
+    );
+    assert_eq!(
+        doc["error"].as_str(),
+        Some("control socket has closed unexpectedly"),
+        "{doc}"
+    );
+}

--- a/riperf3-cli/tests/signal_terminate.rs
+++ b/riperf3-cli/tests/signal_terminate.rs
@@ -648,3 +648,57 @@ fn killed_server_takes_gt_ctrl_closed_shape() {
         "{doc}"
     );
 }
+
+/// #267 r1 F1: the PRE-DATA window (server vanishes with a clean FIN after
+/// the param exchange, before TestStart) — GT emits exactly ONE -J doc:
+/// Connected-stage start (on_connect metadata, no test_start), bare end{},
+/// the IECTRLCLOSE error. A second skeleton doc (the CLI re-render) is the
+/// #225 violation this pin holds shut.
+#[test]
+fn predata_ctrl_close_emits_one_staged_doc() {
+    use std::io::Write;
+
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind mock");
+    let port = listener.local_addr().unwrap().port().to_string();
+    let _mock = std::thread::spawn(move || {
+        if let Ok((mut s, _)) = listener.accept() {
+            let mut cookie = [0u8; 37];
+            let _ = s.read_exact(&mut cookie);
+            let _ = s.write_all(&[9u8]); // ParamExchange
+            let mut len = [0u8; 4];
+            if s.read_exact(&mut len).is_ok() {
+                let n = u32::from_be_bytes(len) as usize;
+                let mut params = vec![0u8; n];
+                let _ = s.read_exact(&mut params);
+            }
+            // clean FIN: drop the socket
+        }
+    });
+
+    let client = spawn(&["-c", "127.0.0.1", "-p", &port, "-t", "5", "-J"]);
+    let (cout, _cerr, ccode) =
+        wait_with_output_bounded(client, Duration::from_secs(10), "-J pre-data FIN");
+    assert_eq!(ccode, 1);
+    let doc: serde_json::Value = serde_json::from_str(cout.trim()).unwrap_or_else(|e| {
+        panic!("exactly ONE -J doc (r1 F1: the CLI must not re-render) ({e}): {cout}")
+    });
+    let start = doc["start"].as_object().expect("start object");
+    assert!(
+        start.contains_key("cookie") && start.contains_key("timestamp"),
+        "Connected-stage start (on_connect metadata): {doc}"
+    );
+    assert!(
+        !start.contains_key("test_start"),
+        "pre-TestStart: no late fields: {doc}"
+    );
+    assert_eq!(
+        doc["end"].as_object().map(serde_json::Map::len),
+        Some(0),
+        "bare end: {doc}"
+    );
+    assert_eq!(
+        doc["error"].as_str(),
+        Some("control socket has closed unexpectedly"),
+        "{doc}"
+    );
+}

--- a/riperf3-test-support/src/lib.rs
+++ b/riperf3-test-support/src/lib.rs
@@ -143,7 +143,10 @@ fn reset_tokens(s: &str) -> bool {
     s.contains("ConnectionReset")
         || s.contains("Connection reset")
         || s.contains("(os error 10054)")
+        // #267: the clean-EOF class now renders GT's IECTRLCLOSE wording;
+        // the old token stays for mixed-version transcripts.
         || s.contains("peer disconnected")
+        || s.contains("control socket has closed unexpectedly")
 }
 
 /// Is every stdout line a SETUP-phase text line (#222's unconditional
@@ -356,7 +359,9 @@ mod tests {
             "riperf3: error - Connection reset by peer (os error 104)",
             "riperf3: error - Connection reset by peer (os error 54)",
             // FreeBSD's FIN-before-RST ordering: the clean-EOF rendering
-            "riperf3: error - peer disconnected",
+            // (#267 renamed the class to GT's IECTRLCLOSE wording; the old
+            // token is kept in the matcher for mixed-version transcripts).
+            "riperf3: error - control socket has closed unexpectedly",
             // Windows WSAECONNRESET: no "reset"-cased substring at all
             "riperf3: error - An existing connection was forcibly closed by \
              the remote host. (os error 10054)",

--- a/riperf3/src/client.rs
+++ b/riperf3/src/client.rs
@@ -905,7 +905,11 @@ impl Client {
         if self.json_output || self.json_stream {
             self.emit_results(ctx, None, true, ctx.measured_secs, Some(&e.to_string()));
         }
-        e
+        // r1 F1: GT folds every abrupt control loss into IECTRLCLOSE —
+        // returning the ONE variant keeps the CLI's #225 single-doc
+        // suppress-list exact (PeerDisconnected shares the Display text but
+        // not the suppress-list entry).
+        RiperfError::ControlSocketClosed
     }
 
     fn on_unexpected_state(&self, ctx: &RunCtx, other: TestState) {

--- a/riperf3/src/client.rs
+++ b/riperf3/src/client.rs
@@ -377,7 +377,17 @@ impl Client {
             // the run_test arm. recv_state is a single 1-byte read, so the
             // select is cancel-safe.
             let state = tokio::select! {
-                s = protocol::recv_state(&mut ctx.ctrl) => s?,
+                s = protocol::recv_state(&mut ctx.ctrl) => match s {
+                    Ok(state) => state,
+                    // #267: a CLEAN close (EOF) is GT's IECTRLCLOSE — dump
+                    // the populated doc. Io-class failures (e.g. a pre-data
+                    // RST, the #195 retry surface) keep their own classes
+                    // and propagate bare, as before.
+                    Err(e @ (RiperfError::PeerDisconnected | RiperfError::ControlSocketClosed)) => {
+                        return Err(self.on_ctrl_lost(&ctx, e))
+                    }
+                    Err(e) => return Err(e),
+                },
                 msg = wait_interrupt(ctx.interrupt.as_mut()) => {
                     return Ok(self.on_interrupted_wait(&mut ctx, &msg).await);
                 }
@@ -768,7 +778,7 @@ impl Client {
     }
 
     async fn on_test_running(&self, ctx: &mut RunCtx) -> Result<StepFlow> {
-        let (secs, event) = self
+        let (secs, event) = match self
             .run_test(
                 &mut ctx.ctrl,
                 &ctx.streams,
@@ -778,7 +788,15 @@ impl Client {
                 ctx.byte_budget.as_ref(),
                 &mut ctx.interrupt,
             )
-            .await?;
+            .await
+        {
+            Ok(v) => v,
+            // #267: run_test surfaces a mid-test control-socket loss as
+            // ControlSocketClosed (IECTRLCLOSE) — GT's errexit emits the
+            // populated doc with a bare end{} on the JSON sinks.
+            Err(e @ RiperfError::ControlSocketClosed) => return Err(self.on_ctrl_lost(ctx, e)),
+            Err(e) => return Err(e),
+        };
         ctx.measured_secs = secs;
         match event {
             Some(ControlEvent::Terminated) => {
@@ -875,6 +893,19 @@ impl Client {
             Some("the server has terminated"),
         );
         RiperfError::ServerTerminated
+    }
+
+    /// #267: the control connection was lost abruptly (GT's IECTRLCLOSE
+    /// class — live captures on the issue). GT's errexit emits the
+    /// populated-so-far document on the JSON sinks: full start, collected
+    /// intervals, and a bare `end: {}` (json_end never filled). Text mode
+    /// dumps nothing — the CLI prints the one stderr line from the returned
+    /// error. The dump reuses the #281 machinery: current stage + bare_end.
+    fn on_ctrl_lost(&self, ctx: &RunCtx, e: RiperfError) -> RiperfError {
+        if self.json_output || self.json_stream {
+            self.emit_results(ctx, None, true, ctx.measured_secs, Some(&e.to_string()));
+        }
+        e
     }
 
     fn on_unexpected_state(&self, ctx: &RunCtx, other: TestState) {

--- a/riperf3/src/error.rs
+++ b/riperf3/src/error.rs
@@ -61,7 +61,9 @@ pub enum RiperfError {
     #[error("the client has terminated")]
     ClientTerminated,
 
-    #[error("peer disconnected")]
+    // #267: GT's IECTRLCLOSE wording — the class covers any abrupt loss of
+    // the control connection (iperf_error.c).
+    #[error("control socket has closed unexpectedly")]
     PeerDisconnected,
 
     /// iperf3's SERVER_ERROR relay (#224): the server failed mid-test and

--- a/riperf3/src/error.rs
+++ b/riperf3/src/error.rs
@@ -61,8 +61,8 @@ pub enum RiperfError {
     #[error("the client has terminated")]
     ClientTerminated,
 
-    // #267: GT's IECTRLCLOSE wording — the class covers any abrupt loss of
-    // the control connection (iperf_error.c).
+    /// #267: GT's IECTRLCLOSE wording — the class covers any abrupt loss of
+    /// the control connection (iperf_error.c).
     #[error("control socket has closed unexpectedly")]
     PeerDisconnected,
 

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -359,10 +359,17 @@ impl Server {
 
         let mut interrupt_fired = self.interrupt.clone().map(|w| w.0);
         loop {
+            // #262 r1 F3: an idle-timeout expiry is GT's silent rc==2 restart
+            // (iperf_server_api.c:133-135) — no stderr line, no banner
+            // re-print, no counter increment; the accept simply re-arms.
+            let mut idle_restart = false;
             match self.handle_one_test(&listener).await {
                 // #137: the daemon loop discards each test's Report; library
                 // users who want it call `run_once`.
                 Ok(_) => {}
+                Err(RiperfError::Aborted(msg)) if msg == "idle timeout" => {
+                    idle_restart = true;
+                }
                 Err(RiperfError::PeerDisconnected) => {
                     if self.verbose {
                         vprintln!("Client disconnected.");
@@ -397,20 +404,22 @@ impl Server {
             if self.one_off {
                 break;
             }
-            // #262: the served round is over — the next banner numbers the
-            // upcoming test.
-            server_test_number += 1;
-            if !json {
-                if self.verbose {
-                    vprintln!("riperf3 {}", env!("CARGO_PKG_VERSION"));
-                    vprintln!("{}", crate::utils::system_info());
+            if !idle_restart {
+                // #262: the served round is over — the next banner numbers
+                // the upcoming test.
+                server_test_number += 1;
+                if !json {
+                    if self.verbose {
+                        vprintln!("riperf3 {}", env!("CARGO_PKG_VERSION"));
+                        vprintln!("{}", crate::utils::system_info());
+                    }
+                    Self::banner_line(sep);
+                    Self::banner_line(&format!(
+                        "Server listening on {} (test #{server_test_number})",
+                        self.port
+                    ));
+                    Self::banner_line(sep);
                 }
-                Self::banner_line(sep);
-                Self::banner_line(&format!(
-                    "Server listening on {} (test #{server_test_number})",
-                    self.port
-                ));
-                Self::banner_line(sep);
             }
         }
         Ok(())

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -314,6 +314,10 @@ impl Server {
         // #290: run-scoped console silence, armed FIRST so the listening
         // banner honors it. Construct-only-when-quiet (see the guard doc).
         let _quiet_guard = (!self.emit_output).then(crate::macros::OutputQuietGuard::set);
+        // #262: GT's per-test banner counter (iperf_server_api.c:137's
+        // server_test_number) — #1 on the first listen, incremented for each
+        // serve round so the re-printed banner numbers the UPCOMING test.
+        let mut server_test_number: u64 = 1;
         // Daemonizing (`-s -D`) is a process-level concern handled by the binary
         // *before* the tokio runtime is built — `daemon()` forks, and a fork from
         // inside a multi-threaded runtime would leave the child with no worker
@@ -346,7 +350,10 @@ impl Server {
                 vprintln!("{}", crate::utils::system_info());
             }
             Self::banner_line(sep);
-            Self::banner_line(&format!("Server listening on {}", self.port));
+            Self::banner_line(&format!(
+                "Server listening on {} (test #{server_test_number})",
+                self.port
+            ));
             Self::banner_line(sep);
         }
 
@@ -390,13 +397,19 @@ impl Server {
             if self.one_off {
                 break;
             }
+            // #262: the served round is over — the next banner numbers the
+            // upcoming test.
+            server_test_number += 1;
             if !json {
                 if self.verbose {
                     vprintln!("riperf3 {}", env!("CARGO_PKG_VERSION"));
                     vprintln!("{}", crate::utils::system_info());
                 }
                 Self::banner_line(sep);
-                Self::banner_line(&format!("Server listening on {}", self.port));
+                Self::banner_line(&format!(
+                    "Server listening on {} (test #{server_test_number})",
+                    self.port
+                ));
                 Self::banner_line(sep);
             }
         }

--- a/riperf3/src/utils.rs
+++ b/riperf3/src/utils.rs
@@ -579,7 +579,7 @@ mod error_tests {
         );
         assert_eq!(
             format!("{}", RiperfError::PeerDisconnected),
-            "peer disconnected"
+            "control socket has closed unexpectedly"
         );
         assert!(format!("{}", RiperfError::Aborted("test".into())).contains("test"));
         assert_eq!(


### PR DESCRIPTION
All three GT-probed live (captures on the issues).

#262: the server banner carries GT's per-test counter — "Server
listening on <port> (test #N)" (iperf_server_api.c:137), #1 on first
listen, incremented per serve round for the re-printed banner.

#267: the abrupt control-loss class takes GT's shape end-to-end:
- Display wording for ControlSocketClosed's sibling PeerDisconnected
  becomes "control socket has closed unexpectedly" (IECTRLCLOSE).
- On the JSON sinks the client now emits the POPULATED document —
  full start, collected intervals, bare end{} (GT's errexit never
  fills json_end) — via on_ctrl_lost, reusing the #281 stage +
  bare_end machinery; run_test's mid-test ControlSocketClosed and the
  central select's clean-EOF classes route through it. Io-class
  failures (the #195 pre-data-RST retry surface) propagate bare,
  unchanged. The CLI suppresses its skeleton re-render for the class
  (the #225 single-doc rule).
- Text mode dumps nothing (GT prints only the stderr line).

#270: the parse-error class prints GT's "parameter error - " wording
with the usage trailer (all three classes probed: end-conditions,
client-only, server-only).

TDD red-first throughout: the realigned #65/#140 pins, the numbered-
banner daemon pin, and the SIGKILLed-server text+JSON pins all ran
red against the old behavior first.

TDD red-first throughout; full workspace 658 green; per-PR compat smoke before merge. GT captures on all three issues.

Closes #262. Closes #267. Closes #270.