### PR TITLE
fix(compat): UDP GSO/GRO params block + server-side honor (#316)

### DIFF
--- a/riperf3-cli/src/cli.rs
+++ b/riperf3-cli/src/cli.rs
@@ -290,8 +290,8 @@ pub struct Cli {
     #[arg(long = "json-stream-full-output")]
     pub json_stream_full_output: bool,
 
-    /// Enable UDP GSO/GRO
-    #[arg(long)]
+    /// enable UDP GSO/GRO on both client and server (client-only option)
+    #[arg(long, verbatim_doc_comment)]
     pub gsro: bool,
 
     /// Use sendmmsg for batched UDP sends (experimental, Linux/FreeBSD/NetBSD)

--- a/riperf3-cli/src/cli.rs
+++ b/riperf3-cli/src/cli.rs
@@ -1791,8 +1791,8 @@ mod cli_tests {
             assert_eq!(c, expected_client("h").interval(0.5).build().unwrap());
         }
 
-        // zerocopy (sendfile) and gsro (UDP GSO/GRO) are rejected by `build()` on
-        // non-unix (cfg(not(unix)) → Unsupported), so gate these wiring tests to
+        // zerocopy (sendfile) is rejected by `build()` on non-unix
+        // (cfg(not(unix)) → Unsupported), so its wiring test is gated to
         // unix to match — same as congestion_flag_wired / bind_dev_wired.
         #[cfg(unix)]
         #[test]
@@ -1802,7 +1802,9 @@ mod cli_tests {
             assert_eq!(c, expected_client("h").zerocopy(true).build().unwrap());
         }
 
-        #[cfg(unix)]
+        // --gsro builds on EVERY platform (#316): GT keeps the flag
+        // available regardless of local support so the request still
+        // reaches the server (iperf_api.c:1799-1804).
         #[test]
         fn gsro_wired() {
             let cli = Cli::parse_from(["riperf3", "-c", "h", "--gsro"]);

--- a/riperf3-cli/src/main.rs
+++ b/riperf3-cli/src/main.rs
@@ -121,6 +121,20 @@ fn main() -> std::process::ExitCode {
         eprintln!("warning: Report format (-f) flag ignored with JSON output (-J)");
     }
 
+    // #316: GT warns at parse end when --gsro rides a client build without
+    // local GSO/GRO support (iperf_api.c:1830-1839 — the flag still travels
+    // in params so the server may enable its side). riperf3 has both on
+    // Linux and neither elsewhere, so only GT's both-missing arm is
+    // reachable. Same bare warning() shape as -f above. The server-role
+    // reject (iperf_api.c:1825-1828, IECLIENTONLY) already fired above.
+    #[cfg(not(target_os = "linux"))]
+    if cli.gsro {
+        eprintln!(
+            "warning: --gsro requested but UDP GSO/GRO not supported on this client; \
+             will only be enabled on server if supported"
+        );
+    }
+
     // The error SINK is chosen by mode, like iperf_errexit (#198): -J puts
     // the message in a JSON document on stdout (nothing on stderr),
     // --json-stream emits an error event + empty end event, --logfile gets

--- a/riperf3-cli/tests/gsro.rs
+++ b/riperf3-cli/tests/gsro.rs
@@ -1,0 +1,152 @@
+//! #316: `--gsro` end-to-end — UDP GSO/GRO on both roles.
+//!
+//! On Linux these runs set real UDP_SEGMENT/UDP_GRO sockopts over loopback,
+//! so a GRO-coalesced read can hand the receiver a multi-datagram train; the
+//! zero-loss asserts are the phantom-loss regression net (the #327 r1
+//! failure: 97% "loss" from parsing one header per read). Elsewhere the
+//! probes fail like GT's `#else` stubs and the run must still complete with
+//! the echo reading 0.
+
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+use serde_json::Value;
+
+mod common;
+
+use common::{udp_serial, wait_bounded, ChildGuard};
+
+/// One `--gsro` UDP run against a one-off server; returns the client's `-J`
+/// doc. `demux` forces the server's shared-socket path (the recycling path
+/// is the Unix default).
+fn run_gsro(demux: bool, who: &str) -> Value {
+    let _serial = udp_serial();
+    let bin = env!("CARGO_BIN_EXE_riperf3");
+    let port = common::free_port().to_string();
+
+    let mut cmd = Command::new(bin);
+    cmd.args(["-s", "-1", "-p", &port])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+    if demux {
+        cmd.env("RIPERF3_UDP_SERVER_DEMUX", "1");
+    }
+    let mut server = ChildGuard(cmd.spawn().unwrap_or_else(|e| panic!("{who}: server: {e}")));
+
+    let retry_deadline = Instant::now() + Duration::from_secs(10);
+    let out = loop {
+        let client = common::run_client(
+            &[
+                "-c",
+                "127.0.0.1",
+                "-p",
+                &port,
+                "-u",
+                "--gsro",
+                "-t",
+                "2",
+                "-P",
+                "2",
+                "-J",
+            ],
+            Duration::from_secs(20),
+            who,
+        );
+        let combined = format!("{}\n{}", client.stderr, client.stdout);
+        if common::refused(&client.status, &combined) && Instant::now() < retry_deadline {
+            std::thread::sleep(Duration::from_millis(100));
+            continue;
+        }
+        assert!(
+            client.status.success(),
+            "{who}: client exited non-zero: {:?}\nstderr: {}\n{}",
+            client.status,
+            client.stderr,
+            client.stdout
+        );
+        break client.stdout;
+    };
+    let _ = wait_bounded(&mut server.0, Duration::from_secs(5));
+    serde_json::from_str(&out).unwrap_or_else(|e| panic!("{who}: not JSON ({e}): {out}"))
+}
+
+fn assert_gsro_run(doc: &Value, who: &str) {
+    // The echo is POST-probe (GT zeroes settings->gso/gro on a failed
+    // setsockopt, iperf_udp.c:459-515): 1 where both sockopts exist
+    // (Linux), 0 where the stubs fail like GT's #else arms.
+    let expect = i64::from(cfg!(target_os = "linux"));
+    let ts = &doc["start"]["test_start"];
+    assert_eq!(ts["gso"].as_i64(), Some(expect), "{who}: gso echo: {ts}");
+    assert_eq!(ts["gro"].as_i64(), Some(expect), "{who}: gro echo: {ts}");
+
+    // The phantom-loss net: with UDP_GRO live on the receiver, coalesced
+    // trains must walk at the blksize stride, not book sequence gaps.
+    let sum = &doc["end"]["sum"];
+    assert!(
+        sum["packets"].as_i64().is_some_and(|p| p > 0),
+        "{who}: no packets moved: {sum}"
+    );
+    assert_eq!(
+        sum["lost_packets"].as_i64(),
+        Some(0),
+        "{who}: phantom loss under GSO/GRO (#316): {sum}"
+    );
+}
+
+#[test]
+fn gsro_recycling_path_zero_loss_and_honest_echo() {
+    let doc = run_gsro(false, "gsro recycling");
+    assert_gsro_run(&doc, "gsro recycling");
+}
+
+#[test]
+fn gsro_demux_path_zero_loss_and_honest_echo() {
+    let doc = run_gsro(true, "gsro demux");
+    assert_gsro_run(&doc, "gsro demux");
+}
+
+/// GT's usage line, verbatim (iperf_locale.c:222).
+#[test]
+fn gsro_help_line_matches_gt() {
+    let out = Command::new(env!("CARGO_BIN_EXE_riperf3"))
+        .arg("--help")
+        .output()
+        .expect("--help");
+    let help = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        help.contains("enable UDP GSO/GRO on both client and server (client-only option)"),
+        "GT's locale line for --gsro: {help}"
+    );
+}
+
+/// GT warns at parse end when --gsro rides a client without local support
+/// (iperf_api.c:1830-1839) — reachable only off-Linux in riperf3, where
+/// both sockopts are absent (GT's both-missing arm). On Linux the client
+/// must stay silent.
+#[test]
+fn gsro_platform_warning_matches_gt() {
+    let _serial = udp_serial();
+    let port = common::free_port().to_string();
+    // No server: the run fails to connect, but the parse-time warning (or
+    // its absence) is already decided before the connect attempt.
+    let client = common::run_client(
+        &["-c", "127.0.0.1", "-p", &port, "-u", "--gsro", "-t", "1"],
+        Duration::from_secs(15),
+        "gsro warning",
+    );
+    let warning = "warning: --gsro requested but UDP GSO/GRO not supported on this client; \
+                   will only be enabled on server if supported";
+    if cfg!(target_os = "linux") {
+        assert!(
+            !client.stderr.contains("warning: --gsro"),
+            "no platform warning on Linux: {}",
+            client.stderr
+        );
+    } else {
+        assert!(
+            client.stderr.contains(warning),
+            "GT's parse-time warning off-Linux: {}",
+            client.stderr
+        );
+    }
+}

--- a/riperf3-cli/tests/gsro.rs
+++ b/riperf3-cli/tests/gsro.rs
@@ -18,7 +18,11 @@ use common::{udp_serial, wait_bounded, ChildGuard};
 
 /// One `--gsro` UDP run against a one-off server; returns the client's `-J`
 /// doc. `demux` forces the server's shared-socket path (the recycling path
-/// is the Unix default).
+/// is the Unix default). `-P 2` EXERCISES the per-accept probe path but
+/// cannot discriminate a pre-loop-only regression (r2 F2: a GRO-off second
+/// stream still walks uncoalesced datagrams to zero loss and the echo
+/// still folds 1) — the sockopt round-trip pin in net.rs plus code review
+/// carry the placement.
 fn run_gsro(demux: bool, who: &str) -> Value {
     let _serial = udp_serial();
     let bin = env!("CARGO_BIN_EXE_riperf3");

--- a/riperf3/src/client.rs
+++ b/riperf3/src/client.rs
@@ -1278,6 +1278,7 @@ impl Client {
                             raw_fd,
                             sock,
                             congestion_used,
+                            udp_offload: None,
                         },
                         task,
                         udp_recv_stats: None,
@@ -1303,6 +1304,10 @@ impl Client {
                 // thread, spawned through the gate so the barrier below can
                 // hold this side's test window until the data plane exists.
                 let mut thread_gate = stream::StreamThreadGate::new();
+                // #316: --gsro probes per socket below; once a probe fails,
+                // GT zeroes the setting and later sockets don't retry
+                // (iperf_udp.c:459-515), and the report echoes POST-probe.
+                let (mut gso_on, mut gro_on) = (self.gsro, self.gsro);
                 for i in 0..total {
                     let udp_sock = net::udp_bind(bind_ip.as_deref(), 0, remote.is_ipv6()).await?;
                     if let Some(ref dev) = self.bind_dev {
@@ -1315,13 +1320,16 @@ impl Client {
                     net::apply_fq_rate(&udp_sock, self.fq_rate.unwrap_or(0));
 
                     // GSO/GRO is deliberately best-effort (#45), matching
-                    // iperf3 3.20+'s --gsro: its iperf_udp_gso/iperf_udp_gro
-                    // disable the feature and continue when the setsockopt
-                    // fails, so a kernel lacking UDP_SEGMENT/UDP_GRO degrades
-                    // to plain sends rather than failing the test.
-                    if self.gsro {
-                        let _ = net::set_udp_gso(&udp_sock, blksize as u16);
-                        let _ = net::set_udp_gro(&udp_sock);
+                    // GT's iperf_udp_connect probes (iperf_udp.c:681-684):
+                    // iperf_udp_gso/iperf_udp_gro disable the feature and
+                    // continue when the setsockopt fails, so a kernel
+                    // lacking UDP_SEGMENT/UDP_GRO degrades to plain sends
+                    // rather than failing the test (#316).
+                    if gso_on {
+                        gso_on = net::set_udp_gso(&udp_sock, blksize as u16).is_ok();
+                    }
+                    if gro_on {
+                        gro_on = net::set_udp_gro(&udp_sock).is_ok();
                     }
                     if self.tos != 0 {
                         // Fatal like the TCP path (#45): iperf3's
@@ -1394,6 +1402,7 @@ impl Client {
                                 raw_fd: None,
                                 sock,
                                 congestion_used: None,
+                                udp_offload: Some((gso_on, gro_on)),
                             },
                             task,
                             udp_recv_stats: Some(stats),
@@ -1409,6 +1418,7 @@ impl Client {
                             raw_fd: None,
                             sock,
                             congestion_used: None,
+                            udp_offload: Some((gso_on, gro_on)),
                         },
                         task,
                         udp_recv_stats: None,
@@ -2330,8 +2340,25 @@ impl Client {
             bare_end: start_meta.bare_end,
             interval: self.interval.unwrap_or(1.0),
             // riperf3's single --gsro flag drives both GSO and GRO.
-            gso: i32::from(self.gsro),
-            gro: i32::from(self.gsro),
+            // #316: POST-probe like GT — iperf_udp_connect's failed probes
+            // zero settings->gso/gro before the test_start echo
+            // (iperf_udp.c:459-515, :681-684). Folded across streams; no
+            // streams yet (pre-connect error report) → the request, which
+            // is GT's pre-probe state at that point too.
+            gso: i32::from(
+                self.gsro
+                    && streams
+                        .iter()
+                        .filter_map(|s| s.meta.udp_offload)
+                        .all(|(g, _)| g),
+            ),
+            gro: i32::from(
+                self.gsro
+                    && streams
+                        .iter()
+                        .filter_map(|s| s.meta.udp_offload)
+                        .all(|(_, g)| g),
+            ),
             // #261/#286: the stage's wall-clock — TestStart's once started; on
             // the upfront-refusal path the connect-time clock (GT stamps
             // start.timestamp at on_connect, after the param exchange, BEFORE
@@ -3722,6 +3749,7 @@ mod tests {
                     rcvbuf_actual: None,
                 },
                 congestion_used: None,
+                udp_offload: None,
             },
             udp_recv_stats: None,
             task: tokio::spawn(async { Ok(()) }),
@@ -3771,6 +3799,7 @@ mod tests {
                     rcvbuf_actual: None,
                 },
                 congestion_used: None,
+                udp_offload: None,
             },
             udp_recv_stats: None,
             task: tokio::spawn(async { Ok(()) }),
@@ -3815,6 +3844,7 @@ mod tests {
                     rcvbuf_actual: None,
                 },
                 congestion_used: None,
+                udp_offload: None,
             },
             udp_recv_stats: None,
             task: tokio::spawn(async { Ok(()) }),

--- a/riperf3/src/client.rs
+++ b/riperf3/src/client.rs
@@ -3306,11 +3306,12 @@ impl ClientBuilder {
                     "TCP congestion control is not supported on this platform".into(),
                 ));
             }
-            if self.gsro {
-                return Err(ConfigError::Unsupported(
-                    "UDP GSO/GRO is not supported on this platform".into(),
-                ));
-            }
+            // --gsro deliberately NOT rejected here (#316): GT keeps the
+            // flag "available regardless of local support to allow client
+            // to request server to use it" (iperf_api.c:1799-1804) — the
+            // params block still carries gso/gro=1, the local probes fail
+            // and zero the adopted state, and the CLI warns at parse time
+            // (iperf_api.c:1830-1839).
         }
 
         // --bind-dev needs SO_BINDTODEVICE (Linux) or IP_BOUND_IF (macOS). The

--- a/riperf3/src/client.rs
+++ b/riperf3/src/client.rs
@@ -1016,6 +1016,21 @@ impl Client {
         // — the server needs it for its upfront total-rate check AND for
         // fq-paced reverse/bidir sending. riperf3 never serialized it.
         p.fqrate = self.fq_rate.filter(|&r| r > 0);
+        // #316: the UDP GSO/GRO block rides unconditionally for UDP like GT
+        // (iperf_api.c:2465-2472): flags from --gsro, dg_size = blksize when
+        // GSO is on (GT :1946-1953), bf_size floored to a dg_size multiple
+        // from the 65507 default (GSO_BF_MAX_SIZE); the defaults ride even
+        // when off, so the server may enable its side independently.
+        if self.protocol == TransportProtocol::Udp {
+            const BF_MAX: i64 = 65507;
+            let on = self.gsro;
+            let dg = if on { blksize as i64 } else { 0 };
+            p.gso = Some(i64::from(on));
+            p.gso_dg_size = Some(dg);
+            p.gso_bf_size = Some(if on && dg > 0 { (BF_MAX / dg) * dg } else { BF_MAX });
+            p.gro = Some(i64::from(on));
+            p.gro_bf_size = Some(BF_MAX);
+        }
         // Sent only when set, like iperf3 (`if (test->settings->burst)`): the
         // server's reverse/bidir sender batches on the client's burst (#160).
         p.burst = (self.burst > 0).then_some(self.burst as i32);

--- a/riperf3/src/client.rs
+++ b/riperf3/src/client.rs
@@ -1326,7 +1326,7 @@ impl Client {
                     // lacking UDP_SEGMENT/UDP_GRO degrades to plain sends
                     // rather than failing the test (#316).
                     if gso_on {
-                        gso_on = net::set_udp_gso(&udp_sock, blksize as u16).is_ok();
+                        gso_on = net::set_udp_gso(&udp_sock, blksize as i32).is_ok();
                     }
                     if gro_on {
                         gro_on = net::set_udp_gro(&udp_sock).is_ok();

--- a/riperf3/src/client.rs
+++ b/riperf3/src/client.rs
@@ -1027,7 +1027,11 @@ impl Client {
             let dg = if on { blksize as i64 } else { 0 };
             p.gso = Some(i64::from(on));
             p.gso_dg_size = Some(dg);
-            p.gso_bf_size = Some(if on && dg > 0 { (BF_MAX / dg) * dg } else { BF_MAX });
+            p.gso_bf_size = Some(if on && dg > 0 {
+                (BF_MAX / dg) * dg
+            } else {
+                BF_MAX
+            });
             p.gro = Some(i64::from(on));
             p.gro_bf_size = Some(BF_MAX);
         }
@@ -4237,6 +4241,42 @@ mod tests {
             let c = ClientBuilder::new("h").build().unwrap();
             assert_eq!(c.protocol, TransportProtocol::Tcp);
             assert_eq!(c.bandwidth, 0);
+        }
+
+        #[test]
+        fn udp_params_carry_the_gsro_block_like_gt() {
+            // #316: GT sends the five GSO/GRO keys unconditionally for UDP
+            // (iperf_api.c:2465-2472) — defaults ride even when off, so the
+            // server may enable its side independently.
+            let c = ClientBuilder::new("h")
+                .protocol(TransportProtocol::Udp)
+                .build()
+                .unwrap();
+            let p = c.build_params(1460);
+            assert_eq!(p.gso, Some(0));
+            assert_eq!(p.gso_dg_size, Some(0));
+            assert_eq!(p.gso_bf_size, Some(65507));
+            assert_eq!(p.gro, Some(0));
+            assert_eq!(p.gro_bf_size, Some(65507));
+
+            // --gsro on: dg = blksize, bf floored to a dg multiple (GT
+            // :1946-1953).
+            let c = ClientBuilder::new("h")
+                .protocol(TransportProtocol::Udp)
+                .gsro(true)
+                .build()
+                .unwrap();
+            let p = c.build_params(1460);
+            assert_eq!(p.gso, Some(1));
+            assert_eq!(p.gso_dg_size, Some(1460));
+            assert_eq!(p.gso_bf_size, Some((65507 / 1460) * 1460));
+            assert_eq!(p.gro, Some(1));
+
+            // TCP: the block is absent, like GT's Pudp gate.
+            let c = ClientBuilder::new("h").build().unwrap();
+            let p = c.build_params(1460);
+            assert_eq!(p.gso, None);
+            assert_eq!(p.gro_bf_size, None);
         }
 
         #[test]

--- a/riperf3/src/net.rs
+++ b/riperf3/src/net.rs
@@ -923,10 +923,14 @@ pub fn set_ipv6_flowlabel<F>(_fd: &F, _label: i32) -> Result<()> {
 
 /// Enable UDP GSO (Generic Segmentation Offload) on a UDP socket.
 /// Sets UDP_SEGMENT to the datagram size so the kernel can batch sends.
+/// The value passes through RAW like GT's `int gso` (iperf_udp.c:464-466,
+/// #316 r2 F3): the KERNEL is the validator — an out-of-range dg_size
+/// EINVALs, the probe fails, and the caller zeroes the setting exactly
+/// like GT. No clamp may invent a success GT would not have.
 #[cfg(target_os = "linux")]
-pub fn set_udp_gso(fd: &impl std::os::unix::io::AsFd, segment_size: u16) -> Result<()> {
+pub fn set_udp_gso(fd: &impl std::os::unix::io::AsFd, segment_size: i32) -> Result<()> {
     use nix::sys::socket::{self, sockopt};
-    socket::setsockopt(fd, sockopt::UdpGsoSegment, &(segment_size as i32))
+    socket::setsockopt(fd, sockopt::UdpGsoSegment, &segment_size)
         .map_err(|e| RiperfError::Io(std::io::Error::from(e)))
 }
 
@@ -934,7 +938,7 @@ pub fn set_udp_gso(fd: &impl std::os::unix::io::AsFd, segment_size: u16) -> Resu
 /// (iperf_udp.c:479-486) — the probe must FAIL here so the adopted state
 /// and the `test_start` echo read 0, not a phantom 1 (#316 r1 F5).
 #[cfg(not(target_os = "linux"))]
-pub fn set_udp_gso<F>(_fd: &F, _segment_size: u16) -> Result<()> {
+pub fn set_udp_gso<F>(_fd: &F, _segment_size: i32) -> Result<()> {
     Err(RiperfError::Config(crate::error::ConfigError::Unsupported(
         "UDP GSO not supported on this platform".to_string(),
     )))
@@ -1060,6 +1064,57 @@ mod fq_rate_tests {
         };
         assert_eq!(rc, 0);
         assert_eq!(val, 5_000_000_000, "u64 payload survives (u32 wrapped)");
+    }
+}
+
+#[cfg(test)]
+mod gsro_sockopt_tests {
+    /// #316 r2 F2: readback pins that the probes actually TAKE on a socket
+    /// (the e2e -P 2 run exercises but cannot discriminate the per-accept
+    /// placement — a regressed pre-loop probe still walks to zero loss).
+    /// Also pins the raw-pass-through posture: the kernel EINVALs an
+    /// out-of-range dg like it does for GT (iperf_udp.c:464-470), so the
+    /// probe FAILS rather than a clamp inventing success (r2 F3).
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn udp_gso_gro_round_trip_and_kernel_validation() {
+        use std::os::fd::AsRawFd;
+        let sock = std::net::UdpSocket::bind("127.0.0.1:0").unwrap();
+
+        super::set_udp_gso(&sock, 1200).unwrap();
+        let mut val: libc::c_int = 0;
+        let mut len = std::mem::size_of::<libc::c_int>() as libc::socklen_t;
+        let rc = unsafe {
+            libc::getsockopt(
+                sock.as_raw_fd(),
+                libc::IPPROTO_UDP,
+                libc::UDP_SEGMENT,
+                &mut val as *mut _ as *mut libc::c_void,
+                &mut len,
+            )
+        };
+        assert_eq!(rc, 0);
+        assert_eq!(val, 1200, "UDP_SEGMENT took the dg size");
+
+        super::set_udp_gro(&sock).unwrap();
+        let mut val: libc::c_int = 0;
+        let rc = unsafe {
+            libc::getsockopt(
+                sock.as_raw_fd(),
+                libc::IPPROTO_UDP,
+                libc::UDP_GRO,
+                &mut val as *mut _ as *mut libc::c_void,
+                &mut len,
+            )
+        };
+        assert_eq!(rc, 0);
+        assert_ne!(val, 0, "UDP_GRO took");
+
+        // The kernel is the validator (GT's design): out-of-range dg fails
+        // the probe — no clamp turns it into success. (0 is NOT an error:
+        // the kernel takes it as GSO-off, and GT inherits the same.)
+        assert!(super::set_udp_gso(&sock, 999_999).is_err());
+        assert!(super::set_udp_gso(&sock, -1).is_err());
     }
 }
 

--- a/riperf3/src/net.rs
+++ b/riperf3/src/net.rs
@@ -930,9 +930,14 @@ pub fn set_udp_gso(fd: &impl std::os::unix::io::AsFd, segment_size: u16) -> Resu
         .map_err(|e| RiperfError::Io(std::io::Error::from(e)))
 }
 
+/// GT's `#else` stub returns -1 and zeroes `settings->gso`
+/// (iperf_udp.c:479-486) — the probe must FAIL here so the adopted state
+/// and the `test_start` echo read 0, not a phantom 1 (#316 r1 F5).
 #[cfg(not(target_os = "linux"))]
 pub fn set_udp_gso<F>(_fd: &F, _segment_size: u16) -> Result<()> {
-    Ok(())
+    Err(RiperfError::Config(crate::error::ConfigError::Unsupported(
+        "UDP GSO not supported on this platform".to_string(),
+    )))
 }
 
 /// Enable UDP GRO (Generic Receive Offload) on a UDP socket.
@@ -943,9 +948,13 @@ pub fn set_udp_gro(fd: &impl std::os::unix::io::AsFd) -> Result<()> {
         .map_err(|e| RiperfError::Io(std::io::Error::from(e)))
 }
 
+/// GT's `#else` stub returns -1 and zeroes `settings->gro`
+/// (iperf_udp.c:508-515) — the probe must FAIL here (#316 r1 F5).
 #[cfg(not(target_os = "linux"))]
 pub fn set_udp_gro<F>(_fd: &F) -> Result<()> {
-    Ok(())
+    Err(RiperfError::Config(crate::error::ConfigError::Unsupported(
+        "UDP GRO not supported on this platform".to_string(),
+    )))
 }
 
 /// Set the TOS/traffic-class byte on a socket, family-aware like iperf3's

--- a/riperf3/src/protocol.rs
+++ b/riperf3/src/protocol.rs
@@ -333,6 +333,21 @@ pub struct TestParams {
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub fqrate: Option<u64>,
 
+    // #316: GT sends the UDP GSO/GRO block unconditionally for UDP
+    // ("Always send these fields to allow server to use GSO/GRO even if
+    // client doesn't support it", iperf_api.c:2465-2472) — flags plus the
+    // datagram/buffer sizes the peer's send/recv paths adopt (:2599-2619).
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub gso: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub gso_dg_size: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub gso_bf_size: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub gro: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub gro_bf_size: Option<i64>,
+
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub pacing_timer: Option<i32>,
 

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -1039,6 +1039,7 @@ impl Server {
                             raw_fd,
                             sock,
                             congestion_used,
+                            udp_offload: None,
                         },
                         task,
                         udp_recv_stats: None,
@@ -1821,17 +1822,12 @@ impl Server {
             self.bind_dev.as_deref(),
         )
         .await?;
-        // #316: honor the client's GSO/GRO request on the server's UDP
-        // sockets — best-effort like the client's #45 posture (a kernel
-        // without UDP_SEGMENT/UDP_GRO degrades to plain sends).
-        if cfg.gso {
-            let _ = net::set_udp_gso(&udp_listener, cfg.gso_dg_size.clamp(1, 65507) as u16);
-        }
-        if cfg.gro {
-            let _ = net::set_udp_gro(&udp_listener);
-        }
-
         protocol::send_state(ctrl, TestState::CreateStreams).await?;
+
+        // #316: the client's GSO/GRO request, probed per accepted socket
+        // below. Once a probe fails, GT zeroes the setting and later
+        // sockets don't retry (iperf_udp.c:459-515).
+        let (mut gso_on, mut gro_on) = (cfg.gso, cfg.gro);
 
         // #178: each stream's spawn_blocking data thread is spawned through
         // the gate; the barrier below holds TestStart until the data plane
@@ -1848,6 +1844,18 @@ impl Server {
                     .await?;
             // The listener is now locked to this client — use it as the data socket
             let data_sock = udp_listener;
+            // #316: per-accept like GT's iperf_udp_accept (iperf_udp.c:
+            // 576-579) — the #320-class placement: the loop recycles a
+            // FRESH listener per stream, so a pre-loop call covered
+            // stream 0 only. Best-effort like GT (failure zeroes, never
+            // fatal).
+            if gso_on {
+                gso_on =
+                    net::set_udp_gso(&data_sock, cfg.gso_dg_size.clamp(1, 65507) as u16).is_ok();
+            }
+            if gro_on {
+                gro_on = net::set_udp_gro(&data_sock).is_ok();
+            }
             // #302 r2: pace EVERY accepted stream — GT's block lives in
             // iperf_udp_accept (iperf_udp.c:581-595), once per stream; the
             // pre-loop listener call covered stream 0 only.
@@ -1915,6 +1923,7 @@ impl Server {
                         raw_fd: None,
                         sock,
                         congestion_used: None,
+                        udp_offload: Some((gso_on, gro_on)),
                     },
                     task,
                     udp_recv_stats: None,
@@ -1937,6 +1946,7 @@ impl Server {
                         raw_fd: None,
                         sock,
                         congestion_used: None,
+                        udp_offload: Some((gso_on, gro_on)),
                     },
                     task,
                     udp_recv_stats: Some(stats),
@@ -1997,12 +2007,13 @@ impl Server {
         // opt-in via RIPERF3_UDP_SERVER_DEMUX.
         net::apply_fq_rate(&udp_sock, cfg.fq_rate);
         // #316: the demux shared socket IS the data socket — same GSO/GRO
-        // honor, best-effort.
-        if cfg.gso {
-            let _ = net::set_udp_gso(&udp_sock, cfg.gso_dg_size.clamp(1, 65507) as u16);
+        // honor, best-effort, probed once for every stream's meta.
+        let (mut gso_on, mut gro_on) = (cfg.gso, cfg.gro);
+        if gso_on {
+            gso_on = net::set_udp_gso(&udp_sock, cfg.gso_dg_size.clamp(1, 65507) as u16).is_ok();
         }
-        if cfg.gro {
-            let _ = net::set_udp_gro(&udp_sock);
+        if gro_on {
+            gro_on = net::set_udp_gro(&udp_sock).is_ok();
         }
 
         protocol::send_state(ctrl, TestState::CreateStreams).await?;
@@ -2175,6 +2186,7 @@ impl Server {
                             rcvbuf_actual,
                         },
                         congestion_used: None,
+                        udp_offload: Some((gso_on, gro_on)),
                     },
                     task,
                     udp_recv_stats: None,
@@ -2205,6 +2217,7 @@ impl Server {
                             rcvbuf_actual,
                         },
                         congestion_used: None,
+                        udp_offload: Some((gso_on, gro_on)),
                     },
                     task,
                     udp_recv_stats: Some(stats),
@@ -2218,9 +2231,10 @@ impl Server {
             let s = shared.clone();
             let d = done.clone();
             let bs = cfg.blksize;
-            *demux_handle = Some(thread_gate.spawn(move || {
-                stream::run_udp_server_demux_receiver(s, routes, bs, d, u64bit)
-            }));
+            *demux_handle =
+                Some(thread_gate.spawn(move || {
+                    stream::run_udp_server_demux_receiver(s, routes, bs, d, u64bit)
+                }));
         }
         // #178: hold TestStart (sent by the caller right after this returns)
         // until every data thread is running — the test clock must not outrun
@@ -2494,9 +2508,24 @@ impl Server {
             // The server reports at its 1s default; it has no -i.
             interval: 1.0,
             // #316: the GSO/GRO request IS exchanged now — GT's server
-            // test_start carries the adopted values (live-probed gso:1).
-            gso: i32::from(cfg.gso),
-            gro: i32::from(cfg.gro),
+            // test_start carries the adopted values POST-probe (a failed
+            // setsockopt zeroes settings->gso/gro, iperf_udp.c:459-515;
+            // live-probed gso:1). Folded across streams like GT's
+            // settings zeroing; no UDP streams → the request as-is.
+            gso: i32::from(
+                cfg.gso
+                    && streams
+                        .iter()
+                        .filter_map(|s| s.meta.udp_offload)
+                        .all(|(g, _)| g),
+            ),
+            gro: i32::from(
+                cfg.gro
+                    && streams
+                        .iter()
+                        .filter_map(|s| s.meta.udp_offload)
+                        .all(|(_, g)| g),
+            ),
             start_time_millis,
             // The client sends --extra-data via the parameter exchange; echo it
             // into the server's -J output too, like iperf3 (#35).

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -40,9 +40,13 @@ pub(crate) struct TestConfig {
     pub udp_counters_64bit: bool,
 }
 
-/// i64→i32 like cJSON's `valueint` saturation (#316 r2 F3): GT adopts the
-/// wire number through cJSON's int (INT_MAX/INT_MIN capped) and hands it
-/// RAW to setsockopt — the kernel is the validator.
+/// i64→i32 for the adopted dg (#316 r2 F3 / r3 nit): GT's bundled cjson
+/// carries `int64_t valueint` (cjson.h:119) and the narrowing happens at
+/// the C `int` field assignment (iperf_api.c:2602) — an
+/// implementation-defined mod-2^32 WRAP. riperf3 saturates instead;
+/// divergence needs a wrap-aliased |dg| >= 2^31 (unreachable from any
+/// real iperf3 build — int settings, blksize <= 65507). Either way the
+/// value then goes RAW to setsockopt — the kernel is the validator.
 fn saturate_i32(v: i64) -> i32 {
     v.clamp(i64::from(i32::MIN), i64::from(i32::MAX)) as i32
 }

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -40,6 +40,13 @@ pub(crate) struct TestConfig {
     pub udp_counters_64bit: bool,
 }
 
+/// i64→i32 like cJSON's `valueint` saturation (#316 r2 F3): GT adopts the
+/// wire number through cJSON's int (INT_MAX/INT_MIN capped) and hands it
+/// RAW to setsockopt — the kernel is the validator.
+fn saturate_i32(v: i64) -> i32 {
+    v.clamp(i64::from(i32::MIN), i64::from(i32::MAX)) as i32
+}
+
 impl TestConfig {
     // Crate-internal: takes the wire `TestParams` (now `pub(crate)` per #67),
     // so it cannot be part of the public API.
@@ -130,7 +137,12 @@ impl TestConfig {
             fq_rate: params.fqrate.unwrap_or(0),
             gso: params.gso.unwrap_or(0) != 0,
             // GT recomputes a zero dg_size from the negotiated blksize
-            // (iperf_api.c:2607-2613); DEFAULT_UDP_BLKSIZE guards blksize 0.
+            // (iperf_api.c:2607-2613). The len-absent arm (1460) is our
+            // choice for a hand-rolled peer: GT's own :2612
+            // DEFAULT_UDP_BLKSIZE arm is unreachable there — it would use
+            // its stale server-default blksize and let the probe EINVAL
+            // (r2 F5) — so 1460 is healthier and equally unreachable from
+            // conforming peers.
             gso_dg_size: match params.gso_dg_size.unwrap_or(0) {
                 0 if params.gso.unwrap_or(0) != 0 => match params.len.unwrap_or(0) {
                     blk if blk > 0 => i64::from(blk),
@@ -1848,10 +1860,13 @@ impl Server {
             // 576-579) — the #320-class placement: the loop recycles a
             // FRESH listener per stream, so a pre-loop call covered
             // stream 0 only. Best-effort like GT (failure zeroes, never
-            // fatal).
+            // fatal). The dg value saturates i64→i32 like cJSON's valueint
+            // and passes RAW — the kernel EINVALs nonsense exactly like it
+            // does for GT (r2 F3). (GT probes BEFORE its 4-byte connect
+            // reply, riperf3 after — no observable delta, the reply is
+            // never segmented; r2 F4.)
             if gso_on {
-                gso_on =
-                    net::set_udp_gso(&data_sock, cfg.gso_dg_size.clamp(1, 65507) as u16).is_ok();
+                gso_on = net::set_udp_gso(&data_sock, saturate_i32(cfg.gso_dg_size)).is_ok();
             }
             if gro_on {
                 gro_on = net::set_udp_gro(&data_sock).is_ok();
@@ -2010,7 +2025,7 @@ impl Server {
         // honor, best-effort, probed once for every stream's meta.
         let (mut gso_on, mut gro_on) = (cfg.gso, cfg.gro);
         if gso_on {
-            gso_on = net::set_udp_gso(&udp_sock, cfg.gso_dg_size.clamp(1, 65507) as u16).is_ok();
+            gso_on = net::set_udp_gso(&udp_sock, saturate_i32(cfg.gso_dg_size)).is_ok();
         }
         if gro_on {
             gro_on = net::set_udp_gro(&udp_sock).is_ok();

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -2217,10 +2217,10 @@ impl Server {
         if !routes.is_empty() {
             let s = shared.clone();
             let d = done.clone();
-            *demux_handle = Some(
-                thread_gate
-                    .spawn(move || stream::run_udp_server_demux_receiver(s, routes, d, u64bit)),
-            );
+            let bs = cfg.blksize;
+            *demux_handle = Some(thread_gate.spawn(move || {
+                stream::run_udp_server_demux_receiver(s, routes, bs, d, u64bit)
+            }));
         }
         // #178: hold TestStart (sent by the caller right after this returns)
         // until every data thread is running — the test clock must not outrun

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -1821,6 +1821,15 @@ impl Server {
             self.bind_dev.as_deref(),
         )
         .await?;
+        // #316: honor the client's GSO/GRO request on the server's UDP
+        // sockets — best-effort like the client's #45 posture (a kernel
+        // without UDP_SEGMENT/UDP_GRO degrades to plain sends).
+        if cfg.gso {
+            let _ = net::set_udp_gso(&udp_listener, cfg.gso_dg_size.clamp(1, 65507) as u16);
+        }
+        if cfg.gro {
+            let _ = net::set_udp_gro(&udp_listener);
+        }
 
         protocol::send_state(ctrl, TestState::CreateStreams).await?;
 
@@ -1987,6 +1996,14 @@ impl Server {
         // which is Windows-default (where the sockopt no-ops) and Linux
         // opt-in via RIPERF3_UDP_SERVER_DEMUX.
         net::apply_fq_rate(&udp_sock, cfg.fq_rate);
+        // #316: the demux shared socket IS the data socket — same GSO/GRO
+        // honor, best-effort.
+        if cfg.gso {
+            let _ = net::set_udp_gso(&udp_sock, cfg.gso_dg_size.clamp(1, 65507) as u16);
+        }
+        if cfg.gro {
+            let _ = net::set_udp_gro(&udp_sock);
+        }
 
         protocol::send_state(ctrl, TestState::CreateStreams).await?;
 
@@ -2476,9 +2493,10 @@ impl Server {
             bare_end: false,
             // The server reports at its 1s default; it has no -i.
             interval: 1.0,
-            // GSO/GRO are client-side knobs, not exchanged; iperf3's server emits 0.
-            gso: 0,
-            gro: 0,
+            // #316: the GSO/GRO request IS exchanged now — GT's server
+            // test_start carries the adopted values (live-probed gso:1).
+            gso: i32::from(cfg.gso),
+            gro: i32::from(cfg.gro),
             start_time_millis,
             // The client sends --extra-data via the parameter exchange; echo it
             // into the server's -J output too, like iperf3 (#35).
@@ -2997,6 +3015,33 @@ impl ServerBuilder {
 
 #[cfg(test)]
 mod tests {
+
+    /// #316: the server adopts the client's exchanged GSO/GRO request
+    /// (GT iperf_api.c:2599-2619), including the zero-dg_size recompute
+    /// from the negotiated blksize (:2607-2613).
+    #[test]
+    fn test_config_adopts_the_gsro_block() {
+        let params = crate::protocol::TestParams {
+            udp: Some(true),
+            len: Some(1200),
+            gso: Some(1),
+            gso_dg_size: Some(0), // old/odd peer: recompute from blksize
+            gro: Some(1),
+            ..Default::default()
+        };
+        let cfg = TestConfig::from_params(&params).unwrap();
+        assert!(cfg.gso && cfg.gro);
+        assert_eq!(cfg.gso_dg_size, 1200, "zero dg_size recomputes from len");
+
+        // Absent block (old peer): everything off.
+        let params = crate::protocol::TestParams {
+            udp: Some(true),
+            ..Default::default()
+        };
+        let cfg = TestConfig::from_params(&params).unwrap();
+        assert!(!cfg.gso && !cfg.gro);
+    }
+
     use super::*;
 
     /// Receive one datagram and return the IP_TOS control message byte, via

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -28,6 +28,12 @@ pub(crate) struct TestConfig {
     /// The client's `--fq-rate` (0 = unset): GT paces its ACCEPTED data
     /// sockets with it too (iperf_tcp.c:138-153, #302).
     pub fq_rate: u64,
+    /// The client's GSO/GRO request (#316, GT iperf_api.c:2599-2619): the
+    /// server enables UDP_SEGMENT/UDP_GRO on its UDP sockets when asked —
+    /// best-effort like the client's #45 posture.
+    pub gso: bool,
+    pub gso_dg_size: i64,
+    pub gro: bool,
     pub pacing_timer: u32,
     pub tos: i32,
     pub congestion: Option<String>,
@@ -122,6 +128,17 @@ impl TestConfig {
             // 1 Mbit/s UDP default is a client-side concern, resolved at build.
             bandwidth: params.bandwidth.unwrap_or(0),
             fq_rate: params.fqrate.unwrap_or(0),
+            gso: params.gso.unwrap_or(0) != 0,
+            // GT recomputes a zero dg_size from the negotiated blksize
+            // (iperf_api.c:2607-2613); DEFAULT_UDP_BLKSIZE guards blksize 0.
+            gso_dg_size: match params.gso_dg_size.unwrap_or(0) {
+                0 if params.gso.unwrap_or(0) != 0 => match params.len.unwrap_or(0) {
+                    blk if blk > 0 => i64::from(blk),
+                    _ => 1460,
+                },
+                v => v,
+            },
+            gro: params.gro.unwrap_or(0) != 0,
             burst,
             // The client's --pacing-timer quantum (#32); iperf3 always sends
             // it. Absent/non-positive (older peers) → iperf3's 1000 µs default.

--- a/riperf3/src/stream.rs
+++ b/riperf3/src/stream.rs
@@ -1624,6 +1624,43 @@ pub(crate) fn run_udp_server_demux_sender(
     )
 }
 
+/// GT's unified UDP receive loop (#316, iperf_udp.c:124-232): one read may
+/// carry a UDP_GRO-coalesced train of datagrams whose headers sit at the
+/// NEGOTIATED blksize stride — GT reads the cmsg segment size but pins the
+/// walk stride to blksize (iperf_udp.c:89-90), so a plain read of the
+/// coalesced payload parses identically to its recvmsg. With GRO off the
+/// buffer holds one datagram and exactly one header parses, same as ever.
+/// Before this walk, UDP_GRO in front of a single-header parse booked the
+/// other segments as sequence-gap loss (the 97% phantom-loss failure from
+/// the #327 r1 review).
+///
+/// RECORDED DEVIATION (short datagrams only): a single datagram >= one
+/// header but < blksize still parses here — GT's full-stride guard
+/// (`buf_sz >= dgram_sz`) skips it and books the gap as loss. Unreachable
+/// from conforming senders (both tools send whole-blksize datagrams), and
+/// parsing is the pre-GSO iperf3 behavior riperf3 always matched.
+fn walk_udp_headers(buf: &[u8], blksize: usize, use_64bit: bool, stats: &Mutex<UdpRecvStats>) {
+    let hdr = UdpHeader::wire_size(use_64bit);
+    // Guard degenerate blksize < header (params floor it in practice):
+    // never walk overlapping headers.
+    let stride = blksize.max(hdr);
+    let Ok(mut st) = stats.lock() else { return };
+    let mut off = 0;
+    while off + hdr <= buf.len() {
+        if let Some(header) = UdpHeader::read_from(&buf[off..], use_64bit) {
+            // GT stamps arrival per header INSIDE the walk
+            // (iperf_udp.c:216) — the jitter EWMA sees distinct transit
+            // values across a train.
+            let arrival = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_secs_f64();
+            st.update(&header, arrival);
+        }
+        off += stride;
+    }
+}
+
 /// Where one client's datagrams are accounted in the single-socket UDP server
 /// demux: the receiving stream's byte counters and its jitter/loss stats.
 pub(crate) struct UdpDemuxRoute {
@@ -1649,6 +1686,7 @@ pub(crate) struct UdpDemuxRoute {
 pub(crate) fn run_udp_server_demux_receiver(
     socket: Arc<std::net::UdpSocket>,
     routes: std::collections::HashMap<std::net::SocketAddr, UdpDemuxRoute>,
+    blksize: usize,
     done: Arc<AtomicBool>,
     use_64bit: bool,
 ) -> Result<()> {
@@ -1681,15 +1719,8 @@ pub(crate) fn run_udp_server_demux_receiver(
                 // and records 0 bytes with no header.
                 if let Some(route) = routes.get(&src) {
                     route.counters.record_received(n as u64);
-                    if let Some(header) = UdpHeader::read_from(&buf[..n], use_64bit) {
-                        let arrival = SystemTime::now()
-                            .duration_since(UNIX_EPOCH)
-                            .unwrap_or_default()
-                            .as_secs_f64();
-                        if let Ok(mut stats) = route.stats.lock() {
-                            stats.update(&header, arrival);
-                        }
-                    }
+                    // #316: GRO-aware — one read may hold a whole train.
+                    walk_udp_headers(&buf[..n], blksize, use_64bit, &route.stats);
                 }
             }
             Err(e)
@@ -1821,15 +1852,8 @@ pub fn run_udp_receiver_blocking(
             Ok(0) => break,
             Ok(n) => {
                 counters.record_received(n as u64);
-                if let Some(header) = UdpHeader::read_from(&buf[..n], use_64bit) {
-                    let arrival = SystemTime::now()
-                        .duration_since(UNIX_EPOCH)
-                        .unwrap_or_default()
-                        .as_secs_f64();
-                    if let Ok(mut stats) = udp_stats.lock() {
-                        stats.update(&header, arrival);
-                    }
-                }
+                // #316: GRO-aware — one read may hold a whole train.
+                walk_udp_headers(&buf[..n], blksize, use_64bit, &udp_stats);
             }
             Err(e)
                 if e.kind() == std::io::ErrorKind::WouldBlock
@@ -3185,6 +3209,89 @@ mod tests {
             std::thread::sleep(Duration::from_millis(25));
         };
         assert!(res.is_ok(), "receiver returned error: {res:?}");
+    }
+
+    // ---- #316: GRO-coalesced trains walk headers at the blksize stride ------
+
+    /// One 3×blksize buffer with sequential headers at each stride — exactly
+    /// what a UDP_GRO socket hands userspace when the kernel coalesces a GSO
+    /// train. GT's unified receive loop walks it at the NEGOTIATED blksize
+    /// (iperf_udp.c:89-90 pins the stride to blksize, :124-232 the walk); a
+    /// single-header parse books the other segments as sequence-gap loss —
+    /// the 97% phantom-loss failure from the #327 review.
+    fn gro_train(blksize: usize, seqs: &[u64]) -> Vec<u8> {
+        let mut buf = vec![0u8; blksize * seqs.len()];
+        for (i, seq) in seqs.iter().enumerate() {
+            UdpHeader {
+                sec: 0,
+                usec: 0,
+                seq: *seq,
+            }
+            .write_to(&mut buf[i * blksize..], false);
+        }
+        buf
+    }
+
+    #[test]
+    fn udp_receiver_walks_coalesced_trains_at_blksize_stride() {
+        let (send, recv) = udp_pair();
+        let counters = Arc::new(StreamCounters::new());
+        let stats = Arc::new(Mutex::new(UdpRecvStats::new()));
+        let done = Arc::new(AtomicBool::new(false));
+
+        let c = counters.clone();
+        let s = stats.clone();
+        let d = done.clone();
+        let h = std::thread::spawn(move || run_udp_receiver_blocking(recv, c, s, 1024, d, false));
+
+        send.send(&gro_train(1024, &[1, 2, 3])).unwrap();
+        std::thread::sleep(Duration::from_millis(200));
+        done.store(true, Ordering::Relaxed);
+        h.join().unwrap().unwrap();
+
+        assert_eq!(counters.bytes_received(), 3072, "bytes count once per read");
+        let st = stats.lock().unwrap();
+        assert_eq!(
+            st.packet_count, 3,
+            "all three train headers walked, not just the first"
+        );
+        assert_eq!(st.cnt_error, 0, "no phantom sequence-gap loss");
+    }
+
+    #[test]
+    fn udp_demux_receiver_walks_coalesced_trains_at_blksize_stride() {
+        let demux = Arc::new(std::net::UdpSocket::bind("127.0.0.1:0").unwrap());
+        let send = std::net::UdpSocket::bind("127.0.0.1:0").unwrap();
+        send.connect(demux.local_addr().unwrap()).unwrap();
+
+        let counters = Arc::new(StreamCounters::new());
+        let stats = Arc::new(Mutex::new(UdpRecvStats::new()));
+        let done = Arc::new(AtomicBool::new(false));
+        let routes = std::collections::HashMap::from([(
+            send.local_addr().unwrap(),
+            UdpDemuxRoute {
+                counters: counters.clone(),
+                stats: stats.clone(),
+            },
+        )]);
+
+        let sock = demux.clone();
+        let d = done.clone();
+        let h =
+            std::thread::spawn(move || run_udp_server_demux_receiver(sock, routes, 1024, d, false));
+
+        send.send(&gro_train(1024, &[1, 2, 3])).unwrap();
+        std::thread::sleep(Duration::from_millis(200));
+        done.store(true, Ordering::Relaxed);
+        h.join().unwrap().unwrap();
+
+        assert_eq!(counters.bytes_received(), 3072, "bytes count once per read");
+        let st = stats.lock().unwrap();
+        assert_eq!(
+            st.packet_count, 3,
+            "all three train headers walked, not just the first"
+        );
+        assert_eq!(st.cnt_error, 0, "no phantom sequence-gap loss");
     }
 }
 

--- a/riperf3/src/stream.rs
+++ b/riperf3/src/stream.rs
@@ -1640,11 +1640,13 @@ pub(crate) fn run_udp_server_demux_sender(
 /// other segments as sequence-gap loss (the 97% phantom-loss failure from
 /// the #327 r1 review).
 ///
-/// RECORDED DEVIATION (short datagrams only): a single datagram >= one
-/// header but < blksize still parses here — GT's full-stride guard
+/// RECORDED DEVIATION (short datagrams only): a buffer tail >= one header
+/// but < blksize still parses here — a lone short datagram OR the short
+/// tail segment of a coalesced train — where GT's full-stride guard
 /// (`buf_sz >= dgram_sz`) skips it and books the gap as loss. Unreachable
-/// from conforming senders (both tools send whole-blksize datagrams), and
-/// parsing is the pre-GSO iperf3 behavior riperf3 always matched.
+/// from conforming senders (both tools send whole-blksize datagrams; GT
+/// floors gso_bf_size to a dg multiple), and parsing is the pre-GSO
+/// iperf3 behavior riperf3 always matched.
 fn walk_udp_headers(buf: &[u8], blksize: usize, use_64bit: bool, stats: &Mutex<UdpRecvStats>) {
     let hdr = UdpHeader::wire_size(use_64bit);
     // Guard degenerate blksize < header (params floor it in practice):
@@ -3251,7 +3253,10 @@ mod tests {
         let h = std::thread::spawn(move || run_udp_receiver_blocking(recv, c, s, 1024, d, false));
 
         send.send(&gro_train(1024, &[1, 2, 3])).unwrap();
-        std::thread::sleep(Duration::from_millis(200));
+        // Bounded poll, not a fixed sleep (r2 F1): a stalled thread start
+        // (the #178/#176 2-core-runner class) would otherwise see `done`
+        // first and DISCARD the queued train in the drain.
+        wait_for_bytes(&counters, 3072);
         done.store(true, Ordering::Relaxed);
         h.join().unwrap().unwrap();
 
@@ -3262,6 +3267,14 @@ mod tests {
             "all three train headers walked, not just the first"
         );
         assert_eq!(st.cnt_error, 0, "no phantom sequence-gap loss");
+    }
+
+    /// Bounded readiness poll for the train tests (r2 F1).
+    fn wait_for_bytes(counters: &StreamCounters, want: u64) {
+        let deadline = Instant::now() + Duration::from_secs(10);
+        while counters.bytes_received() < want && Instant::now() < deadline {
+            std::thread::sleep(Duration::from_millis(10));
+        }
     }
 
     #[test]
@@ -3287,7 +3300,8 @@ mod tests {
             std::thread::spawn(move || run_udp_server_demux_receiver(sock, routes, 1024, d, false));
 
         send.send(&gro_train(1024, &[1, 2, 3])).unwrap();
-        std::thread::sleep(Duration::from_millis(200));
+        // Bounded poll, not a fixed sleep (r2 F1) — see the connected twin.
+        wait_for_bytes(&counters, 3072);
         done.store(true, Ordering::Relaxed);
         h.join().unwrap().unwrap();
 

--- a/riperf3/src/stream.rs
+++ b/riperf3/src/stream.rs
@@ -509,6 +509,12 @@ pub(crate) struct StreamMeta {
     /// `congestion_used` report field (#37). `None` for UDP and on platforms
     /// without TCP_CONGESTION.
     pub congestion_used: Option<String>,
+    /// #316: `(gso_active, gro_active)` — whether UDP_SEGMENT/UDP_GRO
+    /// actually took on this stream's socket. GT zeroes `settings->gso/gro`
+    /// on a failed setsockopt (iperf_udp.c:459-515) and its `test_start`
+    /// echo reads the POST-probe state; the report folds these the same way
+    /// (`congestion_used` precedent). `None` for TCP streams.
+    pub udp_offload: Option<(bool, bool)>,
 }
 
 impl DataStream {


### PR DESCRIPTION
Closes #316.

`--gsro` end to end, matched to GT (iperf 3.21) — r1 found the adoption layer fine but the data path missing; this is the full rework:

- **Params block** (unchanged from r1): the five keys ride unconditionally for UDP (`iperf_api.c:2465-2472`), server adoption with the zero-`dg_size` recompute from the negotiated blksize (`:2607-2613`).
- **GRO-aware receive, both roles** (r1's critical): GT's unified loop walks a coalesced read at the NEGOTIATED blksize stride — it reads the cmsg segment size and then discards it (`iperf_udp.c:89-90`), so a plain read parses identically to its recvmsg. Both receivers (connected + demux) now stride-walk every read (`walk_udp_headers`); before, UDP_GRO in front of a single-header parse booked the other train segments as sequence-gap loss — the 97% phantom-loss failure. Red-proven with a deterministic 3-header train on both paths (1 packet counted before, 3 after). One RECORDED DEVIATION documented at the walk: a lone short datagram (≥ header, < blksize) still parses where GT's full-stride guard would book it as loss — unreachable from conforming senders.
- **Per-accept probes with GT's failure feedback** (r1): the recycling loop probed only the pre-loop listener (stream 0 — the #320 fqrate placement class); probes now run per accepted socket like `iperf_udp_accept` (`:576-579`). A failed setsockopt zeroes the setting for the rest of the run (`:459-515`), later sockets don't retry, and both roles' `test_start` echoes read the POST-probe state (threaded via `StreamMeta.udp_offload`, the `congestion_used` precedent). Non-Linux stubs now FAIL like GT's `#else` stubs instead of echoing a phantom `gso: 1`.
- **CLI surface**: GT's help line verbatim (`iperf_locale.c:222`); the parse-time platform warning (`iperf_api.c:1830-1839` — only the both-missing arm is reachable off-Linux); the server-role reject was already in place.
- **Send side**: riperf3 keeps per-datagram blksize writes (wire-identical to GT's trains — GSO/GRO are host-local batching, the wire carries the same datagrams); UDP_SEGMENT is still set on request so the kernel may batch. GT's `sendmsg`-train send path is a perf optimization, not a compat surface.

**Live cross-tool evidence** (GT 3.21, UDP `-b 0 --gsro -t 3`, virtualized 2-VM link — the r1 repro read 97% loss on the cross-tool receive cells):

| cell | packets | loss |
|---|---|---|
| GT client → riperf3 server (riperf3 receives, GRO live) | 1.31M | **2.37%** |
| GT client -R → riperf3 server | 1.36M | 0.00% |
| riperf3 client → GT server | 1.66M | 0.01% |
| riperf3 client -R → GT server (riperf3 receives, GRO live) | 1.29M | **0.15%** |
| GT → GT forward (baseline) | 1.38M | 1.46% |
| GT → GT -R (baseline) | 1.28M | 0.00% |
| riperf3 → riperf3 forward | 1.58M | 1.21% |
| riperf3 → riperf3 -R | 1.33M | 0.09% |

Cross-tool loss sits in the same band as the same-tool baselines (real congestion at unlimited blast), and every cell echoes `gso: 1, gro: 1` post-probe.

Tests: the two red-proven train walks; `--gsro` e2e against both server paths (zero loss + honest echo, `-P 2` for the per-accept coverage); the GT help line; the platform-warning 2-arm pin (its off-Linux arm rides the FreeBSD/Windows CI legs). Full gate: 715 tests, clippy/fmt clean.

**r2 additions**: the train-walk tests trade their fixed 200 ms sleep for a bounded poll (a stalled thread start — the 2-core-runner class — saw `done` first and the drain discarded the queued train); `set_udp_gso` passes the dg RAW as i32 with cJSON-style saturation, letting the kernel EINVAL out-of-range values exactly like GT (`iperf_udp.c:464-470`) instead of a clamp inventing success — pinned with a Linux getsockopt round-trip (999999/−1 fail; 0 is kernel-valid GSO-off); the `-P 2` e2e claim is scoped to "exercises" (it can't discriminate a pre-loop-only probe regression — the round-trip pin plus review carry the placement); deviation notes widened (short train tails; the len-absent recompute arm vs GT's own unreachable dead arm); the probe-after-reply ordering delta is noted at the accept site (4-byte reply, never segmented). Also in this head: `build()` no longer rejects `--gsro` off-unix (GT keeps the flag so the request travels, `iperf_api.c:1799-1804`) — this was the Windows CI red.
