### PR TITLE
fix(compat): reject -R --bidir with GT's IEREVERSEBIDIR sentence (#309)

### DIFF
--- a/riperf3-cli/src/main.rs
+++ b/riperf3-cli/src/main.rs
@@ -81,6 +81,10 @@ fn main() -> std::process::ExitCode {
         // #263: GT's IEBADFORMAT — only the FIRST character of the argument
         // is inspected (iperf_api.c:1241), and [kmgtKMGT] is the whole set.
         Some("bad format specifier (valid formats are in the set [kmgtKMGT])")
+    } else if cli.reverse && cli.bidir {
+        // #309: GT's IEREVERSEBIDIR — the second of the pair is rejected
+        // inside the getopt loop (iperf_api.c:1423/:1431), either order.
+        Some("cannot be both reverse and bidirectional")
     } else {
         None
     };

--- a/riperf3-cli/src/main.rs
+++ b/riperf3-cli/src/main.rs
@@ -59,7 +59,8 @@ fn main() -> std::process::ExitCode {
     // its getopt loop, ahead of the client-flag-on-server class (r1 F5).
     // RECORDED DEVIATION (r1 F4): with TWO violating flags GT reports the
     // command-line-FIRST one (per-flag getopt checks); riperf3 checks in a
-    // fixed order (duration, then idle-timeout) — clap's derive parse has no
+    // fixed order (duration, idle-timeout, format, reverse+bidir) — clap's
+    // derive parse has no
     // cheap arg-position access, and the divergence needs two simultaneously
     // invalid flags. The u32 arg types make GT's negative arms
     // unrepresentable.

--- a/riperf3-cli/tests/error_format.rs
+++ b/riperf3-cli/tests/error_format.rs
@@ -311,3 +311,31 @@ fn format_specifier_rejections_match_gt() {
         "-f kilobits parses as -f k (optarg[0]): {stderr}"
     );
 }
+
+/// #309: GT rejects `-R --bidir` in the getopt loop with IEREVERSEBIDIR —
+/// `cannot be both reverse and bidirectional` (iperf_api.c:1423/:1431),
+/// both flag orders, parameter-error class (trailer + exit 1). riperf3
+/// used to accept the pair and run a reverse-flagged bidir test.
+#[test]
+fn reverse_plus_bidir_rejects_like_gt() {
+    for args in [
+        &["-c", "127.0.0.1", "-R", "--bidir"][..],
+        &["-c", "127.0.0.1", "--bidir", "-R"][..],
+    ] {
+        let out = std::process::Command::new(env!("CARGO_BIN_EXE_riperf3"))
+            .args(args)
+            .output()
+            .expect("spawn riperf3");
+        assert_eq!(out.status.code(), Some(1), "{args:?} exits 1");
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        assert!(
+            stderr
+                .starts_with("riperf3: parameter error - cannot be both reverse and bidirectional"),
+            "{args:?}: IEREVERSEBIDIR sentence expected: {stderr}"
+        );
+        assert!(
+            stderr.contains("Usage:") && stderr.contains("--help"),
+            "the usage trailer rides parameter errors: {stderr}"
+        );
+    }
+}


### PR DESCRIPTION
Closes #309.

GT rejects the pair inside its getopt loop with `parameter error - cannot be both reverse and bidirectional` (iperf_api.c:1423/:1431), either flag order, parameter-error class (usage trailer + exit 1). riperf3 accepted it and ran a reverse-flagged bidir test. One arm in the pre-sink validation chain + a both-orders CLI pin (red-first). Live-probed GT for the exact shape.