### PR TITLE
fix(compat): params wire-shape deltas (#303)

### DIFF
--- a/riperf3-cli/src/cli.rs
+++ b/riperf3-cli/src/cli.rs
@@ -103,16 +103,22 @@ pub struct Cli {
     pub daemon: bool,
 
     /// Restart idle server after # seconds
-    #[arg(long, value_name = "secs")]
-    pub idle_timeout: Option<u32>,
+    // i64 + negatives accepted at parse (#303): GT's atoi wraps them into
+    // its range checks; the pre-sink chain rejects with GT's wording.
+    #[arg(long, value_name = "secs", allow_negative_numbers = true)]
+    pub idle_timeout: Option<i64>,
 
     /// Server's total bit rate limit
     #[arg(long = "server-bitrate-limit", value_name = "rate")]
     pub server_bitrate_limit: Option<String>,
 
     /// Max time a test can run on the server
-    #[arg(long = "server-max-duration", value_name = "secs")]
-    pub server_max_duration: Option<u32>,
+    #[arg(
+        long = "server-max-duration",
+        value_name = "secs",
+        allow_negative_numbers = true
+    )]
+    pub server_max_duration: Option<i64>,
 
     // -----------------------------------------------------------------------
     // Client-specific arguments
@@ -122,8 +128,8 @@ pub struct Cli {
     pub udp: bool,
 
     /// Time in seconds to transmit for (default 10 secs)
-    #[arg(short = 't', long, value_name = "secs")]
-    pub time: Option<u32>,
+    #[arg(short = 't', long, value_name = "secs", allow_negative_numbers = true)]
+    pub time: Option<i64>,
 
     /// Number of bytes to transmit (instead of -t)
     #[arg(short = 'n', long, value_name = "bytes")]
@@ -176,8 +182,8 @@ pub struct Cli {
     pub tos: Option<String>,
 
     /// Omit the first N seconds of the test
-    #[arg(short = 'O', long, value_name = "secs")]
-    pub omit: Option<u32>,
+    #[arg(short = 'O', long, value_name = "secs", allow_negative_numbers = true)]
+    pub omit: Option<i64>,
 
     /// Prefix every output line with this string
     #[arg(short = 'T', long, value_name = "title")]
@@ -498,7 +504,7 @@ impl Cli {
             builder = builder.protocol(riperf3::TransportProtocol::Udp);
         }
         if let Some(t) = self.time {
-            builder = builder.duration(t);
+            builder = builder.duration(u32::try_from(t).unwrap_or(u32::MAX));
         }
         if let Some(ref s) = self.pacing_timer {
             builder = builder.pacing_timer_str(s)?;
@@ -540,7 +546,7 @@ impl Cli {
             builder = builder.tos_str(s)?;
         }
         if let Some(o) = self.omit {
-            builder = builder.omit(o);
+            builder = builder.omit(u32::try_from(o).unwrap_or(u32::MAX));
         }
         if let Some(i) = self.interval {
             builder = builder.interval(i);
@@ -683,13 +689,13 @@ impl Cli {
             builder = builder.json_stream_full_output(true);
         }
         if let Some(secs) = self.idle_timeout {
-            builder = builder.idle_timeout(secs);
+            builder = builder.idle_timeout(u32::try_from(secs).unwrap_or(u32::MAX));
         }
         if let Some(ref s) = self.server_bitrate_limit {
             builder = builder.server_bitrate_limit_str(s)?;
         }
         if let Some(secs) = self.server_max_duration {
-            builder = builder.server_max_duration(secs);
+            builder = builder.server_max_duration(u32::try_from(secs).unwrap_or(u32::MAX));
         }
         if self.forceflush {
             builder = builder.forceflush(true);

--- a/riperf3-cli/src/main.rs
+++ b/riperf3-cli/src/main.rs
@@ -62,8 +62,7 @@ fn main() -> std::process::ExitCode {
     // fixed order (duration, idle-timeout, format, reverse+bidir) — clap's
     // derive parse has no
     // cheap arg-position access, and the divergence needs two simultaneously
-    // invalid flags. The u32 arg types make GT's negative arms
-    // unrepresentable.
+    // invalid flags.
     const MAX_TIME_SECS: i64 = 86_400;
     // #303 item 3: the args parse as i64 with negatives allowed, so GT's
     // atoi-wrapped negative arms land in the SAME range checks and wordings

--- a/riperf3-cli/src/main.rs
+++ b/riperf3-cli/src/main.rs
@@ -64,9 +64,15 @@ fn main() -> std::process::ExitCode {
     // cheap arg-position access, and the divergence needs two simultaneously
     // invalid flags. The u32 arg types make GT's negative arms
     // unrepresentable.
-    const MAX_TIME_SECS: u32 = 86_400;
-    let range_violation = if cli.time.is_some_and(|t| t > MAX_TIME_SECS)
-        || cli.server_max_duration.is_some_and(|d| d > MAX_TIME_SECS)
+    const MAX_TIME_SECS: i64 = 86_400;
+    // #303 item 3: the args parse as i64 with negatives allowed, so GT's
+    // atoi-wrapped negative arms land in the SAME range checks and wordings
+    // (live-probed: `-t -1` → the duration sentence, `--idle-timeout -5` →
+    // the idle sentence, `-O -3`/`-O 700` → IEOMIT's bogus-value sentence).
+    let range_violation = if cli.time.is_some_and(|t| !(0..=MAX_TIME_SECS).contains(&t))
+        || cli
+            .server_max_duration
+            .is_some_and(|d| !(0..=MAX_TIME_SECS).contains(&d))
     {
         Some("test duration valid values are 0 to 86400 seconds")
     } else if cli
@@ -74,6 +80,9 @@ fn main() -> std::process::ExitCode {
         .is_some_and(|t| !(1..=MAX_TIME_SECS).contains(&t))
     {
         Some("idle timeout parameter is not positive or larger than allowed limit")
+    } else if cli.omit.is_some_and(|o| !(0..=600).contains(&o)) {
+        // GT's IEOMIT (MAX_OMIT_TIME 600, iperf.h:473), in-loop like the rest.
+        Some("bogus value for --omit (maximum = 600 seconds)")
     } else if cli
         .format
         .as_deref()

--- a/riperf3-cli/tests/error_format.rs
+++ b/riperf3-cli/tests/error_format.rs
@@ -257,6 +257,58 @@ fn duration_range_validations_match_gt() {
             "the usage trailer rides parameter errors (GT shape): {stderr}"
         );
     }
+    // #303 item 3: NEGATIVE args take GT's parameter-error class — its
+    // atoi wraps them into the same range checks (live-probed wordings) —
+    // and -O has GT's own bounds check (MAX_OMIT_TIME 600, in-loop).
+    let neg_cases: &[(&[&str], &str)] = &[
+        (
+            &["-c", "127.0.0.1", "-t", "-1"],
+            "parameter error - test duration valid values are 0 to 86400 seconds",
+        ),
+        (
+            &["-s", "--idle-timeout", "-5"],
+            "parameter error - idle timeout parameter is not positive or larger than allowed limit",
+        ),
+        (
+            &["-c", "127.0.0.1", "-O", "-3"],
+            "parameter error - bogus value for --omit (maximum = 600 seconds)",
+        ),
+        (
+            &["-c", "127.0.0.1", "-O", "700"],
+            "parameter error - bogus value for --omit (maximum = 600 seconds)",
+        ),
+        (
+            &["-s", "--server-max-duration", "-2"],
+            "parameter error - test duration valid values are 0 to 86400 seconds",
+        ),
+    ];
+    for (args, want) in neg_cases {
+        let out = std::process::Command::new(env!("CARGO_BIN_EXE_riperf3"))
+            .args(*args)
+            .output()
+            .expect("spawn riperf3");
+        assert_eq!(out.status.code(), Some(1), "{args:?} exits 1 like GT");
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        assert!(
+            stderr.starts_with(&format!("riperf3: {want}")),
+            "{args:?}: GT wording expected, got: {stderr}"
+        );
+        assert!(
+            stderr.contains("Usage:") && stderr.contains("--help"),
+            "the usage trailer rides parameter errors: {stderr}"
+        );
+    }
+    // -O 600 is the legal boundary (fails later on connect, not at parse).
+    let out = std::process::Command::new(env!("CARGO_BIN_EXE_riperf3"))
+        .args(["-c", "127.0.0.1", "-p", "9", "-O", "600"])
+        .output()
+        .expect("spawn riperf3");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        !stderr.contains("parameter error"),
+        "-O 600 is legal (0..=600): {stderr}"
+    );
+
     // The boundary VALUES are legal: -t 86400 must not be rejected at parse
     // time (it fails later on connect, not with a parameter error).
     let out = std::process::Command::new(env!("CARGO_BIN_EXE_riperf3"))

--- a/riperf3/src/client.rs
+++ b/riperf3/src/client.rs
@@ -1005,11 +1005,12 @@ impl Client {
         }
         p.mss = self.mss;
         p.window = self.window;
-        // Always carry the resolved rate (incl. 0 = unlimited) so the server
-        // paces correctly in reverse/bidir; matches iperf3, which always sends
-        // it. `bandwidth` is the effective rate after the build-time default
-        // (UDP unset → 1 Mbit/s), so 0 here unambiguously means unlimited (#17).
-        p.bandwidth = Some(self.bandwidth);
+        // GT sends `bandwidth` only when nonzero (iperf_api.c:2456, #303) —
+        // absent reads as 0 = unlimited on both sides, so `-b 0` stays
+        // unlimited server-side while the raw param JSON matches GT
+        // byte-wise. The UDP build-time default (unset → 1 Mbit/s) is
+        // nonzero and rides the wire like GT's UDP_RATE default.
+        p.bandwidth = (self.bandwidth > 0).then_some(self.bandwidth);
         // #260 r1 F2: GT sends `fqrate` whenever nonzero (iperf_api.c:2457-8)
         // — the server needs it for its upfront total-rate check AND for
         // fq-paced reverse/bidir sending. riperf3 never serialized it.
@@ -1035,12 +1036,12 @@ impl Client {
             p.udp_counters_64bit = Some(1);
         }
         p.client_version = Some(format!("riperf3 {}", env!("CARGO_PKG_VERSION")));
-        if let Some(bytes) = self.bytes_to_send {
-            p.num = Some(bytes);
-        }
-        if let Some(blocks) = self.blocks_to_send {
-            p.blockcount = Some(blocks);
-        }
+        // GT serializes num/blockcount UNCONDITIONALLY (iperf_api.c:
+        // 2436-2437), sending 0 for a plain -t run — the read side's
+        // normalize_unlimited already treats Some(0) as no-limit (#119),
+        // so the wire now matches GT byte-wise too (#303).
+        p.num = Some(self.bytes_to_send.unwrap_or(0));
+        p.blockcount = Some(self.blocks_to_send.unwrap_or(0));
 
         // Auth: encrypt credentials if username and public key are set
         if let (Some(ref username), Some(ref pubkey_path)) =
@@ -4214,15 +4215,27 @@ mod tests {
         }
 
         #[test]
-        fn udp_build_params_carries_bandwidth_including_zero() {
-            // The negotiated rate must reach the server (in `len`/`bandwidth`)
-            // so reverse-mode -b 0 is unlimited server-side, not throttled.
+        fn build_params_matches_gt_wire_gates() {
+            // #303: GT sends `bandwidth` only when nonzero (iperf_api.c:2456)
+            // — absent reads as 0 = unlimited on both sides, so reverse -b 0
+            // stays unlimited server-side with a GT-identical raw param doc.
             let c = ClientBuilder::new("h")
                 .protocol(TransportProtocol::Udp)
                 .bandwidth(0)
                 .build()
                 .unwrap();
-            assert_eq!(c.build_params(1460).bandwidth, Some(0));
+            let p = c.build_params(1460);
+            assert_eq!(p.bandwidth, None, "-b 0 omits the key like GT");
+            // GT sends num/blockcount unconditionally (:2436-2437) — 0 for
+            // a plain -t run; the read side normalizes Some(0) to no-limit.
+            assert_eq!(p.num, Some(0));
+            assert_eq!(p.blockcount, Some(0));
+
+            let c = ClientBuilder::new("h")
+                .bandwidth(5_000_000)
+                .build()
+                .unwrap();
+            assert_eq!(c.build_params(1460).bandwidth, Some(5_000_000));
         }
 
         // #32: iperf3 ALWAYS sends pacing_timer in the param exchange (default

--- a/riperf3/src/client.rs
+++ b/riperf3/src/client.rs
@@ -1007,9 +1007,10 @@ impl Client {
         p.window = self.window;
         // GT sends `bandwidth` only when nonzero (iperf_api.c:2456, #303) —
         // absent reads as 0 = unlimited on both sides, so `-b 0` stays
-        // unlimited server-side while the raw param JSON matches GT
-        // byte-wise. The UDP build-time default (unset → 1 Mbit/s) is
-        // nonzero and rides the wire like GT's UDP_RATE default.
+        // unlimited server-side with a key-set-identical raw param doc
+        // (key ORDER differs; JSON receivers are order-blind). The UDP
+        // build-time default (unset → 1 Mbit/s) is nonzero and rides the
+        // wire like GT's UDP_RATE default.
         p.bandwidth = (self.bandwidth > 0).then_some(self.bandwidth);
         // #260 r1 F2: GT sends `fqrate` whenever nonzero (iperf_api.c:2457-8)
         // — the server needs it for its upfront total-rate check AND for
@@ -1039,7 +1040,7 @@ impl Client {
         // GT serializes num/blockcount UNCONDITIONALLY (iperf_api.c:
         // 2436-2437), sending 0 for a plain -t run — the read side's
         // normalize_unlimited already treats Some(0) as no-limit (#119),
-        // so the wire now matches GT byte-wise too (#303).
+        // so the key sets now match GT too (#303).
         p.num = Some(self.bytes_to_send.unwrap_or(0));
         p.blockcount = Some(self.blocks_to_send.unwrap_or(0));
 

--- a/riperf3/src/protocol.rs
+++ b/riperf3/src/protocol.rs
@@ -376,8 +376,8 @@ pub struct TestParams {
 impl TestParams {
     /// Normalize a `0` byte/block limit to `None` (= no limit). iperf3
     /// *unconditionally* serializes `num`/`blockcount`, sending `0` for a plain
-    /// `-t` run, whereas riperf3 omits them — and serde `default` only fills a
-    /// *missing* field, so a real iperf3 client arrives as `Some(0)`. Without
+    /// `-t` run — and since #303 riperf3 sends them the same way — while serde
+    /// `default` only fills a *missing* field, so the pair arrives `Some(0)`. Without
     /// this, the server's `is_none()`/`is_some()` limit checks misread a duration
     /// run as byte-limited: it disables the UDP-sender `-t` deadline (#5 hang
     /// risk) and skews the summary window (#103). Call once at param ingest. #119


### PR DESCRIPTION
Closes #303.

**Item 1** — `bandwidth` rides the params exchange only when nonzero, like GT (`iperf_api.c:2456`); absent reads as 0 = unlimited on both sides, so `-b 0` semantics are unchanged while the raw param JSON matches GT byte-wise.
**Item 2** — `num`/`blockcount` serialize unconditionally like GT (`:2436-2437`), sending 0 for a plain `-t` run; the read side's `normalize_unlimited` (#119) already treats `Some(0)` as no-limit.
**Item 3** — `-t`/`--idle-timeout`/`--server-max-duration`/`-O` parse as i64 with negatives allowed and land in the pre-sink parameter-error chain exactly where GT's atoi-wrapped values land (live-probed: `-t -1` → the duration sentence; `--idle-timeout -5` → the idle sentence; `-O -3`/`-O 700` → `bogus value for --omit (maximum = 600 seconds)`, GT's IEOMIT with MAX_OMIT_TIME 600). Previously these produced clap's invalid-value/unexpected-argument shapes, and the omit bound surfaced as a run-error instead of the parse class.

Red-first pins: build_params wire gates (bandwidth omit/keep + num/blockcount always) and five negative/over-range CLI cases + the `-O 600` legal boundary. Full gate: 693 tests, clippy/fmt clean.