### PR TITLE
test: IperfDone wire pin + counter-order constraint docs (#296)

### DIFF
--- a/riperf3-cli/tests/wire_shape.rs
+++ b/riperf3-cli/tests/wire_shape.rs
@@ -1,0 +1,82 @@
+//! #296: wire-shape pins for behavior the end-to-end suites can't see.
+//!
+//! The client's final `IperfDone` state byte is indistinguishable from a
+//! fast close to a real server (its end loop tolerates a vanished client
+//! by design), so only a mock asserting the byte BEFORE the socket closes
+//! can pin it — GT's client always sends it (iperf_client_api.c, the
+//! DISPLAY_RESULTS → IPERF_DONE transition).
+
+use std::io::{Read, Write};
+use std::time::{Duration, Instant};
+
+mod common;
+
+/// The mock speaks the full protocol through the results exchange, then
+/// asserts the next control byte is IperfDone(16) — not EOF.
+#[test]
+fn client_sends_iperf_done_after_the_results_exchange() {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind mock");
+    let port = listener.local_addr().unwrap().port().to_string();
+
+    let mock = std::thread::spawn(move || -> u8 {
+        let read_exact = |s: &mut std::net::TcpStream, n: usize| -> Vec<u8> {
+            let mut b = vec![0u8; n];
+            s.read_exact(&mut b).expect("mock read");
+            b
+        };
+        let read_json = |s: &mut std::net::TcpStream| {
+            let len = u32::from_be_bytes(read_exact(s, 4).try_into().unwrap()) as usize;
+            read_exact(s, len)
+        };
+        let write_json = |s: &mut std::net::TcpStream, payload: &str| {
+            s.write_all(&(payload.len() as u32).to_be_bytes()).unwrap();
+            s.write_all(payload.as_bytes()).unwrap();
+        };
+
+        let (mut ctrl, _) = listener.accept().expect("ctrl accept");
+        read_exact(&mut ctrl, 37); // cookie
+        ctrl.write_all(&[9u8]).unwrap(); // ParamExchange
+        read_json(&mut ctrl); // params
+        ctrl.write_all(&[10u8]).unwrap(); // CreateStreams
+        let (mut data, _) = listener.accept().expect("data accept");
+        read_exact(&mut data, 37); // data-stream cookie
+        ctrl.write_all(&[1u8]).unwrap(); // TestStart
+        ctrl.write_all(&[2u8]).unwrap(); // TestRunning
+        let drain = std::thread::spawn(move || {
+            let mut buf = vec![0u8; 65536];
+            while data.read(&mut buf).map(|n| n > 0).unwrap_or(false) {}
+        });
+        assert_eq!(read_exact(&mut ctrl, 1)[0], 4, "TestEnd");
+        ctrl.write_all(&[13u8]).unwrap(); // ExchangeResults
+        read_json(&mut ctrl); // the client's results
+        write_json(
+            &mut ctrl,
+            r#"{"cpu_util_total":1.0,"cpu_util_user":0.5,"cpu_util_system":0.5,"sender_has_retransmits":1,"streams":[{"id":1,"bytes":102400,"retransmits":0,"jitter":0,"errors":0,"packets":0,"start_time":0,"end_time":1}]}"#,
+        );
+        ctrl.write_all(&[14u8]).unwrap(); // DisplayResults
+                                          // The pin: the next control byte is IperfDone(16), not EOF.
+        let done = read_exact(&mut ctrl, 1)[0];
+        let _ = drain.join();
+        done
+    });
+
+    let client = common::run_client(
+        &["-c", "127.0.0.1", "-p", &port, "-n", "100K", "-J"],
+        Duration::from_secs(15),
+        "iperf-done client",
+    );
+    assert_eq!(client.status.code(), Some(0), "{}", client.stderr);
+
+    let deadline = Instant::now() + Duration::from_secs(5);
+    let done_byte = loop {
+        if mock.is_finished() {
+            break mock.join().expect("mock");
+        }
+        assert!(Instant::now() < deadline, "mock never saw the final byte");
+        std::thread::sleep(Duration::from_millis(25));
+    };
+    assert_eq!(
+        done_byte, 16,
+        "the client's last control byte is IperfDone(16), like GT"
+    );
+}

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -211,6 +211,12 @@ struct EndState {
     test_duration: f64,
 }
 
+/// INVARIANT (#296): `build_result_streams` runs before
+/// `finish_server_output` — the exchange figures are captured before the
+/// capture-finish renders text summaries from the same live counters. No
+/// suite can pin the inversion deterministically (post-flush counters are
+/// settled); the pipeline comment at the call site is the guard.
+///
 /// Where the test's rich report stands after `finish_server_output` (#287):
 /// either already built (the JSON-mode --get-server-output pre-exchange build,
 /// #33 — the drained collections are inside) or still pending, carrying the
@@ -582,8 +588,13 @@ impl Server {
         // ---- Shut down streams + flush the reporter ----
         let end = self.shutdown_and_flush(&mut ctx).await;
 
-        // Built BEFORE the --get-server-output finish, preserving the
-        // monolith's counter read order.
+        // ORDER CONSTRAINT (#296): built BEFORE the --get-server-output
+        // finish. Both read live stream counters; the exchange figures must
+        // be captured before the capture-finish renders text summaries, or
+        // a still-draining receiver could send the peer fresher numbers
+        // than its own rendered rows. Post-flush the counters are usually
+        // settled, so no deterministic pin can catch an inversion — this
+        // comment (and TestRunCtx's docs) are the guard.
         let result_streams = self.build_result_streams(&ctx, &end);
 
         // The ONE drain of the reporter's collections (#287): the reporter was

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -142,6 +142,14 @@ impl TestConfig {
 /// test accumulates as it advances. One instance per served test; the
 /// phase-local variables the old monolithic `handle_one_test` mutated in
 /// place are now named fields with one owner.
+/// INVARIANT (#296): `build_result_streams` runs before
+/// `finish_server_output` — both read the same live stream counters, and
+/// the pipeline preserves the monolith's read order (the exchange figures
+/// are captured first; with live counters either order carries a small
+/// freshness skew — GT sidesteps it by snapshotting at TEST_END — so the
+/// order itself is the contract). No suite can pin an inversion
+/// deterministically (post-flush counters are settled); this doc and the
+/// pipeline comment at the call site are the guard.
 struct TestRunCtx {
     ctrl: tokio::net::TcpStream,
     /// The control-socket peer, for `start.accepted_connection` (#50):
@@ -211,12 +219,6 @@ struct EndState {
     test_duration: f64,
 }
 
-/// INVARIANT (#296): `build_result_streams` runs before
-/// `finish_server_output` — the exchange figures are captured before the
-/// capture-finish renders text summaries from the same live counters. No
-/// suite can pin the inversion deterministically (post-flush counters are
-/// settled); the pipeline comment at the call site is the guard.
-///
 /// Where the test's rich report stands after `finish_server_output` (#287):
 /// either already built (the JSON-mode --get-server-output pre-exchange build,
 /// #33 — the drained collections are inside) or still pending, carrying the


### PR DESCRIPTION
Closes #296.

**Gap 1** — the client's `IperfDone` send is now pinned by a full-protocol mock asserting the final control byte is 16, not EOF (a real server tolerates a vanished client by design, so only a wire mock can see it). Red-proven: skipping the send fails the pin.
**Gap 2** — the server's counter-read order (`build_result_streams` before `finish_server_output`): the issue's own analysis holds — post-flush counters are settled, so no deterministic pin can catch an inversion. Taken the issue's documented fallback: the constraint is now spelled out at the call site and in `TestRunCtx`'s docs.

Full gate: 695 tests, clippy/fmt clean.