### PR TITLE
fix(compat): end-loop CLIENT_TERMINATE, IEMESSAGE, one-off errexit (#325)

### DIFF
--- a/riperf3-cli/tests/wire_shape.rs
+++ b/riperf3-cli/tests/wire_shape.rs
@@ -104,11 +104,15 @@ const MOCK_RESULTS: &str = r#"{"cpu_util_total":1.0,"cpu_util_user":0.5,"cpu_uti
 /// phase (#325 r2 F1). Otherwise the round runs through DisplayResults and
 /// sends `final_byte` in place of IperfDone(16) — the end loop.
 fn drive_mock_round(port: u16, final_byte: u8, junk_mid_test: bool) {
+    drive_mock_round_params(port, final_byte, junk_mid_test, MOCK_PARAMS);
+}
+
+fn drive_mock_round_params(port: u16, final_byte: u8, junk_mid_test: bool, params: &str) {
     let cookie = [b'x'; 37];
     let mut ctrl = std::net::TcpStream::connect(("127.0.0.1", port)).expect("ctrl");
     ctrl.write_all(&cookie).unwrap();
     assert_eq!(read_exact(&mut ctrl, 1)[0], 9);
-    write_json_blob(&mut ctrl, MOCK_PARAMS);
+    write_json_blob(&mut ctrl, params);
     assert_eq!(read_exact(&mut ctrl, 1)[0], 10);
     let mut data = std::net::TcpStream::connect(("127.0.0.1", port)).expect("data");
     data.write_all(&cookie).unwrap();
@@ -136,6 +140,15 @@ fn run_scenario(
     final_byte: u8,
     junk_mid_test: bool,
 ) -> (String, String, std::process::ExitStatus) {
+    run_scenario_params(json, final_byte, junk_mid_test, MOCK_PARAMS)
+}
+
+fn run_scenario_params(
+    json: bool,
+    final_byte: u8,
+    junk_mid_test: bool,
+    params: &'static str,
+) -> (String, String, std::process::ExitStatus) {
     let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind");
     let port = listener.local_addr().unwrap().port();
     drop(listener);
@@ -159,7 +172,9 @@ fn run_scenario(
         riperf3_test_support::drain_reader(server.0.stderr.take().expect("piped stderr"));
     std::thread::sleep(std::time::Duration::from_millis(400));
 
-    let mock = std::thread::spawn(move || drive_mock_round(port, final_byte, junk_mid_test));
+    let mock = std::thread::spawn(move || {
+        drive_mock_round_params(port, final_byte, junk_mid_test, params)
+    });
     mock.join().expect("mock");
     let status =
         riperf3_test_support::wait_bounded(&mut server.0, std::time::Duration::from_secs(5))
@@ -360,8 +375,10 @@ fn persistent_server_keeps_serving_after_iemessage() {
     for _ in 0..2 {
         drive_mock_round(port, 99, false);
     }
-    // Grace for the second round's finalize + print before the kill.
-    std::thread::sleep(std::time::Duration::from_secs(1));
+    // Grace for the second round's finalize + print before the kill —
+    // the file's 5 s bound convention (r3 F5: 1 s was the tightest margin
+    // in the file and the likeliest 2-core-runner flake).
+    std::thread::sleep(std::time::Duration::from_secs(5));
     server.0.kill().expect("kill persistent server");
     let _ = server.0.wait();
     let serr = serr_reader.join().expect("stderr");
@@ -370,6 +387,84 @@ fn persistent_server_keeps_serving_after_iemessage() {
         serr.lines().filter(|l| *l == line).count(),
         2,
         "one IEMESSAGE line per failed round: {serr}"
+    );
+}
+
+const MOCK_PARAMS_GSO: &str = r#"{"tcp":true,"omit":0,"time":1,"num":0,"blockcount":0,"parallel":1,"len":131072,"pacing_timer":1000,"get_server_output":1,"client_version":"riperf3 0.0.0"}"#;
+
+/// #325 r3 F2: --get-server-output's text capture must not render the
+/// summary block on the mid-test IEMESSAGE path — GT prints only the
+/// stderr line there (its reporter is dead; live-verified with
+/// get_server_output: 1 in params).
+#[test]
+fn mid_test_unknown_byte_with_get_server_output_prints_no_summary() {
+    let (sout, serr, status) = run_scenario_params(false, 99, true, MOCK_PARAMS_GSO);
+    assert_eq!(
+        serr.trim(),
+        format!("riperf3: error - {IEMESSAGE}"),
+        "GT's single IEMESSAGE line"
+    );
+    assert_eq!(
+        sout.matches(SUMMARY_SEPARATOR).count(),
+        0,
+        "the capture render must not resurrect the summary (r3 F2): {sout}"
+    );
+    assert!(status.success(), "one-off exits 0 like GT");
+}
+
+/// #325 r3 F1: a hostile peer that sends the junk byte and then HOLDS its
+/// sockets open must not park the server — GT cleanup_servers immediately
+/// when handle_message fails (iperf_server_api.c:764-767). Pre-fix the
+/// stream-task joins waited out the peer's whole hold (live: a 30 s hold
+/// held the one-off 33 s and blocked the stderr line with it).
+#[test]
+fn mid_test_unknown_byte_exits_bounded_while_peer_holds() {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind");
+    let port = listener.local_addr().unwrap().port();
+    drop(listener);
+    let port_s = port.to_string();
+
+    let mut server = common::ChildGuard(
+        std::process::Command::new(env!("CARGO_BIN_EXE_riperf3"))
+            .args(["-s", "-1", "-p", &port_s])
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::piped())
+            .spawn()
+            .expect("spawn server"),
+    );
+    let serr_reader =
+        riperf3_test_support::drain_reader(server.0.stderr.take().expect("piped stderr"));
+    std::thread::sleep(std::time::Duration::from_millis(400));
+
+    // The holding mock: full protocol to the data phase, junk byte, then
+    // KEEP both sockets open far past the assertion window. Detached — the
+    // sockets close when the test binary exits.
+    std::thread::spawn(move || {
+        let cookie = [b'x'; 37];
+        let mut ctrl = std::net::TcpStream::connect(("127.0.0.1", port)).expect("ctrl");
+        ctrl.write_all(&cookie).unwrap();
+        assert_eq!(read_exact(&mut ctrl, 1)[0], 9);
+        write_json_blob(&mut ctrl, MOCK_PARAMS);
+        assert_eq!(read_exact(&mut ctrl, 1)[0], 10);
+        let mut data = std::net::TcpStream::connect(("127.0.0.1", port)).expect("data");
+        data.write_all(&cookie).unwrap();
+        assert_eq!(read_exact(&mut ctrl, 1)[0], 1);
+        assert_eq!(read_exact(&mut ctrl, 1)[0], 2);
+        data.write_all(&[0u8; 4096]).unwrap();
+        ctrl.write_all(&[99u8]).unwrap();
+        std::thread::sleep(std::time::Duration::from_secs(30));
+        drop((ctrl, data));
+    });
+
+    let status =
+        riperf3_test_support::wait_bounded(&mut server.0, std::time::Duration::from_secs(8))
+            .expect("server exits while the peer still holds (r3 F1)");
+    assert!(status.success(), "one-off exits 0 like GT");
+    let serr = serr_reader.join().expect("stderr");
+    assert_eq!(
+        serr.trim(),
+        format!("riperf3: error - {IEMESSAGE}"),
+        "the line prints NOW, not after the peer relents"
     );
 }
 

--- a/riperf3-cli/tests/wire_shape.rs
+++ b/riperf3-cli/tests/wire_shape.rs
@@ -80,3 +80,172 @@ fn client_sends_iperf_done_after_the_results_exchange() {
         "the client's last control byte is IperfDone(16), like GT"
     );
 }
+
+/// #325: GT honors CLIENT_TERMINATE at any message point — a terminate
+/// landing in the END loop (after DisplayResults) still dumps the
+/// client-terminated shape (iperf_server_api.c:289-308), where the old
+/// tolerant arm swallowed it and reported clean success.
+#[test]
+fn end_loop_client_terminate_takes_the_terminated_shape() {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind");
+    let port = listener.local_addr().unwrap().port().to_string();
+    drop(listener);
+
+    let mut server = common::ChildGuard(
+        std::process::Command::new(env!("CARGO_BIN_EXE_riperf3"))
+            .args(["-s", "-1", "-p", &port, "-J"])
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .spawn()
+            .expect("spawn server"),
+    );
+    let sdoc_reader =
+        riperf3_test_support::drain_reader(server.0.stdout.take().expect("piped stdout"));
+    let serr_reader =
+        riperf3_test_support::drain_reader(server.0.stderr.take().expect("piped stderr"));
+    std::thread::sleep(std::time::Duration::from_millis(400));
+
+    let mock = std::thread::spawn({
+        let port: u16 = port.parse().unwrap();
+        move || {
+            let read_exact = |s: &mut std::net::TcpStream, n: usize| -> Vec<u8> {
+                let mut b = vec![0u8; n];
+                s.read_exact(&mut b).expect("mock read");
+                b
+            };
+            let read_json = |s: &mut std::net::TcpStream| {
+                let len = u32::from_be_bytes(read_exact(s, 4).try_into().unwrap()) as usize;
+                read_exact(s, len)
+            };
+            let write_json = |s: &mut std::net::TcpStream, payload: &str| {
+                s.write_all(&(payload.len() as u32).to_be_bytes()).unwrap();
+                s.write_all(payload.as_bytes()).unwrap();
+            };
+            let cookie = [b'x'; 37];
+            let mut ctrl = std::net::TcpStream::connect(("127.0.0.1", port)).expect("ctrl");
+            ctrl.write_all(&cookie).unwrap();
+            assert_eq!(read_exact(&mut ctrl, 1)[0], 9);
+            write_json(
+                &mut ctrl,
+                r#"{"tcp":true,"omit":0,"time":1,"num":0,"blockcount":0,"parallel":1,"len":131072,"pacing_timer":1000,"client_version":"riperf3 0.0.0"}"#,
+            );
+            assert_eq!(read_exact(&mut ctrl, 1)[0], 10);
+            let mut data = std::net::TcpStream::connect(("127.0.0.1", port)).expect("data");
+            data.write_all(&cookie).unwrap();
+            assert_eq!(read_exact(&mut ctrl, 1)[0], 1);
+            assert_eq!(read_exact(&mut ctrl, 1)[0], 2);
+            data.write_all(&[0u8; 4096]).unwrap();
+            ctrl.write_all(&[4u8]).unwrap(); // TestEnd
+            assert_eq!(read_exact(&mut ctrl, 1)[0], 13);
+            write_json(
+                &mut ctrl,
+                r#"{"cpu_util_total":1.0,"cpu_util_user":0.5,"cpu_util_system":0.5,"sender_has_retransmits":1,"streams":[{"id":1,"bytes":4096,"retransmits":0,"jitter":0,"errors":0,"packets":0,"start_time":0,"end_time":1}]}"#,
+            );
+            read_json(&mut ctrl); // server results
+            assert_eq!(read_exact(&mut ctrl, 1)[0], 14); // DisplayResults
+                                                         // The end-loop terminate: 12 instead of IperfDone(16).
+            ctrl.write_all(&[12u8]).unwrap();
+            std::thread::sleep(std::time::Duration::from_millis(500));
+        }
+    });
+
+    mock.join().expect("mock");
+    let status =
+        riperf3_test_support::wait_bounded(&mut server.0, std::time::Duration::from_secs(5))
+            .expect("server exits");
+    let sdoc = sdoc_reader.join().expect("stdout");
+    let serr = serr_reader.join().expect("stderr");
+    let doc: serde_json::Value =
+        serde_json::from_str(sdoc.trim()).unwrap_or_else(|e| panic!("one -J doc ({e}): {sdoc}"));
+    assert_eq!(
+        doc["error"].as_str(),
+        Some("the client has terminated"),
+        "the end-loop terminate dumps GT's IECLIENTTERM shape: {doc}"
+    );
+    assert!(
+        serr.trim().is_empty(),
+        "-J suppresses the stderr line like iperf_err's sink rule: {serr}"
+    );
+    assert!(
+        status.success(),
+        "CLIENT_TERMINATE sets IPERF_DONE and ends cleanly like GT"
+    );
+}
+
+/// #325: an UNKNOWN control byte errors with GT's IEMESSAGE sentence
+/// (iperf_error.c:302) — GT's state switch has no tolerant default. The
+/// byte lands where the server reads STATES (the end loop).
+#[test]
+fn unknown_control_byte_takes_gt_iemessage() {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind");
+    let port = listener.local_addr().unwrap().port().to_string();
+    drop(listener);
+
+    let mut server = common::ChildGuard(
+        std::process::Command::new(env!("CARGO_BIN_EXE_riperf3"))
+            .args(["-s", "-1", "-p", &port])
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::piped())
+            .spawn()
+            .expect("spawn server"),
+    );
+    let serr_reader =
+        riperf3_test_support::drain_reader(server.0.stderr.take().expect("piped stderr"));
+    std::thread::sleep(std::time::Duration::from_millis(400));
+
+    let mock = std::thread::spawn({
+        let port: u16 = port.parse().unwrap();
+        move || {
+            let read_exact = |s: &mut std::net::TcpStream, n: usize| -> Vec<u8> {
+                let mut b = vec![0u8; n];
+                s.read_exact(&mut b).expect("mock read");
+                b
+            };
+            let read_json = |s: &mut std::net::TcpStream| {
+                let len = u32::from_be_bytes(read_exact(s, 4).try_into().unwrap()) as usize;
+                read_exact(s, len)
+            };
+            let write_json = |s: &mut std::net::TcpStream, payload: &str| {
+                s.write_all(&(payload.len() as u32).to_be_bytes()).unwrap();
+                s.write_all(payload.as_bytes()).unwrap();
+            };
+            let cookie = [b'x'; 37];
+            let mut ctrl = std::net::TcpStream::connect(("127.0.0.1", port)).expect("ctrl");
+            ctrl.write_all(&cookie).unwrap();
+            assert_eq!(read_exact(&mut ctrl, 1)[0], 9);
+            write_json(
+                &mut ctrl,
+                r#"{"tcp":true,"omit":0,"time":1,"num":0,"blockcount":0,"parallel":1,"len":131072,"pacing_timer":1000,"client_version":"riperf3 0.0.0"}"#,
+            );
+            assert_eq!(read_exact(&mut ctrl, 1)[0], 10);
+            let mut data = std::net::TcpStream::connect(("127.0.0.1", port)).expect("data");
+            data.write_all(&cookie).unwrap();
+            assert_eq!(read_exact(&mut ctrl, 1)[0], 1);
+            assert_eq!(read_exact(&mut ctrl, 1)[0], 2);
+            data.write_all(&[0u8; 4096]).unwrap();
+            ctrl.write_all(&[4u8]).unwrap(); // TestEnd
+            assert_eq!(read_exact(&mut ctrl, 1)[0], 13);
+            write_json(
+                &mut ctrl,
+                r#"{"cpu_util_total":1.0,"cpu_util_user":0.5,"cpu_util_system":0.5,"sender_has_retransmits":1,"streams":[{"id":1,"bytes":4096,"retransmits":0,"jitter":0,"errors":0,"packets":0,"start_time":0,"end_time":1}]}"#,
+            );
+            read_json(&mut ctrl); // server results
+            assert_eq!(read_exact(&mut ctrl, 1)[0], 14); // DisplayResults
+            ctrl.write_all(&[99u8]).unwrap(); // the unknown byte
+            std::thread::sleep(std::time::Duration::from_millis(500));
+        }
+    });
+
+    mock.join().expect("mock");
+    let status =
+        riperf3_test_support::wait_bounded(&mut server.0, std::time::Duration::from_secs(5))
+            .expect("server exits");
+    let serr = serr_reader.join().expect("stderr");
+    assert!(
+        serr.contains(
+            "received an unknown control message (ensure other side is iperf3 and not iperf)"
+        ),
+        "GT's IEMESSAGE sentence: {serr}"
+    );
+    assert!(!status.success(), "the IEMESSAGE run errors like GT");
+}

--- a/riperf3-cli/tests/wire_shape.rs
+++ b/riperf3-cli/tests/wire_shape.rs
@@ -81,15 +81,67 @@ fn client_sends_iperf_done_after_the_results_exchange() {
     );
 }
 
-/// One end-of-test run against a mock client (#325): full protocol through
-/// DisplayResults, then `final_byte` instead of IperfDone(16). Returns
-/// (stdout, stderr, exit status) of the one-off server.
-fn run_end_loop_scenario(json: bool, final_byte: u8) -> (String, String, std::process::ExitStatus) {
-    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind");
-    let port = listener.local_addr().unwrap().port().to_string();
-    drop(listener);
+/// Mock-side wire primitives shared by the #325 scenarios.
+fn read_exact(s: &mut std::net::TcpStream, n: usize) -> Vec<u8> {
+    let mut b = vec![0u8; n];
+    s.read_exact(&mut b).expect("mock read");
+    b
+}
+fn read_json_blob(s: &mut std::net::TcpStream) -> Vec<u8> {
+    let len = u32::from_be_bytes(read_exact(s, 4).try_into().unwrap()) as usize;
+    read_exact(s, len)
+}
+fn write_json_blob(s: &mut std::net::TcpStream, payload: &str) {
+    s.write_all(&(payload.len() as u32).to_be_bytes()).unwrap();
+    s.write_all(payload.as_bytes()).unwrap();
+}
 
-    let mut args = vec!["-s", "-1", "-p", &port];
+const MOCK_PARAMS: &str = r#"{"tcp":true,"omit":0,"time":1,"num":0,"blockcount":0,"parallel":1,"len":131072,"pacing_timer":1000,"client_version":"riperf3 0.0.0"}"#;
+const MOCK_RESULTS: &str = r#"{"cpu_util_total":1.0,"cpu_util_user":0.5,"cpu_util_system":0.5,"sender_has_retransmits":1,"streams":[{"id":1,"bytes":4096,"retransmits":0,"jitter":0,"errors":0,"packets":0,"start_time":0,"end_time":1}]}"#;
+
+/// Drive one mock-client round against a riperf3 server on `port`.
+/// `junk_mid_test`: send `final_byte` in place of TestEnd(4) — the data
+/// phase (#325 r2 F1). Otherwise the round runs through DisplayResults and
+/// sends `final_byte` in place of IperfDone(16) — the end loop.
+fn drive_mock_round(port: u16, final_byte: u8, junk_mid_test: bool) {
+    let cookie = [b'x'; 37];
+    let mut ctrl = std::net::TcpStream::connect(("127.0.0.1", port)).expect("ctrl");
+    ctrl.write_all(&cookie).unwrap();
+    assert_eq!(read_exact(&mut ctrl, 1)[0], 9);
+    write_json_blob(&mut ctrl, MOCK_PARAMS);
+    assert_eq!(read_exact(&mut ctrl, 1)[0], 10);
+    let mut data = std::net::TcpStream::connect(("127.0.0.1", port)).expect("data");
+    data.write_all(&cookie).unwrap();
+    assert_eq!(read_exact(&mut ctrl, 1)[0], 1);
+    assert_eq!(read_exact(&mut ctrl, 1)[0], 2);
+    data.write_all(&[0u8; 4096]).unwrap();
+    if junk_mid_test {
+        ctrl.write_all(&[final_byte]).unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(500));
+        return;
+    }
+    ctrl.write_all(&[4u8]).unwrap(); // TestEnd
+    assert_eq!(read_exact(&mut ctrl, 1)[0], 13);
+    write_json_blob(&mut ctrl, MOCK_RESULTS);
+    read_json_blob(&mut ctrl); // server results
+    assert_eq!(read_exact(&mut ctrl, 1)[0], 14); // DisplayResults
+    ctrl.write_all(&[final_byte]).unwrap();
+    std::thread::sleep(std::time::Duration::from_millis(500));
+}
+
+/// One scenario run against a one-off server: spawn, drive one mock round,
+/// return (stdout, stderr, exit status).
+fn run_scenario(
+    json: bool,
+    final_byte: u8,
+    junk_mid_test: bool,
+) -> (String, String, std::process::ExitStatus) {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind");
+    let port = listener.local_addr().unwrap().port();
+    drop(listener);
+    let port_s = port.to_string();
+
+    let mut args = vec!["-s", "-1", "-p", &port_s];
     if json {
         args.push("-J");
     }
@@ -107,49 +159,7 @@ fn run_end_loop_scenario(json: bool, final_byte: u8) -> (String, String, std::pr
         riperf3_test_support::drain_reader(server.0.stderr.take().expect("piped stderr"));
     std::thread::sleep(std::time::Duration::from_millis(400));
 
-    let mock = std::thread::spawn({
-        let port: u16 = port.parse().unwrap();
-        move || {
-            let read_exact = |s: &mut std::net::TcpStream, n: usize| -> Vec<u8> {
-                let mut b = vec![0u8; n];
-                s.read_exact(&mut b).expect("mock read");
-                b
-            };
-            let read_json = |s: &mut std::net::TcpStream| {
-                let len = u32::from_be_bytes(read_exact(s, 4).try_into().unwrap()) as usize;
-                read_exact(s, len)
-            };
-            let write_json = |s: &mut std::net::TcpStream, payload: &str| {
-                s.write_all(&(payload.len() as u32).to_be_bytes()).unwrap();
-                s.write_all(payload.as_bytes()).unwrap();
-            };
-            let cookie = [b'x'; 37];
-            let mut ctrl = std::net::TcpStream::connect(("127.0.0.1", port)).expect("ctrl");
-            ctrl.write_all(&cookie).unwrap();
-            assert_eq!(read_exact(&mut ctrl, 1)[0], 9);
-            write_json(
-                &mut ctrl,
-                r#"{"tcp":true,"omit":0,"time":1,"num":0,"blockcount":0,"parallel":1,"len":131072,"pacing_timer":1000,"client_version":"riperf3 0.0.0"}"#,
-            );
-            assert_eq!(read_exact(&mut ctrl, 1)[0], 10);
-            let mut data = std::net::TcpStream::connect(("127.0.0.1", port)).expect("data");
-            data.write_all(&cookie).unwrap();
-            assert_eq!(read_exact(&mut ctrl, 1)[0], 1);
-            assert_eq!(read_exact(&mut ctrl, 1)[0], 2);
-            data.write_all(&[0u8; 4096]).unwrap();
-            ctrl.write_all(&[4u8]).unwrap(); // TestEnd
-            assert_eq!(read_exact(&mut ctrl, 1)[0], 13);
-            write_json(
-                &mut ctrl,
-                r#"{"cpu_util_total":1.0,"cpu_util_user":0.5,"cpu_util_system":0.5,"sender_has_retransmits":1,"streams":[{"id":1,"bytes":4096,"retransmits":0,"jitter":0,"errors":0,"packets":0,"start_time":0,"end_time":1}]}"#,
-            );
-            read_json(&mut ctrl); // server results
-            assert_eq!(read_exact(&mut ctrl, 1)[0], 14); // DisplayResults
-            ctrl.write_all(&[final_byte]).unwrap();
-            std::thread::sleep(std::time::Duration::from_millis(500));
-        }
-    });
-
+    let mock = std::thread::spawn(move || drive_mock_round(port, final_byte, junk_mid_test));
     mock.join().expect("mock");
     let status =
         riperf3_test_support::wait_bounded(&mut server.0, std::time::Duration::from_secs(5))
@@ -161,8 +171,13 @@ fn run_end_loop_scenario(json: bool, final_byte: u8) -> (String, String, std::pr
     )
 }
 
+fn run_end_loop_scenario(json: bool, final_byte: u8) -> (String, String, std::process::ExitStatus) {
+    run_scenario(json, final_byte, false)
+}
+
 const IEMESSAGE: &str =
     "received an unknown control message (ensure other side is iperf3 and not iperf)";
+const SUMMARY_SEPARATOR: &str = "- - - - - - - - - - - - - - - - - - - - - - - - -";
 
 /// #325: GT honors CLIENT_TERMINATE at any message point — a terminate
 /// landing in the END loop (after DisplayResults) still dumps the
@@ -188,19 +203,44 @@ fn end_loop_client_terminate_takes_the_terminated_shape() {
     );
 }
 
-/// #325 r1 F1/F2: an UNKNOWN control byte is GT's IEMESSAGE
+/// #325 r2 F2: the text half of the end-loop terminate. RECORDED DEVIATION:
+/// GT prints the summary block TWICE (its TEST_END arm ran the reporter and
+/// the terminate arm re-runs it under DISPLAY_RESULTS); riperf3 prints ONE
+/// dump plus GT's bare terminate line.
+#[test]
+fn end_loop_client_terminate_prints_one_dump_and_the_line_in_text() {
+    let (sout, serr, status) = run_end_loop_scenario(false, 12);
+    assert_eq!(
+        serr.trim(),
+        "riperf3: the client has terminated",
+        "GT's IECLIENTTERM line, no `error - ` prefix"
+    );
+    assert_eq!(
+        sout.matches(SUMMARY_SEPARATOR).count(),
+        1,
+        "one summary dump (recorded deviation: GT double-dumps): {sout}"
+    );
+    assert!(status.success(), "exit 0 like GT");
+}
+
+/// #325 r1 F1/F2: an UNKNOWN control byte in the end loop is GT's IEMESSAGE
 /// (iperf_server_api.c:309-311). Text mode prints main.c:174's line — the
 /// bare sentence behind `error - `, EXACTLY once (no "protocol violation"
-/// wrapper, no CLI double print) — and the one-off still exits 0: a failed
-/// test is rc -1, which GT's main errexits on only below -1 (live-verified
-/// against GT 3.21 in r1).
+/// wrapper, no CLI double print) — after the summary block (the exchange
+/// completed), and the one-off still exits 0: a failed test is rc -1, which
+/// GT's main errexits on only below -1 (live-verified against GT 3.21).
 #[test]
 fn end_loop_unknown_byte_prints_gt_iemessage_once_in_text() {
-    let (_sout, serr, status) = run_end_loop_scenario(false, 99);
+    let (sout, serr, status) = run_end_loop_scenario(false, 99);
     assert_eq!(
         serr.trim(),
         format!("riperf3: error - {IEMESSAGE}"),
         "GT prints the IEMESSAGE line once, unwrapped"
+    );
+    assert_eq!(
+        sout.matches(SUMMARY_SEPARATOR).count(),
+        1,
+        "the failed round still prints its summary (r2 F5): {sout}"
     );
     assert!(
         status.success(),
@@ -208,9 +248,9 @@ fn end_loop_unknown_byte_prints_gt_iemessage_once_in_text() {
     );
 }
 
-/// #325 r1 F4: under -J the IEMESSAGE run still emits the FULL accumulated
-/// doc — populated `end` plus the `error - `-prefixed sentence (main.c:174
-/// through iperf_err's json sink) — with stderr silent and exit 0.
+/// #325 r1 F4: under -J the end-loop IEMESSAGE run still emits the FULL
+/// accumulated doc — populated `end` plus the `error - `-prefixed sentence
+/// (main.c:174 through iperf_err's json sink) — with stderr silent, exit 0.
 #[test]
 fn end_loop_unknown_byte_takes_gt_iemessage_shape_in_json() {
     let (sout, serr, status) = run_end_loop_scenario(true, 99);
@@ -225,7 +265,7 @@ fn end_loop_unknown_byte_takes_gt_iemessage_shape_in_json() {
         doc["end"]["streams"]
             .as_array()
             .is_some_and(|a| !a.is_empty()),
-        "GT dumps the populated end block, not a skeleton: {doc}"
+        "the exchange completed — GT dumps the populated end block: {doc}"
     );
     assert!(
         serr.trim().is_empty(),
@@ -247,4 +287,133 @@ fn end_loop_known_stray_state_is_iemessage_like_gt() {
         "a known-but-unhandled state takes GT's IEMESSAGE default"
     );
     assert!(status.success(), "one-off exits 0 like GT");
+}
+
+/// #325 r2 F1: an unmapped byte DURING the data phase (in place of TestEnd)
+/// is the same IEMESSAGE default, but GT's end processing never ran — the
+/// -J doc keeps the accumulated intervals with a BARE `end: {}` (live-
+/// verified skeleton), stderr silent, exit 0. Before this fix the run
+/// produced no document at all.
+#[test]
+fn mid_test_unknown_byte_emits_the_accumulated_doc_in_json() {
+    let (sout, serr, status) = run_scenario(true, 99, true);
+    let doc: serde_json::Value =
+        serde_json::from_str(sout.trim()).unwrap_or_else(|e| panic!("one -J doc ({e}): {sout}"));
+    assert_eq!(
+        doc["error"].as_str(),
+        Some(format!("error - {IEMESSAGE}").as_str()),
+        "the doc carries GT's prefixed IEMESSAGE: {doc}"
+    );
+    assert!(
+        doc["end"].as_object().is_some_and(|o| o.is_empty()),
+        "the final stats dump never ran — GT's end is bare {{}}: {doc}"
+    );
+    assert!(
+        serr.trim().is_empty(),
+        "-J suppresses the stderr line like iperf_err's sink rule: {serr}"
+    );
+    assert!(status.success(), "one-off exits 0 like GT");
+}
+
+/// #325 r2 F1, text half: the mid-test IEMESSAGE prints GT's single stderr
+/// line and NO summary block (GT's reporter never ran), exit 0.
+#[test]
+fn mid_test_unknown_byte_prints_the_line_and_no_summary_in_text() {
+    let (sout, serr, status) = run_scenario(false, 99, true);
+    assert_eq!(
+        serr.trim(),
+        format!("riperf3: error - {IEMESSAGE}"),
+        "GT's single IEMESSAGE line"
+    );
+    assert_eq!(
+        sout.matches(SUMMARY_SEPARATOR).count(),
+        0,
+        "no summary block mid-test (GT's reporter never ran): {sout}"
+    );
+    assert!(status.success(), "one-off exits 0 like GT");
+}
+
+/// #325 r2 F5: a PERSISTENT server prints the IEMESSAGE line once per
+/// failed round and keeps serving — GT live-verified two junk rounds with
+/// its banner renumbering between them.
+#[test]
+fn persistent_server_keeps_serving_after_iemessage() {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind");
+    let port = listener.local_addr().unwrap().port();
+    drop(listener);
+    let port_s = port.to_string();
+
+    let mut server = common::ChildGuard(
+        std::process::Command::new(env!("CARGO_BIN_EXE_riperf3"))
+            .args(["-s", "-p", &port_s])
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::piped())
+            .spawn()
+            .expect("spawn server"),
+    );
+    let serr_reader =
+        riperf3_test_support::drain_reader(server.0.stderr.take().expect("piped stderr"));
+    std::thread::sleep(std::time::Duration::from_millis(400));
+
+    // Two full rounds, each ending in an end-loop junk byte. The second
+    // round completing its handshake IS the keeps-serving proof.
+    for _ in 0..2 {
+        drive_mock_round(port, 99, false);
+    }
+    // Grace for the second round's finalize + print before the kill.
+    std::thread::sleep(std::time::Duration::from_secs(1));
+    server.0.kill().expect("kill persistent server");
+    let _ = server.0.wait();
+    let serr = serr_reader.join().expect("stderr");
+    let line = format!("riperf3: error - {IEMESSAGE}");
+    assert_eq!(
+        serr.lines().filter(|l| *l == line).count(),
+        2,
+        "one IEMESSAGE line per failed round: {serr}"
+    );
+}
+
+/// #325 r2 F6: the CLIENT side of the same default — GT's client message
+/// handler IEMESSAGEs an unmapped byte too (iperf_client_api.c:409-411).
+/// The byte replaces ExchangeResults(13) at the client's direct state wait
+/// (mid-TEST_RUNNING reads keep their pre-recorded Err→Closed deviation).
+/// Text: the bare-sentence line behind `error - `, exit 1.
+#[test]
+fn client_state_wait_unknown_byte_takes_gt_iemessage() {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind mock");
+    let port = listener.local_addr().unwrap().port().to_string();
+
+    let mock = std::thread::spawn(move || {
+        let (mut ctrl, _) = listener.accept().expect("ctrl accept");
+        read_exact(&mut ctrl, 37); // cookie
+        ctrl.write_all(&[9u8]).unwrap(); // ParamExchange
+        read_json_blob(&mut ctrl); // params
+        ctrl.write_all(&[10u8]).unwrap(); // CreateStreams
+        let (mut data, _) = listener.accept().expect("data accept");
+        read_exact(&mut data, 37); // data-stream cookie
+        ctrl.write_all(&[1u8]).unwrap(); // TestStart
+        ctrl.write_all(&[2u8]).unwrap(); // TestRunning
+        let drain = std::thread::spawn(move || {
+            let mut buf = vec![0u8; 65536];
+            while data.read(&mut buf).map(|n| n > 0).unwrap_or(false) {}
+        });
+        assert_eq!(read_exact(&mut ctrl, 1)[0], 4, "client's TestEnd");
+        // The unknown byte in place of ExchangeResults(13).
+        ctrl.write_all(&[99u8]).unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(500));
+        let _ = drain.join();
+    });
+
+    let client = common::run_client(
+        &["-c", "127.0.0.1", "-p", &port, "-n", "100K"],
+        Duration::from_secs(15),
+        "client iemessage",
+    );
+    mock.join().expect("mock");
+    assert_eq!(
+        client.stderr.trim(),
+        format!("riperf3: error - {IEMESSAGE}"),
+        "GT's client IEMESSAGE line"
+    );
+    assert_eq!(client.status.code(), Some(1), "GT's client errexits 1");
 }

--- a/riperf3-cli/tests/wire_shape.rs
+++ b/riperf3-cli/tests/wire_shape.rs
@@ -81,25 +81,27 @@ fn client_sends_iperf_done_after_the_results_exchange() {
     );
 }
 
-/// #325: GT honors CLIENT_TERMINATE at any message point — a terminate
-/// landing in the END loop (after DisplayResults) still dumps the
-/// client-terminated shape (iperf_server_api.c:289-308), where the old
-/// tolerant arm swallowed it and reported clean success.
-#[test]
-fn end_loop_client_terminate_takes_the_terminated_shape() {
+/// One end-of-test run against a mock client (#325): full protocol through
+/// DisplayResults, then `final_byte` instead of IperfDone(16). Returns
+/// (stdout, stderr, exit status) of the one-off server.
+fn run_end_loop_scenario(json: bool, final_byte: u8) -> (String, String, std::process::ExitStatus) {
     let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind");
     let port = listener.local_addr().unwrap().port().to_string();
     drop(listener);
 
+    let mut args = vec!["-s", "-1", "-p", &port];
+    if json {
+        args.push("-J");
+    }
     let mut server = common::ChildGuard(
         std::process::Command::new(env!("CARGO_BIN_EXE_riperf3"))
-            .args(["-s", "-1", "-p", &port, "-J"])
+            .args(&args)
             .stdout(std::process::Stdio::piped())
             .stderr(std::process::Stdio::piped())
             .spawn()
             .expect("spawn server"),
     );
-    let sdoc_reader =
+    let sout_reader =
         riperf3_test_support::drain_reader(server.0.stdout.take().expect("piped stdout"));
     let serr_reader =
         riperf3_test_support::drain_reader(server.0.stderr.take().expect("piped stderr"));
@@ -143,8 +145,7 @@ fn end_loop_client_terminate_takes_the_terminated_shape() {
             );
             read_json(&mut ctrl); // server results
             assert_eq!(read_exact(&mut ctrl, 1)[0], 14); // DisplayResults
-                                                         // The end-loop terminate: 12 instead of IperfDone(16).
-            ctrl.write_all(&[12u8]).unwrap();
+            ctrl.write_all(&[final_byte]).unwrap();
             std::thread::sleep(std::time::Duration::from_millis(500));
         }
     });
@@ -153,10 +154,25 @@ fn end_loop_client_terminate_takes_the_terminated_shape() {
     let status =
         riperf3_test_support::wait_bounded(&mut server.0, std::time::Duration::from_secs(5))
             .expect("server exits");
-    let sdoc = sdoc_reader.join().expect("stdout");
-    let serr = serr_reader.join().expect("stderr");
+    (
+        sout_reader.join().expect("stdout"),
+        serr_reader.join().expect("stderr"),
+        status,
+    )
+}
+
+const IEMESSAGE: &str =
+    "received an unknown control message (ensure other side is iperf3 and not iperf)";
+
+/// #325: GT honors CLIENT_TERMINATE at any message point — a terminate
+/// landing in the END loop (after DisplayResults) still dumps the
+/// client-terminated shape (iperf_server_api.c:289-308), where the old
+/// tolerant arm swallowed it and reported clean success.
+#[test]
+fn end_loop_client_terminate_takes_the_terminated_shape() {
+    let (sout, serr, status) = run_end_loop_scenario(true, 12);
     let doc: serde_json::Value =
-        serde_json::from_str(sdoc.trim()).unwrap_or_else(|e| panic!("one -J doc ({e}): {sdoc}"));
+        serde_json::from_str(sout.trim()).unwrap_or_else(|e| panic!("one -J doc ({e}): {sout}"));
     assert_eq!(
         doc["error"].as_str(),
         Some("the client has terminated"),
@@ -172,80 +188,63 @@ fn end_loop_client_terminate_takes_the_terminated_shape() {
     );
 }
 
-/// #325: an UNKNOWN control byte errors with GT's IEMESSAGE sentence
-/// (iperf_error.c:302) — GT's state switch has no tolerant default. The
-/// byte lands where the server reads STATES (the end loop).
+/// #325 r1 F1/F2: an UNKNOWN control byte is GT's IEMESSAGE
+/// (iperf_server_api.c:309-311). Text mode prints main.c:174's line — the
+/// bare sentence behind `error - `, EXACTLY once (no "protocol violation"
+/// wrapper, no CLI double print) — and the one-off still exits 0: a failed
+/// test is rc -1, which GT's main errexits on only below -1 (live-verified
+/// against GT 3.21 in r1).
 #[test]
-fn unknown_control_byte_takes_gt_iemessage() {
-    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind");
-    let port = listener.local_addr().unwrap().port().to_string();
-    drop(listener);
-
-    let mut server = common::ChildGuard(
-        std::process::Command::new(env!("CARGO_BIN_EXE_riperf3"))
-            .args(["-s", "-1", "-p", &port])
-            .stdout(std::process::Stdio::null())
-            .stderr(std::process::Stdio::piped())
-            .spawn()
-            .expect("spawn server"),
+fn end_loop_unknown_byte_prints_gt_iemessage_once_in_text() {
+    let (_sout, serr, status) = run_end_loop_scenario(false, 99);
+    assert_eq!(
+        serr.trim(),
+        format!("riperf3: error - {IEMESSAGE}"),
+        "GT prints the IEMESSAGE line once, unwrapped"
     );
-    let serr_reader =
-        riperf3_test_support::drain_reader(server.0.stderr.take().expect("piped stderr"));
-    std::thread::sleep(std::time::Duration::from_millis(400));
-
-    let mock = std::thread::spawn({
-        let port: u16 = port.parse().unwrap();
-        move || {
-            let read_exact = |s: &mut std::net::TcpStream, n: usize| -> Vec<u8> {
-                let mut b = vec![0u8; n];
-                s.read_exact(&mut b).expect("mock read");
-                b
-            };
-            let read_json = |s: &mut std::net::TcpStream| {
-                let len = u32::from_be_bytes(read_exact(s, 4).try_into().unwrap()) as usize;
-                read_exact(s, len)
-            };
-            let write_json = |s: &mut std::net::TcpStream, payload: &str| {
-                s.write_all(&(payload.len() as u32).to_be_bytes()).unwrap();
-                s.write_all(payload.as_bytes()).unwrap();
-            };
-            let cookie = [b'x'; 37];
-            let mut ctrl = std::net::TcpStream::connect(("127.0.0.1", port)).expect("ctrl");
-            ctrl.write_all(&cookie).unwrap();
-            assert_eq!(read_exact(&mut ctrl, 1)[0], 9);
-            write_json(
-                &mut ctrl,
-                r#"{"tcp":true,"omit":0,"time":1,"num":0,"blockcount":0,"parallel":1,"len":131072,"pacing_timer":1000,"client_version":"riperf3 0.0.0"}"#,
-            );
-            assert_eq!(read_exact(&mut ctrl, 1)[0], 10);
-            let mut data = std::net::TcpStream::connect(("127.0.0.1", port)).expect("data");
-            data.write_all(&cookie).unwrap();
-            assert_eq!(read_exact(&mut ctrl, 1)[0], 1);
-            assert_eq!(read_exact(&mut ctrl, 1)[0], 2);
-            data.write_all(&[0u8; 4096]).unwrap();
-            ctrl.write_all(&[4u8]).unwrap(); // TestEnd
-            assert_eq!(read_exact(&mut ctrl, 1)[0], 13);
-            write_json(
-                &mut ctrl,
-                r#"{"cpu_util_total":1.0,"cpu_util_user":0.5,"cpu_util_system":0.5,"sender_has_retransmits":1,"streams":[{"id":1,"bytes":4096,"retransmits":0,"jitter":0,"errors":0,"packets":0,"start_time":0,"end_time":1}]}"#,
-            );
-            read_json(&mut ctrl); // server results
-            assert_eq!(read_exact(&mut ctrl, 1)[0], 14); // DisplayResults
-            ctrl.write_all(&[99u8]).unwrap(); // the unknown byte
-            std::thread::sleep(std::time::Duration::from_millis(500));
-        }
-    });
-
-    mock.join().expect("mock");
-    let status =
-        riperf3_test_support::wait_bounded(&mut server.0, std::time::Duration::from_secs(5))
-            .expect("server exits");
-    let serr = serr_reader.join().expect("stderr");
     assert!(
-        serr.contains(
-            "received an unknown control message (ensure other side is iperf3 and not iperf)"
-        ),
-        "GT's IEMESSAGE sentence: {serr}"
+        status.success(),
+        "GT's one-off exits 0 on a failed test (main.c `rc < -1` only)"
     );
-    assert!(!status.success(), "the IEMESSAGE run errors like GT");
+}
+
+/// #325 r1 F4: under -J the IEMESSAGE run still emits the FULL accumulated
+/// doc — populated `end` plus the `error - `-prefixed sentence (main.c:174
+/// through iperf_err's json sink) — with stderr silent and exit 0.
+#[test]
+fn end_loop_unknown_byte_takes_gt_iemessage_shape_in_json() {
+    let (sout, serr, status) = run_end_loop_scenario(true, 99);
+    let doc: serde_json::Value =
+        serde_json::from_str(sout.trim()).unwrap_or_else(|e| panic!("one -J doc ({e}): {sout}"));
+    assert_eq!(
+        doc["error"].as_str(),
+        Some(format!("error - {IEMESSAGE}").as_str()),
+        "GT's in-doc IEMESSAGE carries the `error - ` prefix: {doc}"
+    );
+    assert!(
+        doc["end"]["streams"]
+            .as_array()
+            .is_some_and(|a| !a.is_empty()),
+        "GT dumps the populated end block, not a skeleton: {doc}"
+    );
+    assert!(
+        serr.trim().is_empty(),
+        "-J suppresses the stderr line like iperf_err's sink rule: {serr}"
+    );
+    assert!(status.success(), "one-off exits 0 like GT");
+}
+
+/// #325 r1 F3: GT's end-loop switch has arms for only TEST_START /
+/// TEST_END / IPERF_DONE / CLIENT_TERMINATE — a KNOWN state landing here
+/// (TEST_RUNNING=2, live-verified against GT 3.21) hits the same IEMESSAGE
+/// default, where riperf3's old #145 arm tolerated it as clean success.
+#[test]
+fn end_loop_known_stray_state_is_iemessage_like_gt() {
+    let (_sout, serr, status) = run_end_loop_scenario(false, 2);
+    assert_eq!(
+        serr.trim(),
+        format!("riperf3: error - {IEMESSAGE}"),
+        "a known-but-unhandled state takes GT's IEMESSAGE default"
+    );
+    assert!(status.success(), "one-off exits 0 like GT");
 }

--- a/riperf3-cli/tests/wire_shape.rs
+++ b/riperf3-cli/tests/wire_shape.rs
@@ -412,13 +412,12 @@ fn mid_test_unknown_byte_with_get_server_output_prints_no_summary() {
     assert!(status.success(), "one-off exits 0 like GT");
 }
 
-/// #325 r3 F1: a hostile peer that sends the junk byte and then HOLDS its
-/// sockets open must not park the server — GT cleanup_servers immediately
-/// when handle_message fails (iperf_server_api.c:764-767). Pre-fix the
-/// stream-task joins waited out the peer's whole hold (live: a 30 s hold
-/// held the one-off 33 s and blocked the stderr line with it).
-#[test]
-fn mid_test_unknown_byte_exits_bounded_while_peer_holds() {
+/// Holding-peer harness (#325 r3 F1 / r4 NF-1): drive the protocol, send
+/// `final_byte` (mid-test or end-loop), then HOLD both sockets far past
+/// the assertion window. Returns the server's stderr and exit status —
+/// which must arrive while the peer still holds. Detached mock thread;
+/// the sockets close when the test binary exits.
+fn run_holding_scenario(final_byte: u8, junk_mid_test: bool) -> (String, std::process::ExitStatus) {
     let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind");
     let port = listener.local_addr().unwrap().port();
     drop(listener);
@@ -436,9 +435,6 @@ fn mid_test_unknown_byte_exits_bounded_while_peer_holds() {
         riperf3_test_support::drain_reader(server.0.stderr.take().expect("piped stderr"));
     std::thread::sleep(std::time::Duration::from_millis(400));
 
-    // The holding mock: full protocol to the data phase, junk byte, then
-    // KEEP both sockets open far past the assertion window. Detached — the
-    // sockets close when the test binary exits.
     std::thread::spawn(move || {
         let cookie = [b'x'; 37];
         let mut ctrl = std::net::TcpStream::connect(("127.0.0.1", port)).expect("ctrl");
@@ -451,20 +447,52 @@ fn mid_test_unknown_byte_exits_bounded_while_peer_holds() {
         assert_eq!(read_exact(&mut ctrl, 1)[0], 1);
         assert_eq!(read_exact(&mut ctrl, 1)[0], 2);
         data.write_all(&[0u8; 4096]).unwrap();
-        ctrl.write_all(&[99u8]).unwrap();
+        if !junk_mid_test {
+            ctrl.write_all(&[4u8]).unwrap(); // TestEnd
+            assert_eq!(read_exact(&mut ctrl, 1)[0], 13);
+            write_json_blob(&mut ctrl, MOCK_RESULTS);
+            read_json_blob(&mut ctrl); // server results
+            assert_eq!(read_exact(&mut ctrl, 1)[0], 14); // DisplayResults
+        }
+        ctrl.write_all(&[final_byte]).unwrap();
         std::thread::sleep(std::time::Duration::from_secs(30));
         drop((ctrl, data));
     });
 
     let status =
         riperf3_test_support::wait_bounded(&mut server.0, std::time::Duration::from_secs(8))
-            .expect("server exits while the peer still holds (r3 F1)");
+            .expect("server exits while the peer still holds");
+    (serr_reader.join().expect("stderr"), status)
+}
+
+/// #325 r3 F1: a hostile peer that sends the junk byte and then HOLDS its
+/// sockets open must not park the server — GT cleanup_servers immediately
+/// when handle_message fails (iperf_server_api.c:764-767). Pre-fix the
+/// stream-task joins waited out the peer's whole hold (live: a 30 s hold
+/// held the one-off 33 s and blocked the stderr line with it).
+#[test]
+fn mid_test_unknown_byte_exits_bounded_while_peer_holds() {
+    let (serr, status) = run_holding_scenario(99, true);
     assert!(status.success(), "one-off exits 0 like GT");
-    let serr = serr_reader.join().expect("stderr");
     assert_eq!(
         serr.trim(),
         format!("riperf3: error - {IEMESSAGE}"),
         "the line prints NOW, not after the peer relents"
+    );
+}
+
+/// #325 r4 NF-1: the same hold one byte over — CLIENT_TERMINATE in the end
+/// loop. GT's terminate arm closes the stream sockets INLINE
+/// (iperf_server_api.c:301-305) and exits on its own clock; the joins must
+/// not wait out the peer's hold.
+#[test]
+fn end_loop_client_terminate_exits_bounded_while_peer_holds() {
+    let (serr, status) = run_holding_scenario(12, false);
+    assert!(status.success(), "terminate ends cleanly like GT");
+    assert_eq!(
+        serr.trim(),
+        "riperf3: the client has terminated",
+        "GT's bare IECLIENTTERM line, printed while the peer still holds"
     );
 }
 

--- a/riperf3-cli/tests/wire_shape.rs
+++ b/riperf3-cli/tests/wire_shape.rs
@@ -496,6 +496,20 @@ fn end_loop_client_terminate_exits_bounded_while_peer_holds() {
     );
 }
 
+/// #325 r5 nit: the mid-test terminate hold, pinned explicitly (the gates
+/// are shared with the two cells above, but a pin per cell keeps a silent
+/// regression impossible).
+#[test]
+fn mid_test_client_terminate_exits_bounded_while_peer_holds() {
+    let (serr, status) = run_holding_scenario(12, true);
+    assert!(status.success(), "terminate ends cleanly like GT");
+    assert_eq!(
+        serr.trim(),
+        "riperf3: the client has terminated",
+        "GT's bare IECLIENTTERM line, printed while the peer still holds"
+    );
+}
+
 /// #325 r2 F6: the CLIENT side of the same default — GT's client message
 /// handler IEMESSAGEs an unmapped byte too (iperf_client_api.c:409-411).
 /// The byte replaces ExchangeResults(13) at the client's direct state wait

--- a/riperf3/src/error.rs
+++ b/riperf3/src/error.rs
@@ -59,8 +59,13 @@ pub enum RiperfError {
     /// iperf3's IEMESSAGE (#325): an unhandled control byte. GT's end-loop
     /// switch has arms for only TEST_START / TEST_END / IPERF_DONE /
     /// CLIENT_TERMINATE — every other value, known state or not, hits
-    /// `default: i_errno = IEMESSAGE` (iperf_server_api.c:309-311). GT's
-    /// sentence, no "protocol violation" wrapper (#151 convention).
+    /// `default: i_errno = IEMESSAGE` (iperf_server_api.c:309-311). The
+    /// CLIENT's message handler defaults to the same code
+    /// (iperf_client_api.c:409-411), so recv_state surfaces this on both
+    /// roles — the client's text line and -J doc match GT byte-for-byte
+    /// (r2-verified; the client doc carries the BARE sentence, no
+    /// `error - ` prefix). GT's sentence, no "protocol violation" wrapper
+    /// (#151 convention).
     #[error("received an unknown control message (ensure other side is iperf3 and not iperf)")]
     UnknownControlMessage,
 

--- a/riperf3/src/error.rs
+++ b/riperf3/src/error.rs
@@ -56,6 +56,14 @@ pub enum RiperfError {
     #[error("unable to receive results")]
     RecvResultsFailed,
 
+    /// iperf3's IEMESSAGE (#325): an unhandled control byte. GT's end-loop
+    /// switch has arms for only TEST_START / TEST_END / IPERF_DONE /
+    /// CLIENT_TERMINATE — every other value, known state or not, hits
+    /// `default: i_errno = IEMESSAGE` (iperf_server_api.c:309-311). GT's
+    /// sentence, no "protocol violation" wrapper (#151 convention).
+    #[error("received an unknown control message (ensure other side is iperf3 and not iperf)")]
+    UnknownControlMessage,
+
     /// iperf3's IESERVERTERM: the server sent SERVER_TERMINATE mid-test; a
     /// partial summary is rendered from local data before this surfaces (#170).
     #[error("the server has terminated")]

--- a/riperf3/src/error.rs
+++ b/riperf3/src/error.rs
@@ -62,10 +62,11 @@ pub enum RiperfError {
     /// `default: i_errno = IEMESSAGE` (iperf_server_api.c:309-311). The
     /// CLIENT's message handler defaults to the same code
     /// (iperf_client_api.c:409-411), so recv_state surfaces this on both
-    /// roles — the client's text line and -J doc match GT byte-for-byte
-    /// (r2-verified; the client doc carries the BARE sentence, no
-    /// `error - ` prefix). GT's sentence, no "protocol violation" wrapper
-    /// (#151 convention).
+    /// roles — the client's stderr line, -J error key (BARE sentence, no
+    /// `error - ` prefix), and exit 1 match GT (r2/r3-verified); the
+    /// client's -J doc BODY is the skeleton error_document where GT emits
+    /// its accumulated doc — the #330 item-2 gap, tracked there. GT's
+    /// sentence, no "protocol violation" wrapper (#151 convention).
     #[error("received an unknown control message (ensure other side is iperf3 and not iperf)")]
     UnknownControlMessage,
 

--- a/riperf3/src/json_report.rs
+++ b/riperf3/src/json_report.rs
@@ -480,7 +480,7 @@ pub struct IntervalSum {
 #[derive(Debug, Clone)]
 #[non_exhaustive]
 pub struct End {
-    /// #261/#281: true ONLY on the upfront-refusal path — the whole object
+    /// #261/#281: true on the upfront-refusal path and the mid-test IEMESSAGE dump (#325) — the whole object
     /// serializes as GT's bare `{}`. Every other dump (success, mid-test or
     /// pre-TestStart interrupt, SERVER_TERMINATE) renders the full structure,
     /// including `streams: []` when no stream ever existed.
@@ -823,7 +823,7 @@ pub(crate) struct ReportInput {
     /// the three-stage `start` field gating (see [`StartStage`]). The client
     /// derives it from its run stage; the server always builds at `Started`.
     pub start_stage: StartStage,
-    /// True ONLY on the upfront server-refusal path (#261): the `end` object
+    /// True on the upfront server-refusal path (#261) and the mid-test IEMESSAGE dump (#325 — GT's final stats never ran): the `end` object
     /// serializes bare (`{}`). Interrupt dumps — mid-test OR pre-TestStart —
     /// keep the full end structure (GT emits zeroed sums + `streams: []`
     /// there, #281).

--- a/riperf3/src/protocol.rs
+++ b/riperf3/src/protocol.rs
@@ -1589,7 +1589,7 @@ mod transition_table_tests {
         assert_eq!(legal_next(IperfDone, Role::Client), &[]);
     }
 
-    // -- Role::Server: the server only reads peer state in two phases --
+    // -- Role::Server: the data phase is the one surviving consult (#325) --
 
     #[test]
     fn server_legal_sets_are_exact() {
@@ -1597,17 +1597,16 @@ mod transition_table_tests {
             legal_next(TestRunning, Role::Server),
             &[TestEnd, ClientTerminate]
         );
-        assert_eq!(
-            legal_next(DisplayResults, Role::Server),
-            &[IperfDone, ClientTerminate]
-        );
+        // #325 dropped the DisplayResults row: GT's end loop IEMESSAGEs
+        // strays instead of tolerating them, so nothing consults it.
+        assert_eq!(legal_next(DisplayResults, Role::Server), &[]);
     }
 
     #[test]
     fn server_other_currents_have_no_successors() {
         // Exhaustive over the remaining variants — the server consults the
-        // table only in the data phase (TestRunning) and the end loop
-        // (DisplayResults); everything else is the empty set.
+        // table only in the data phase (TestRunning); everything else is
+        // the empty set (#325 dropped the end-loop row).
         for current in [
             TestStart,
             TestEnd,

--- a/riperf3/src/protocol.rs
+++ b/riperf3/src/protocol.rs
@@ -105,13 +105,16 @@ pub(crate) enum Role {
 /// processed and which `role` it plays.
 ///
 /// AUDITABILITY TABLE, NOT AN IDEALIZED PROTOCOL. This deliberately matches
-/// iperf3's *actual* tolerances — derived from the server's send sequence plus
-/// the two documented loosenesses (a re-sent `TEST_RUNNING` is a no-op on the
-/// client; the server's end-of-test loop tolerates intervening bytes) — rather
-/// than a stricter ideal. It is consulted ONLY to emit diagnostics
-/// (`log::debug!`, off by default). It is NEVER used to reject or error on a
-/// sequence: iperf3 itself is loose here, and a stricter riperf3 would break
-/// interop. Default-tolerant by design (#145).
+/// iperf3's *actual* tolerances — derived from the server's send sequence
+/// plus its one documented looseness (a re-sent `TEST_RUNNING` is a no-op on
+/// the client) — rather than a stricter ideal. (#325 established that GT's
+/// server end-of-test loop does NOT tolerate intervening bytes — its switch
+/// IEMESSAGEs everything but TEST_START/TEST_END/IPERF_DONE/CLIENT_TERMINATE
+/// — so the server end loop no longer consults this table at all.) It is
+/// consulted ONLY to emit diagnostics (`log::debug!`, off by default). It is
+/// NEVER used to reject or error on a sequence: iperf3 itself is loose in
+/// the surviving rows, and a stricter riperf3 would break interop.
+/// Default-tolerant by design (#145).
 ///
 /// `ServerTerminate`/`ServerError` can arrive in any client state (the client
 /// adopts them via their own dispatch arms, and `watch_control` returns on
@@ -135,9 +138,9 @@ pub(crate) fn legal_next(current: TestState, role: Role) -> &'static [TestState]
             _ => &[],
         },
         Role::Server => match current {
-            // The server only READS peer state in two phases.
+            // The server consults this in ONE phase now: the end-of-test
+            // loop dropped its row with #325 (GT IEMESSAGEs strays there).
             TestRunning => &[TestEnd, ClientTerminate], // data phase
-            DisplayResults => &[IperfDone, ClientTerminate], // end-of-test loop
             _ => &[],
         },
     }
@@ -1635,11 +1638,16 @@ mod transition_table_tests {
     }
 
     #[test]
-    fn server_end_loop_tolerates_client_terminate() {
-        // The server's end-of-test loop tolerates intervening bytes; the
-        // table reflects CLIENT_TERMINATE as legal there.
-        assert!(is_legal_next(DisplayResults, ClientTerminate, Role::Server));
+    fn server_data_phase_accepts_client_terminate() {
+        // The data phase is the one surviving server consult (#325 dropped
+        // the end-loop row: GT IEMESSAGEs strays there); CLIENT_TERMINATE
+        // stays legal mid-test.
         assert!(is_legal_next(TestRunning, ClientTerminate, Role::Server));
+        assert!(!is_legal_next(
+            DisplayResults,
+            ClientTerminate,
+            Role::Server
+        ));
     }
 
     #[test]

--- a/riperf3/src/protocol.rs
+++ b/riperf3/src/protocol.rs
@@ -237,7 +237,16 @@ pub async fn recv_state(stream: &mut TcpStream) -> Result<TestState> {
     if n == 0 {
         return Err(RiperfError::PeerDisconnected);
     }
-    TestState::from_wire(buf[0] as i8).map_err(|u| RiperfError::Protocol(u.to_string()))
+    // #325: GT's IEMESSAGE — an unmapped control byte fails with its exact
+    // sentence (iperf_error.c:302; the server's state switch has no
+    // tolerant default, iperf_server_api.c:309-311).
+    TestState::from_wire(buf[0] as i8).map_err(|u| {
+        log::debug!("control byte {} is not a known state", u.0);
+        RiperfError::Protocol(
+            "received an unknown control message (ensure other side is iperf3 and not iperf)"
+                .to_string(),
+        )
+    })
 }
 
 // ---------------------------------------------------------------------------

--- a/riperf3/src/protocol.rs
+++ b/riperf3/src/protocol.rs
@@ -239,13 +239,11 @@ pub async fn recv_state(stream: &mut TcpStream) -> Result<TestState> {
     }
     // #325: GT's IEMESSAGE — an unmapped control byte fails with its exact
     // sentence (iperf_error.c:302; the server's state switch has no
-    // tolerant default, iperf_server_api.c:309-311).
+    // tolerant default, iperf_server_api.c:309-311). Dedicated variant so
+    // the sentence prints bare, not "protocol violation: "-wrapped (r1 F2).
     TestState::from_wire(buf[0] as i8).map_err(|u| {
         log::debug!("control byte {} is not a known state", u.0);
-        RiperfError::Protocol(
-            "received an unknown control message (ensure other side is iperf3 and not iperf)"
-                .to_string(),
-        )
+        RiperfError::UnknownControlMessage
     })
 }
 

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -1658,12 +1658,13 @@ impl Server {
         (server_output_text, server_output_json, report_source)
     }
 
-    /// The one `build_report` plumbing site for the pipeline (#289). The
-    /// drained collections arrive BY VALUE and move into the report, so the
-    /// old "must be built exactly once" comment-invariant is structural
-    /// (#287): the pre-exchange --get-server-output build consumes them into
-    /// `ReportSource::Built` (#33/#137), else they ride `Pending` to the
-    /// single post-exchange build.
+    /// The one report-build plumbing site for the pipeline (#289), split
+    /// from the printer so `--get-server-output` (#33) can build ONCE
+    /// pre-exchange and reuse at print time. The drained collections arrive
+    /// BY VALUE and move into the report, so the "must be built exactly
+    /// once" invariant is structural (#287): the pre-exchange build consumes
+    /// them into `ReportSource::Built` (#33/#137), else they ride `Pending`
+    /// to the single post-exchange build.
     fn build_ctx_report(
         &self,
         ctx: &TestRunCtx,
@@ -2638,41 +2639,6 @@ impl Server {
         };
 
         input
-    }
-
-    /// Build the server's full `-J` report. Split from the printer so
-    /// `--get-server-output` (#33) can build it ONCE pre-exchange (attaching it
-    /// to the results) and reuse it at print time — `build_report_input`
-    /// drains the interval collector destructively, so it must run once.
-    #[allow(clippy::too_many_arguments)]
-    fn build_report(
-        &self,
-        streams: &[DataStream],
-        cfg: &TestConfig,
-        params: &TestParams,
-        cpu_util: &crate::cpu::CpuUtilization,
-        test_duration: f64,
-        cookie: &[u8; protocol::COOKIE_SIZE],
-        accepted_host: &str,
-        accepted_port: u16,
-        start_time_millis: u64,
-        collected: crate::reporter::CollectedIntervals,
-        error: Option<&str>,
-    ) -> crate::json_report::Report {
-        self.build_report_input(
-            streams,
-            cfg,
-            params,
-            cpu_util,
-            test_duration,
-            cookie,
-            accepted_host,
-            accepted_port,
-            start_time_millis,
-            collected,
-            error,
-        )
-        .build()
     }
 
     /// `-J`: pretty-print the server's single batched report blob (#50), or a

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -731,8 +731,13 @@ impl Server {
         // Join stream tasks (best-effort, they should be done).
         // #322 r1 F1: a mid-EXCHANGE interrupt postdates shutdown_and_flush's
         // abort gate — abort here so a wedged peer can't park the joins.
-        // #325 r3 F1: an END-LOOP IEMESSAGE postdates it the same way.
-        if ctx.interrupted.is_some() || ctx.unknown_message {
+        // #325 r3 F1: an END-LOOP IEMESSAGE postdates it the same way, and
+        // r4 NF-1: so does an end-loop CLIENT_TERMINATE — GT's terminate arm
+        // closes the stream sockets INLINE (iperf_server_api.c:301-305), so
+        // a peer that sends 12 and then holds its sockets must not park the
+        // joins (it held the process for the peer's whole hold; GT exits on
+        // its own clock). Covers the pre-existing mid-test terminate too.
+        if ctx.interrupted.is_some() || ctx.unknown_message || ctx.client_terminated {
             for s in &ctx.streams {
                 s.task.abort();
             }
@@ -1447,7 +1452,11 @@ impl Server {
         // the next await); the UDP runners are spawn_blocking, where abort
         // is a no-op once running — their joins stay bounded anyway by the
         // 500 ms read-timeout + `done` polling in the blocking loops.
-        if ctx.server_error.is_some() || ctx.interrupted.is_some() || ctx.unknown_message {
+        if ctx.server_error.is_some()
+            || ctx.interrupted.is_some()
+            || ctx.unknown_message
+            || ctx.client_terminated
+        {
             // #322 r1 F1: interrupts take the same abort — a wedged peer
             // holding sockets open must not park the joins (GT closes its
             // data sockets at TEST_END and sigend exits in milliseconds).

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -244,12 +244,18 @@ struct TestRunCtx {
     /// #210: a peer-terminated or interrupted test skips the results
     /// exchange (the peer is gone) but still dumps local results.
     client_terminated: bool,
-    /// #325: an unhandled control byte in the end loop — GT's IEMESSAGE
-    /// class (iperf_server_api.c:309-311). The dump still renders (the
-    /// exchange already completed); the doc carries the `error - `-prefixed
-    /// sentence and the run counts as a failed test (rc -1 in GT — which
-    /// main.c does NOT errexit on, so one-off still exits 0).
+    /// #325: an unhandled control byte — GT's IEMESSAGE class
+    /// (iperf_server_api.c:309-311; ONE switch serves every phase). The doc
+    /// carries the `error - `-prefixed sentence and the run counts as a
+    /// failed test (rc -1 in GT — which main.c does NOT errexit on, so
+    /// one-off still exits 0).
     unknown_message: bool,
+    /// #325 r2 F1: the final stats dump never ran (a mid-test IEMESSAGE
+    /// fires before GT's TEST_END processing) — the -J doc keeps the
+    /// accumulated intervals with a BARE `end: {}` (live-verified), and
+    /// text prints no summary block, only the stderr line. The end-loop
+    /// IEMESSAGE keeps its populated end: there the exchange completed.
+    bare_end: bool,
     interrupted: Option<String>,
 }
 
@@ -624,6 +630,7 @@ impl Server {
             server_error: None,
             client_terminated: false,
             unknown_message: false,
+            bare_end: false,
             interrupted: None,
         };
         // Signal `done` on every exit path (incl. early `?` returns) so a UDP
@@ -1337,9 +1344,9 @@ impl Server {
         loop {
             tokio::select! {
                 state = protocol::recv_state(&mut ctx.ctrl) => {
-                    match state? {
-                        TestState::TestEnd => break,
-                        TestState::ClientTerminate => {
+                    match state {
+                        Ok(TestState::TestEnd) => break,
+                        Ok(TestState::ClientTerminate) => {
                             // iperf_got_sigend's peer half (#210): dump the
                             // partial results in the finalize phases (the old
                             // early return leaked the reporter — the #147
@@ -1348,9 +1355,11 @@ impl Server {
                             break;
                         }
                         // #145: AUDITABILITY ONLY — log an out-of-sequence
-                        // control byte during the data phase, then STILL
-                        // swallow it (behavior unchanged, default-tolerant).
-                        other => {
+                        // KNOWN control byte during the data phase, then
+                        // STILL swallow it. GT's single message switch would
+                        // IEMESSAGE these too — tracked with the rest of the
+                        // generic-surface parity in #330.
+                        Ok(other) => {
                             if !protocol::is_legal_next(
                                 TestState::TestRunning,
                                 other,
@@ -1362,6 +1371,17 @@ impl Server {
                                 );
                             }
                         }
+                        // #325 r2 F1: an UNMAPPED byte during the data phase
+                        // is the same IEMESSAGE default — GT's end processing
+                        // never runs, so the doc keeps the accumulated
+                        // intervals with a bare end{} and text skips the
+                        // summary (live-verified against GT 3.21).
+                        Err(RiperfError::UnknownControlMessage) => {
+                            ctx.unknown_message = true;
+                            ctx.bare_end = true;
+                            break;
+                        }
+                        Err(e) => return Err(e),
                     }
                 }
                 msg = crate::client::wait_interrupt(interrupt_rx.as_mut()) => {
@@ -1650,7 +1670,7 @@ impl Server {
         end: &EndState,
         collected: crate::reporter::CollectedIntervals,
     ) -> crate::json_report::Report {
-        self.build_report(
+        let mut input = self.build_report_input(
             &ctx.streams,
             &ctx.cfg,
             &ctx.params,
@@ -1662,7 +1682,12 @@ impl Server {
             ctx.test_start_millis,
             collected,
             end.report_error.as_deref(),
-        )
+        );
+        // #325 r2 F1: the mid-test IEMESSAGE doc renders GT's bare end{}
+        // (the final stats dump never ran); every other path keeps the
+        // populated structure the input builder assembled.
+        input.bare_end = ctx.bare_end;
+        input.build()
     }
 
     /// ExchangeResults + the DisplayResults / IperfDone end-of-test loop.
@@ -1676,7 +1701,11 @@ impl Server {
         server_output_text: Option<String>,
         server_output_json: Option<serde_json::Value>,
     ) -> Result<()> {
-        if !ctx.client_terminated && ctx.interrupted.is_none() && ctx.server_error.is_none() {
+        if !ctx.client_terminated
+            && !ctx.unknown_message
+            && ctx.interrupted.is_none()
+            && ctx.server_error.is_none()
+        {
             // Built only when the exchange actually runs — it was dead work
             // on every terminate path (#224).
             let server_results = TestResultsJson {
@@ -1747,8 +1776,13 @@ impl Server {
                     // #325: GT honors CLIENT_TERMINATE at ANY message point
                     // (iperf_server_api.c:289-308: dump under
                     // DISPLAY_RESULTS + IECLIENTTERM) — the finalize phases
-                    // render the terminated shape exactly like the mid-test
-                    // arm.
+                    // render the terminated shape like the mid-test arm.
+                    // RECORDED DEVIATION (r2 F2, text mode only): GT prints
+                    // the summary TWICE here — its TEST_END arm already ran
+                    // reporter_callback (:276) and the terminate arm re-runs
+                    // it under DISPLAY_RESULTS (:293-297, live-verified two
+                    // full blocks). riperf3 prints one dump; -J is identical
+                    // on both (single doc, error key).
                     Ok(TestState::ClientTerminate) => {
                         ctx.client_terminated = true;
                         return Ok(());
@@ -1805,7 +1839,7 @@ impl Server {
         } else if self.json_output {
             // Emit the iperf3-schema JSON report on stdout (#50).
             self.print_results_json(report);
-        } else if !was_captured && ctx.server_error.is_none() {
+        } else if !was_captured && ctx.server_error.is_none() && !ctx.bare_end {
             // Print summary: per-stream lines plus aggregate [SUM] row(s) for
             // parallel streams (issue #4), via the shared path the client uses.
             // Also skipped on self-terminate: iperf3 prints NO summary there

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -502,6 +502,12 @@ impl Server {
     /// accept loop. Unlike `run`, it does not print the "Server listening"
     /// banner — it is a library entry point, not the daemon. The test report is
     /// still printed to stdout in `-J` / text mode, like `Client::run`.
+    ///
+    /// Peer-caused test failures surface as errors AFTER the report was
+    /// rendered to the active sink: a CLIENT_TERMINATE returns
+    /// [`RiperfError::ClientTerminated`] and an unhandled control byte
+    /// returns [`RiperfError::UnknownControlMessage`] (#325) — both mirror
+    /// GT's failed-test rc, which its one-off still exits 0 on.
     pub async fn run_once(&self) -> Result<crate::json_report::Report> {
         let listener = self.listen().await?;
         self.serve_once(&listener).await
@@ -725,7 +731,8 @@ impl Server {
         // Join stream tasks (best-effort, they should be done).
         // #322 r1 F1: a mid-EXCHANGE interrupt postdates shutdown_and_flush's
         // abort gate — abort here so a wedged peer can't park the joins.
-        if ctx.interrupted.is_some() {
+        // #325 r3 F1: an END-LOOP IEMESSAGE postdates it the same way.
+        if ctx.interrupted.is_some() || ctx.unknown_message {
             for s in &ctx.streams {
                 s.task.abort();
             }
@@ -1376,6 +1383,10 @@ impl Server {
                         // never runs, so the doc keeps the accumulated
                         // intervals with a bare end{} and text skips the
                         // summary (live-verified against GT 3.21).
+                        // RECORDED DEVIATION (r3 F3): riperf3's flush adds
+                        // one partial catch-up interval (the #210 terminate
+                        // convention); GT's reporter dies with only whole
+                        // ticks in the doc.
                         Err(RiperfError::UnknownControlMessage) => {
                             ctx.unknown_message = true;
                             ctx.bare_end = true;
@@ -1436,10 +1447,15 @@ impl Server {
         // the next await); the UDP runners are spawn_blocking, where abort
         // is a no-op once running — their joins stay bounded anyway by the
         // 500 ms read-timeout + `done` polling in the blocking loops.
-        if ctx.server_error.is_some() || ctx.interrupted.is_some() {
+        if ctx.server_error.is_some() || ctx.interrupted.is_some() || ctx.unknown_message {
             // #322 r1 F1: interrupts take the same abort — a wedged peer
             // holding sockets open must not park the joins (GT closes its
             // data sockets at TEST_END and sigend exits in milliseconds).
+            // #325 r3 F1: the mid-test IEMESSAGE too — GT cleanup_servers
+            // immediately on a failed handle_message (iperf_server_api.c:
+            // 764-767); without the abort a hostile peer holding its
+            // sockets open parks the joins (and, persistent, the accept
+            // loop) for the whole hold.
             for s in &ctx.streams {
                 s.task.abort();
             }
@@ -1597,7 +1613,12 @@ impl Server {
         collected: crate::reporter::CollectedIntervals,
     ) -> (Option<String>, Option<serde_json::Value>, ReportSource) {
         let mut report_source = ReportSource::Pending(collected);
-        let (server_output_text, server_output_json) = if let Some(capture) = ctx.capture.take() {
+        // #325 r3 F2: the mid-test IEMESSAGE path renders NO summary — GT's
+        // reporter is dead (live-verified: GT with get_server_output prints
+        // only the stderr line). Dropping the capture un-sets was_captured,
+        // and the exchange skip already discards the relay.
+        let capture = ctx.capture.take().filter(|_| !ctx.bare_end);
+        let (server_output_text, server_output_json) = if let Some(capture) = capture {
             let summaries = Self::text_summaries(&ctx.streams, end.test_duration, &ctx.cfg);
             let with_retr = summaries.iter().any(|s| s.retransmits.is_some());
             crate::reporter::print_separator();

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -434,6 +434,13 @@ impl Server {
                     if !crate::macros::output_quiet() {
                         eprintln!("riperf3: error - {e}");
                     }
+                    // #325: GT's one-off errexits on a failed test (main.c
+                    // runs the server once and exits 1 on <0); persistent
+                    // servers print and keep serving (GT caps at 5
+                    // consecutive errors — untracked here).
+                    if self.one_off {
+                        return Err(e);
+                    }
                 }
             }
 
@@ -664,6 +671,10 @@ impl Server {
         if end.report_error.is_none() {
             if let Some(msg) = &ctx.interrupted {
                 end.report_error = Some(msg.clone());
+            } else if ctx.client_terminated {
+                // #325: an end-loop CLIENT_TERMINATE postdates EndState's
+                // resolution exactly like the #322 mid-exchange interrupt.
+                end.report_error = Some("the client has terminated".to_string());
             }
         }
 
@@ -1705,10 +1716,19 @@ impl Server {
                 };
                 match next {
                     Ok(TestState::IperfDone) => break,
-                    // #145: AUDITABILITY ONLY — log an out-of-table control
-                    // byte in the end-of-test loop, then STILL continue
-                    // (behavior unchanged, default-tolerant; iperf3's
-                    // end-loop tolerates intervening bytes).
+                    // #325: GT honors CLIENT_TERMINATE at ANY message point
+                    // (iperf_server_api.c:289-308: dump under
+                    // DISPLAY_RESULTS + IECLIENTTERM) — the finalize phases
+                    // render the terminated shape exactly like the mid-test
+                    // arm.
+                    Ok(TestState::ClientTerminate) => {
+                        ctx.client_terminated = true;
+                        return Ok(());
+                    }
+                    // #145: log an out-of-sequence KNOWN control byte, then
+                    // continue — GT's switch has an arm for every known
+                    // state at this point (unknown BYTES error as IEMESSAGE
+                    // in recv_state, #325).
                     Ok(other) => {
                         if !protocol::is_legal_next(
                             TestState::DisplayResults,

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -244,6 +244,12 @@ struct TestRunCtx {
     /// #210: a peer-terminated or interrupted test skips the results
     /// exchange (the peer is gone) but still dumps local results.
     client_terminated: bool,
+    /// #325: an unhandled control byte in the end loop — GT's IEMESSAGE
+    /// class (iperf_server_api.c:309-311). The dump still renders (the
+    /// exchange already completed); the doc carries the `error - `-prefixed
+    /// sentence and the run counts as a failed test (rc -1 in GT — which
+    /// main.c does NOT errexit on, so one-off still exits 0).
+    unknown_message: bool,
     interrupted: Option<String>,
 }
 
@@ -430,16 +436,20 @@ impl Server {
                         eprintln!("riperf3: {}", RiperfError::ClientTerminated);
                     }
                 }
+                Err(RiperfError::UnknownControlMessage) => {
+                    // #325: GT main.c:174 prints `iperf3: error - <IEMESSAGE
+                    // sentence>` once and keeps serving; a failed test is
+                    // rc -1, which main errexits on only below -1 (setup
+                    // failures), so one-off still exits 0 (r1 F1, #224).
+                    // Under -J iperf_err's sink carried it in the doc —
+                    // stderr stays silent, like the terminate arm above.
+                    if !json && !crate::macros::output_quiet() {
+                        eprintln!("riperf3: error - {}", RiperfError::UnknownControlMessage);
+                    }
+                }
                 Err(e) => {
                     if !crate::macros::output_quiet() {
                         eprintln!("riperf3: error - {e}");
-                    }
-                    // #325: GT's one-off errexits on a failed test (main.c
-                    // runs the server once and exits 1 on <0); persistent
-                    // servers print and keep serving (GT caps at 5
-                    // consecutive errors — untracked here).
-                    if self.one_off {
-                        return Err(e);
                     }
                 }
             }
@@ -613,6 +623,7 @@ impl Server {
             interval_handle: None,
             server_error: None,
             client_terminated: false,
+            unknown_message: false,
             interrupted: None,
         };
         // Signal `done` on every exit path (incl. early `?` returns) so a UDP
@@ -675,6 +686,12 @@ impl Server {
                 // #325: an end-loop CLIENT_TERMINATE postdates EndState's
                 // resolution exactly like the #322 mid-exchange interrupt.
                 end.report_error = Some("the client has terminated".to_string());
+            } else if ctx.unknown_message {
+                // #325: GT's IEMESSAGE reaches the doc through main.c:174's
+                // `iperf_err(test, "error - %s", ...)` json sink — the
+                // in-doc value carries the prefix (live-captured), unlike
+                // IECLIENTTERM's bare sentence above.
+                end.report_error = Some(format!("error - {}", RiperfError::UnknownControlMessage));
             }
         }
 
@@ -722,6 +739,14 @@ impl Server {
             // The dump above already rendered; the caller prints iperf3's
             // "the client has terminated" (no "error - " prefix) (#210).
             return Err(RiperfError::ClientTerminated);
+        }
+        if ctx.unknown_message {
+            // #325: the dump above rendered with the in-doc `error - ` form;
+            // the caller prints GT's single stderr line (text mode only) and
+            // keeps serving. A failed TEST is rc -1 in GT, which main.c does
+            // NOT errexit on even for one-off (`if (rc < -1)` — setup
+            // failures only), so this must not become a process error (#224).
+            return Err(RiperfError::UnknownControlMessage);
         }
         Ok(Some(report))
     }
@@ -1716,6 +1741,9 @@ impl Server {
                 };
                 match next {
                     Ok(TestState::IperfDone) => break,
+                    // GT's TEST_START arm is a bare no-op
+                    // (iperf_server_api.c:266-267).
+                    Ok(TestState::TestStart) => continue,
                     // #325: GT honors CLIENT_TERMINATE at ANY message point
                     // (iperf_server_api.c:289-308: dump under
                     // DISPLAY_RESULTS + IECLIENTTERM) — the finalize phases
@@ -1725,22 +1753,22 @@ impl Server {
                         ctx.client_terminated = true;
                         return Ok(());
                     }
-                    // #145: log an out-of-sequence KNOWN control byte, then
-                    // continue — GT's switch has an arm for every known
-                    // state at this point (unknown BYTES error as IEMESSAGE
-                    // in recv_state, #325).
-                    Ok(other) => {
-                        if !protocol::is_legal_next(
-                            TestState::DisplayResults,
-                            other,
-                            protocol::Role::Server,
-                        ) {
-                            log::debug!(
-                                "server: out-of-sequence control state {other:?} \
-                                 in the end-of-test loop (ignored)"
-                            );
-                        }
-                        continue;
+                    // GT's switch has arms for only TEST_START / TEST_END /
+                    // IPERF_DONE / CLIENT_TERMINATE — every OTHER byte,
+                    // known state or not, is `default: IEMESSAGE`
+                    // (iperf_server_api.c:265-311; r1 F3 — live-verified:
+                    // GT errors on bytes 2/9/14 here). The old #145
+                    // tolerance is gone. RECORDED DEVIATION for TEST_END
+                    // only: GT re-runs the whole end block — stats, stream
+                    // close, a SECOND results exchange (:268-286) — but a
+                    // conforming client can't resend 4 from this window
+                    // (it only sends TEST_END from TEST_RUNNING), and
+                    // re-entering the exchange against a peer that didn't
+                    // would wedge both sides; it takes the IEMESSAGE class
+                    // instead.
+                    Ok(_) | Err(RiperfError::UnknownControlMessage) => {
+                        ctx.unknown_message = true;
+                        return Ok(());
                     }
                     Err(RiperfError::PeerDisconnected) => break,
                     Err(e) => return Err(e),


### PR DESCRIPTION
Closes #325.

The server's end-of-test surface, matched to GT's actual end-loop switch (`iperf_server_api.c:265-311`) — r1 live-verified all shapes against the GT 3.21 binary and corrected two inverted citations in the first cut:

- **CLIENT_TERMINATE at any message point** (`:289-308`): the end-loop arm takes the same terminated shape as the mid-test one — doc `error: "the client has terminated"` (via the EndState re-resolve; the terminate postdates resolution exactly like #322's mid-exchange interrupt), stderr silent under `-J` per the iperf_err sink rule, clean exit 0 (GT sets IPERF_DONE).
- **IEMESSAGE for every other byte, known state or not**: GT's switch has arms for only TEST_START (no-op) / TEST_END / IPERF_DONE / CLIENT_TERMINATE; everything else hits `default: IEMESSAGE` — live-verified with bytes 2/9/14/99. The old #145 tolerant arm is gone. The sentence lives in a dedicated `RiperfError::UnknownControlMessage` variant so it prints bare (`riperf3: error - received an unknown control message (ensure other side is iperf3 and not iperf)`, once — no "protocol violation" wrapper, #151 convention). Under `-J` the run emits the full accumulated doc with the `error - `-prefixed value (GT main.c:174 through iperf_err's json sink), stderr silent.
- **Exit codes**: a failed test is rc -1 in GT, and `main.c:181` errexits only on `rc < -1` (setup failures) — so the one-off exits **0** on IEMESSAGE, and persistent servers print once and keep serving. (The first cut's one-off errexit inverted this; it also matched the #224 wart already recorded in-tree.)
- **RECORDED DEVIATION (TEST_END only)**: GT's TEST_END arm re-runs the entire end block including a second results exchange (`:268-286`). A conforming client cannot resend 4 from this window, and mirroring the re-entry against a peer that didn't re-enter would wedge both sides — it takes the IEMESSAGE class instead, documented at the arm.

Red-first: four full-protocol wire mocks through DisplayResults (terminate-instead-of-IperfDone; byte 99 in text and `-J`; known-stray byte 2), each red-proven against a targeted revert. Full gate: 707 tests, clippy/fmt clean.

**r2 additions**: the MID-TEST unknown byte (r2's blocker — it previously produced no `-J` document at all) now emits GT's accumulated doc: intervals so far, BARE `end: {}` (the final stats dump never ran), the `error - `-prefixed key, silent stderr, exit 0 — via `ctx.bare_end` through the `#281` bare-end rendering, with the text summary skipped like the `#224` split. The end-loop terminate's text single-dump is a RECORDED DEVIATION (GT double-dumps — its TEST_END arm ran the reporter and the terminate arm re-runs it). `legal_next` docs corrected and the dead end-loop row dropped. New pins: mid-test `-J` + text, terminate text cell, persistent keeps-serving (two junk rounds), and the client's state-wait IEMESSAGE surface (iperf_client_api.c:409-411). End-loop EOF parity (IECTRLCLOSE) filed on #330.

**r3 additions**: bounded teardown on the mid-test IEMESSAGE (r3's blocker — GT `cleanup_server`s immediately on a failed `handle_message`, `iperf_server_api.c:764-767`; pre-fix a hostile peer holding its sockets parked the joins and the stderr line for the whole hold): both abort gates now include `unknown_message`, pinned with a holding-peer mock (8 s bound vs a 30 s hold; red-proven — both gates reverted wedges, either alone bounds). The `--get-server-output` text capture no longer resurrects the summary on the mid-test path (pinned with `get_server_output` in params). RECORDED DEVIATION added for the flush's partial catch-up interval (GT's dead reporter carries whole ticks only). Doc fixes: error.rs scopes the client `-J` parity claim (doc-body skeleton gap = #330 item 2), json_report's `bare_end` comments gain the second producer, `run_once` documents the `ClientTerminated`/`UnknownControlMessage` propagation. The persistence pin's kill-grace joins the 5 s convention.

**r4 addition**: the holding-peer probe moved one byte over caught the same wedge on the end-loop CLIENT_TERMINATE arm (GT's terminate arm closes stream sockets inline, `iperf_server_api.c:301-305`) — both abort gates now include `client_terminated` (also bounding the pre-existing mid-test terminate hold), with the holding-peer pin generalized to the terminate cell and red-proven. The success-path variant (IperfDone-then-hold) is a graceful-join design call, filed as #331.
