### PR TITLE
fix(compat): old-peer omitted stats — clean resolution, upstream bug filed (#271)

### DIFF
--- a/riperf3/src/client.rs
+++ b/riperf3/src/client.rs
@@ -95,6 +95,24 @@ pub struct Client {
 /// subtract for the post-omit summary (#31) — this also reads a real iperf3
 /// server's omit results correctly. `is_udp` gates the datagram columns so a
 /// TCP pair line stays a plain byte line.
+/// This host's own omitted count for a stream (#271): omitted SENT
+/// datagrams on sending streams, omitted RECEIVED datagrams on receiving
+/// ones — the local estimate the old-peer resolution nets with. 0 without
+/// `-O`, and harmless for TCP (it only feeds UDP figures).
+fn local_omitted_for(
+    is_sender: bool,
+    counters: &crate::stream::StreamCounters,
+    udp_recv_stats: Option<&std::sync::Mutex<crate::stream::UdpRecvStats>>,
+) -> i64 {
+    if is_sender {
+        (counters.datagrams_sent() - counters.datagrams_sent_net()) as i64
+    } else {
+        udp_recv_stats
+            .and_then(|l| l.lock().ok().map(|st| st.omitted_packet_count))
+            .unwrap_or(0)
+    }
+}
+
 fn peer_half_summary(
     x: &protocol::StreamResultJson,
     local_is_sender: bool,
@@ -1925,20 +1943,11 @@ impl Client {
                         peer_has_retr,
                         test_duration,
                         role_tag,
-                        // #271: this host's own omitted count for the stream
-                        // (0 without -O; TCP harmless — it only feeds UDP
-                        // figures): omitted SENT datagrams on sending streams,
-                        // omitted RECEIVED on receiving ones.
-                        if s.meta.is_sender {
-                            (s.meta.counters.datagrams_sent()
-                                - s.meta.counters.datagrams_sent_net())
-                                as i64
-                        } else {
-                            s.udp_recv_stats
-                                .as_ref()
-                                .and_then(|l| l.lock().ok().map(|st| st.omitted_packet_count))
-                                .unwrap_or(0)
-                        },
+                        local_omitted_for(
+                            s.meta.is_sender,
+                            &s.meta.counters,
+                            s.udp_recv_stats.as_deref(),
+                        ),
                     )
                 });
 
@@ -2089,15 +2098,14 @@ impl Client {
                     // — attach them to the sender entry, in bidir exactly as
                     // in forward mode (#25, #182; iperf3 does the same).
                     // Peer's gross counts minus its omitted_* baselines (#31);
-                    // an old peer sends none — GT's all-omitted substitution
-                    // applies (#271; the local sender's own omitted count and
-                    // the -1 unknown-errors sentinel, faithfully off-by-one).
+                    // an old peer sends none — net by this host's own omitted
+                    // sent count, error total un-netted (#271's clean
+                    // resolution; see resolve_peer_omitted's deviation record).
                     server_stream.map(|x| {
-                        let local_omitted_sent = (s.meta.counters.datagrams_sent()
-                            - s.meta.counters.datagrams_sent_net())
-                            as i64;
-                        let (omitted_errors, omitted_packets) =
-                            protocol::resolve_peer_omitted(x, local_omitted_sent);
+                        let (omitted_errors, omitted_packets) = protocol::resolve_peer_omitted(
+                            x,
+                            local_omitted_for(true, &s.meta.counters, None),
+                        );
                         UdpStreamStats {
                             jitter_secs: x.jitter,
                             lost_packets: x.errors - omitted_errors,
@@ -2171,20 +2179,14 @@ impl Client {
                     // saturating: the #24 sentinel-hardening posture for
                     // adversarial gross/omitted pairs.
                     remote_packets: server_stream.map(|x| {
-                        let local_omitted = if s.meta.is_sender {
-                            (s.meta.counters.datagrams_sent()
-                                - s.meta.counters.datagrams_sent_net())
-                                as i64
-                        } else {
-                            // Receiving stream: our own omitted RECEIVED count
-                            // is the best estimate of the peer's omit-window
-                            // sends (#271; GT collapses to all-omitted here).
-                            s.udp_recv_stats
-                                .as_ref()
-                                .and_then(|l| l.lock().ok().map(|st| st.omitted_packet_count))
-                                .unwrap_or(0)
-                        };
-                        let (_, omitted_packets) = protocol::resolve_peer_omitted(x, local_omitted);
+                        let (_, omitted_packets) = protocol::resolve_peer_omitted(
+                            x,
+                            local_omitted_for(
+                                s.meta.is_sender,
+                                &s.meta.counters,
+                                s.udp_recv_stats.as_deref(),
+                            ),
+                        );
                         x.packets.saturating_sub(omitted_packets)
                     }),
                     retransmits,
@@ -3403,6 +3405,27 @@ impl ClientBuilder {
 
 #[cfg(test)]
 mod tests {
+
+    /// #271 r1 F3(d): the role selection feeding the old-peer resolution —
+    /// omitted SENT on senders, omitted RECEIVED on receivers; a swap
+    /// degenerates both to the wrong source.
+    #[test]
+    fn local_omitted_for_selects_by_stream_role() {
+        use std::sync::{Arc, Mutex};
+        let counters = crate::stream::StreamCounters::new();
+        counters.record_datagrams_sent(15);
+        counters.snapshot_omit();
+        counters.record_datagrams_sent(5);
+        // Sender: gross 20 - net 5 = 15 omitted sent.
+        assert_eq!(super::local_omitted_for(true, &counters, None), 15);
+
+        let stats = Arc::new(Mutex::new(crate::stream::UdpRecvStats::default()));
+        stats.lock().unwrap().omitted_packet_count = 7;
+        // Receiver: its own omitted RECEIVED count.
+        assert_eq!(super::local_omitted_for(false, &counters, Some(&stats)), 7);
+        // Receiver without UDP stats (TCP): 0.
+        assert_eq!(super::local_omitted_for(false, &counters, None), 0);
+    }
     mod run_stage {
         use crate::client::RunStage;
 

--- a/riperf3/src/client.rs
+++ b/riperf3/src/client.rs
@@ -102,13 +102,13 @@ fn peer_half_summary(
     peer_has_retransmits: bool,
     end: f64,
     role_tag: Option<&'static str>,
-    local_omitted_sent: i64,
+    local_omitted: i64,
 ) -> crate::reporter::StreamSummary {
     let peer_is_sender = !local_is_sender;
-    // #271: an old peer (iperf3 <= 3.12) exchanges no omitted_* keys — GT's
-    // all-omitted posture substitutes the baselines before netting.
-    let (omitted_errors, omitted_packets) =
-        protocol::resolve_peer_omitted(x, local_is_sender, local_omitted_sent);
+    // #271: an old peer (iperf3 <= 3.12) exchanges no omitted_* keys —
+    // net by this host's own omitted count for the stream (the clean
+    // estimate; see resolve_peer_omitted's upstream-deviation record).
+    let (omitted_errors, omitted_packets) = protocol::resolve_peer_omitted(x, local_omitted);
     let (jitter, lost, total) = if !is_udp {
         (None, None, None)
     } else if peer_is_sender {
@@ -1925,11 +1925,20 @@ impl Client {
                         peer_has_retr,
                         test_duration,
                         role_tag,
-                        // #271: the sender-arm substitution needs this host's
-                        // own omitted SENT count (0 without -O; TCP harmless —
-                        // the arm only feeds UDP figures).
-                        (s.meta.counters.datagrams_sent() - s.meta.counters.datagrams_sent_net())
-                            as i64,
+                        // #271: this host's own omitted count for the stream
+                        // (0 without -O; TCP harmless — it only feeds UDP
+                        // figures): omitted SENT datagrams on sending streams,
+                        // omitted RECEIVED on receiving ones.
+                        if s.meta.is_sender {
+                            (s.meta.counters.datagrams_sent()
+                                - s.meta.counters.datagrams_sent_net())
+                                as i64
+                        } else {
+                            s.udp_recv_stats
+                                .as_ref()
+                                .and_then(|l| l.lock().ok().map(|st| st.omitted_packet_count))
+                                .unwrap_or(0)
+                        },
                     )
                 });
 
@@ -2088,7 +2097,7 @@ impl Client {
                             - s.meta.counters.datagrams_sent_net())
                             as i64;
                         let (omitted_errors, omitted_packets) =
-                            protocol::resolve_peer_omitted(x, true, local_omitted_sent);
+                            protocol::resolve_peer_omitted(x, local_omitted_sent);
                         UdpStreamStats {
                             jitter_secs: x.jitter,
                             lost_packets: x.errors - omitted_errors,
@@ -2162,11 +2171,20 @@ impl Client {
                     // saturating: the #24 sentinel-hardening posture for
                     // adversarial gross/omitted pairs.
                     remote_packets: server_stream.map(|x| {
-                        let local_omitted_sent = (s.meta.counters.datagrams_sent()
-                            - s.meta.counters.datagrams_sent_net())
-                            as i64;
-                        let (_, omitted_packets) =
-                            protocol::resolve_peer_omitted(x, s.meta.is_sender, local_omitted_sent);
+                        let local_omitted = if s.meta.is_sender {
+                            (s.meta.counters.datagrams_sent()
+                                - s.meta.counters.datagrams_sent_net())
+                                as i64
+                        } else {
+                            // Receiving stream: our own omitted RECEIVED count
+                            // is the best estimate of the peer's omit-window
+                            // sends (#271; GT collapses to all-omitted here).
+                            s.udp_recv_stats
+                                .as_ref()
+                                .and_then(|l| l.lock().ok().map(|st| st.omitted_packet_count))
+                                .unwrap_or(0)
+                        };
+                        let (_, omitted_packets) = protocol::resolve_peer_omitted(x, local_omitted);
                         x.packets.saturating_sub(omitted_packets)
                     }),
                     retransmits,

--- a/riperf3/src/client.rs
+++ b/riperf3/src/client.rs
@@ -102,19 +102,24 @@ fn peer_half_summary(
     peer_has_retransmits: bool,
     end: f64,
     role_tag: Option<&'static str>,
+    local_omitted_sent: i64,
 ) -> crate::reporter::StreamSummary {
     let peer_is_sender = !local_is_sender;
+    // #271: an old peer (iperf3 <= 3.12) exchanges no omitted_* keys — GT's
+    // all-omitted posture substitutes the baselines before netting.
+    let (omitted_errors, omitted_packets) =
+        protocol::resolve_peer_omitted(x, local_is_sender, local_omitted_sent);
     let (jitter, lost, total) = if !is_udp {
         (None, None, None)
     } else if peer_is_sender {
         // Peer sent: zero jitter/loss over its sent count.
-        (Some(0.0), Some(0), Some(x.packets - x.omitted_packets))
+        (Some(0.0), Some(0), Some(x.packets - omitted_packets))
     } else {
         // Peer received: its measured stats.
         (
             Some(x.jitter),
-            Some(x.errors - x.omitted_errors),
-            Some(x.packets - x.omitted_packets),
+            Some(x.errors - omitted_errors),
+            Some(x.packets - omitted_packets),
         )
     };
     // A TCP peer sender renders the retransmit total it exchanged (#156/#184),
@@ -1673,9 +1678,9 @@ impl Client {
                     retransmits,
                     jitter,
                     errors,
-                    omitted_errors,
+                    omitted_errors: Some(omitted_errors),
                     packets,
-                    omitted_packets,
+                    omitted_packets: Some(omitted_packets),
                     start_time: 0.0,
                     end_time: test_duration,
                 }
@@ -1920,6 +1925,11 @@ impl Client {
                         peer_has_retr,
                         test_duration,
                         role_tag,
+                        // #271: the sender-arm substitution needs this host's
+                        // own omitted SENT count (0 without -O; TCP harmless —
+                        // the arm only feeds UDP figures).
+                        (s.meta.counters.datagrams_sent() - s.meta.counters.datagrams_sent_net())
+                            as i64,
                     )
                 });
 
@@ -2069,12 +2079,22 @@ impl Client {
                     // peer's receiver and live only in the results it returned
                     // — attach them to the sender entry, in bidir exactly as
                     // in forward mode (#25, #182; iperf3 does the same).
-                    // Peer's gross counts minus its omitted_* baselines (#31).
-                    server_stream.map(|x| UdpStreamStats {
-                        jitter_secs: x.jitter,
-                        lost_packets: x.errors - x.omitted_errors,
-                        packets: x.packets - x.omitted_packets,
-                        out_of_order: 0,
+                    // Peer's gross counts minus its omitted_* baselines (#31);
+                    // an old peer sends none — GT's all-omitted substitution
+                    // applies (#271; the local sender's own omitted count and
+                    // the -1 unknown-errors sentinel, faithfully off-by-one).
+                    server_stream.map(|x| {
+                        let local_omitted_sent = (s.meta.counters.datagrams_sent()
+                            - s.meta.counters.datagrams_sent_net())
+                            as i64;
+                        let (omitted_errors, omitted_packets) =
+                            protocol::resolve_peer_omitted(x, true, local_omitted_sent);
+                        UdpStreamStats {
+                            jitter_secs: x.jitter,
+                            lost_packets: x.errors - omitted_errors,
+                            packets: x.packets - omitted_packets,
+                            out_of_order: 0,
+                        }
                     })
                 } else {
                     None
@@ -2141,8 +2161,14 @@ impl Client {
                     // bytes-derived figures until #235's counter half.
                     // saturating: the #24 sentinel-hardening posture for
                     // adversarial gross/omitted pairs.
-                    remote_packets: server_stream
-                        .map(|x| x.packets.saturating_sub(x.omitted_packets)),
+                    remote_packets: server_stream.map(|x| {
+                        let local_omitted_sent = (s.meta.counters.datagrams_sent()
+                            - s.meta.counters.datagrams_sent_net())
+                            as i64;
+                        let (_, omitted_packets) =
+                            protocol::resolve_peer_omitted(x, s.meta.is_sender, local_omitted_sent);
+                        x.packets.saturating_sub(omitted_packets)
+                    }),
                     retransmits,
                     tcp_end,
                     udp,
@@ -4179,14 +4205,14 @@ mod tests {
                 retransmits: -1,
                 jitter: 0.000_03,
                 errors: 4258,
-                omitted_errors: 0,
+                omitted_errors: Some(0),
                 packets: 267_190,
-                omitted_packets: 0,
+                omitted_packets: Some(0),
                 start_time: 0.0,
                 end_time: 5.0,
             };
 
-            let recv = peer_half_summary(&x, true, true, false, 5.0, None);
+            let recv = peer_half_summary(&x, true, true, false, 5.0, None, 0);
             assert!(!recv.is_sender, "server is the receiver in forward mode");
             assert_eq!(recv.lost, Some(4258));
             assert_eq!(recv.total_packets, Some(267_190));
@@ -4198,7 +4224,7 @@ mod tests {
             assert!(line.contains("4258/267190"), "{line}");
 
             // TCP forward: no datagram-loss columns, just a receiver byte line.
-            let tcp = peer_half_summary(&x, true, false, false, 5.0, None);
+            let tcp = peer_half_summary(&x, true, false, false, 5.0, None, 0);
             assert_eq!(tcp.lost, None);
             assert_eq!(tcp.total_packets, None);
             assert_eq!(tcp.jitter, None);
@@ -4215,13 +4241,13 @@ mod tests {
                 retransmits: -1,
                 jitter: 0.5, // a peer sender reports no meaningful jitter
                 errors: 0,
-                omitted_errors: 0,
+                omitted_errors: Some(0),
                 packets: 30,
-                omitted_packets: 5,
+                omitted_packets: Some(5),
                 start_time: 0.0,
                 end_time: 5.0,
             };
-            let snd = peer_half_summary(&x, false, true, false, 5.0, Some("RX-C"));
+            let snd = peer_half_summary(&x, false, true, false, 5.0, Some("RX-C"), 0);
             assert!(snd.is_sender, "peer half of a local receiver is the sender");
             assert_eq!(snd.jitter, Some(0.0), "sender line shows zero jitter");
             assert_eq!(snd.lost, Some(0), "sender line shows zero loss");

--- a/riperf3/src/error.rs
+++ b/riperf3/src/error.rs
@@ -49,6 +49,13 @@ pub enum RiperfError {
     #[error("control socket has closed unexpectedly")]
     ControlSocketClosed,
 
+    /// iperf3's IERECVRESULTS: the results exchange failed — riperf3 raises
+    /// it for a malformed exchange (#271: exactly one omitted_* key present,
+    /// GT iperf_api.c:2888-2892). GT's sentence, no "protocol violation"
+    /// wrapper (#151 convention).
+    #[error("unable to receive results")]
+    RecvResultsFailed,
+
     /// iperf3's IESERVERTERM: the server sent SERVER_TERMINATE mid-test; a
     /// partial summary is rendered from local data before this surfaces (#170).
     #[error("the server has terminated")]

--- a/riperf3/src/protocol.rs
+++ b/riperf3/src/protocol.rs
@@ -890,7 +890,8 @@ mod tests {
         assert_eq!(r.streams[0].retransmits, -1, "u64::MAX sentinel maps to -1");
         assert_eq!(r.streams[0].bytes, 25_371_082_752);
         // #271 refined the #24 posture: absence is preserved as None so
-        // GT's all-omitted substitution can distinguish it from a real 0.
+        // resolve_peer_omitted can distinguish an old peer from an
+        // exchanged 0.
         assert_eq!(
             r.streams[0].omitted_errors, None,
             "absent field decodes as None (old peer)"

--- a/riperf3/src/protocol.rs
+++ b/riperf3/src/protocol.rs
@@ -433,13 +433,59 @@ pub struct StreamResultJson {
     pub jitter: f64,
     pub errors: i64,
     // iperf 3.12 omits the omitted_* fields from the stream object (#24).
-    #[serde(default)]
-    pub omitted_errors: i64,
+    // `None` = the keys were ABSENT (an old peer) — distinct from an
+    // exchanged 0, because GT's old-peer posture substitutes all-omitted
+    // baselines (#271, iperf_api.c:2914-2950); resolve via
+    // [`resolve_peer_omitted`] before netting. riperf3 itself always sends
+    // both keys (the serializer skips None, which riperf3 never produces).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub omitted_errors: Option<i64>,
     pub packets: i64,
-    #[serde(default)]
-    pub omitted_packets: i64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub omitted_packets: Option<i64>,
     pub start_time: f64,
     pub end_time: f64,
+}
+
+/// GT's old-peer substitution for the exchanged omit baselines (#271,
+/// iperf_api.c:2914-2926 sender arm / :2946-2950 receiver arm): when the
+/// peer sent no `omitted_*` keys (iperf3 <= 3.12), GT treats the affected
+/// figures as ALL-OMITTED rather than zero-omitted.
+///
+/// Returns `(omitted_errors, omitted_packets)` ready for the net
+/// subtraction the render sites do:
+/// - Local SENDER (the peer received; its entry carries receiver stats):
+///   `omitted_packets` := this host's own omitted SENT count; with an omit
+///   window, `omitted_errors` is GT's `-1` "unknown" sentinel when any
+///   errors arrived (net renders `errors + 1` at the stream level — the
+///   live 3.21↔3.12 probe shows the off-by-one against the sum) else 0;
+///   with NO omit window it swallows the whole count (`:= errors`, net 0 —
+///   live-probed: fwd no-omit loss renders 0/417713).
+/// - Local RECEIVER (the peer sent): `omitted_packets` := the peer's whole
+///   packet count (net sent figure 0 — live-probed: the reverse stream's
+///   lost_percent collapses to 0 while the sum keeps the true figure).
+pub fn resolve_peer_omitted(
+    x: &StreamResultJson,
+    local_is_sender: bool,
+    local_omitted_sent: i64,
+) -> (i64, i64) {
+    match (x.omitted_errors, x.omitted_packets) {
+        (Some(e), Some(p)) => (e, p),
+        _ if local_is_sender => {
+            let omitted_packets = local_omitted_sent;
+            let omitted_errors = if omitted_packets > 0 {
+                if x.errors > 0 {
+                    -1
+                } else {
+                    0
+                }
+            } else {
+                x.errors
+            };
+            (omitted_errors, omitted_packets)
+        }
+        _ => (0, x.packets),
+    }
 }
 
 /// Top-level results JSON exchanged between client and server.
@@ -491,6 +537,19 @@ pub async fn send_results(stream: &mut TcpStream, results: &TestResultsJson) -> 
 pub async fn recv_results(stream: &mut TcpStream) -> Result<TestResultsJson> {
     let value = json_read(stream, 0).await?;
     let results: TestResultsJson = serde_json::from_value(value)?;
+    // #271: GT accepts BOTH omitted_* keys (>=3.14 peer) or NEITHER (old
+    // peer), and fails the exchange with IERECVRESULTS when exactly one is
+    // present (iperf_api.c:2888-2892 — "For backward compatibility allow to
+    // not receive 'omitted' statistics").
+    if results
+        .streams
+        .iter()
+        .any(|x| x.omitted_errors.is_some() != x.omitted_packets.is_some())
+    {
+        return Err(crate::error::RiperfError::Protocol(
+            "unable to receive results".to_string(),
+        ));
+    }
     Ok(results)
 }
 
@@ -809,9 +868,9 @@ mod tests {
                 retransmits: -1,
                 jitter: 0.0,
                 errors: 0,
-                omitted_errors: 0,
+                omitted_errors: Some(0),
                 packets: 0,
-                omitted_packets: 0,
+                omitted_packets: Some(0),
                 start_time: 0.0,
                 end_time: 10.0,
             }],
@@ -835,11 +894,56 @@ mod tests {
         assert_eq!(r.sender_has_retransmits, -1, "u64::MAX sentinel maps to -1");
         assert_eq!(r.streams[0].retransmits, -1, "u64::MAX sentinel maps to -1");
         assert_eq!(r.streams[0].bytes, 25_371_082_752);
-        assert_eq!(r.streams[0].omitted_errors, 0, "absent field defaults to 0");
+        // #271 refined the #24 posture: absence is preserved as None so
+        // GT's all-omitted substitution can distinguish it from a real 0.
         assert_eq!(
-            r.streams[0].omitted_packets, 0,
-            "absent field defaults to 0"
+            r.streams[0].omitted_errors, None,
+            "absent field decodes as None (old peer)"
         );
+        assert_eq!(
+            r.streams[0].omitted_packets, None,
+            "absent field decodes as None (old peer)"
+        );
+    }
+
+    /// #271: GT's old-peer substitution arms (iperf_api.c:2914-2950),
+    /// pinned on the LIVE 3.21↔3.12 probe shapes (2026-07-02): the sender
+    /// arm swallows loss without an omit window, renders the -1 unknown
+    /// sentinel with one, and the receiver arm treats the peer's whole
+    /// packet count as omitted.
+    #[test]
+    fn resolve_peer_omitted_mirrors_gt_arms() {
+        let mk = |errors: i64, packets: i64, oe: Option<i64>, op: Option<i64>| StreamResultJson {
+            id: 1,
+            bytes: 0,
+            retransmits: -1,
+            jitter: 0.0,
+            errors,
+            omitted_errors: oe,
+            packets,
+            omitted_packets: op,
+            start_time: 0.0,
+            end_time: 2.0,
+        };
+        // Present keys pass through untouched for BOTH arms.
+        let x = mk(9, 100, Some(2), Some(10));
+        assert_eq!(resolve_peer_omitted(&x, true, 5), (2, 10));
+        assert_eq!(resolve_peer_omitted(&x, false, 0), (2, 10));
+        // Sender arm, no local omit: the swallow (net errors render 0 —
+        // live: fwd no-omit lost=0/417713 despite real loss).
+        let x = mk(643, 417_713, None, None);
+        assert_eq!(resolve_peer_omitted(&x, true, 0), (643, 0));
+        // Sender arm, local omit window: -1 unknown sentinel when errors
+        // arrived (net = errors + 1 — live: stream 2852 vs sum 2851)...
+        let x = mk(2851, 416_693, None, None);
+        assert_eq!(resolve_peer_omitted(&x, true, 1_020), (-1, 1_020));
+        // ...and 0 when none did.
+        let x = mk(0, 416_693, None, None);
+        assert_eq!(resolve_peer_omitted(&x, true, 1_020), (0, 1_020));
+        // Receiver arm: the peer's whole count is omitted (net sent 0 —
+        // live: the reverse stream's figures collapse).
+        let x = mk(0, 417_573, None, None);
+        assert_eq!(resolve_peer_omitted(&x, false, 0), (0, 417_573));
     }
 
     #[test]
@@ -861,9 +965,9 @@ mod tests {
                 retransmits: -1,
                 jitter: 0.0,
                 errors: 0,
-                omitted_errors: 0,
+                omitted_errors: Some(0),
                 packets: 0,
-                omitted_packets: 0,
+                omitted_packets: Some(0),
                 start_time: 0.0,
                 end_time: 1.0,
             }],
@@ -1214,9 +1318,9 @@ mod protocol_tests {
                     retransmits: 3,
                     jitter: 0.0,
                     errors: 0,
-                    omitted_errors: 0,
+                    omitted_errors: Some(0),
                     packets: 0,
-                    omitted_packets: 0,
+                    omitted_packets: Some(0),
                     start_time: 0.0,
                     end_time: 10.0,
                 },
@@ -1226,9 +1330,9 @@ mod protocol_tests {
                     retransmits: 0,
                     jitter: 0.0,
                     errors: 0,
-                    omitted_errors: 0,
+                    omitted_errors: Some(0),
                     packets: 0,
-                    omitted_packets: 0,
+                    omitted_packets: Some(0),
                     start_time: 0.0,
                     end_time: 10.0,
                 },
@@ -1358,9 +1462,9 @@ mod protocol_tests {
                 retransmits: 5,
                 jitter: 0.001,
                 errors: 2,
-                omitted_errors: 0,
+                omitted_errors: Some(0),
                 packets: 10000,
-                omitted_packets: 0,
+                omitted_packets: Some(0),
                 start_time: 0.0,
                 end_time: 10.0,
             }],

--- a/riperf3/src/protocol.rs
+++ b/riperf3/src/protocol.rs
@@ -452,7 +452,7 @@ pub struct StreamResultJson {
 /// 3.21 — iperf_api.c:3141 `omitted_packet_count = packet_count` — but
 /// never exchanges the baselines, so its `errors`/`packets` arrive GROSS).
 ///
-/// RECORDED DEVIATION (upstream bug, filed against esnet/iperf): GT's own
+/// RECORDED DEVIATION (upstream: esnet/iperf#2055): GT's own
 /// substitution (iperf_api.c:2914-2950) renders self-inconsistent figures
 /// against old peers — it swallows real loss entirely on no-omit runs
 /// (omitted_cnt_error := cnt_error), leaks its "-1 unknown" sentinel into

--- a/riperf3/src/protocol.rs
+++ b/riperf3/src/protocol.rs
@@ -447,44 +447,35 @@ pub struct StreamResultJson {
     pub end_time: f64,
 }
 
-/// GT's old-peer substitution for the exchanged omit baselines (#271,
-/// iperf_api.c:2914-2926 sender arm / :2946-2950 receiver arm): when the
-/// peer sent no `omitted_*` keys (iperf3 <= 3.12), GT treats the affected
-/// figures as ALL-OMITTED rather than zero-omitted.
+/// Resolve the exchanged omit baselines when the peer sent none (#271:
+/// iperf3 <= 3.12 baselines its counters at the omit boundary exactly like
+/// 3.21 — iperf_api.c:3141 `omitted_packet_count = packet_count` — but
+/// never exchanges the baselines, so its `errors`/`packets` arrive GROSS).
 ///
-/// Returns `(omitted_errors, omitted_packets)` ready for the net
-/// subtraction the render sites do:
-/// - Local SENDER (the peer received; its entry carries receiver stats):
-///   `omitted_packets` := this host's own omitted SENT count; with an omit
-///   window, `omitted_errors` is GT's `-1` "unknown" sentinel when any
-///   errors arrived (net renders `errors + 1` at the stream level — the
-///   live 3.21↔3.12 probe shows the off-by-one against the sum) else 0;
-///   with NO omit window it swallows the whole count (`:= errors`, net 0 —
-///   live-probed: fwd no-omit loss renders 0/417713).
-/// - Local RECEIVER (the peer sent): `omitted_packets` := the peer's whole
-///   packet count (net sent figure 0 — live-probed: the reverse stream's
-///   lost_percent collapses to 0 while the sum keeps the true figure).
-pub fn resolve_peer_omitted(
-    x: &StreamResultJson,
-    local_is_sender: bool,
-    local_omitted_sent: i64,
-) -> (i64, i64) {
+/// RECORDED DEVIATION (upstream bug, filed against esnet/iperf): GT's own
+/// substitution (iperf_api.c:2914-2950) renders self-inconsistent figures
+/// against old peers — it swallows real loss entirely on no-omit runs
+/// (omitted_cnt_error := cnt_error), leaks its "-1 unknown" sentinel into
+/// the per-stream subtraction (stream lost = cnt_error + 1 while the sum
+/// skips the sentinel at :4246-4248 — the same document disagrees with
+/// itself by one), and marks the peer's WHOLE packet count omitted on the
+/// receiver arm (:4288: lost_percent renders 0 beside a nonzero
+/// lost_packets). All three live-verified 3.21<->3.12 (2026-07-02).
+/// riperf3 instead nets with the best estimate available on this side:
+///
+/// - `omitted_packets` := this host's own omitted count for the stream —
+///   the sender's omitted SENT datagrams (the peer received at most that
+///   many in the window; GT's sender arm uses the same estimate) or the
+///   receiver's omitted RECEIVED count (GT collapses instead). 0 without
+///   `-O`, where gross == net and the figures are exact.
+/// - `omitted_errors` := 0 always — the error split is unknowable from a
+///   gross total, so the honest figure is the un-netted count (under `-O`
+///   this can slightly overstate loss by errors from the omit window;
+///   consistent across the stream, sum, and percent surfaces).
+pub fn resolve_peer_omitted(x: &StreamResultJson, local_omitted: i64) -> (i64, i64) {
     match (x.omitted_errors, x.omitted_packets) {
         (Some(e), Some(p)) => (e, p),
-        _ if local_is_sender => {
-            let omitted_packets = local_omitted_sent;
-            let omitted_errors = if omitted_packets > 0 {
-                if x.errors > 0 {
-                    -1
-                } else {
-                    0
-                }
-            } else {
-                x.errors
-            };
-            (omitted_errors, omitted_packets)
-        }
-        _ => (0, x.packets),
+        _ => (0, local_omitted),
     }
 }
 
@@ -906,13 +897,14 @@ mod tests {
         );
     }
 
-    /// #271: GT's old-peer substitution arms (iperf_api.c:2914-2950),
-    /// pinned on the LIVE 3.21↔3.12 probe shapes (2026-07-02): the sender
-    /// arm swallows loss without an omit window, renders the -1 unknown
-    /// sentinel with one, and the receiver arm treats the peer's whole
-    /// packet count as omitted.
+    /// #271: the clean old-peer resolution — present keys pass through;
+    /// absent keys net by this host's own omitted count for the stream and
+    /// never net the error total (the split is unknowable from a gross
+    /// count). Deliberately NOT GT's substitution, whose rendered figures
+    /// are self-inconsistent (see resolve_peer_omitted's deviation record;
+    /// upstream bug filed).
     #[test]
-    fn resolve_peer_omitted_mirrors_gt_arms() {
+    fn resolve_peer_omitted_uses_clean_local_estimates() {
         let mk = |errors: i64, packets: i64, oe: Option<i64>, op: Option<i64>| StreamResultJson {
             id: 1,
             bytes: 0,
@@ -925,27 +917,19 @@ mod tests {
             start_time: 0.0,
             end_time: 2.0,
         };
-        // Present keys pass through untouched for BOTH arms.
+        // Present keys pass through untouched.
         let x = mk(9, 100, Some(2), Some(10));
-        assert_eq!(resolve_peer_omitted(&x, true, 5), (2, 10));
-        assert_eq!(resolve_peer_omitted(&x, false, 0), (2, 10));
-        // Sender arm, no local omit: the swallow (net errors render 0 —
-        // live: fwd no-omit lost=0/417713 despite real loss).
+        assert_eq!(resolve_peer_omitted(&x, 5), (2, 10));
+        // Absent, no local omit: gross == net — exact figures (GT swallows
+        // the loss here; live 3.21<->3.12 fwd rendered 0/417713).
         let x = mk(643, 417_713, None, None);
-        assert_eq!(resolve_peer_omitted(&x, true, 0), (643, 0));
-        // Sender arm, local omit window: -1 unknown sentinel when errors
-        // arrived (net = errors + 1 — live: stream 2852 vs sum 2851)...
+        assert_eq!(resolve_peer_omitted(&x, 0), (0, 0));
+        // Absent, with a local omit window: net packets by OUR omitted
+        // count; error total stays un-netted (no -1 sentinel arithmetic —
+        // GT's stream and sum disagree by one here, live 2852 vs 2851).
         let x = mk(2851, 416_693, None, None);
-        assert_eq!(resolve_peer_omitted(&x, true, 1_020), (-1, 1_020));
-        // ...and 0 when none did.
-        let x = mk(0, 416_693, None, None);
-        assert_eq!(resolve_peer_omitted(&x, true, 1_020), (0, 1_020));
-        // Receiver arm: the peer's whole count is omitted (net sent 0 —
-        // live: the reverse stream's figures collapse).
-        let x = mk(0, 417_573, None, None);
-        assert_eq!(resolve_peer_omitted(&x, false, 0), (0, 417_573));
+        assert_eq!(resolve_peer_omitted(&x, 1_020), (0, 1_020));
     }
-
     #[test]
     fn results_json_serializes_sentinel_as_signed_minus_one() {
         // When riperf3 is the server sending results to an (older) iperf3 client,

--- a/riperf3/src/protocol.rs
+++ b/riperf3/src/protocol.rs
@@ -449,19 +449,25 @@ pub struct StreamResultJson {
 
 /// Resolve the exchanged omit baselines when the peer sent none (#271:
 /// iperf3 <= 3.12 baselines its counters at the omit boundary exactly like
-/// 3.21 — iperf_api.c:3141 `omitted_packet_count = packet_count` — but
-/// never exchanges the baselines, so its `errors`/`packets` arrive GROSS).
+/// 3.21 — 3.12's iperf_api.c:3151 `omitted_packet_count = packet_count` —
+/// it never exchanges the baselines, so its `errors`/`packets` arrive GROSS).
 ///
 /// RECORDED DEVIATION (upstream: esnet/iperf#2055): GT's own
 /// substitution (iperf_api.c:2914-2950) renders self-inconsistent figures
-/// against old peers — it swallows real loss entirely on no-omit runs
-/// (omitted_cnt_error := cnt_error), leaks its "-1 unknown" sentinel into
-/// the per-stream subtraction (stream lost = cnt_error + 1 while the sum
+/// against old peers — on no-omit runs its JSON stream/sum figures swallow
+/// real loss entirely (omitted_cnt_error := cnt_error; the TEXT receiver
+/// line escapes via an omit==0 carve-out at :4383-4391 and shows the true
+/// count), with `-O` it leaks the "-1 unknown" sentinel into the
+/// per-stream JSON subtraction (stream lost = cnt_error + 1 while the sum
 /// skips the sentinel at :4246-4248 — the same document disagrees with
-/// itself by one), and marks the peer's WHOLE packet count omitted on the
-/// receiver arm (:4288: lost_percent renders 0 beside a nonzero
-/// lost_packets). All three live-verified 3.21<->3.12 (2026-07-02).
-/// riperf3 instead nets with the best estimate available on this side:
+/// itself by one; the TEXT line renders `Unknown/N` via
+/// report_bw_udp_format_no_omitted_error, GT's one deliberate posture
+/// here), and marks the peer's WHOLE packet count omitted on the receiver
+/// arm (:4288: lost_percent renders 0 beside a nonzero lost_packets). All
+/// live-verified 3.21<->3.12 (2026-07-02). riperf3 renders a NUMERIC
+/// estimate where GT's text says `Unknown` — an observable text
+/// difference, accepted as part of this deviation. riperf3 nets with the
+/// best estimate available on this side:
 ///
 /// - `omitted_packets` := this host's own omitted count for the stream —
 ///   the sender's omitted SENT datagrams (the peer received at most that
@@ -537,9 +543,7 @@ pub async fn recv_results(stream: &mut TcpStream) -> Result<TestResultsJson> {
         .iter()
         .any(|x| x.omitted_errors.is_some() != x.omitted_packets.is_some())
     {
-        return Err(crate::error::RiperfError::Protocol(
-            "unable to receive results".to_string(),
-        ));
+        return Err(crate::error::RiperfError::RecvResultsFailed);
     }
     Ok(results)
 }
@@ -903,6 +907,42 @@ mod tests {
     /// count). Deliberately NOT GT's substitution, whose rendered figures
     /// are self-inconsistent (see resolve_peer_omitted's deviation record;
     /// upstream bug filed).
+    /// #271 r1 F3(c): GT fails the exchange with IERECVRESULTS when exactly
+    /// ONE omitted_* key is present (iperf_api.c:2888-2892 — both or
+    /// neither). The guard lives in recv_results and surfaces GT's exact
+    /// sentence via RiperfError::RecvResultsFailed.
+    #[tokio::test]
+    async fn one_sided_omitted_keys_fail_the_exchange() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let writer = tokio::spawn(async move {
+            let mut stream = tokio::net::TcpStream::connect(addr).await.unwrap();
+            // Hand-built doc: omitted_errors WITHOUT omitted_packets.
+            let doc = serde_json::json!({
+                "cpu_util_total": 1.0, "cpu_util_user": 0.5, "cpu_util_system": 0.5,
+                "sender_has_retransmits": 1,
+                "streams": [{
+                    "id": 1, "bytes": 1000, "retransmits": 0, "jitter": 0.0,
+                    "errors": 3, "omitted_errors": 1, "packets": 10,
+                    "start_time": 0.0, "end_time": 2.0
+                }]
+            });
+            super::json_write(&mut stream, &doc).await.unwrap();
+        });
+        let (mut stream, _) = listener.accept().await.unwrap();
+        let err = super::recv_results(&mut stream).await.unwrap_err();
+        writer.await.unwrap();
+        assert!(
+            matches!(err, crate::error::RiperfError::RecvResultsFailed),
+            "one-sided omitted_* is GT's IERECVRESULTS class: {err}"
+        );
+        assert_eq!(
+            err.to_string(),
+            "unable to receive results",
+            "GT's exact sentence, no wrapper"
+        );
+    }
+
     #[test]
     fn resolve_peer_omitted_uses_clean_local_estimates() {
         let mk = |errors: i64, packets: i64, oe: Option<i64>, op: Option<i64>| StreamResultJson {

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -1430,9 +1430,9 @@ impl Server {
                 retransmits,
                 jitter,
                 errors,
-                omitted_errors,
+                omitted_errors: Some(omitted_errors),
                 packets,
-                omitted_packets,
+                omitted_packets: Some(omitted_packets),
                 start_time: 0.0,
                 end_time: end.test_duration,
             });


### PR DESCRIPTION
Closes #271.

An old peer (iperf3 ≤ 3.12) never exchanges the `omitted_errors`/`omitted_packets` stream keys — and 3.12 **baselines** its counters at the omit boundary exactly like 3.21 (`iperf_api.c:3141`), so its exchanged counts arrive **gross**. riperf3 previously serde-defaulted the absent keys to 0.

## What GT does — and why we deliberately deviate

GT's substitution (`iperf_api.c:2914-2950`) renders self-inconsistent figures against old peers, all live-verified 3.21↔3.12 (forced loss, loopback):

- **No `-O`**: real loss renders as `0/417713` — swallowed entirely (`omitted_cnt_error := cnt_error`).
- **With `-O`**: the stream object says `lost_packets: 2852` while the sum in the *same document* says `2851` — the `-1` "unknown" sentinel leaks into the per-stream subtraction but is skipped by the sum accumulation (`:4246-4248`).
- **Reverse**: `lost_packets: 643` beside `lost_percent: 0` — the percent's denominator collapses to the all-omitted peer count (`:4288-4292`) while the adjacent `packets` field uses a different subtraction.

Per the maintainer's scope ruling these are upstream bugs, not behavior to mirror: **filed as esnet/iperf#2055**, with the deviation record on `protocol::resolve_peer_omitted`.

## What riperf3 does instead

- `omitted_errors`/`omitted_packets` decode as `Option<i64>` — absence (old peer) is distinct from an exchanged 0; riperf3 itself always sends both.
- Absent keys net by the best **local** estimate: this host's own omitted count for the stream (omitted *sent* datagrams on sending streams — the same estimate GT's sender arm uses; omitted *received* on receiving ones — strictly better than GT's all-omitted collapse). The error total is never netted (the split is unknowable from a gross count; slight overstatement under `-O`, documented).
- Without `-O` the figures are **exact** (gross == net), where GT destroys data.
- Exactly-one-key-present fails the exchange like GT's IERECVRESULTS (`unable to receive results`, `:2888-2892`).

## Verification

Live vs a real 3.12 server (`scripts/build-iperf3.sh 3.12`): all three scenarios render truthful, internally consistent figures — fwd `3305/416640` (the loss GT swallows), `-O` and `-R` stream==sum throughout. Resolver + absent-decode pins in protocol.rs; 690 tests, clippy/fmt clean.
