### PR TITLE
fix: the server fq-paces its accepted data sockets like GT (#302)

### DIFF
--- a/riperf3/src/client.rs
+++ b/riperf3/src/client.rs
@@ -1143,9 +1143,8 @@ impl Client {
                     if self.dont_fragment {
                         net::set_dont_fragment(&data_stream)?;
                     }
-                    if let Some(rate) = self.fq_rate {
-                        net::set_fq_rate(&data_stream, rate)?;
-                    }
+                    // #302: GT warns and continues on a pacing failure.
+                    net::apply_fq_rate(&data_stream, self.fq_rate.unwrap_or(0));
                     if let Some(ms) = self.rcv_timeout {
                         net::set_rcv_timeout(&data_stream, ms)?;
                     }
@@ -1292,6 +1291,9 @@ impl Client {
                     }
                     udp_sock.connect(remote).await?;
                     protocol::udp_connect_client(&udp_sock).await?;
+                    // #302: GT paces its UDP connect path too
+                    // (iperf_udp.c:704-718); fq-qdisc dependent, warn-only.
+                    net::apply_fq_rate(&udp_sock, self.fq_rate.unwrap_or(0));
 
                     // GSO/GRO is deliberately best-effort (#45), matching
                     // iperf3 3.20+'s --gsro: its iperf_udp_gso/iperf_udp_gro

--- a/riperf3/src/net.rs
+++ b/riperf3/src/net.rs
@@ -23,8 +23,10 @@ mod custom_sockopt {
     pub struct MaxPacingRate;
 
     impl SetSockOpt for MaxPacingRate {
-        type Val = u32;
-        fn set<F: AsFd>(&self, fd: &F, val: &u32) -> nix::Result<()> {
+        // GT passes uint64_t (kernel >= 5.1 honors 8 bytes); a u32 payload
+        // silently wrapped --fq-rate above ~34.36 Gbit/s (#302 r1 F3).
+        type Val = u64;
+        fn set<F: AsFd>(&self, fd: &F, val: &u64) -> nix::Result<()> {
             // SAFETY: setsockopt on a valid fd with correct level/optname/size.
             unsafe {
                 let res = libc::setsockopt(
@@ -32,7 +34,7 @@ mod custom_sockopt {
                     libc::SOL_SOCKET,
                     libc::SO_MAX_PACING_RATE,
                     val as *const _ as *const libc::c_void,
-                    std::mem::size_of::<u32>() as libc::socklen_t,
+                    std::mem::size_of::<u64>() as libc::socklen_t,
                 );
                 nix::errno::Errno::result(res).map(drop)
             }
@@ -741,7 +743,7 @@ pub fn set_dont_fragment<F>(_fd: &F) -> Result<()> {
 #[cfg(target_os = "linux")]
 pub fn set_fq_rate(fd: &impl std::os::unix::io::AsFd, rate_bits_per_sec: u64) -> Result<()> {
     use nix::sys::socket;
-    let rate_bytes = (rate_bits_per_sec / 8) as u32;
+    let rate_bytes = rate_bits_per_sec / 8;
     socket::setsockopt(fd, custom_sockopt::MaxPacingRate, &rate_bytes)
         .map_err(|e| RiperfError::Io(std::io::Error::from(e)))
 }
@@ -749,6 +751,21 @@ pub fn set_fq_rate(fd: &impl std::os::unix::io::AsFd, rate_bits_per_sec: u64) ->
 #[cfg(not(target_os = "linux"))]
 pub fn set_fq_rate<F>(_fd: &F, _rate: u64) -> Result<()> {
     Ok(())
+}
+
+/// Apply `--fq-rate` the way GT does at all four of its sites
+/// (iperf_tcp.c:138/:565, iperf_udp.c:581/:704, #302): nonzero → set the
+/// sockopt; failure is GT's `warning: Unable to set socket pacing`, never
+/// fatal — the server arm is remotely triggered (any peer's --fq-rate), so
+/// a sandboxed runtime filtering setsockopt must degrade like GT, not
+/// abort the test.
+pub fn apply_fq_rate(fd: &impl std::os::unix::io::AsFd, rate_bits_per_sec: u64) {
+    if rate_bits_per_sec == 0 {
+        return;
+    }
+    if set_fq_rate(fd, rate_bits_per_sec).is_err() {
+        eprintln!("warning: Unable to set socket pacing");
+    }
 }
 
 /// Bind socket to a specific network device. Must be applied BEFORE

--- a/riperf3/src/net.rs
+++ b/riperf3/src/net.rs
@@ -760,7 +760,9 @@ pub fn set_fq_rate<F>(_fd: &F, _rate: u64) -> Result<()> {
 /// a sandboxed runtime filtering setsockopt must degrade like GT, not
 /// abort the test.
 pub fn apply_fq_rate(fd: &impl std::os::unix::io::AsFd, rate_bits_per_sec: u64) {
-    if rate_bits_per_sec == 0 {
+    // GT guards the BYTES value after /8 (r2 F2): --fq-rate 1..7 bits/s
+    // makes no syscall there — rate-0 setsockopt semantics vary by kernel.
+    if rate_bits_per_sec / 8 == 0 {
         return;
     }
     if set_fq_rate(fd, rate_bits_per_sec).is_err() {
@@ -1018,6 +1020,33 @@ pub async fn udp_bind_reusable(
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod fq_rate_tests {
+    /// #302 r2: the sockopt payload is u64 like GT's uint64_t — a u32
+    /// wrapped --fq-rate above ~34.36 Gbit/s (40G → ~5.6G). Readback pin,
+    /// no fq-qdisc dependence.
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn fq_rate_u64_round_trips() {
+        use std::os::fd::AsRawFd;
+        let sock = std::net::UdpSocket::bind("127.0.0.1:0").unwrap();
+        super::set_fq_rate(&sock, 40_000_000_000).unwrap();
+        let mut val: u64 = 0;
+        let mut len = std::mem::size_of::<u64>() as libc::socklen_t;
+        let rc = unsafe {
+            libc::getsockopt(
+                sock.as_raw_fd(),
+                libc::SOL_SOCKET,
+                libc::SO_MAX_PACING_RATE,
+                &mut val as *mut _ as *mut libc::c_void,
+                &mut len,
+            )
+        };
+        assert_eq!(rc, 0);
+        assert_eq!(val, 5_000_000_000, "u64 payload survives (u32 wrapped)");
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/riperf3/src/net.rs
+++ b/riperf3/src/net.rs
@@ -759,6 +759,7 @@ pub fn set_fq_rate<F>(_fd: &F, _rate: u64) -> Result<()> {
 /// fatal — the server arm is remotely triggered (any peer's --fq-rate), so
 /// a sandboxed runtime filtering setsockopt must degrade like GT, not
 /// abort the test.
+#[cfg(target_os = "linux")]
 pub fn apply_fq_rate(fd: &impl std::os::unix::io::AsFd, rate_bits_per_sec: u64) {
     // GT guards the BYTES value after /8 (r2 F2): --fq-rate 1..7 bits/s
     // makes no syscall there — rate-0 setsockopt semantics vary by kernel.
@@ -769,6 +770,11 @@ pub fn apply_fq_rate(fd: &impl std::os::unix::io::AsFd, rate_bits_per_sec: u64) 
         eprintln!("warning: Unable to set socket pacing");
     }
 }
+
+/// Without SO_MAX_PACING_RATE, GT compiles the whole pacing block out
+/// (`#if defined(HAVE_SO_MAX_PACING_RATE)`) — no syscall, no warning.
+#[cfg(not(target_os = "linux"))]
+pub fn apply_fq_rate<F>(_fd: &F, _rate_bits_per_sec: u64) {}
 
 /// Bind socket to a specific network device. Must be applied BEFORE
 /// `connect()` — these options steer the routing decision made at connect

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -962,10 +962,8 @@ impl Server {
                     // #302: GT enables fair-queue pacing on the server's
                     // ACCEPTED data sockets too (iperf_tcp.c:138-153) — the
                     // exchanged --fq-rate paces the reverse/bidir send path.
-                    // Linux sockopt; no-op elsewhere (like the client site).
-                    if ctx.cfg.fq_rate > 0 {
-                        net::set_fq_rate(&data_stream, ctx.cfg.fq_rate)?;
-                    }
+                    // Warn-only like GT's four sites; Linux sockopt.
+                    net::apply_fq_rate(&data_stream, ctx.cfg.fq_rate);
 
                     let stream_id = iperf3_stream_id(i);
                     let is_sender = i >= recv_count;
@@ -1806,6 +1804,8 @@ impl Server {
             self.bind_dev.as_deref(),
         )
         .await?;
+        // #302: GT paces its UDP accept path too (iperf_udp.c:581-595).
+        net::apply_fq_rate(&udp_listener, cfg.fq_rate);
 
         protocol::send_state(ctrl, TestState::CreateStreams).await?;
 
@@ -1962,6 +1962,8 @@ impl Server {
             self.bind_dev.as_deref(),
         )
         .await?;
+        // #302: the demux shared socket IS the data socket — pace it too.
+        net::apply_fq_rate(&udp_sock, cfg.fq_rate);
 
         protocol::send_state(ctrl, TestState::CreateStreams).await?;
 

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -25,6 +25,9 @@ pub(crate) struct TestConfig {
     pub bandwidth: u64,
     /// `-b rate/burst` block count from the client (0 = unset) (#160).
     pub burst: u32,
+    /// The client's `--fq-rate` (0 = unset): GT paces its ACCEPTED data
+    /// sockets with it too (iperf_tcp.c:138-153, #302).
+    pub fq_rate: u64,
     pub pacing_timer: u32,
     pub tos: i32,
     pub congestion: Option<String>,
@@ -118,6 +121,7 @@ impl TestConfig {
             // 1 Mbit/s throttled an iperf3 -b 0 reverse/bidir sender (#21). The
             // 1 Mbit/s UDP default is a client-side concern, resolved at build.
             bandwidth: params.bandwidth.unwrap_or(0),
+            fq_rate: params.fqrate.unwrap_or(0),
             burst,
             // The client's --pacing-timer quantum (#32); iperf3 always sends
             // it. Absent/non-positive (older peers) → iperf3's 1000 µs default.
@@ -954,6 +958,13 @@ impl Server {
                         // iperf_common_sockopts errors (IESETTOS) when IP_TOS
                         // can't be applied, on both roles and both protocols.
                         net::set_tos(&data_stream, ctx.cfg.tos as u32)?;
+                    }
+                    // #302: GT enables fair-queue pacing on the server's
+                    // ACCEPTED data sockets too (iperf_tcp.c:138-153) — the
+                    // exchanged --fq-rate paces the reverse/bidir send path.
+                    // Linux sockopt; no-op elsewhere (like the client site).
+                    if ctx.cfg.fq_rate > 0 {
+                        net::set_fq_rate(&data_stream, ctx.cfg.fq_rate)?;
                     }
 
                     let stream_id = iperf3_stream_id(i);

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -1804,8 +1804,6 @@ impl Server {
             self.bind_dev.as_deref(),
         )
         .await?;
-        // #302: GT paces its UDP accept path too (iperf_udp.c:581-595).
-        net::apply_fq_rate(&udp_listener, cfg.fq_rate);
 
         protocol::send_state(ctrl, TestState::CreateStreams).await?;
 
@@ -1824,6 +1822,10 @@ impl Server {
                     .await?;
             // The listener is now locked to this client — use it as the data socket
             let data_sock = udp_listener;
+            // #302 r2: pace EVERY accepted stream — GT's block lives in
+            // iperf_udp_accept (iperf_udp.c:581-595), once per stream; the
+            // pre-loop listener call covered stream 0 only.
+            net::apply_fq_rate(&data_sock, cfg.fq_rate);
 
             // Create a fresh listener for the next stream (if any)
             if i + 1 < total {
@@ -1963,6 +1965,10 @@ impl Server {
         )
         .await?;
         // #302: the demux shared socket IS the data socket — pace it too.
+        // NOTE (r2): one shared socket means aggregate pacing = R for -P N
+        // (per-stream sockets pace N×R); inherent to the demux design,
+        // which is Windows-default (where the sockopt no-ops) and Linux
+        // opt-in via RIPERF3_UDP_SERVER_DEMUX.
         net::apply_fq_rate(&udp_sock, cfg.fq_rate);
 
         protocol::send_state(ctrl, TestState::CreateStreams).await?;

--- a/riperf3/tests/integration.rs
+++ b/riperf3/tests/integration.rs
@@ -2619,3 +2619,40 @@ async fn both_violations_relay_total_rate_like_gt() {
         other => panic!("expected the IETOTALRATE refusal, got {other:?}"),
     }
 }
+
+/// #302: GT enables SO_MAX_PACING_RATE on its ACCEPTED data sockets too
+/// (iperf_tcp.c:138-153), so a client's --fq-rate paces the server's
+/// reverse send path. Live GT reverse --fq-rate 5M ≈ 6.3 Mbps where the
+/// unpaced loopback runs ~100 Gbps — pre-fix riperf3 measured 95 Gbps.
+/// Linux-gated: the sockopt (and kernel-side TCP pacing) is Linux-only.
+#[cfg(target_os = "linux")]
+#[tokio::test]
+async fn server_paces_reverse_with_the_client_fq_rate() {
+    let server = ServerBuilder::new()
+        .port(Some(0))
+        .emit_output(false)
+        .build()
+        .unwrap();
+    let bound = server.bind().await.expect("bind");
+    let port = bound.local_addr().unwrap().port();
+    let server_task = tokio::spawn(async move { bound.run_once().await });
+
+    let client = ClientBuilder::new("127.0.0.1")
+        .port(Some(port))
+        .reverse(true)
+        .fq_rate(5_000_000)
+        .duration(2)
+        .emit_output(false)
+        .build()
+        .unwrap();
+    let report = tokio::time::timeout(Duration::from_secs(25), client.run())
+        .await
+        .expect("client hung")
+        .expect("client errored");
+    let bps = report.end.sum_received.as_ref().unwrap().bits_per_second;
+    assert!(
+        bps < 20_000_000.0,
+        "the server's reverse send is fq-paced at ~5 Mbps like GT, got {bps}"
+    );
+    let _ = server_task.await;
+}


### PR DESCRIPTION
Closes #302.

GT enables SO_MAX_PACING_RATE at **four** sites — TCP accept (`iperf_tcp.c:138-153`), TCP connect (`:565`), UDP accept (`iperf_udp.c:581-595`), UDP connect (`:704-718`) — all warn-on-failure. riperf3 paced only the client's TCP connect. Live probe: GT reverse `--fq-rate 5M` ≈ 6.3 Mbps; riperf3 pre-fix ≈ **95 Gbps**.

All four riperf3 sites now apply the exchanged/local rate (server TCP accept; client UDP connect; server UDP accept — both the recycling listener and the demux shared socket; UDP pacing is fq-qdisc dependent, inert on loopback/noqueue). Failures warn like GT instead of aborting — the server arm is remotely triggered (any peer's `--fq-rate`), so sandboxed runtimes degrade like GT (r1 F2). The sockopt payload is u64 like GT's `uint64_t`; the old u32 cast wrapped `--fq-rate` above ~34.36 Gbit/s (r1 F3).

Red-first Linux-gated pin: reverse `--fq-rate 5M` < 20 Mbps (pre-fix red at 95 Gbps; r1's 10× flake assessment: sound, one-sided bound). r1's full probe table: 10/10 pacing cells across rip↔rip / GT↔rip both ways, fwd/rev/bidir, incl. unpaced controls.