### PR TITLE
fix(compat): -f flag surface (#263) + GT-exact text row formats (#264)

### DIFF
--- a/riperf3-cli/src/cli.rs
+++ b/riperf3-cli/src/cli.rs
@@ -35,7 +35,7 @@ pub struct Cli {
     #[arg(short, long)]
     pub port: Option<u16>,
 
-    /// Format to report: Kbits, Mbits, Gbits, Tbits
+    /// [kmgtKMGT] format to report: Kbits, Mbits, Gbits, Tbits
     // iperf3 has NO default -f: absent, every figure auto-scales
     // (unit_snprintf 'a'/'A'). The old forced "m" default printed
     // 12120.88 MBytes where iperf3 prints 11.8 GBytes (#221). NB: a ///

--- a/riperf3-cli/src/cli.rs
+++ b/riperf3-cli/src/cli.rs
@@ -1,4 +1,4 @@
-use clap::{ArgGroup, Parser, ValueEnum};
+use clap::{ArgGroup, Parser};
 
 /// iperf3's IEENDCONDITIONS text, verbatim (#140).
 pub const END_CONDITIONS_MSG: &str = "only one test end condition (-t, -n, -k) may be specified";
@@ -43,8 +43,12 @@ pub struct Cli {
     // Case-sensitive like iperf3's [kmgtKMGT] (#241): lowercase = bit-rates,
     // UPPERCASE = byte-rates — ignore_case used to collapse `-f K` into
     // Kbits, silently a different unit.
-    #[arg(short, long, value_enum, value_name = "format")]
-    pub format: Option<Format>,
+    // A plain String, not a ValueEnum (#263): GT parses only `*optarg`, so
+    // `-f kilobits` means `-f k` — validation happens post-parse via
+    // [`parse_format_char`], rejecting with GT's IEBADFORMAT sentence
+    // instead of a clap invalid-value error.
+    #[arg(short, long, value_name = "format")]
+    pub format: Option<String>,
 
     /// Seconds between periodic throughput reports
     #[arg(short, long, value_name = "interval")]
@@ -483,8 +487,8 @@ impl Cli {
 
         // Format (#241): case-sensitive [kmgtKMGT], uppercase = byte-rates;
         // absent → the library's adaptive default ('a'), like iperf3 (#221).
-        if let Some(f) = &self.format {
-            builder = builder.format_char(f.as_char());
+        if let Some(c) = self.format.as_deref().and_then(parse_format_char) {
+            builder = builder.format_char(c);
         }
 
         if let Some(port) = self.port {
@@ -657,8 +661,8 @@ impl Cli {
         // Format (#242): the server-side -f was silently dropped — never
         // wired through the builder, every render site hardcoded adaptive.
         // Same case-sensitive mapping as the client (#241).
-        if let Some(f) = &self.format {
-            builder = builder.format_char(f.as_char());
+        if let Some(c) = self.format.as_deref().and_then(parse_format_char) {
+            builder = builder.format_char(c);
         }
         if let Some(port) = self.port {
             builder = builder.port(Some(port));
@@ -722,48 +726,12 @@ impl Cli {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, ValueEnum)]
-pub enum Format {
-    /// Kbits/sec
-    #[value(name = "k")]
-    Kbits,
-    /// Mbits/sec
-    #[value(name = "m")]
-    Mbits,
-    /// Gbits/sec
-    #[value(name = "g")]
-    Gbits,
-    /// Tbits/sec
-    #[value(name = "t")]
-    Tbits,
-    /// KBytes/sec
-    #[value(name = "K")]
-    KBytes,
-    /// MBytes/sec
-    #[value(name = "M")]
-    MBytes,
-    /// GBytes/sec
-    #[value(name = "G")]
-    GBytes,
-    /// TBytes/sec
-    #[value(name = "T")]
-    TBytes,
-}
-
-impl Format {
-    /// The unit_snprintf-style char the lib's `format_char` expects.
-    fn as_char(&self) -> char {
-        match self {
-            Format::Kbits => 'k',
-            Format::Mbits => 'm',
-            Format::Gbits => 'g',
-            Format::Tbits => 't',
-            Format::KBytes => 'K',
-            Format::MBytes => 'M',
-            Format::GBytes => 'G',
-            Format::TBytes => 'T',
-        }
-    }
+/// #263: GT's `-f` parse (iperf_api.c:1236-1256) reads `*optarg` — the
+/// FIRST character only, so `-f kilobits` is `-f k` — and accepts exactly
+/// [kmgtKMGT]; anything else is IEBADFORMAT. 'B'/'b' stay lib-only in both
+/// tools (GT's getopt rejects them; unit_snprintf supports them).
+pub fn parse_format_char(arg: &str) -> Option<char> {
+    arg.chars().next().filter(|c| "kmgtKMGT".contains(*c))
 }
 
 // ---------------------------------------------------------------------------
@@ -813,31 +781,25 @@ mod cli_tests {
 
         #[test]
         fn test_common_format() {
-            // #241: case is semantic — all 8 of iperf3's [kmgtKMGT], each to
-            // its own variant, on both roles.
-            for (letter, want) in [
-                ("k", Format::Kbits),
-                ("m", Format::Mbits),
-                ("g", Format::Gbits),
-                ("t", Format::Tbits),
-                ("K", Format::KBytes),
-                ("M", Format::MBytes),
-                ("G", Format::GBytes),
-                ("T", Format::TBytes),
-            ] {
+            // #241: case is semantic — all 8 of iperf3's [kmgtKMGT] parse on
+            // both roles; #263: the raw string is kept (GT's *optarg rule
+            // applies at validation, not parse).
+            for letter in ["k", "m", "g", "t", "K", "M", "G", "T"] {
                 let cli = Cli::parse_from(["riperf3", "--server", "--format", letter]);
-                assert_eq!(cli.format, Some(want.clone()), "-f {letter} (server)");
+                assert_eq!(cli.format.as_deref(), Some(letter), "-f {letter} (server)");
                 let cli = Cli::parse_from(["riperf3", "--client", "localhost", "--format", letter]);
-                assert_eq!(cli.format, Some(want), "-f {letter} (client)");
+                assert_eq!(cli.format.as_deref(), Some(letter), "-f {letter} (client)");
             }
         }
 
         #[test]
         fn test_format_chars_match_unit_snprintf() {
-            // The CLI→lib glue: each variant maps to the exact unit_snprintf
-            // char; uppercase survives (the old ignore_case + 4-variant enum
-            // collapsed K to 'k').
-            for (letter, ch) in [
+            // The CLI→lib glue: each accepted letter maps to the exact
+            // unit_snprintf char; uppercase survives (the old ignore_case +
+            // 4-variant enum collapsed K to 'k'). #263: only the FIRST char
+            // counts (GT's *optarg), and non-[kmgtKMGT] leads are rejected —
+            // including lib-only 'b'/'B'.
+            for (arg, ch) in [
                 ("k", 'k'),
                 ("m", 'm'),
                 ("g", 'g'),
@@ -846,9 +808,13 @@ mod cli_tests {
                 ("M", 'M'),
                 ("G", 'G'),
                 ("T", 'T'),
+                ("kilobits", 'k'),
+                ("MBytes", 'M'),
             ] {
-                let cli = Cli::parse_from(["riperf3", "--server", "--format", letter]);
-                assert_eq!(cli.format.unwrap().as_char(), ch, "-f {letter}");
+                assert_eq!(parse_format_char(arg), Some(ch), "-f {arg}");
+            }
+            for bad in ["x", "b", "B", "a", "A", "", "9k"] {
+                assert_eq!(parse_format_char(bad), None, "-f {bad} is IEBADFORMAT");
             }
         }
     }
@@ -1839,8 +1805,11 @@ mod cli_tests {
         #[test]
         fn format_wired() {
             // An explicit `-f g` must propagate (absent -f, the lib default
-            // 'a' stands — #221).
+            // 'a' stands — #221). #263: a full word rides its first char.
             let cli = Cli::parse_from(["riperf3", "-c", "h", "-f", "g"]);
+            let c = build_client_from_cli(&cli);
+            assert_eq!(c, expected_client("h").format_char('g').build().unwrap());
+            let cli = Cli::parse_from(["riperf3", "-c", "h", "-f", "gigabits"]);
             let c = build_client_from_cli(&cli);
             assert_eq!(c, expected_client("h").format_char('g').build().unwrap());
         }

--- a/riperf3-cli/src/main.rs
+++ b/riperf3-cli/src/main.rs
@@ -73,6 +73,14 @@ fn main() -> std::process::ExitCode {
         .is_some_and(|t| !(1..=MAX_TIME_SECS).contains(&t))
     {
         Some("idle timeout parameter is not positive or larger than allowed limit")
+    } else if cli
+        .format
+        .as_deref()
+        .is_some_and(|f| cli::parse_format_char(f).is_none())
+    {
+        // #263: GT's IEBADFORMAT — only the FIRST character of the argument
+        // is inspected (iperf_api.c:1241), and [kmgtKMGT] is the whole set.
+        Some("bad format specifier (valid formats are in the set [kmgtKMGT])")
     } else {
         None
     };
@@ -89,6 +97,15 @@ fn main() -> std::process::ExitCode {
         eprintln!("riperf3: parameter error - {msg}");
         print_usage_trailer();
         return std::process::ExitCode::FAILURE;
+    }
+
+    // #263: GT warns when an explicit -f rides JSON output — end of
+    // iperf_parse_arguments (iperf_api.c:2015-2017), both roles, and
+    // --json-stream sets json_output too (:1281). GT's warning() is a bare
+    // `warning: %s` fprintf to stderr, bypassing every sink (the -J document
+    // and --logfile included).
+    if (cli.json || cli.json_stream) && cli.format.is_some() {
+        eprintln!("warning: Report format (-f) flag ignored with JSON output (-J)");
     }
 
     // The error SINK is chosen by mode, like iperf_errexit (#198): -J puts

--- a/riperf3-cli/tests/error_format.rs
+++ b/riperf3-cli/tests/error_format.rs
@@ -261,3 +261,45 @@ fn duration_range_validations_match_gt() {
         "-t 86400 is legal (0..=86400): {stderr}"
     );
 }
+
+/// #263: GT's -f parse (iperf_api.c:1236-1256) takes `*optarg` — the FIRST
+/// character only — and rejects anything outside [kmgtKMGT] with
+/// IEBADFORMAT's exact sentence. 'b'/'B' are CLI-unreachable in GT too
+/// (lib-only unit_snprintf arms), so riperf3 rejects them identically.
+#[test]
+fn format_specifier_rejections_match_gt() {
+    const WANT: &str =
+        "parameter error - bad format specifier (valid formats are in the set [kmgtKMGT])";
+    for args in [
+        &["-c", "127.0.0.1", "-f", "x"][..],
+        &["-c", "127.0.0.1", "-f", "b"][..],
+        &["-c", "127.0.0.1", "-f", "B"][..],
+        &["-s", "-f", "x"][..],
+    ] {
+        let out = std::process::Command::new(env!("CARGO_BIN_EXE_riperf3"))
+            .args(args)
+            .output()
+            .expect("spawn riperf3");
+        assert_eq!(out.status.code(), Some(1), "{args:?} exits 1 like GT");
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        assert!(
+            stderr.starts_with(&format!("riperf3: {WANT}")),
+            "{args:?}: GT's IEBADFORMAT sentence expected, got: {stderr}"
+        );
+        assert!(
+            stderr.contains("Usage:") && stderr.contains("--help"),
+            "the usage trailer rides parameter errors: {stderr}"
+        );
+    }
+    // First-char parse: `-f kilobits` is `-f k` in GT (*optarg), NOT an
+    // invalid-value rejection. It sails past parsing and fails on connect.
+    let out = std::process::Command::new(env!("CARGO_BIN_EXE_riperf3"))
+        .args(["-c", "127.0.0.1", "-p", "9", "-f", "kilobits"])
+        .output()
+        .expect("spawn riperf3");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        !stderr.contains("parameter error") && stderr.contains("unable to connect"),
+        "-f kilobits parses as -f k (optarg[0]): {stderr}"
+    );
+}

--- a/riperf3-cli/tests/error_format.rs
+++ b/riperf3-cli/tests/error_format.rs
@@ -164,6 +164,14 @@ fn usage_errors_exit_one() {
         .output()
         .unwrap();
     assert_eq!(out.status.code(), Some(0));
+    // #263 r1 n1: dropping the ValueEnum must not cost -f's accepted-charset
+    // discoverability — GT's help names the set: `[kmgtKMGT] format to
+    // report: Kbits, Mbits, Gbits, Tbits`.
+    let help = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        help.contains("[kmgtKMGT] format to report"),
+        "-f help names the accepted charset like GT: {help}"
+    );
     let out = std::process::Command::new(bin)
         .arg("--version")
         .output()

--- a/riperf3-cli/tests/format_flag.rs
+++ b/riperf3-cli/tests/format_flag.rs
@@ -202,3 +202,107 @@ fn client_uppercase_k_is_byte_rate_lowercase_is_bit_rate() {
         );
     }
 }
+
+/// #263: GT parses only `optarg[0]` (iperf_api.c:1241), so a full word is
+/// its first letter — `-f kilobits` renders Kbits/sec rows exactly like
+/// `-f k` (live-verified: GT accepts it and fails later on connect, never
+/// with a format rejection).
+#[test]
+fn full_word_format_parses_as_first_char() {
+    let ps = common::free_port().to_string();
+    let server = spawn_server(&[], &ps);
+    std::thread::sleep(Duration::from_millis(300));
+
+    let client = common::run_client(
+        &[
+            "-c",
+            "127.0.0.1",
+            "-p",
+            &ps,
+            "-t",
+            "1",
+            "-b",
+            "10M",
+            "-f",
+            "kilobits",
+        ],
+        Duration::from_secs(30),
+        "client -f kilobits",
+    );
+    let _ = collect(server, "server");
+
+    assert_eq!(client.status.code(), Some(0), "{}", client.stderr);
+    assert!(
+        client.stdout.contains(" Kbits/sec"),
+        "-f kilobits is -f k: {out}",
+        out = client.stdout
+    );
+}
+
+/// #263: GT warns `warning: Report format (-f) flag ignored with JSON
+/// output (-J)` on STDERR when -J rides with an explicit -f
+/// (iperf_api.c:2016, warning() prints bare `warning: %s` — no program
+/// prefix). The JSON document still lands on stdout. --json-stream sets
+/// json_output too (iperf_api.c:1281), so it warns identically. Text mode
+/// never warns.
+#[test]
+fn json_with_format_warns_on_stderr() {
+    const WARNING: &str = "warning: Report format (-f) flag ignored with JSON output (-J)";
+    let bin = env!("CARGO_BIN_EXE_riperf3");
+
+    // -J client (connect-refused, so the run is short and errors).
+    let out = Command::new(bin)
+        .args(["-c", "127.0.0.1", "-p", "1", "-J", "-f", "k"])
+        .output()
+        .unwrap();
+    assert_eq!(out.status.code(), Some(1));
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert_eq!(
+        stderr.trim(),
+        WARNING,
+        "the warning is stderr's ONLY line under -J (errors go in the doc)"
+    );
+    let doc: serde_json::Value =
+        serde_json::from_str(String::from_utf8_lossy(&out.stdout).trim())
+            .expect("stdout still carries the JSON document");
+    assert!(doc["error"].as_str().is_some());
+
+    // --json-stream implies json_output in GT, so it warns the same way.
+    let out = Command::new(bin)
+        .args(["-c", "127.0.0.1", "-p", "1", "--json-stream", "-f", "m"])
+        .output()
+        .unwrap();
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert_eq!(stderr.trim(), WARNING, "--json-stream + -f warns too");
+
+    // Text mode: no warning (unit_format simply applies).
+    let out = Command::new(bin)
+        .args(["-c", "127.0.0.1", "-p", "1", "-f", "k"])
+        .output()
+        .unwrap();
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        !stderr.contains("warning"),
+        "no warning without JSON output: {stderr}"
+    );
+
+    // The server role warns at startup too (GT's check is role-agnostic,
+    // end of iperf_parse_arguments).
+    let ps = common::free_port().to_string();
+    let mut server = spawn_server(&["-J", "-f", "k"], &ps);
+    std::thread::sleep(Duration::from_millis(400));
+    let _ = server.0.kill();
+    let mut err = String::new();
+    use std::io::Read;
+    server
+        .0
+        .stderr
+        .take()
+        .expect("piped")
+        .read_to_string(&mut err)
+        .expect("read server stderr");
+    assert!(
+        err.contains(WARNING),
+        "server -J -f warns at startup: {err:?}"
+    );
+}

--- a/riperf3-cli/tests/format_flag.rs
+++ b/riperf3-cli/tests/format_flag.rs
@@ -262,9 +262,8 @@ fn json_with_format_warns_on_stderr() {
         WARNING,
         "the warning is stderr's ONLY line under -J (errors go in the doc)"
     );
-    let doc: serde_json::Value =
-        serde_json::from_str(String::from_utf8_lossy(&out.stdout).trim())
-            .expect("stdout still carries the JSON document");
+    let doc: serde_json::Value = serde_json::from_str(String::from_utf8_lossy(&out.stdout).trim())
+        .expect("stdout still carries the JSON document");
     assert!(doc["error"].as_str().is_some());
 
     // --json-stream implies json_output in GT, so it warns the same way.

--- a/riperf3-cli/tests/udp_demux.rs
+++ b/riperf3-cli/tests/udp_demux.rs
@@ -191,20 +191,11 @@ fn demux_server_connected_block_maps_streams_to_client_ports() {
     let mut server = ChildGuard(server);
 
     // Drain the server's stdout from a reader thread, NOT after exit: the
-    // doc for a bidir -P 2 UDP run exceeds FreeBSD's 16 KiB pipe buffer, so
-    // a wait-for-exit-then-read sequence deadlocks — the server blocks in
-    // write(2) on the full pipe (procstat: pipe_direct_write) while the
-    // test waits for it to exit (#305 r0: deterministic FreeBSD-CI hang;
-    // Linux's 64 KiB pipes masked it locally).
-    let sdoc_reader = {
-        let mut stdout = server.0.stdout.take().expect("piped server stdout");
-        std::thread::spawn(move || {
-            use std::io::Read;
-            let mut s = String::new();
-            let _ = stdout.read_to_string(&mut s);
-            s
-        })
-    };
+    // bidir -P 2 doc is a single >= 8 KiB write, which FreeBSD's
+    // pipe_direct_write blocks until read — wait-for-exit-then-read
+    // deadlocked FreeBSD CI (#305; see drain_reader's doc for the class).
+    let sdoc_reader =
+        riperf3_test_support::drain_reader(server.0.stdout.take().expect("piped server stdout"));
 
     let retry_deadline = Instant::now() + Duration::from_secs(10);
     let out = loop {

--- a/riperf3-cli/tests/udp_demux.rs
+++ b/riperf3-cli/tests/udp_demux.rs
@@ -181,11 +181,15 @@ fn demux_server_connected_block_maps_streams_to_client_ports() {
     let port = free_port();
     let port_s = port.to_string();
 
+    // TEMP DEBUG (#305 FreeBSD hang): capture server stderr to a file so a
+    // hung-but-panicked server is visible on timeout. Reverted before merge.
+    let errfile =
+        std::env::temp_dir().join(format!("riperf3-demux-dbg-{}.err", std::process::id()));
     let server = Command::new(bin)
         .args(["-s", "-1", "-p", &port_s, "-J"])
         .env("RIPERF3_UDP_SERVER_DEMUX", "1")
         .stdout(Stdio::piped())
-        .stderr(Stdio::null())
+        .stderr(std::fs::File::create(&errfile).expect("errfile"))
         .spawn()
         .expect("spawn server");
     let mut server = ChildGuard(server);
@@ -229,6 +233,28 @@ fn demux_server_connected_block_maps_streams_to_client_ports() {
     // Server exits after the one test (-1); read its whole doc.
     let deadline = Instant::now() + Duration::from_secs(10);
     while server.0.try_wait().expect("try_wait").is_none() {
+        // TEMP DEBUG (#305 FreeBSD hang): on timeout, dump the hung server's
+        // kernel/user stacks and its captured stderr before failing.
+        if Instant::now() >= deadline {
+            let pid = server.0.id().to_string();
+            for cmd in [
+                &["procstat", "-kk", &pid][..],
+                &["ps", "-o", "pid,state,wchan,command", "-p", &pid][..],
+            ] {
+                if let Ok(o) = Command::new(cmd[0]).args(&cmd[1..]).output() {
+                    eprintln!(
+                        "--- {:?} ---\n{}{}",
+                        cmd,
+                        String::from_utf8_lossy(&o.stdout),
+                        String::from_utf8_lossy(&o.stderr)
+                    );
+                }
+            }
+            eprintln!(
+                "--- server stderr ---\n{}",
+                std::fs::read_to_string(&errfile).unwrap_or_default()
+            );
+        }
         assert!(Instant::now() < deadline, "server did not exit");
         std::thread::sleep(Duration::from_millis(50));
     }

--- a/riperf3-cli/tests/udp_demux.rs
+++ b/riperf3-cli/tests/udp_demux.rs
@@ -181,18 +181,30 @@ fn demux_server_connected_block_maps_streams_to_client_ports() {
     let port = free_port();
     let port_s = port.to_string();
 
-    // TEMP DEBUG (#305 FreeBSD hang): capture server stderr to a file so a
-    // hung-but-panicked server is visible on timeout. Reverted before merge.
-    let errfile =
-        std::env::temp_dir().join(format!("riperf3-demux-dbg-{}.err", std::process::id()));
     let server = Command::new(bin)
         .args(["-s", "-1", "-p", &port_s, "-J"])
         .env("RIPERF3_UDP_SERVER_DEMUX", "1")
         .stdout(Stdio::piped())
-        .stderr(std::fs::File::create(&errfile).expect("errfile"))
+        .stderr(Stdio::null())
         .spawn()
         .expect("spawn server");
     let mut server = ChildGuard(server);
+
+    // Drain the server's stdout from a reader thread, NOT after exit: the
+    // doc for a bidir -P 2 UDP run exceeds FreeBSD's 16 KiB pipe buffer, so
+    // a wait-for-exit-then-read sequence deadlocks — the server blocks in
+    // write(2) on the full pipe (procstat: pipe_direct_write) while the
+    // test waits for it to exit (#305 r0: deterministic FreeBSD-CI hang;
+    // Linux's 64 KiB pipes masked it locally).
+    let sdoc_reader = {
+        let mut stdout = server.0.stdout.take().expect("piped server stdout");
+        std::thread::spawn(move || {
+            use std::io::Read;
+            let mut s = String::new();
+            let _ = stdout.read_to_string(&mut s);
+            s
+        })
+    };
 
     let retry_deadline = Instant::now() + Duration::from_secs(10);
     let out = loop {
@@ -230,43 +242,14 @@ fn demux_server_connected_block_maps_streams_to_client_ports() {
         break String::from_utf8_lossy(&client.stdout).into_owned();
     };
 
-    // Server exits after the one test (-1); read its whole doc.
+    // Server exits after the one test (-1); the reader thread hits EOF as it
+    // does and hands back the whole doc.
     let deadline = Instant::now() + Duration::from_secs(10);
     while server.0.try_wait().expect("try_wait").is_none() {
-        // TEMP DEBUG (#305 FreeBSD hang): on timeout, dump the hung server's
-        // kernel/user stacks and its captured stderr before failing.
-        if Instant::now() >= deadline {
-            let pid = server.0.id().to_string();
-            for cmd in [
-                &["procstat", "-kk", &pid][..],
-                &["ps", "-o", "pid,state,wchan,command", "-p", &pid][..],
-            ] {
-                if let Ok(o) = Command::new(cmd[0]).args(&cmd[1..]).output() {
-                    eprintln!(
-                        "--- {:?} ---\n{}{}",
-                        cmd,
-                        String::from_utf8_lossy(&o.stdout),
-                        String::from_utf8_lossy(&o.stderr)
-                    );
-                }
-            }
-            eprintln!(
-                "--- server stderr ---\n{}",
-                std::fs::read_to_string(&errfile).unwrap_or_default()
-            );
-        }
         assert!(Instant::now() < deadline, "server did not exit");
         std::thread::sleep(Duration::from_millis(50));
     }
-    let mut sdoc = String::new();
-    use std::io::Read;
-    server
-        .0
-        .stdout
-        .take()
-        .expect("piped")
-        .read_to_string(&mut sdoc)
-        .expect("read server doc");
+    let sdoc = sdoc_reader.join().expect("server stdout reader");
 
     let cv: Value = serde_json::from_str(&out).expect("client doc parses");
     let sv: Value = serde_json::from_str(&sdoc).expect("server doc parses");

--- a/riperf3-test-support/src/lib.rs
+++ b/riperf3-test-support/src/lib.rs
@@ -193,6 +193,25 @@ fn json_output_is_setup_only(stdout: &str) -> bool {
     stdout.contains("{\"event\":") && !stdout.contains("{\"event\":\"interval\"")
 }
 
+/// Drain a piped child stream on a reader thread, returning the collected
+/// text at `join()`. Start this at SPAWN time, never after waiting for the
+/// child: FreeBSD routes any single unread pipe write(2) of >= 8 KiB
+/// (PIPE_MINDIRECT) through `pipe_direct_write`, which sleeps until the
+/// reader consumes it — and Rust's stdout `LineWriter` flushes a multi-line
+/// `println!` (a whole pretty-printed -J document) as ONE write. A
+/// wait-for-exit-then-read sequence therefore deadlocks the moment the doc
+/// crosses 8 KiB (#305: deterministic FreeBSD-CI hangs; Linux's 64 KiB
+/// buffered pipes masked it locally). Concurrent draining is what
+/// `Command::output()` does; this is the primitive for harnesses that need
+/// a deadline around `try_wait` as well.
+pub fn drain_reader<R: Read + Send + 'static>(mut pipe: R) -> std::thread::JoinHandle<String> {
+    std::thread::spawn(move || {
+        let mut s = String::new();
+        let _ = pipe.read_to_string(&mut s);
+        s
+    })
+}
+
 /// Run a riperf3 CLI binary to completion with a hard timeout, retrying while
 /// the run is REFUSED for up to a bounded retry window. This replaces fixed
 /// server-bind sleeps: on loaded CI runners the (debug, cold) server can take
@@ -219,6 +238,9 @@ pub fn run_client_with(bin: &str, args: &[&str], timeout: Duration, who: &str) -
             .spawn()
             .unwrap_or_else(|e| panic!("{who}: spawn failed: {e}"));
 
+        let out_reader = drain_reader(child.stdout.take().expect("piped stdout"));
+        let err_reader = drain_reader(child.stderr.take().expect("piped stderr"));
+
         let deadline = Instant::now() + timeout;
         let status = loop {
             match child.try_wait().expect("try_wait") {
@@ -226,16 +248,10 @@ pub fn run_client_with(bin: &str, args: &[&str], timeout: Duration, who: &str) -
                 None if Instant::now() >= deadline => {
                     let _ = child.kill();
                     let _ = child.wait();
-                    // Post-kill the pipes are EOF — drain what the child got
-                    // out before dying, for the panic message.
-                    let mut out = String::new();
-                    let mut err = String::new();
-                    if let Some(mut s) = child.stdout.take() {
-                        let _ = s.read_to_string(&mut out);
-                    }
-                    if let Some(mut s) = child.stderr.take() {
-                        let _ = s.read_to_string(&mut err);
-                    }
+                    // The kill EOFs the pipes; the readers hand back what the
+                    // child got out before dying, for the panic message.
+                    let out = out_reader.join().unwrap_or_default();
+                    let err = err_reader.join().unwrap_or_default();
                     panic!("{who}: timed out; stdout so far: {out}; stderr so far: {err}");
                 }
                 None => std::thread::sleep(Duration::from_millis(50)),
@@ -243,20 +259,8 @@ pub fn run_client_with(bin: &str, args: &[&str], timeout: Duration, who: &str) -
         };
         let elapsed = started.elapsed();
 
-        let mut stdout = String::new();
-        child
-            .stdout
-            .take()
-            .unwrap()
-            .read_to_string(&mut stdout)
-            .unwrap();
-        let mut stderr = String::new();
-        child
-            .stderr
-            .take()
-            .unwrap()
-            .read_to_string(&mut stderr)
-            .unwrap();
+        let stdout = out_reader.join().expect("stdout reader");
+        let stderr = err_reader.join().expect("stderr reader");
 
         // #198 moved -J/--json-stream error text into STDOUT (the document /
         // the error event) with stderr empty — scan both sinks for the

--- a/riperf3/src/reporter.rs
+++ b/riperf3/src/reporter.rs
@@ -2772,7 +2772,11 @@ mod interval_reporter_tests {
             "a >=10% empty tail is reported like GT; got {} intervals",
             g.intervals.len()
         );
-        assert_eq!(g.intervals.last().unwrap().sum.bytes, 0, "the tail is the zero row");
+        assert_eq!(
+            g.intervals.last().unwrap().sum.bytes,
+            0,
+            "the tail is the zero row"
+        );
     }
 }
 

--- a/riperf3/src/reporter.rs
+++ b/riperf3/src/reporter.rs
@@ -184,61 +184,65 @@ fn interval_cells(bytes: u64, start: f64, end: f64, format_char: char) -> (Strin
 
 /// Render one interval line (no trailing newline). Pure, so the exact row
 /// bytes are pinnable against live GT captures (#264).
+///
+/// Each branch is a 1:1 port of an iperf_locale.c template — time columns
+/// `%6.2f-%-6.2f`, cells joined by exactly two spaces with NO cell-level
+/// alignment (the figure pad inside unit_snprintf IS the alignment), and
+/// each template's literal tail spacing before the final %s (the omit
+/// marker here; the role word in [`format_summary_line`]).
 pub fn format_interval_line(interval: &StreamInterval, format_char: char) -> String {
     let id = fmt_id_role(interval.stream_id, interval.role_tag);
     let (transfer, rate) =
         interval_cells(interval.bytes, interval.start, interval.end, format_char);
 
-    let omit_tag = if interval.omitted { "(omitted) " } else { "" };
+    // iperf_locale.c:429 — the marker fills the template's final %s bare.
+    let omit_tag = if interval.omitted { "(omitted)" } else { "" };
 
     if let (Some(jitter), Some(lost), Some(total)) =
         (interval.jitter, interval.lost, interval.total_packets)
     {
-        let pct = lost_percent(lost, total);
+        // report_bw_udp_format: `%5.3f ms  %d/%d (%.2g%%)  %s`.
+        let pct = units::g2(lost_percent(lost, total));
         format!(
-            "[{id}] {:5.2}-{:<5.2} sec  {:>10}  {:>12}  {:7.3} ms  {}/{} ({:.2}%)  {}",
+            "[{id}] {:6.2}-{:<6.2} sec  {transfer}  {rate}  {:5.3} ms  {lost}/{total} ({pct}%)  {omit_tag}",
             interval.start,
             interval.end,
-            transfer,
-            rate,
             jitter * 1000.0,
-            lost,
-            total,
-            pct,
-            omit_tag,
         )
     } else if let Some(sent) = interval.sent_packets {
-        // UDP sender row: the sent-datagram count, with the blank jitter/loss
-        // pad ONLY in bidir — iperf3's zbuf is 10 spaces in bidir and empty
-        // otherwise (report_bw_udp_sender_format; #187 review r1 n4).
+        // report_bw_udp_sender_format: `/sec %s %d  %s` — the blank
+        // jitter/loss zbuf is 10 spaces in bidir and empty otherwise
+        // (#187 review r1 n4).
         let pad = if interval.role_tag.is_some() {
             "          " // iperf3's zbuf: exactly 10 spaces
         } else {
             ""
         };
         format!(
-            "[{id}] {:5.2}-{:<5.2} sec  {:>10}  {:>12}  {pad}{sent}  {}",
-            interval.start, interval.end, transfer, rate, omit_tag,
+            "[{id}] {:6.2}-{:<6.2} sec  {transfer}  {rate} {pad} {sent}  {omit_tag}",
+            interval.start, interval.end,
         )
     } else if let (Some(retr), None) = (interval.retransmits, interval.snd_cwnd) {
-        // TCP [SUM] with retransmits: iperf3's report_sum_bw_retrans_format
-        // carries Retr but no Cwnd (a SUM has no single congestion window) —
-        // without this branch the populated Retr fell through to the bare
-        // format and vanished (#143 review r1 n3).
+        // TCP [SUM] with retransmits: report_sum_bw_retrans_format carries
+        // Retr (`%3ld` + THIRTEEN spaces) but no Cwnd (a SUM has no single
+        // congestion window) — without this branch the populated Retr fell
+        // through to the bare format and vanished (#143 review r1 n3).
         format!(
-            "[{id}] {:5.2}-{:<5.2} sec  {:>10}  {:>12}  {:4}            {}",
-            interval.start, interval.end, transfer, rate, retr, omit_tag,
+            "[{id}] {:6.2}-{:<6.2} sec  {transfer}  {rate}  {retr:3}             {omit_tag}",
+            interval.start, interval.end,
         )
     } else if let (Some(retr), Some(cwnd)) = (interval.retransmits, interval.snd_cwnd) {
+        // report_bw_retrans_cwnd_format: `%3ld   %ss       %s`.
         let cwnd_str = units::format_bytes(cwnd as f64, 'A');
         format!(
-            "[{id}] {:5.2}-{:<5.2} sec  {:>10}  {:>12}  {:4}   {:>10}  {}",
-            interval.start, interval.end, transfer, rate, retr, cwnd_str, omit_tag,
+            "[{id}] {:6.2}-{:<6.2} sec  {transfer}  {rate}  {retr:3}   {cwnd_str}       {omit_tag}",
+            interval.start, interval.end,
         )
     } else {
+        // report_bw_format: eighteen spaces before the final %s.
         format!(
-            "[{id}] {:5.2}-{:<5.2} sec  {:>10}  {:>12}  {}",
-            interval.start, interval.end, transfer, rate, omit_tag,
+            "[{id}] {:6.2}-{:<6.2} sec  {transfer}  {rate}                  {omit_tag}",
+            interval.start, interval.end,
         )
     }
 }
@@ -256,6 +260,16 @@ pub fn print_separator() {
     titled(format_args!(
         "- - - - - - - - - - - - - - - - - - - - - - - - -"
     ));
+}
+
+/// GT's final-partial-interval keep rule (iperf_print_intermediate,
+/// iperf_api.c:3853-3880, #264): a run's trailing sub-interval survives iff
+/// it spans at least 10% of the stats interval OR it actually moved bytes —
+/// GT drops only the short empty tail its comment attributes to control
+/// messages queuing behind data. With `-i 0` the threshold is zero, so the
+/// whole-run flush is unconditionally kept.
+fn keep_final_interval(len_secs: f64, interval_secs: f64, residual_bytes: u64) -> bool {
+    len_secs >= interval_secs * 0.10 || residual_bytes > 0
 }
 
 /// UDP loss as a percentage of total datagrams, guarding the zero-total case
@@ -290,28 +304,31 @@ pub fn format_summary_line(summary: &StreamSummary, format_char: char) -> String
     if let (Some(jitter), Some(lost), Some(total)) =
         (summary.jitter, summary.lost, summary.total_packets)
     {
-        let pct = lost_percent(lost, total);
+        // report_bw_udp_format with the role word in the final %s (#264).
+        let pct = units::g2(lost_percent(lost, total));
         format!(
-            "[{id}] {:5.2}-{:<5.2} sec  {:>10}  {:>12}  {:7.3} ms  {}/{} ({:.2}%)  {}",
+            "[{id}] {:6.2}-{:<6.2} sec  {transfer}  {rate}  {:5.3} ms  {lost}/{total} ({pct}%)  {role}",
             summary.start,
             summary.end,
-            transfer,
-            rate,
             jitter * 1000.0,
-            lost,
-            total,
-            pct,
-            role,
         )
     } else if let Some(retr) = summary.retransmits {
+        // Per-stream rows take report_bw_retrans_format (`%3ld` + TWELVE
+        // spaces); [SUM] rows take report_sum_bw_retrans_format (THIRTEEN).
+        let tail = if summary.stream_id < 0 {
+            "             "
+        } else {
+            "            "
+        };
         format!(
-            "[{id}] {:5.2}-{:<5.2} sec  {:>10}  {:>12}  {:4}             {}",
-            summary.start, summary.end, transfer, rate, retr, role,
+            "[{id}] {:6.2}-{:<6.2} sec  {transfer}  {rate}  {retr:3}{tail}{role}",
+            summary.start, summary.end,
         )
     } else {
+        // report_bw_format / report_sum_bw_format: eighteen spaces.
         format!(
-            "[{id}] {:5.2}-{:<5.2} sec  {:>10}  {:>12}                    {}",
-            summary.start, summary.end, transfer, rate, role,
+            "[{id}] {:6.2}-{:<6.2} sec  {transfer}  {rate}                  {role}",
+            summary.start, summary.end,
         )
     }
 }
@@ -1330,12 +1347,13 @@ pub fn spawn_interval_reporter(
                     // final interval `[last_boundary, end_secs]` using the
                     // driver's authoritative end time, then stop.
                     //
-                    // Skip a remainder that is zero-length (the run ended on a
-                    // boundary — the sender driver passes the exact `-t`, so this
-                    // is exact) OR carries no residual bytes (the receiver side:
-                    // the peer has stopped, so its boundary-aligned tail is empty
-                    // even though `end_secs` trails the boundary by the control
-                    // round-trip).
+                    // The keep/skip decision is GT's iperf_print_intermediate
+                    // rule (#264): keep iff the tail spans >= 10% of the stats
+                    // interval or moved bytes. The previous ad-hoc `>1ms AND
+                    // bytes>0` both invented rows GT suppresses and hid the
+                    // long empty tails GT prints. `len > 0.0` guards the
+                    // boundary-aligned end (and any clock inversion) — GT
+                    // can't construct a zero-length gather at all.
                     let last_end = interval_num as f64 * config.interval_secs;
                     let end_secs = reporter_end.end_secs();
                     let residual_bytes: u64 = streams
@@ -1348,7 +1366,9 @@ pub fn spawn_interval_reporter(
                             }
                         })
                         .sum();
-                    if end_secs > last_end + 1e-3 && residual_bytes > 0 {
+                    let len = end_secs - last_end;
+                    if len > 0.0 && keep_final_interval(len, config.interval_secs, residual_bytes)
+                    {
                         // Normal final partial flush; `in_warmup` is only true
                         // here when the run died before the boundary
                         // (error/abort path), tagging the flush omitted.
@@ -1498,6 +1518,239 @@ mod tests {
         };
         // Should print [SUM] instead of a number
         print_interval(&interval, 'm');
+    }
+
+    // ---- #264: byte-exact row pins vs GT's locale templates ----------------
+    //
+    // Every expected string below is derived from iperf_locale.c's format
+    // strings (iperf 3.21 @ d39cf41) and cross-checked against live captures
+    // (2026-07-02, loopback): time columns are `%6.2f-%-6.2f sec`, cells are
+    // unit_snprintf output (figure %4.2f/%4.1f/%4.0f — right-padded to 4)
+    // joined by exactly two spaces with NO cell-level alignment, and each
+    // template carries its own literal tail spacing before the final %s
+    // (omit marker or role word).
+
+    fn tcp_interval(bytes: u64, retr: Option<i64>, cwnd: Option<u64>) -> StreamInterval {
+        StreamInterval {
+            stream_id: 5,
+            start: 0.0,
+            end: 1.0,
+            bytes,
+            retransmits: retr,
+            snd_cwnd: cwnd,
+            jitter: None,
+            lost: None,
+            total_packets: None,
+            sent_packets: None,
+            role_tag: None,
+            omitted: false,
+        }
+    }
+
+    /// report_bw_retrans_cwnd_format: `%3ld` Retr, three spaces, Cwnd cell,
+    /// SEVEN trailing spaces (live: `...  0   1.12 MBytes       $`).
+    #[test]
+    fn interval_row_retr_cwnd_matches_gt_bytes() {
+        let iv = tcp_interval(36 * 1024 * 1024, Some(0), Some(1_174_405));
+        assert_eq!(
+            format_interval_line(&iv, 'a'),
+            "[  5]   0.00-1.00   sec  36.0 MBytes   302 Mbits/sec    0   1.12 MBytes       "
+        );
+    }
+
+    /// report_bw_format: retr-less rows end in EIGHTEEN spaces (the empty
+    /// omit slot keeps the tail — live reverse rows end `...Gbits/sec` + 18sp).
+    #[test]
+    fn interval_row_bare_matches_gt_bytes() {
+        let iv = tcp_interval(1024 * 1024 * 1024, None, None);
+        assert_eq!(
+            format_interval_line(&iv, 'a'),
+            "[  5]   0.00-1.00   sec  1.00 GBytes  8.59 Gbits/sec                  "
+        );
+    }
+
+    /// The omit marker fills the template's final %s — "(omitted)", no
+    /// surrounding spaces of its own (iperf_locale.c:429).
+    #[test]
+    fn interval_row_omitted_marker_in_gt_slot() {
+        let mut iv = tcp_interval(1024 * 1024 * 1024, None, None);
+        iv.omitted = true;
+        assert_eq!(
+            format_interval_line(&iv, 'a'),
+            "[  5]   0.00-1.00   sec  1.00 GBytes  8.59 Gbits/sec                  (omitted)"
+        );
+    }
+
+    /// `%6.2f-%-6.2f`: two-digit seconds eat the pad — ` 10.00-11.00  sec`
+    /// (live p2 row 14: `[  5]  10.00-11.01  sec`).
+    #[test]
+    fn interval_row_time_columns_are_width_six() {
+        let mut iv = tcp_interval(1024 * 1024 * 1024, None, None);
+        iv.start = 10.0;
+        iv.end = 11.0;
+        assert_eq!(
+            format_interval_line(&iv, 'a'),
+            "[  5]  10.00-11.00  sec  1.00 GBytes  8.59 Gbits/sec                  "
+        );
+    }
+
+    fn udp_recv_interval(lost: i64, total: i64) -> StreamInterval {
+        StreamInterval {
+            stream_id: 5,
+            start: 0.0,
+            end: 1.0,
+            bytes: 393_216,
+            retransmits: None,
+            snd_cwnd: None,
+            jitter: Some(0.000_016),
+            lost: Some(lost),
+            total_packets: Some(total),
+            sent_packets: None,
+            role_tag: None,
+            omitted: false,
+        }
+    }
+
+    /// report_bw_udp_format: jitter `%5.3f ms`, loss `(%.2g%%)`, two trailing
+    /// spaces (live: `0.016 ms  0/12 (0%)  `). The zero-loss row prints
+    /// `(0%)`, never `(0.00%)`.
+    #[test]
+    fn udp_interval_row_matches_gt_bytes() {
+        assert_eq!(
+            format_interval_line(&udp_recv_interval(0, 12), 'a'),
+            "[  5]   0.00-1.00   sec   384 KBytes  3.15 Mbits/sec  0.016 ms  0/12 (0%)  "
+        );
+    }
+
+    /// `%.2g` is two SIGNIFICANT digits with C's %g trailing-zero strip and
+    /// e-notation switch: 25 → `25`, 1/12 → `8.3`, full loss → `1e+02`.
+    #[test]
+    fn udp_loss_percent_uses_c_percent_2g() {
+        let row = |lost, total| format_interval_line(&udp_recv_interval(lost, total), 'a');
+        assert!(row(3, 12).contains("3/12 (25%)  "), "{}", row(3, 12));
+        assert!(row(1, 12).contains("1/12 (8.3%)  "), "{}", row(1, 12));
+        assert!(row(12, 12).contains("12/12 (1e+02%)  "), "{}", row(12, 12));
+    }
+
+    /// report_bw_udp_sender_format: `/sec %s %d  ` — empty zbuf outside
+    /// bidir, the sent count, two trailing spaces (live: `1.05 Mbits/sec  4  `).
+    #[test]
+    fn udp_sender_interval_row_matches_gt_bytes() {
+        let iv = StreamInterval {
+            stream_id: 5,
+            start: 0.0,
+            end: 1.0,
+            bytes: 131_072,
+            retransmits: None,
+            snd_cwnd: None,
+            jitter: None,
+            lost: None,
+            total_packets: None,
+            sent_packets: Some(4),
+            role_tag: None,
+            omitted: false,
+        };
+        assert_eq!(
+            format_interval_line(&iv, 'a'),
+            "[  5]   0.00-1.00   sec   128 KBytes  1.05 Mbits/sec  4  "
+        );
+    }
+
+    /// report_sum_bw_retrans_format: [SUM] retr rows pad `%3ld` then
+    /// THIRTEEN spaces (one more than the per-stream twelve).
+    #[test]
+    fn sum_interval_retr_row_matches_gt_bytes() {
+        let mut iv = tcp_interval(1_000_000, Some(3), None);
+        iv.stream_id = -1;
+        assert_eq!(
+            format_interval_line(&iv, 'a'),
+            "[SUM]   0.00-1.00   sec   977 KBytes  8.00 Mbits/sec    3             "
+        );
+    }
+
+    fn tcp_final(id: i32, is_sender: bool, bytes: u64, retr: Option<i64>) -> StreamSummary {
+        StreamSummary {
+            stream_id: id,
+            start: 0.0,
+            end: 3.0,
+            bytes,
+            is_sender,
+            retransmits: retr,
+            jitter: None,
+            lost: None,
+            total_packets: None,
+            role_tag: None,
+        }
+    }
+
+    /// report_bw_retrans_format (per-stream summary): `%3ld` + TWELVE spaces
+    /// + role (live: `...  0            sender$`).
+    #[test]
+    fn summary_sender_retr_row_matches_gt_bytes() {
+        assert_eq!(
+            format_summary_line(&tcp_final(5, true, 108 * 1024 * 1024, Some(0)), 'a'),
+            "[  5]   0.00-3.00   sec   108 MBytes   302 Mbits/sec    0            sender"
+        );
+    }
+
+    /// report_bw_format (receiver summary): EIGHTEEN spaces + role
+    /// (live: `...Mbits/sec                  receiver$`).
+    #[test]
+    fn summary_receiver_row_matches_gt_bytes() {
+        assert_eq!(
+            format_summary_line(&tcp_final(5, false, 108 * 1024 * 1024, None), 'a'),
+            "[  5]   0.00-3.00   sec   108 MBytes   302 Mbits/sec                  receiver"
+        );
+    }
+
+    /// report_sum_bw_retrans_format ([SUM] summary): THIRTEEN spaces after
+    /// the retr cell — one wider than the per-stream row above.
+    #[test]
+    fn sum_summary_retr_row_matches_gt_bytes() {
+        assert_eq!(
+            format_summary_line(&tcp_final(-1, true, 216 * 1024 * 1024, Some(0)), 'a'),
+            "[SUM]   0.00-3.00   sec   216 MBytes   604 Mbits/sec    0             sender"
+        );
+    }
+
+    /// report_bw_udp_format as a summary: `%5.3f ms`, `(%.2g%%)`, role in the
+    /// final slot (live: `0.000 ms  0/12 (0%)  receiver`).
+    #[test]
+    fn udp_summary_row_matches_gt_bytes() {
+        let s = StreamSummary {
+            stream_id: 5,
+            start: 0.0,
+            end: 3.0,
+            bytes: 393_216,
+            is_sender: false,
+            retransmits: None,
+            jitter: Some(0.0),
+            lost: Some(0),
+            total_packets: Some(12),
+            role_tag: None,
+        };
+        assert_eq!(
+            format_summary_line(&s, 'a'),
+            "[  5]   0.00-3.00   sec   384 KBytes  1.05 Mbits/sec  0.000 ms  0/12 (0%)  receiver"
+        );
+    }
+
+    // ---- #264: GT's final-partial-interval keep rule ------------------------
+
+    /// iperf_print_intermediate's rule (iperf_api.c:3853-3880): keep the
+    /// final partial interval iff it spans >= 10% of the stats interval OR
+    /// it moved bytes. Today's ad-hoc `>1ms AND bytes>0` both invents rows
+    /// GT suppresses and hides long empty tails GT prints.
+    #[test]
+    fn final_flush_follows_gt_keep_rule() {
+        // GT's skip case: a sub-10% empty tail (control-lag artifact).
+        assert!(!keep_final_interval(0.004, 1.0, 0));
+        // Bytes force a keep at any length.
+        assert!(keep_final_interval(0.004, 1.0, 4096));
+        // A long EMPTY tail is kept — GT prints the zero row.
+        assert!(keep_final_interval(0.5, 1.0, 0));
+        // -i 0: interval_secs 0 keeps the whole-run flush unconditionally.
+        assert!(keep_final_interval(0.0, 0.0, 0));
     }
 
     // ---- sum_summaries (issue #4: final [SUM] row for -P > 1) ----------------
@@ -2386,12 +2639,13 @@ mod interval_reporter_tests {
         );
     }
 
-    /// #55 receiver-side guard: a receiver whose `end_secs` trails the last
-    /// boundary (the control round-trip that delivers TEST_END) but whose tail
-    /// has no residual bytes (the peer already stopped) must not emit a trailing
-    /// empty interval. Mirrors the server's situation.
+    /// #55/#264 receiver-side guard, GT's shape: a receiver whose `end_secs`
+    /// trails the last boundary by LESS than 10% of the interval (the control
+    /// round-trip that delivers TEST_END) with no residual bytes must not
+    /// emit a trailing empty interval — iperf_print_intermediate's exact
+    /// skip case (iperf_api.c:3853-3880).
     #[tokio::test]
-    async fn no_partial_for_receiver_with_no_residual() {
+    async fn no_partial_for_sub_ten_percent_empty_tail() {
         use crate::reporter::{CollectedIntervals, IntervalStreamRef};
         use crate::stream::StreamCounters;
         use std::sync::Mutex;
@@ -2439,9 +2693,74 @@ mod interval_reporter_tests {
         counters.record_received(1000);
         tokio::time::sleep(Duration::from_millis(650)).await; // tick @0.5 -> [0,0.5]=1000
 
-        // end_secs trails the 0.5 boundary (as TEST_END would), but the tail is
-        // empty — the residual-bytes guard must drop it.
+        // end_secs trails the 0.5 boundary by 0.02s — 4% of the interval,
+        // inside GT's 10% suppression window — and the tail is empty.
         // #159 invariant: done precedes finish (the driver order).
+        done.store(true, Ordering::Relaxed);
+        reporter_end.finish(0.52);
+        let _ = handle.await;
+
+        let g = collector.lock().unwrap();
+        assert_eq!(
+            g.intervals.len(),
+            1,
+            "no trailing empty interval for a sub-10% idle tail; got {} intervals",
+            g.intervals.len()
+        );
+    }
+
+    /// #264, the other half of GT's rule: an empty tail that spans at least
+    /// 10% of the stats interval IS reported — GT prints the zero row (only
+    /// the short control-lag artifact is suppressed). The old ad-hoc guard
+    /// (`bytes > 0` unconditionally) hid these.
+    #[tokio::test]
+    async fn long_empty_tail_is_kept_like_gt() {
+        use crate::reporter::{CollectedIntervals, IntervalStreamRef};
+        use crate::stream::StreamCounters;
+        use std::sync::Mutex;
+        use std::time::Duration;
+
+        let interval = 0.5_f64;
+        let counters = Arc::new(StreamCounters::new());
+        let done = Arc::new(AtomicBool::new(false));
+        let collector = Arc::new(Mutex::new(CollectedIntervals::default()));
+
+        let stream_ref = IntervalStreamRef {
+            id: 1,
+            is_sender: false,
+            counters: counters.clone(),
+            udp_recv_stats: None,
+            raw_fd: None,
+        };
+        let config = IntervalReporterConfig {
+            interval_secs: interval,
+            protocol: TransportProtocol::Tcp,
+            format_char: 'a',
+            omit_secs: 0,
+            forceflush: false,
+            json_stream: false,
+            print: false,
+            blksize: 128 * 1024,
+            keep_intervals: false,
+            bidir: false,
+            is_server: false,
+        };
+        let reporter_end = Arc::new(ReporterEnd::new());
+        let handle = spawn_interval_reporter(
+            config,
+            vec![stream_ref],
+            done.clone(),
+            reporter_end.clone(),
+            Some(collector.clone()),
+            None,
+            None,
+        )
+        .expect("reporter spawns for a positive interval");
+
+        counters.record_received(1000);
+        tokio::time::sleep(Duration::from_millis(650)).await; // tick @0.5 -> [0,0.5]=1000
+
+        // A 0.12s empty tail — 24% of the interval, past GT's 10% line.
         done.store(true, Ordering::Relaxed);
         reporter_end.finish(0.62);
         let _ = handle.await;
@@ -2449,10 +2768,11 @@ mod interval_reporter_tests {
         let g = collector.lock().unwrap();
         assert_eq!(
             g.intervals.len(),
-            1,
-            "no trailing empty interval for an idle receiver tail; got {} intervals",
+            2,
+            "a >=10% empty tail is reported like GT; got {} intervals",
             g.intervals.len()
         );
+        assert_eq!(g.intervals.last().unwrap().sum.bytes, 0, "the tail is the zero row");
     }
 }
 

--- a/riperf3/src/reporter.rs
+++ b/riperf3/src/reporter.rs
@@ -182,8 +182,9 @@ fn interval_cells(bytes: u64, start: f64, end: f64, format_char: char) -> (Strin
     (transfer, units::format_rate(bits_per_sec, format_char))
 }
 
-/// Print one interval line.
-pub fn print_interval(interval: &StreamInterval, format_char: char) {
+/// Render one interval line (no trailing newline). Pure, so the exact row
+/// bytes are pinnable against live GT captures (#264).
+pub fn format_interval_line(interval: &StreamInterval, format_char: char) -> String {
     let id = fmt_id_role(interval.stream_id, interval.role_tag);
     let (transfer, rate) =
         interval_cells(interval.bytes, interval.start, interval.end, format_char);
@@ -194,7 +195,7 @@ pub fn print_interval(interval: &StreamInterval, format_char: char) {
         (interval.jitter, interval.lost, interval.total_packets)
     {
         let pct = lost_percent(lost, total);
-        titled(format_args!(
+        format!(
             "[{id}] {:5.2}-{:<5.2} sec  {:>10}  {:>12}  {:7.3} ms  {}/{} ({:.2}%)  {}",
             interval.start,
             interval.end,
@@ -205,7 +206,7 @@ pub fn print_interval(interval: &StreamInterval, format_char: char) {
             total,
             pct,
             omit_tag,
-        ));
+        )
     } else if let Some(sent) = interval.sent_packets {
         // UDP sender row: the sent-datagram count, with the blank jitter/loss
         // pad ONLY in bidir — iperf3's zbuf is 10 spaces in bidir and empty
@@ -215,31 +216,39 @@ pub fn print_interval(interval: &StreamInterval, format_char: char) {
         } else {
             ""
         };
-        titled(format_args!(
+        format!(
             "[{id}] {:5.2}-{:<5.2} sec  {:>10}  {:>12}  {pad}{sent}  {}",
             interval.start, interval.end, transfer, rate, omit_tag,
-        ));
+        )
     } else if let (Some(retr), None) = (interval.retransmits, interval.snd_cwnd) {
         // TCP [SUM] with retransmits: iperf3's report_sum_bw_retrans_format
         // carries Retr but no Cwnd (a SUM has no single congestion window) —
         // without this branch the populated Retr fell through to the bare
         // format and vanished (#143 review r1 n3).
-        titled(format_args!(
+        format!(
             "[{id}] {:5.2}-{:<5.2} sec  {:>10}  {:>12}  {:4}            {}",
             interval.start, interval.end, transfer, rate, retr, omit_tag,
-        ));
+        )
     } else if let (Some(retr), Some(cwnd)) = (interval.retransmits, interval.snd_cwnd) {
         let cwnd_str = units::format_bytes(cwnd as f64, 'A');
-        titled(format_args!(
+        format!(
             "[{id}] {:5.2}-{:<5.2} sec  {:>10}  {:>12}  {:4}   {:>10}  {}",
             interval.start, interval.end, transfer, rate, retr, cwnd_str, omit_tag,
-        ));
+        )
     } else {
-        titled(format_args!(
+        format!(
             "[{id}] {:5.2}-{:<5.2} sec  {:>10}  {:>12}  {}",
             interval.start, interval.end, transfer, rate, omit_tag,
-        ));
+        )
     }
+}
+
+/// Print one interval line.
+pub fn print_interval(interval: &StreamInterval, format_char: char) {
+    titled(format_args!(
+        "{}",
+        format_interval_line(interval, format_char)
+    ));
 }
 
 /// Print the separator line.

--- a/riperf3/src/units.rs
+++ b/riperf3/src/units.rs
@@ -13,6 +13,11 @@ pub fn format_bytes(bytes: f64, format_char: char) -> String {
     match format_char {
         'A' => adaptive_bytes(bytes),
         'a' => adaptive_bits(bytes * 8.0),
+        // 'B'/'b' mirror GT's lib-level unit_snprintf arms (units.c:305,
+        // UNIT_CONV): the raw figure, no magnitude conversion. CLI-unreachable
+        // in both tools — GT's getopt rejects them with IEBADFORMAT (#263).
+        'B' => format!("{} Bytes", ladder(bytes)),
+        'b' => format!("{} bits", ladder(bytes * 8.0)),
         'K' => format!("{} KBytes", ladder(bytes / 1024.0)),
         'k' => format!("{} Kbits", ladder(bytes * 8.0 / 1000.0)),
         'M' => format!("{} MBytes", ladder(bytes / (1024.0 * 1024.0))),
@@ -31,16 +36,44 @@ pub fn format_bytes(bytes: f64, format_char: char) -> String {
 /// iperf3's unit_snprintf precision ladder (#221): the printed figure keeps
 /// ~3 significant digits — < 9.995 → 2 dp, < 99.95 → 1 dp, else 0 dp. The
 /// boundaries are round-aware (units.c: "9.995 would be rounded to 10.0",
-/// "99.95 would be rounded to 100"). iperf3 also left-pads to a 4-char
-/// minimum (%4.Xf); riperf3's row templates own column alignment, so the
-/// pad is theirs, not this function's.
+/// "99.95 would be rounded to 100"), and the figure is right-padded to four
+/// characters (`%4.2f`/`%4.1f`/`%4.0f`) — GT's row templates drop the cell
+/// in with no alignment of their own, so the pad IS the column alignment
+/// (#264; only 3-digit `%.0f` figures actually gain a space).
 fn ladder(n: f64) -> String {
     if n < 9.995 {
-        format!("{n:.2}")
+        format!("{n:4.2}")
     } else if n < 99.95 {
-        format!("{n:.1}")
+        format!("{n:4.1}")
     } else {
-        format!("{n:.0}")
+        format!("{n:4.0}")
+    }
+}
+
+/// C's `%.2g`, for GT's UDP loss percent (report_bw_udp_format's `(%.2g%%)`,
+/// #264): two significant digits, trailing zeros stripped, switching to
+/// e-notation when the ROUNDED exponent falls outside [-4, 2) — C99
+/// fprintf's %g rules, decided after rounding (99.6 → 100 → `1e+02`).
+pub(crate) fn g2(v: f64) -> String {
+    if v == 0.0 {
+        return "0".to_string();
+    }
+    // {:.1e} rounds to 2 significant digits and normalizes the mantissa,
+    // giving the post-rounding exponent C uses for the notation switch.
+    let sci = format!("{v:.1e}");
+    let (mant, exp) = sci.split_once('e').expect("LowerExp always has an e");
+    let exp: i32 = exp.parse().expect("integer exponent");
+    if exp < -4 || exp >= 2 {
+        let mant = mant.trim_end_matches('0').trim_end_matches('.');
+        format!("{mant}e{}{:02}", if exp < 0 { '-' } else { '+' }, exp.abs())
+    } else {
+        let prec = (1 - exp).max(0) as usize;
+        let s = format!("{v:.prec$}");
+        if s.contains('.') {
+            s.trim_end_matches('0').trim_end_matches('.').to_string()
+        } else {
+            s
+        }
     }
 }
 
@@ -53,6 +86,9 @@ fn ladder(n: f64) -> String {
 pub fn format_rate(bits_per_sec: f64, format_char: char) -> String {
     let bytes_per_sec = bits_per_sec / 8.0;
     match format_char {
+        // Lib-level 'B'/'b' twins of the format_bytes arms (#263).
+        'B' => format!("{} Bytes/sec", ladder(bytes_per_sec)),
+        'b' => format!("{} bits/sec", ladder(bits_per_sec)),
         'k' => format!("{} Kbits/sec", ladder(bits_per_sec / 1000.0)),
         'm' => format!("{} Mbits/sec", ladder(bits_per_sec / 1_000_000.0)),
         'g' => format!("{} Gbits/sec", ladder(bits_per_sec / 1_000_000_000.0)),
@@ -163,7 +199,7 @@ mod tests {
         assert_eq!(format_bytes(50.0, 'A'), "50.0 Bytes");
         assert_eq!(format_rate(0.0, 'a'), "0.00 bits/sec");
         assert_eq!(format_bytes(1.0, 'a'), "8.00 bits");
-        assert_eq!(format_bytes(500.0, 'A'), "500 Bytes");
+        assert_eq!(format_bytes(500.0, 'A'), " 500 Bytes");
         assert_eq!(format_bytes(1024.0, 'A'), "1.00 KBytes");
         assert_eq!(format_bytes(1024.0 * 1024.0 * 1.5, 'A'), "1.50 MBytes");
         assert_eq!(
@@ -213,13 +249,13 @@ mod tests {
         let b = 11.7 * 1024.0 * 1024.0 * 1024.0;
         assert_eq!(format_bytes(b, 'A'), "11.7 GBytes");
         // 101 Gbits/sec (>=99.95 -> %.0f)
-        assert_eq!(format_rate(101.0e9, 'a'), "101 Gbits/sec");
+        assert_eq!(format_rate(101.0e9, 'a'), " 101 Gbits/sec");
         // boundary: 9.994 stays 2dp, 9.996 promotes to 1dp ("10.0")
         assert_eq!(format_rate(9.994e9, 'a'), "9.99 Gbits/sec");
         assert_eq!(format_rate(9.996e9, 'a'), "10.0 Gbits/sec");
         // boundary: 99.94 stays 1dp, 99.96 promotes to 0dp ("100")
         assert_eq!(format_rate(99.94e9, 'a'), "99.9 Gbits/sec");
-        assert_eq!(format_rate(99.96e9, 'a'), "100 Gbits/sec");
+        assert_eq!(format_rate(99.96e9, 'a'), " 100 Gbits/sec");
     }
 
     #[test]
@@ -268,13 +304,57 @@ mod tests {
             format_rate(8.0 * 1024.0 * 1024.0 * 1.5, 'A'),
             "1.50 MBytes/sec"
         );
-        assert_eq!(format_rate(800.0, 'A'), "100 Bytes/sec");
+        assert_eq!(format_rate(800.0, 'A'), " 100 Bytes/sec");
     }
 
     #[test]
     fn format_rate_adaptive() {
-        assert_eq!(format_rate(500.0, 'a'), "500 bits/sec");
+        assert_eq!(format_rate(500.0, 'a'), " 500 bits/sec");
         assert_eq!(format_rate(1_500_000.0, 'a'), "1.50 Mbits/sec");
         assert_eq!(format_rate(9_420_000_000.0, 'a'), "9.42 Gbits/sec");
+    }
+
+    /// #264: unit_snprintf right-pads the FIGURE to four characters
+    /// (`%4.2f`/`%4.1f`/`%4.0f`) — the pad belongs to the cell, not the row
+    /// template. Only 3-digit `%.0f` figures gain a space; 4+ digits and
+    /// 2-dp/1-dp figures are already four wide.
+    #[test]
+    fn figures_pad_to_gt_width_four() {
+        assert_eq!(format_rate(300_000_000.0, 'a'), " 300 Mbits/sec");
+        assert_eq!(format_bytes(384.0 * 1024.0, 'A'), " 384 KBytes");
+        // 4-digit and sub-100 figures carry no extra pad.
+        assert_eq!(format_rate(1_000_000_000.0, 'm'), "1000 Mbits/sec");
+        assert_eq!(format_rate(9_420_000_000.0, 'a'), "9.42 Gbits/sec");
+    }
+
+    /// #263: 'B'/'b' mirror GT's lib-level unit_snprintf arms — raw Bytes /
+    /// bits with NO magnitude conversion (units.c:305, UNIT_CONV), ladder
+    /// precision applied to the raw figure. CLI-unreachable in both tools
+    /// (GT rejects them with IEBADFORMAT), lib-reachable via format_char.
+    #[test]
+    fn b_chars_mirror_gt_lib_behavior() {
+        assert_eq!(format_bytes(500.0, 'B'), " 500 Bytes");
+        assert_eq!(format_bytes(500.0, 'b'), "4000 bits");
+        assert_eq!(format_bytes(1_000_000.0, 'b'), "8000000 bits");
+        assert_eq!(format_rate(4000.0, 'b'), "4000 bits/sec");
+        assert_eq!(format_rate(4096.0, 'B'), " 512 Bytes/sec");
+    }
+
+    /// #264: C's `%.2g` for the UDP loss percent — two significant digits,
+    /// trailing zeros stripped, e-notation once the rounded exponent
+    /// reaches the precision (C99 fprintf %g rules; cross-checked against
+    /// coreutils printf %.2g).
+    #[test]
+    fn percent_g2_matches_c_printf() {
+        assert_eq!(g2(0.0), "0");
+        assert_eq!(g2(0.5), "0.5");
+        assert_eq!(g2(2.5), "2.5");
+        assert_eq!(g2(25.0), "25");
+        assert_eq!(g2(8.333_333), "8.3");
+        assert_eq!(g2(33.333), "33");
+        assert_eq!(g2(0.033), "0.033");
+        assert_eq!(g2(100.0), "1e+02");
+        // Rounding happens BEFORE the notation switch: 99.6 → 100 → 1e+02.
+        assert_eq!(g2(99.6), "1e+02");
     }
 }

--- a/riperf3/src/units.rs
+++ b/riperf3/src/units.rs
@@ -55,6 +55,16 @@ fn ladder(n: f64) -> String {
 /// e-notation when the ROUNDED exponent falls outside [-4, 2) — C99
 /// fprintf's %g rules, decided after rounding (99.6 → 100 → `1e+02`).
 pub(crate) fn g2(v: f64) -> String {
+    if !v.is_finite() {
+        // C's %g renders these as words; {:.1e} has no exponent to split on.
+        return if v.is_nan() {
+            "nan".to_string()
+        } else if v > 0.0 {
+            "inf".to_string()
+        } else {
+            "-inf".to_string()
+        };
+    }
     if v == 0.0 {
         return "0".to_string();
     }
@@ -356,5 +366,11 @@ mod tests {
         assert_eq!(g2(100.0), "1e+02");
         // Rounding happens BEFORE the notation switch: 99.6 → 100 → 1e+02.
         assert_eq!(g2(99.6), "1e+02");
+        // Non-finite inputs render like C's %g instead of panicking on the
+        // missing exponent (r1 n2 — unreachable from lost_percent, but g2
+        // is pub(crate) and a future caller must not hit the expect()).
+        assert_eq!(g2(f64::NAN), "nan");
+        assert_eq!(g2(f64::INFINITY), "inf");
+        assert_eq!(g2(f64::NEG_INFINITY), "-inf");
     }
 }

--- a/riperf3/src/units.rs
+++ b/riperf3/src/units.rs
@@ -63,7 +63,7 @@ pub(crate) fn g2(v: f64) -> String {
     let sci = format!("{v:.1e}");
     let (mant, exp) = sci.split_once('e').expect("LowerExp always has an e");
     let exp: i32 = exp.parse().expect("integer exponent");
-    if exp < -4 || exp >= 2 {
+    if !(-4..2).contains(&exp) {
         let mant = mant.trim_end_matches('0').trim_end_matches('.');
         format!("{mant}e{}{:02}", if exp < 0 { '-' } else { '+' }, exp.abs())
     } else {


### PR DESCRIPTION
Closes #263, closes #264.

Byte-level text parity with GT (iperf 3.21 @ d39cf41) for the `-f` surface and the interval/summary row formats, live-probed side-by-side before and after.

## #263 — the `-f` surface

- **`optarg[0]`-only parse**: `-f` is now a plain string; only the first character counts (`iperf_api.c:1241`), so `-f kilobits` ≡ `-f k`. The clap `ValueEnum` (which rejected full words with a clap-shaped error) is gone.
- **IEBADFORMAT**: invalid leads reject with GT's exact sentence `bad format specifier (valid formats are in the set [kmgtKMGT])` + usage trailer + exit 1, in the same parameter-error class as #259/#270. `b`/`B` are CLI-rejected exactly like GT.
- **JSON + `-f` warning**: `warning: Report format (-f) flag ignored with JSON output (-J)` on stderr (bare `warning:` prefix, `iperf_api.c:126`), both roles, and for `--json-stream` too (it sets `json_output`, `iperf_api.c:1281`). The JSON document still lands on stdout.
- **`B`/`b` lib chars**: mirror GT's `unit_snprintf` arms (units.c:305) — raw Bytes/bits, no magnitude conversion, ladder precision applied. Lib-reachable via `format_char`, CLI-unreachable in both tools.

## #264 — GT-exact row templates

Ported each `iperf_locale.c` template 1:1 (pure `format_interval_line` extracted first, no-behavior-change commit):

- Time columns `%6.2f-%-6.2f sec` (were width 5).
- Figures right-padded to 4 inside the cell (`%4.2f/%4.1f/%4.0f`) — cell-level `{:>10}`/`{:>12}` padding removed; the figure pad IS the column alignment.
- Retr `%3ld` (was `{:4}`); per-stream retr summary tail 12 spaces, `[SUM]` 13; retr-less rows 18-space tails; cwnd rows `+3/+7` spacing.
- UDP jitter `%5.3f ms` (was `{:7.3}`); loss percent `(%.2g%%)` via a C-semantics `g2` helper — `(0%)` not `(0.00%)`, `(8.3%)`, `(1e+02%)`.
- Omit marker `(omitted)` fills the template's final `%s` bare (iperf_locale.c:429).
- **Final partial interval**: adopted GT's keep rule verbatim (`iperf_print_intermediate`): keep iff the tail spans ≥ 10% of the stats interval OR moved bytes. The old ad-hoc `>1ms AND bytes>0` both invented rows GT suppresses (the issue's extra reverse-mode row) and hid long empty tails GT prints. `-i 0` keeps the whole-run flush unconditionally (threshold 0).

## Verification

- Every row class pinned byte-exact at the pure builders (expected strings derived from the locale templates, cross-checked against live captures).
- Live side-by-side (loopback, GT server+client vs riperf3 pair): TCP forward paced, UDP, reverse — masked-layout diffs identical; raw diffs show only measurement variance.
- `g2` pinned against coreutils `printf %.2g` outputs.
- Full gate: 28 binaries, 680 tests, 0 failures; clippy/fmt clean.
