### PR TITLE
fix: the server's exchange reads join the interrupt surface (#319)

### DIFF
--- a/riperf3-cli/tests/signal_terminate.rs
+++ b/riperf3-cli/tests/signal_terminate.rs
@@ -778,3 +778,78 @@ fn mid_exchange_wedge_still_exits_on_signal() {
         "the sigend dump carries the interrupt error key: {doc}"
     );
 }
+
+/// #319 (sibling of #268): the SERVER's exchange reads must not outlive a
+/// signal when the CLIENT wedges mid-results-payload. Pre-fix the server
+/// hung in recv_results past SIGTERM.
+#[test]
+fn server_survives_a_mid_exchange_client_wedge() {
+    use std::io::Write;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::Arc;
+
+    let port = free_port();
+    let ps = port.to_string();
+    let server = spawn(&["-s", "-1", "-p", &ps, "-J"]);
+    std::thread::sleep(Duration::from_millis(400));
+
+    let wedged = Arc::new(AtomicBool::new(false));
+    let wedged_w = wedged.clone();
+    let _mock = std::thread::spawn(move || {
+        let read_exact = |s: &mut std::net::TcpStream, n: usize| -> Vec<u8> {
+            let mut b = vec![0u8; n];
+            s.read_exact(&mut b).expect("mock read");
+            b
+        };
+        let write_json = |s: &mut std::net::TcpStream, payload: &str| {
+            s.write_all(&(payload.len() as u32).to_be_bytes()).unwrap();
+            s.write_all(payload.as_bytes()).unwrap();
+        };
+        let cookie = [b'x'; 37];
+        let mut ctrl = std::net::TcpStream::connect(("127.0.0.1", port)).expect("ctrl");
+        ctrl.write_all(&cookie).unwrap();
+        assert_eq!(read_exact(&mut ctrl, 1)[0], 9, "ParamExchange");
+        write_json(
+            &mut ctrl,
+            r#"{"tcp":true,"omit":0,"time":1,"num":0,"blockcount":0,"parallel":1,"len":131072,"pacing_timer":1000,"client_version":"riperf3 0.0.0"}"#,
+        );
+        assert_eq!(read_exact(&mut ctrl, 1)[0], 10, "CreateStreams");
+        let mut data = std::net::TcpStream::connect(("127.0.0.1", port)).expect("data");
+        data.write_all(&cookie).unwrap();
+        assert_eq!(read_exact(&mut ctrl, 1)[0], 1, "TestStart");
+        assert_eq!(read_exact(&mut ctrl, 1)[0], 2, "TestRunning");
+        data.write_all(&[0u8; 4096]).unwrap();
+        ctrl.write_all(&[4u8]).unwrap(); // TestEnd
+        assert_eq!(read_exact(&mut ctrl, 1)[0], 13, "ExchangeResults");
+        // The wedge: announce 500 bytes of results, deliver 40, stall.
+        ctrl.write_all(&500u32.to_be_bytes()).unwrap();
+        ctrl.write_all(&[b'{'; 40]).unwrap();
+        wedged_w.store(true, Ordering::SeqCst);
+        std::thread::sleep(Duration::from_secs(15));
+        drop(data);
+    });
+
+    let t0 = Instant::now();
+    while !wedged.load(std::sync::atomic::Ordering::SeqCst) {
+        assert!(
+            t0.elapsed() < Duration::from_secs(10),
+            "mock never reached the wedge"
+        );
+        std::thread::sleep(Duration::from_millis(25));
+    }
+    std::thread::sleep(Duration::from_millis(300)); // park in the bulk read
+    unsafe {
+        libc::kill(server.0.id() as i32, libc::SIGTERM);
+    }
+    let (sout, _serr, scode) =
+        wait_with_output_bounded(server, Duration::from_secs(5), "server mid-exchange wedge");
+    assert_eq!(scode, 0, "signal-normal exit despite the wedged read");
+    let doc: serde_json::Value =
+        serde_json::from_str(sout.trim()).unwrap_or_else(|e| panic!("one -J doc ({e}): {sout}"));
+    assert!(
+        doc["error"]
+            .as_str()
+            .is_some_and(|e| e.contains("terminated")),
+        "the sigend dump carries the interrupt error key: {doc}"
+    );
+}

--- a/riperf3-cli/tests/signal_terminate.rs
+++ b/riperf3-cli/tests/signal_terminate.rs
@@ -779,6 +779,89 @@ fn mid_exchange_wedge_still_exits_on_signal() {
     );
 }
 
+/// #322 r1 F3: the SECOND server read — the IperfDone wait — takes the
+/// same interrupt surface. The mock completes the results exchange, reads
+/// DisplayResults, then never sends IperfDone.
+#[test]
+fn server_survives_a_client_that_never_sends_iperf_done() {
+    use std::io::Write;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::Arc;
+
+    let port = free_port();
+    let ps = port.to_string();
+    let server = spawn(&["-s", "-1", "-p", &ps, "-J"]);
+    std::thread::sleep(Duration::from_millis(400));
+
+    let parked = Arc::new(AtomicBool::new(false));
+    let parked_w = parked.clone();
+    let _mock = std::thread::spawn(move || {
+        let read_exact = |s: &mut std::net::TcpStream, n: usize| -> Vec<u8> {
+            let mut b = vec![0u8; n];
+            s.read_exact(&mut b).expect("mock read");
+            b
+        };
+        let read_json = |s: &mut std::net::TcpStream| {
+            let len = u32::from_be_bytes(read_exact(s, 4).try_into().unwrap()) as usize;
+            read_exact(s, len)
+        };
+        let write_json = |s: &mut std::net::TcpStream, payload: &str| {
+            s.write_all(&(payload.len() as u32).to_be_bytes()).unwrap();
+            s.write_all(payload.as_bytes()).unwrap();
+        };
+        let cookie = [b'x'; 37];
+        let mut ctrl = std::net::TcpStream::connect(("127.0.0.1", port)).expect("ctrl");
+        ctrl.write_all(&cookie).unwrap();
+        assert_eq!(read_exact(&mut ctrl, 1)[0], 9, "ParamExchange");
+        write_json(
+            &mut ctrl,
+            r#"{"tcp":true,"omit":0,"time":1,"num":0,"blockcount":0,"parallel":1,"len":131072,"pacing_timer":1000,"client_version":"riperf3 0.0.0"}"#,
+        );
+        assert_eq!(read_exact(&mut ctrl, 1)[0], 10, "CreateStreams");
+        let mut data = std::net::TcpStream::connect(("127.0.0.1", port)).expect("data");
+        data.write_all(&cookie).unwrap();
+        assert_eq!(read_exact(&mut ctrl, 1)[0], 1, "TestStart");
+        assert_eq!(read_exact(&mut ctrl, 1)[0], 2, "TestRunning");
+        data.write_all(&[0u8; 4096]).unwrap();
+        ctrl.write_all(&[4u8]).unwrap(); // TestEnd
+        assert_eq!(read_exact(&mut ctrl, 1)[0], 13, "ExchangeResults");
+        write_json(
+            &mut ctrl,
+            r#"{"cpu_util_total":1.0,"cpu_util_user":0.5,"cpu_util_system":0.5,"sender_has_retransmits":1,"streams":[{"id":1,"bytes":4096,"retransmits":0,"jitter":0,"errors":0,"packets":0,"start_time":0,"end_time":1}]}"#,
+        );
+        read_json(&mut ctrl); // the server's results
+        assert_eq!(read_exact(&mut ctrl, 1)[0], 14, "DisplayResults");
+        parked_w.store(true, Ordering::SeqCst);
+        // Never send IperfDone; hold both sockets open.
+        std::thread::sleep(Duration::from_secs(15));
+        drop(data);
+    });
+
+    let t0 = Instant::now();
+    while !parked.load(std::sync::atomic::Ordering::SeqCst) {
+        assert!(
+            t0.elapsed() < Duration::from_secs(10),
+            "mock never parked the server"
+        );
+        std::thread::sleep(Duration::from_millis(25));
+    }
+    std::thread::sleep(Duration::from_millis(300));
+    unsafe {
+        libc::kill(server.0.id() as i32, libc::SIGTERM);
+    }
+    let (sout, _serr, scode) =
+        wait_with_output_bounded(server, Duration::from_secs(2), "server IperfDone wedge");
+    assert_eq!(scode, 0, "signal-normal exit despite the missing IperfDone");
+    let doc: serde_json::Value =
+        serde_json::from_str(sout.trim()).unwrap_or_else(|e| panic!("one -J doc ({e}): {sout}"));
+    assert!(
+        doc["error"]
+            .as_str()
+            .is_some_and(|e| e.contains("terminated")),
+        "the sigend dump carries the interrupt error key: {doc}"
+    );
+}
+
 /// #319 (sibling of #268): the SERVER's exchange reads must not outlive a
 /// signal when the CLIENT wedges mid-results-payload. Pre-fix the server
 /// hung in recv_results past SIGTERM.
@@ -841,8 +924,10 @@ fn server_survives_a_mid_exchange_client_wedge() {
     unsafe {
         libc::kill(server.0.id() as i32, libc::SIGTERM);
     }
+    // #322 r1 F2: 2s pins the GRACEFUL exit — the CLI's #211 bailout is 5s,
+    // so a revert that only exits via the bailout goes red here.
     let (sout, _serr, scode) =
-        wait_with_output_bounded(server, Duration::from_secs(5), "server mid-exchange wedge");
+        wait_with_output_bounded(server, Duration::from_secs(2), "server mid-exchange wedge");
     assert_eq!(scode, 0, "signal-normal exit despite the wedged read");
     let doc: serde_json::Value =
         serde_json::from_str(sout.trim()).unwrap_or_else(|e| panic!("one -J doc ({e}): {sout}"));

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -588,7 +588,7 @@ impl Server {
         self.await_test_end(&mut ctx).await?;
 
         // ---- Shut down streams + flush the reporter ----
-        let end = self.shutdown_and_flush(&mut ctx).await;
+        let mut end = self.shutdown_and_flush(&mut ctx).await;
 
         // ORDER CONSTRAINT (#296): built BEFORE the --get-server-output
         // finish. Both read live stream counters; the exchange figures must
@@ -618,6 +618,17 @@ impl Server {
             server_output_json,
         )
         .await?;
+
+        // #319: an interrupt landing INSIDE the exchange phase fires after
+        // EndState froze report_error — re-resolve so the sigend dump
+        // carries the interrupt key like the mid-test arms. (A pre-exchange
+        // --get-server-output capture keeps its frozen shape: it was built
+        // before the signal by definition.)
+        if end.report_error.is_none() {
+            if let Some(msg) = &ctx.interrupted {
+                end.report_error = Some(msg.clone());
+            }
+        }
 
         // #137/#287: the report is built exactly ONCE per test, by
         // construction — the collections moved either into the pre-exchange
@@ -1594,11 +1605,25 @@ impl Server {
             };
 
             protocol::send_state(&mut ctx.ctrl, TestState::ExchangeResults).await?;
+            // #319 (sibling of #268): both post-test reads race the
+            // interrupt watch — a client wedging mid-results (or never
+            // sending IperfDone) must not hold the server past a signal.
+            // GT's server sigend longjmps out of the same reads. On fire:
+            // tell the client (best-effort), record the interrupt, and let
+            // the finalize phases render the sigend dump.
+            let mut exchange_interrupt = self.interrupt.clone().map(|w| w.0);
             // iperf3 protocol: server reads client results first, then sends its
             // own. The client's results are not used in the server's own report —
             // iperf3's server reports only its own measured bytes and a 0 remote
             // CPU (#50).
-            let _client_results = protocol::recv_results(&mut ctx.ctrl).await?;
+            let _client_results = tokio::select! {
+                r = protocol::recv_results(&mut ctx.ctrl) => r?,
+                msg = crate::client::wait_interrupt(exchange_interrupt.as_mut()) => {
+                    let _ = protocol::send_state(&mut ctx.ctrl, TestState::ServerTerminate).await;
+                    ctx.interrupted = Some(msg);
+                    return Ok(());
+                }
+            };
             protocol::send_results(&mut ctx.ctrl, &server_results).await?;
 
             // ---- DisplayResults / IperfDone ----
@@ -1606,7 +1631,15 @@ impl Server {
 
             // Wait for client to send IperfDone
             loop {
-                match protocol::recv_state(&mut ctx.ctrl).await {
+                let next = tokio::select! {
+                    r = protocol::recv_state(&mut ctx.ctrl) => r,
+                    msg = crate::client::wait_interrupt(exchange_interrupt.as_mut()) => {
+                        let _ = protocol::send_state(&mut ctx.ctrl, TestState::ServerTerminate).await;
+                        ctx.interrupted = Some(msg);
+                        return Ok(());
+                    }
+                };
+                match next {
                     Ok(TestState::IperfDone) => break,
                     // #145: AUDITABILITY ONLY — log an out-of-table control
                     // byte in the end-of-test loop, then STILL continue

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -636,13 +636,31 @@ impl Server {
         // post-exchange build. handle_one_test returns it (run discards it;
         // run_once hands it back to the library caller).
         let report = match report_source {
-            ReportSource::Built(report) => *report,
+            ReportSource::Built(mut report) => {
+                // #322 r1 F4: a mid-exchange interrupt postdates the
+                // pre-exchange --get-server-output build — carry the key
+                // like GT's exit-time json_finish.
+                if report.error.is_none() {
+                    report.error = end.report_error.clone();
+                }
+                *report
+            }
             ReportSource::Pending(collected) => self.build_ctx_report(&ctx, &end, collected),
         };
 
         self.emit_final_output(&ctx, &end, &report, was_captured);
 
-        // Join stream tasks (best-effort, they should be done)
+        // Join stream tasks (best-effort, they should be done).
+        // #322 r1 F1: a mid-EXCHANGE interrupt postdates shutdown_and_flush's
+        // abort gate — abort here so a wedged peer can't park the joins.
+        if ctx.interrupted.is_some() {
+            for s in &ctx.streams {
+                s.task.abort();
+            }
+            if let Some(h) = &ctx.udp_demux_handle {
+                h.abort();
+            }
+        }
         for s in ctx.streams {
             let _ = s.task.await;
         }
@@ -1319,7 +1337,10 @@ impl Server {
         // the next await); the UDP runners are spawn_blocking, where abort
         // is a no-op once running — their joins stay bounded anyway by the
         // 500 ms read-timeout + `done` polling in the blocking loops.
-        if ctx.server_error.is_some() {
+        if ctx.server_error.is_some() || ctx.interrupted.is_some() {
+            // #322 r1 F1: interrupts take the same abort — a wedged peer
+            // holding sockets open must not park the joins (GT closes its
+            // data sockets at TEST_END and sigend exits in milliseconds).
             for s in &ctx.streams {
                 s.task.abort();
             }


### PR DESCRIPTION
Closes #319.

Sibling of #268 (the client fix in #315): the server's `recv_results` and the IperfDone wait were plain awaits — a client wedging mid-results-payload held the server past SIGTERM, where GT's server sigend longjmps out of the same reads. Both reads now race the interrupt watch; on fire the server sends a best-effort `ServerTerminate`, records the interrupt, and the finalize phases render the sigend dump. One subtlety: `EndState` freezes `report_error` before the exchange phase, so it's re-resolved afterward — the dump carries the interrupt key exactly like the mid-test arms (the pre-exchange `--get-server-output` capture keeps its frozen shape, built before the signal by definition).

Red-first: an inverted wedge mock (the CLIENT announces 500 result bytes, delivers 40, stalls) — pre-fix the server outlived SIGTERM to the bound; post-fix exits 0 with the interrupt-keyed doc. Full gate: 695 tests, clippy/fmt clean.