### PR TITLE
fix(compat): -t 0 arms no end deadline, unbounded like GT (#321)

### DIFF
--- a/riperf3-cli/tests/end_conditions.rs
+++ b/riperf3-cli/tests/end_conditions.rs
@@ -5,6 +5,8 @@
 
 use std::process::Command;
 
+mod common;
+
 #[test]
 fn conflicting_end_conditions_exit_before_side_effects() {
     let bin = env!("CARGO_BIN_EXE_riperf3");
@@ -46,4 +48,47 @@ fn conflicting_end_conditions_exit_before_side_effects() {
         "the rejection must fire BEFORE side effects (iperf3 creates no pidfile); found {pidfile:?}"
     );
     let _ = std::fs::remove_file(&pidfile);
+}
+
+/// #321: GT arms NO end timer for `-t 0` (iperf_client_api.c:229's
+/// `if (duration != 0)` gate) — the run is unbounded until signaled.
+/// Pre-fix riperf3 completed instantly (a zero-length sleep).
+#[cfg(unix)]
+#[test]
+fn time_zero_runs_until_signaled() {
+    let port = common::free_port();
+    let ps = port.to_string();
+    let mut server = common::ChildGuard(
+        std::process::Command::new(env!("CARGO_BIN_EXE_riperf3"))
+            .args(["-s", "-1", "-p", &ps])
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .spawn()
+            .expect("spawn server"),
+    );
+    std::thread::sleep(std::time::Duration::from_millis(400));
+
+    let client = common::ChildGuard(
+        std::process::Command::new(env!("CARGO_BIN_EXE_riperf3"))
+            .args(["-c", "127.0.0.1", "-p", &ps, "-t", "0", "-J"])
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::null())
+            .spawn()
+            .expect("spawn client"),
+    );
+    // The client must STILL be running well past any instant-complete
+    // window (pre-fix it exited in <1s).
+    std::thread::sleep(std::time::Duration::from_millis(2_500));
+    let mut client = client;
+    assert!(
+        client.0.try_wait().expect("try_wait").is_none(),
+        "-t 0 runs unbounded like GT"
+    );
+    unsafe {
+        libc::kill(client.0.id() as i32, libc::SIGTERM);
+    }
+    let out = riperf3_test_support::wait_bounded(&mut client.0, std::time::Duration::from_secs(8))
+        .expect("client exits on signal");
+    assert!(out.success(), "signal-normal exit like GT's sigend");
+    let _ = server.0.kill();
 }

--- a/riperf3-cli/tests/end_conditions.rs
+++ b/riperf3-cli/tests/end_conditions.rs
@@ -50,6 +50,63 @@ fn conflicting_end_conditions_exit_before_side_effects() {
     let _ = std::fs::remove_file(&pidfile);
 }
 
+/// #321 r1: the UDP half — the senders' self-enforced deadline (#5) must
+/// not arm at 0 either, or a UDP `-t 0` run silently sends ZERO bytes
+/// forever (the senders self-terminate instantly while the process keeps
+/// running). The nonzero-bytes assert is what kills that mutation.
+#[cfg(unix)]
+#[test]
+fn udp_time_zero_keeps_sending_until_signaled() {
+    let port = common::free_port();
+    let ps = port.to_string();
+    let mut server = common::ChildGuard(
+        std::process::Command::new(env!("CARGO_BIN_EXE_riperf3"))
+            .args(["-s", "-1", "-p", &ps])
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .spawn()
+            .expect("spawn server"),
+    );
+    std::thread::sleep(std::time::Duration::from_millis(400));
+
+    let mut client = common::ChildGuard(
+        std::process::Command::new(env!("CARGO_BIN_EXE_riperf3"))
+            .args(["-c", "127.0.0.1", "-p", &ps, "-u", "-t", "0", "-J"])
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::null())
+            .spawn()
+            .expect("spawn client"),
+    );
+    std::thread::sleep(std::time::Duration::from_millis(2_500));
+    assert!(
+        client.0.try_wait().expect("try_wait").is_none(),
+        "-u -t 0 runs unbounded like GT"
+    );
+    unsafe {
+        libc::kill(client.0.id() as i32, libc::SIGTERM);
+    }
+    let out = riperf3_test_support::wait_bounded(&mut client.0, std::time::Duration::from_secs(8))
+        .expect("client exits on signal");
+    assert!(out.success(), "signal-normal exit");
+    let mut doc = String::new();
+    use std::io::Read;
+    client
+        .0
+        .stdout
+        .take()
+        .expect("piped")
+        .read_to_string(&mut doc)
+        .expect("read doc");
+    let v: serde_json::Value = serde_json::from_str(doc.trim()).expect("one -J doc");
+    let sent = v["end"]["sum_sent"]["bytes"].as_u64().unwrap_or(0);
+    assert!(
+        sent > 100_000,
+        "the senders kept sending (~1 Mbit/s default) instead of \
+         self-terminating on a zero deadline: sent={sent}"
+    );
+    let _ = server.0.kill();
+}
+
 /// #321: GT arms NO end timer for `-t 0` (iperf_client_api.c:229's
 /// `if (duration != 0)` gate) — the run is unbounded until signaled.
 /// Pre-fix riperf3 completed instantly (a zero-length sleep).

--- a/riperf3/src/client.rs
+++ b/riperf3/src/client.rs
@@ -1093,7 +1093,11 @@ impl Client {
         // sender stops itself at `-t` so termination never depends on `done`
         // being set by a CPU-starved runtime. Only in duration mode;
         // byte/block-limited tests stop on `done`.
-        let max_duration = (self.bytes_to_send.is_none() && self.blocks_to_send.is_none())
+        let max_duration = (self.bytes_to_send.is_none()
+            && self.blocks_to_send.is_none()
+            // #321: GT arms NO end timer for -t 0 (iperf_client_api.c:229)
+            // — the run is unbounded until a signal or the peer ends it.
+            && self.duration > 0)
             .then(|| Duration::from_secs((self.duration + self.omit) as u64));
 
         // `-n`/`-k` shared byte budget for the sending streams: they collectively
@@ -1565,7 +1569,10 @@ impl Client {
                 // post-omit `-t` (its timeline restarts at the boundary).
                 let wall = dur + Duration::from_secs(self.omit as u64);
                 tokio::select! {
-                    _ = tokio::time::sleep(wall) => dur.as_secs_f64(),
+                    // #321: -t 0 arms no deadline, like GT's
+                    // `if (test->duration != 0)` timer gate — the run ends
+                    // only on a signal or a control-channel event.
+                    _ = tokio::time::sleep(wall), if !dur.is_zero() => dur.as_secs_f64(),
                     ev = watch_control(ctrl) => {
                         control_event = Some(ev);
                         watch_end_secs(report_start.elapsed().as_secs_f64())


### PR DESCRIPTION
Closes #321.

GT creates no end timer for `-t 0` (`iperf_client_api.c:229`'s `if (duration != 0)` gate) — the run is unbounded until a signal or the peer ends it. riperf3 completed instantly (a zero-length sleep). The duration select's sleep arm is now gated on nonzero, and the UDP senders' self-enforced deadline (#5) is likewise not armed at 0 — the run ends via the interrupt watch or a control-channel event, exactly the two arms GT's sigend/select provide. The server side already had GT's shape (#230's watchdog gate).

Red-first pin: a `-t 0` client must still be running at 2.5s (pre-fix exited <1s), then exit signal-normal on SIGTERM. Full gate: 699 tests, clippy/fmt clean.