### PR TITLE
fix(compat): ctrl-EOF takes GT's IECTRLCLOSE surface; mid-test strays IEMESSAGE (#330)

### DIFF
--- a/riperf3-cli/tests/wire_shape.rs
+++ b/riperf3-cli/tests/wire_shape.rs
@@ -104,10 +104,12 @@ const MOCK_RESULTS: &str = r#"{"cpu_util_total":1.0,"cpu_util_user":0.5,"cpu_uti
 /// phase (#325 r2 F1). Otherwise the round runs through DisplayResults and
 /// sends `final_byte` in place of IperfDone(16) — the end loop.
 fn drive_mock_round(port: u16, final_byte: u8, junk_mid_test: bool) {
-    drive_mock_round_params(port, final_byte, junk_mid_test, MOCK_PARAMS);
+    drive_mock_round_full(port, Some(final_byte), junk_mid_test, MOCK_PARAMS);
 }
 
-fn drive_mock_round_params(port: u16, final_byte: u8, junk_mid_test: bool, params: &str) {
+/// `final_action`: Some(byte) sends the byte; None closes both sockets —
+/// the abrupt-EOF cells (#330).
+fn drive_mock_round_full(port: u16, final_action: Option<u8>, mid_test: bool, params: &str) {
     let cookie = [b'x'; 37];
     let mut ctrl = std::net::TcpStream::connect(("127.0.0.1", port)).expect("ctrl");
     ctrl.write_all(&cookie).unwrap();
@@ -119,17 +121,17 @@ fn drive_mock_round_params(port: u16, final_byte: u8, junk_mid_test: bool, param
     assert_eq!(read_exact(&mut ctrl, 1)[0], 1);
     assert_eq!(read_exact(&mut ctrl, 1)[0], 2);
     data.write_all(&[0u8; 4096]).unwrap();
-    if junk_mid_test {
-        ctrl.write_all(&[final_byte]).unwrap();
-        std::thread::sleep(std::time::Duration::from_millis(500));
-        return;
+    if !mid_test {
+        ctrl.write_all(&[4u8]).unwrap(); // TestEnd
+        assert_eq!(read_exact(&mut ctrl, 1)[0], 13);
+        write_json_blob(&mut ctrl, MOCK_RESULTS);
+        read_json_blob(&mut ctrl); // server results
+        assert_eq!(read_exact(&mut ctrl, 1)[0], 14); // DisplayResults
     }
-    ctrl.write_all(&[4u8]).unwrap(); // TestEnd
-    assert_eq!(read_exact(&mut ctrl, 1)[0], 13);
-    write_json_blob(&mut ctrl, MOCK_RESULTS);
-    read_json_blob(&mut ctrl); // server results
-    assert_eq!(read_exact(&mut ctrl, 1)[0], 14); // DisplayResults
-    ctrl.write_all(&[final_byte]).unwrap();
+    match final_action {
+        Some(b) => ctrl.write_all(&[b]).unwrap(),
+        None => drop((ctrl, data)), // abrupt EOF, both sockets (#330)
+    }
     std::thread::sleep(std::time::Duration::from_millis(500));
 }
 
@@ -147,6 +149,15 @@ fn run_scenario_params(
     json: bool,
     final_byte: u8,
     junk_mid_test: bool,
+    params: &'static str,
+) -> (String, String, std::process::ExitStatus) {
+    run_scenario_full(json, Some(final_byte), junk_mid_test, params)
+}
+
+fn run_scenario_full(
+    json: bool,
+    final_action: Option<u8>,
+    mid_test: bool,
     params: &'static str,
 ) -> (String, String, std::process::ExitStatus) {
     let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind");
@@ -172,9 +183,8 @@ fn run_scenario_params(
         riperf3_test_support::drain_reader(server.0.stderr.take().expect("piped stderr"));
     std::thread::sleep(std::time::Duration::from_millis(400));
 
-    let mock = std::thread::spawn(move || {
-        drive_mock_round_params(port, final_byte, junk_mid_test, params)
-    });
+    let mock =
+        std::thread::spawn(move || drive_mock_round_full(port, final_action, mid_test, params));
     mock.join().expect("mock");
     let status =
         riperf3_test_support::wait_bounded(&mut server.0, std::time::Duration::from_secs(5))
@@ -507,6 +517,151 @@ fn mid_test_client_terminate_exits_bounded_while_peer_holds() {
         serr.trim(),
         "riperf3: the client has terminated",
         "GT's bare IECLIENTTERM line, printed while the peer still holds"
+    );
+}
+
+const CTRL_CLOSED: &str = "the client has unexpectedly closed the connection";
+
+/// #330: an abrupt EOF DURING the data phase is GT's IECTRLCLOSE read-site
+/// surface (iperf_server_api.c:249-254, live-probed): the doc carries the
+/// BARE sentence (direct iperf_err — no `error - ` prefix) over the
+/// accumulated intervals + bare end{}, stderr silent under -J, clean exit.
+#[test]
+fn mid_test_eof_takes_gt_ctrl_closed_shape_in_json() {
+    let (sout, serr, status) = run_scenario_full(true, None, true, MOCK_PARAMS);
+    let doc: serde_json::Value =
+        serde_json::from_str(sout.trim()).unwrap_or_else(|e| panic!("one -J doc ({e}): {sout}"));
+    assert_eq!(
+        doc["error"].as_str(),
+        Some(CTRL_CLOSED),
+        "GT's bare read-site sentence: {doc}"
+    );
+    assert!(
+        doc["end"].as_object().is_some_and(|o| o.is_empty()),
+        "the final stats dump never ran — GT's end is bare {{}}: {doc}"
+    );
+    assert!(serr.trim().is_empty(), "-J stderr silent: {serr}");
+    assert!(status.success(), "GT sets IPERF_DONE — clean exit");
+}
+
+/// #330, text half: the single line, no summary block, exit 0
+/// (live-probed).
+#[test]
+fn mid_test_eof_prints_the_line_and_no_summary_in_text() {
+    let (sout, serr, status) = run_scenario_full(false, None, true, MOCK_PARAMS);
+    assert_eq!(serr.trim(), format!("riperf3: {CTRL_CLOSED}"));
+    assert_eq!(
+        sout.matches(SUMMARY_SEPARATOR).count(),
+        0,
+        "no summary mid-test: {sout}"
+    );
+    assert!(status.success(), "clean exit like GT");
+}
+
+/// #330: EOF in the END loop — the fast-close-instead-of-IperfDone cell.
+/// GT prints the same sentence with the POPULATED end (its reporter ran at
+/// TEST_END; live-probed doc has sum_sent/sum_received/streams), where the
+/// old arm broke silently clean with no error key at all.
+#[test]
+fn end_loop_eof_takes_gt_ctrl_closed_shape_in_json() {
+    let (sout, serr, status) = run_scenario_full(true, None, false, MOCK_PARAMS);
+    let doc: serde_json::Value =
+        serde_json::from_str(sout.trim()).unwrap_or_else(|e| panic!("one -J doc ({e}): {sout}"));
+    assert_eq!(
+        doc["error"].as_str(),
+        Some(CTRL_CLOSED),
+        "GT's bare sentence rides the completed doc: {doc}"
+    );
+    assert!(
+        doc["end"]["streams"]
+            .as_array()
+            .is_some_and(|a| !a.is_empty()),
+        "the exchange completed — end stays populated: {doc}"
+    );
+    assert!(serr.trim().is_empty(), "-J stderr silent: {serr}");
+    assert!(status.success(), "clean exit like GT");
+}
+
+/// #330, text half of the end-loop EOF: one summary dump + the line.
+#[test]
+fn end_loop_eof_prints_summary_and_the_line_in_text() {
+    let (sout, serr, status) = run_scenario_full(false, None, false, MOCK_PARAMS);
+    assert_eq!(serr.trim(), format!("riperf3: {CTRL_CLOSED}"));
+    assert_eq!(
+        sout.matches(SUMMARY_SEPARATOR).count(),
+        1,
+        "the completed round prints its summary: {sout}"
+    );
+    assert!(status.success(), "clean exit like GT");
+}
+
+/// #330: a KNOWN state (ParamExchange=9) landing mid-test is GT's same
+/// IEMESSAGE default — its ONE message switch serves every phase
+/// (live-probed: byte 9 mid-test = the prefixed doc key + exit 0). The old
+/// #145 arm tolerated it as clean success.
+#[test]
+fn mid_test_known_stray_state_is_iemessage_like_gt() {
+    let (_sout, serr, status) = run_scenario_full(false, Some(9), true, MOCK_PARAMS);
+    assert_eq!(
+        serr.trim(),
+        format!("riperf3: error - {IEMESSAGE}"),
+        "GT's IEMESSAGE default covers known strays mid-test"
+    );
+    assert!(status.success(), "one-off exits 0 like GT");
+}
+
+/// #330: TEST_START (1) mid-test stays GT's no-op arm
+/// (iperf_server_api.c:266-267) — the round completes clean after it.
+#[test]
+fn mid_test_test_start_byte_is_a_gt_noop() {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind");
+    let port = listener.local_addr().unwrap().port();
+    drop(listener);
+    let port_s = port.to_string();
+
+    let mut server = common::ChildGuard(
+        std::process::Command::new(env!("CARGO_BIN_EXE_riperf3"))
+            .args(["-s", "-1", "-p", &port_s])
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::piped())
+            .spawn()
+            .expect("spawn server"),
+    );
+    let serr_reader =
+        riperf3_test_support::drain_reader(server.0.stderr.take().expect("piped stderr"));
+    std::thread::sleep(std::time::Duration::from_millis(400));
+
+    let mock = std::thread::spawn(move || {
+        let cookie = [b'x'; 37];
+        let mut ctrl = std::net::TcpStream::connect(("127.0.0.1", port)).expect("ctrl");
+        ctrl.write_all(&cookie).unwrap();
+        assert_eq!(read_exact(&mut ctrl, 1)[0], 9);
+        write_json_blob(&mut ctrl, MOCK_PARAMS);
+        assert_eq!(read_exact(&mut ctrl, 1)[0], 10);
+        let mut data = std::net::TcpStream::connect(("127.0.0.1", port)).expect("data");
+        data.write_all(&cookie).unwrap();
+        assert_eq!(read_exact(&mut ctrl, 1)[0], 1);
+        assert_eq!(read_exact(&mut ctrl, 1)[0], 2);
+        data.write_all(&[0u8; 4096]).unwrap();
+        ctrl.write_all(&[1u8]).unwrap(); // stray TEST_START: GT no-op
+        ctrl.write_all(&[4u8]).unwrap(); // then the real TestEnd
+        assert_eq!(read_exact(&mut ctrl, 1)[0], 13);
+        write_json_blob(&mut ctrl, MOCK_RESULTS);
+        read_json_blob(&mut ctrl);
+        assert_eq!(read_exact(&mut ctrl, 1)[0], 14);
+        ctrl.write_all(&[16u8]).unwrap(); // IperfDone — clean round
+        std::thread::sleep(std::time::Duration::from_millis(300));
+    });
+
+    mock.join().expect("mock");
+    let status =
+        riperf3_test_support::wait_bounded(&mut server.0, std::time::Duration::from_secs(5))
+            .expect("server exits");
+    let serr = serr_reader.join().expect("stderr");
+    assert!(status.success(), "clean round");
+    assert!(
+        serr.trim().is_empty(),
+        "no error surface for GT's no-op arm: {serr}"
     );
 }
 

--- a/riperf3-cli/tests/wire_shape.rs
+++ b/riperf3-cli/tests/wire_shape.rs
@@ -665,6 +665,114 @@ fn mid_test_test_start_byte_is_a_gt_noop() {
     );
 }
 
+/// #330 r1 F1: a mid-test IPERF_DONE is GT's explicit CLEAN arm
+/// (iperf_server_api.c:287-288 + the byte lands in test->state, exiting
+/// its run loop): NO error key, NO stderr, bare end{}, exit 0
+/// (live-probed) — not the IEMESSAGE default.
+#[test]
+fn mid_test_iperf_done_ends_clean_and_bare_in_json() {
+    let (sout, serr, status) = run_scenario_full(true, Some(16), true, MOCK_PARAMS);
+    let doc: serde_json::Value =
+        serde_json::from_str(sout.trim()).unwrap_or_else(|e| panic!("one -J doc ({e}): {sout}"));
+    assert!(
+        doc["error"].is_null(),
+        "GT's IPERF_DONE arm carries no error: {doc}"
+    );
+    assert!(
+        doc["end"].as_object().is_some_and(|o| o.is_empty()),
+        "the final stats dump never ran — bare end{{}}: {doc}"
+    );
+    assert!(serr.trim().is_empty(), "no stderr surface: {serr}");
+    assert!(status.success(), "clean exit like GT");
+}
+
+/// #330 r1 F1, text half: nothing on stderr, no summary, exit 0.
+#[test]
+fn mid_test_iperf_done_ends_clean_in_text() {
+    let (sout, serr, status) = run_scenario_full(false, Some(16), true, MOCK_PARAMS);
+    assert!(serr.trim().is_empty(), "no stderr surface: {serr}");
+    assert_eq!(
+        sout.matches(SUMMARY_SEPARATOR).count(),
+        0,
+        "no summary mid-test: {sout}"
+    );
+    assert!(status.success(), "clean exit like GT");
+}
+
+/// #330 r1 F6: the -J twin of the mid-test known-stray cell — the
+/// prefixed doc key over the bare end (live-probed byte 9 ≡ byte 99).
+#[test]
+fn mid_test_known_stray_state_takes_iemessage_shape_in_json() {
+    let (sout, serr, status) = run_scenario_full(true, Some(9), true, MOCK_PARAMS);
+    let doc: serde_json::Value =
+        serde_json::from_str(sout.trim()).unwrap_or_else(|e| panic!("one -J doc ({e}): {sout}"));
+    assert_eq!(
+        doc["error"].as_str(),
+        Some(format!("error - {IEMESSAGE}").as_str()),
+        "the prefixed IEMESSAGE key: {doc}"
+    );
+    assert!(
+        doc["end"].as_object().is_some_and(|o| o.is_empty()),
+        "bare end mid-test: {doc}"
+    );
+    assert!(serr.trim().is_empty(), "-J stderr silent: {serr}");
+    assert!(status.success(), "one-off exits 0 like GT");
+}
+
+/// #330 r1 F5: ctrl EOF while the peer HOLDS the data socket — the
+/// abort-gate cell the both-sockets-close pins can't discriminate (data
+/// tasks EOF on their own there). GT's cleanup closes the data sockets
+/// and exits on its own clock.
+#[test]
+fn mid_test_ctrl_eof_with_data_held_exits_bounded() {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind");
+    let port = listener.local_addr().unwrap().port();
+    drop(listener);
+    let port_s = port.to_string();
+
+    let mut server = common::ChildGuard(
+        std::process::Command::new(env!("CARGO_BIN_EXE_riperf3"))
+            .args(["-s", "-1", "-p", &port_s])
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::piped())
+            .spawn()
+            .expect("spawn server"),
+    );
+    let serr_reader =
+        riperf3_test_support::drain_reader(server.0.stderr.take().expect("piped stderr"));
+    std::thread::sleep(std::time::Duration::from_millis(400));
+
+    // Close ONLY the control socket; the data socket stays held far past
+    // the assertion window (detached thread; closes at process exit).
+    std::thread::spawn(move || {
+        let cookie = [b'x'; 37];
+        let mut ctrl = std::net::TcpStream::connect(("127.0.0.1", port)).expect("ctrl");
+        ctrl.write_all(&cookie).unwrap();
+        assert_eq!(read_exact(&mut ctrl, 1)[0], 9);
+        write_json_blob(&mut ctrl, MOCK_PARAMS);
+        assert_eq!(read_exact(&mut ctrl, 1)[0], 10);
+        let mut data = std::net::TcpStream::connect(("127.0.0.1", port)).expect("data");
+        data.write_all(&cookie).unwrap();
+        assert_eq!(read_exact(&mut ctrl, 1)[0], 1);
+        assert_eq!(read_exact(&mut ctrl, 1)[0], 2);
+        data.write_all(&[0u8; 4096]).unwrap();
+        drop(ctrl);
+        std::thread::sleep(std::time::Duration::from_secs(30));
+        drop(data);
+    });
+
+    let status =
+        riperf3_test_support::wait_bounded(&mut server.0, std::time::Duration::from_secs(8))
+            .expect("server exits while the peer still holds the data socket");
+    assert!(status.success(), "clean exit like GT");
+    let serr = serr_reader.join().expect("stderr");
+    assert_eq!(
+        serr.trim(),
+        format!("riperf3: {CTRL_CLOSED}"),
+        "the line prints NOW, not after the peer relents"
+    );
+}
+
 /// #325 r2 F6: the CLIENT side of the same default — GT's client message
 /// handler IEMESSAGEs an unmapped byte too (iperf_client_api.c:409-411).
 /// The byte replaces ExchangeResults(13) at the client's direct state wait

--- a/riperf3/src/error.rs
+++ b/riperf3/src/error.rs
@@ -45,7 +45,11 @@ pub enum RiperfError {
     #[error("test aborted: {0}")]
     Aborted(String),
 
-    /// iperf3's IECTRLCLOSE: the control connection died mid-test (#170).
+    /// iperf3's IECTRLCLOSE: the control connection died mid-test — the
+    /// client's class (#170), and since #330 the SERVER's doc'd mid/end-loop
+    /// EOF return from `run_once` (the doc/stderr carry GT's read-site
+    /// sentence "the client has unexpectedly closed the connection"; the
+    /// round is clean in GT, exit 0).
     #[error("control socket has closed unexpectedly")]
     ControlSocketClosed,
 

--- a/riperf3/src/protocol.rs
+++ b/riperf3/src/protocol.rs
@@ -93,12 +93,13 @@ impl TestState {
 
 /// Which side of the control connection a peer is, for the transition table.
 ///
-/// The legal-next set depends on the role because the client and the server
-/// read peer state in different phases (#145).
+/// CLIENT-ONLY since #330: the server's message handling is arm-explicit
+/// like GT's single switch (#325 removed its end-loop consult, #330 the
+/// data-phase one), so only the client's diagnostics consult the table.
+/// The enum stays so a future server row would be an additive change.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum Role {
     Client,
-    Server,
 }
 
 /// The states it is LEGAL to RECEIVE next, given the last state this side
@@ -111,10 +112,11 @@ pub(crate) enum Role {
 /// server end-of-test loop does NOT tolerate intervening bytes — its switch
 /// IEMESSAGEs everything but TEST_START/TEST_END/IPERF_DONE/CLIENT_TERMINATE
 /// — so the server end loop no longer consults this table at all.) It is
-/// consulted ONLY to emit diagnostics (`log::debug!`, off by default). It is
-/// NEVER used to reject or error on a sequence: iperf3 itself is loose in
-/// the surviving rows, and a stricter riperf3 would break interop.
-/// Default-tolerant by design (#145).
+/// consulted ONLY to emit diagnostics (`log::debug!`, off by default), and
+/// ONLY by the client (#330 removed the server's last consult — its message
+/// loops are arm-explicit like GT's switch). It is NEVER used to reject or
+/// error on a sequence: iperf3 itself is loose in the surviving rows, and a
+/// stricter riperf3 would break interop. Default-tolerant by design (#145).
 ///
 /// `ServerTerminate`/`ServerError` can arrive in any client state (the client
 /// adopts them via their own dispatch arms, and `watch_control` returns on
@@ -135,12 +137,6 @@ pub(crate) fn legal_next(current: TestState, role: Role) -> &'static [TestState]
             DisplayResults => &[IperfDone, ServerError, ServerTerminate],
             // Terminal — the client adopts these and stops.
             ServerTerminate | ServerError | AccessDenied => &[],
-            _ => &[],
-        },
-        Role::Server => match current {
-            // The server consults this in ONE phase now: the end-of-test
-            // loop dropped its row with #325 (GT IEMESSAGEs strays there).
-            TestRunning => &[TestEnd, ClientTerminate], // data phase
             _ => &[],
         },
     }
@@ -1589,44 +1585,9 @@ mod transition_table_tests {
         assert_eq!(legal_next(IperfDone, Role::Client), &[]);
     }
 
-    // -- Role::Server: the data phase is the one surviving consult (#325) --
-
-    #[test]
-    fn server_legal_sets_are_exact() {
-        assert_eq!(
-            legal_next(TestRunning, Role::Server),
-            &[TestEnd, ClientTerminate]
-        );
-        // #325 dropped the DisplayResults row: GT's end loop IEMESSAGEs
-        // strays instead of tolerating them, so nothing consults it.
-        assert_eq!(legal_next(DisplayResults, Role::Server), &[]);
-    }
-
-    #[test]
-    fn server_other_currents_have_no_successors() {
-        // Exhaustive over the remaining variants — the server consults the
-        // table only in the data phase (TestRunning); everything else is
-        // the empty set (#325 dropped the end-loop row).
-        for current in [
-            TestStart,
-            TestEnd,
-            ParamExchange,
-            CreateStreams,
-            ServerTerminate,
-            ClientTerminate,
-            ExchangeResults,
-            IperfStart,
-            IperfDone,
-            AccessDenied,
-            ServerError,
-        ] {
-            assert_eq!(
-                legal_next(current, Role::Server),
-                &[],
-                "server legal_next({current:?}) must be empty"
-            );
-        }
-    }
+    // (#325/#330: the server-side rows and their tests are gone — the
+    // server's message loops are arm-explicit like GT's single switch, and
+    // Role is client-only now.)
 
     // -- is_legal_next membership: documented loosenesses + sample rejects --
 
@@ -1634,19 +1595,6 @@ mod transition_table_tests {
     fn resent_test_running_is_legal_for_client() {
         // iperf3 no-op tolerance: a re-sent TEST_RUNNING is legal to receive.
         assert!(is_legal_next(TestRunning, TestRunning, Role::Client));
-    }
-
-    #[test]
-    fn server_data_phase_accepts_client_terminate() {
-        // The data phase is the one surviving server consult (#325 dropped
-        // the end-loop row: GT IEMESSAGEs strays there); CLIENT_TERMINATE
-        // stays legal mid-test.
-        assert!(is_legal_next(TestRunning, ClientTerminate, Role::Server));
-        assert!(!is_legal_next(
-            DisplayResults,
-            ClientTerminate,
-            Role::Server
-        ));
     }
 
     #[test]
@@ -1663,11 +1611,6 @@ mod transition_table_tests {
         // The client never receives a client/server-internal byte as "next":
         assert!(!is_legal_next(TestRunning, TestEnd, Role::Client));
         assert!(!is_legal_next(TestRunning, ClientTerminate, Role::Client));
-        // Server side:
-        assert!(!is_legal_next(TestRunning, IperfDone, Role::Server));
-        assert!(!is_legal_next(DisplayResults, TestEnd, Role::Server));
-        assert!(!is_legal_next(ParamExchange, CreateStreams, Role::Server));
-        assert!(!is_legal_next(IperfStart, ParamExchange, Role::Server));
     }
 
     #[test]
@@ -1689,7 +1632,7 @@ mod transition_table_tests {
             AccessDenied,
             ServerError,
         ];
-        for role in [Role::Client, Role::Server] {
+        for role in [Role::Client] {
             for current in all {
                 let legal = legal_next(current, role);
                 for got in all {

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -40,6 +40,12 @@ pub(crate) struct TestConfig {
     pub udp_counters_64bit: bool,
 }
 
+/// GT's IECTRLCLOSE read-site sentence (iperf_server_api.c:249-254,
+/// live-probed #330): any post-accept control EOF prints/docs this BARE
+/// (direct iperf_err — no `error - ` prefix), sets IPERF_DONE, and the
+/// round ends CLEAN (exit 0, persistent keeps serving).
+const CTRL_CLOSED_MSG: &str = "the client has unexpectedly closed the connection";
+
 /// i64→i32 for the adopted dg (#316 r2 F3 / r3 nit): GT's bundled cjson
 /// carries `int64_t valueint` (cjson.h:119) and the narrowing happens at
 /// the C `int` field assignment (iperf_api.c:2602) — an
@@ -256,6 +262,11 @@ struct TestRunCtx {
     /// text prints no summary block, only the stderr line. The end-loop
     /// IEMESSAGE keeps its populated end: there the exchange completed.
     bare_end: bool,
+    /// #330: a control-connection EOF mid-test or in the end loop — GT's
+    /// IECTRLCLOSE read-site surface ([`CTRL_CLOSED_MSG`], clean round).
+    /// Mid-test rides bare_end (no final dump); end-loop keeps the
+    /// populated end (the exchange completed) — both live-probed.
+    ctrl_closed: bool,
     interrupted: Option<String>,
 }
 
@@ -430,6 +441,16 @@ impl Server {
                 Err(RiperfError::PeerDisconnected) => {
                     if self.verbose {
                         vprintln!("Client disconnected.");
+                    }
+                }
+                Err(RiperfError::ControlSocketClosed) => {
+                    // #330: the mid-test / end-loop control EOF — GT prints
+                    // its read-site sentence once (iperf_server_api.c:
+                    // 249-254) and keeps serving; under -J the doc carried
+                    // it (sink rule). Pre-test EOFs (port scans) stay on
+                    // the quiet PeerDisconnected arm above.
+                    if !json && !crate::macros::output_quiet() {
+                        eprintln!("riperf3: {CTRL_CLOSED_MSG}");
                     }
                 }
                 Err(RiperfError::ClientTerminated) => {
@@ -636,6 +657,7 @@ impl Server {
             server_error: None,
             client_terminated: false,
             unknown_message: false,
+            ctrl_closed: false,
             bare_end: false,
             interrupted: None,
         };
@@ -705,6 +727,10 @@ impl Server {
                 // in-doc value carries the prefix (live-captured), unlike
                 // IECLIENTTERM's bare sentence above.
                 end.report_error = Some(format!("error - {}", RiperfError::UnknownControlMessage));
+            } else if ctx.ctrl_closed {
+                // #330: IECTRLCLOSE's read-site line is a DIRECT iperf_err
+                // — bare, no prefix (live-probed both windows).
+                end.report_error = Some(CTRL_CLOSED_MSG.to_string());
             }
         }
 
@@ -737,7 +763,13 @@ impl Server {
         // a peer that sends 12 and then holds its sockets must not park the
         // joins (it held the process for the peer's whole hold; GT exits on
         // its own clock). Covers the pre-existing mid-test terminate too.
-        if ctx.interrupted.is_some() || ctx.unknown_message || ctx.client_terminated {
+        // #330: ctrl_closed joins — a peer may EOF the control socket
+        // while holding the DATA sockets open; GT's cleanup closes them.
+        if ctx.interrupted.is_some()
+            || ctx.unknown_message
+            || ctx.client_terminated
+            || ctx.ctrl_closed
+        {
             for s in &ctx.streams {
                 s.task.abort();
             }
@@ -766,6 +798,12 @@ impl Server {
             // NOT errexit on even for one-off (`if (rc < -1)` — setup
             // failures only), so this must not become a process error (#224).
             return Err(RiperfError::UnknownControlMessage);
+        }
+        if ctx.ctrl_closed {
+            // #330: distinct from the broad PeerDisconnected so the serve
+            // loop prints GT's read-site line for exactly this class (the
+            // doc'd mid/end-loop EOF), while pre-test EOFs stay quiet.
+            return Err(RiperfError::ControlSocketClosed);
         }
         Ok(Some(report))
     }
@@ -1366,22 +1404,18 @@ impl Server {
                             ctx.client_terminated = true;
                             break;
                         }
-                        // #145: AUDITABILITY ONLY — log an out-of-sequence
-                        // KNOWN control byte during the data phase, then
-                        // STILL swallow it. GT's single message switch would
-                        // IEMESSAGE these too — tracked with the rest of the
-                        // generic-surface parity in #330.
-                        Ok(other) => {
-                            if !protocol::is_legal_next(
-                                TestState::TestRunning,
-                                other,
-                                protocol::Role::Server,
-                            ) {
-                                log::debug!(
-                                    "server: out-of-sequence control state {other:?} \
-                                     during the data phase (ignored)"
-                                );
-                            }
+                        // GT's TEST_START arm is a bare no-op mid-test too
+                        // (iperf_server_api.c:266-267) — ONE switch serves
+                        // every phase.
+                        Ok(TestState::TestStart) => {}
+                        // #330: every OTHER known state mid-test hits GT's
+                        // same IEMESSAGE default (live-probed: byte 9 = the
+                        // prefixed doc key, exit 0). The #145 tolerance is
+                        // gone on this loop like the end loop's (#329).
+                        Ok(_) => {
+                            ctx.unknown_message = true;
+                            ctx.bare_end = true;
+                            break;
                         }
                         // #325 r2 F1: an UNMAPPED byte during the data phase
                         // is the same IEMESSAGE default — GT's end processing
@@ -1394,6 +1428,14 @@ impl Server {
                         // ticks in the doc.
                         Err(RiperfError::UnknownControlMessage) => {
                             ctx.unknown_message = true;
+                            ctx.bare_end = true;
+                            break;
+                        }
+                        // #330: control EOF mid-test — GT's IECTRLCLOSE
+                        // read-site surface, a CLEAN round (IPERF_DONE):
+                        // bare sentence in the doc, no summary, exit 0.
+                        Err(RiperfError::PeerDisconnected) => {
+                            ctx.ctrl_closed = true;
                             ctx.bare_end = true;
                             break;
                         }
@@ -1456,6 +1498,7 @@ impl Server {
             || ctx.interrupted.is_some()
             || ctx.unknown_message
             || ctx.client_terminated
+            || ctx.ctrl_closed
         {
             // #322 r1 F1: interrupts take the same abort — a wedged peer
             // holding sockets open must not park the joins (GT closes its
@@ -1734,6 +1777,7 @@ impl Server {
     ) -> Result<()> {
         if !ctx.client_terminated
             && !ctx.unknown_message
+            && !ctx.ctrl_closed
             && ctx.interrupted.is_none()
             && ctx.server_error.is_none()
         {
@@ -1835,7 +1879,14 @@ impl Server {
                         ctx.unknown_message = true;
                         return Ok(());
                     }
-                    Err(RiperfError::PeerDisconnected) => break,
+                    // #330: EOF instead of IperfDone — the fast-close
+                    // cell. GT prints its read-site sentence and the doc
+                    // keeps the error key over the POPULATED end (the
+                    // exchange completed; live-probed).
+                    Err(RiperfError::PeerDisconnected) => {
+                        ctx.ctrl_closed = true;
+                        break;
+                    }
                     Err(e) => return Err(e),
                 }
             }

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -267,6 +267,12 @@ struct TestRunCtx {
     /// Mid-test rides bare_end (no final dump); end-loop keeps the
     /// populated end (the exchange completed) — both live-probed.
     ctrl_closed: bool,
+    /// #330 r1 F1: a mid-test IPERF_DONE — GT's switch has an EXPLICIT
+    /// no-error arm for it (iperf_server_api.c:287-288) and Nread wrote
+    /// the byte into test->state, so its run loop exits CLEAN: no error
+    /// key, no stderr, bare end{}, exit 0 (live-probed). The exchange is
+    /// skipped (the peer has left the protocol).
+    early_done: bool,
     interrupted: Option<String>,
 }
 
@@ -438,17 +444,15 @@ impl Server {
                 Err(RiperfError::Aborted(msg)) if msg == "idle timeout" => {
                     idle_restart = true;
                 }
-                Err(RiperfError::PeerDisconnected) => {
-                    if self.verbose {
-                        vprintln!("Client disconnected.");
-                    }
-                }
                 Err(RiperfError::ControlSocketClosed) => {
                     // #330: the mid-test / end-loop control EOF — GT prints
                     // its read-site sentence once (iperf_server_api.c:
                     // 249-254) and keeps serving; under -J the doc carried
-                    // it (sink rule). Pre-test EOFs (port scans) stay on
-                    // the quiet PeerDisconnected arm above.
+                    // it (sink rule). (r1 F3: the old PeerDisconnected arm
+                    // is gone — both server recv_state sites convert EOF to
+                    // this class now, so it had no constructor left.
+                    // Pre-test EOFs like port scans ride the generic Io arm
+                    // below, same as GT's per-scan cookie-read error line.)
                     if !json && !crate::macros::output_quiet() {
                         eprintln!("riperf3: {CTRL_CLOSED_MSG}");
                     }
@@ -524,11 +528,12 @@ impl Server {
     /// banner — it is a library entry point, not the daemon. The test report is
     /// still printed to stdout in `-J` / text mode, like `Client::run`.
     ///
-    /// Peer-caused test failures surface as errors AFTER the report was
+    /// Peer-caused test endings surface as errors AFTER the report was
     /// rendered to the active sink: a CLIENT_TERMINATE returns
-    /// [`RiperfError::ClientTerminated`] and an unhandled control byte
-    /// returns [`RiperfError::UnknownControlMessage`] (#325) — both mirror
-    /// GT's failed-test rc, which its one-off still exits 0 on.
+    /// [`RiperfError::ClientTerminated`], an unhandled control byte
+    /// returns [`RiperfError::UnknownControlMessage`] (#325), and a
+    /// control-connection EOF returns [`RiperfError::ControlSocketClosed`]
+    /// (#330) — all mirror GT rounds its one-off still exits 0 on.
     pub async fn run_once(&self) -> Result<crate::json_report::Report> {
         let listener = self.listen().await?;
         self.serve_once(&listener).await
@@ -658,6 +663,7 @@ impl Server {
             client_terminated: false,
             unknown_message: false,
             ctrl_closed: false,
+            early_done: false,
             bare_end: false,
             interrupted: None,
         };
@@ -769,6 +775,7 @@ impl Server {
             || ctx.unknown_message
             || ctx.client_terminated
             || ctx.ctrl_closed
+            || ctx.early_done
         {
             for s in &ctx.streams {
                 s.task.abort();
@@ -1405,12 +1412,21 @@ impl Server {
                             break;
                         }
                         // GT's TEST_START arm is a bare no-op mid-test too
-                        // (iperf_server_api.c:266-267) — ONE switch serves
-                        // every phase.
+                        // (iperf_server_api.c:266-267).
                         Ok(TestState::TestStart) => {}
+                        // #330 r1 F1: IPERF_DONE has its own CLEAN arm in
+                        // GT (:287-288) — the byte lands in test->state and
+                        // the run loop exits with no error surface at all
+                        // (live-probed: doc error null, bare end, exit 0).
+                        Ok(TestState::IperfDone) => {
+                            ctx.early_done = true;
+                            ctx.bare_end = true;
+                            break;
+                        }
                         // #330: every OTHER known state mid-test hits GT's
-                        // same IEMESSAGE default (live-probed: byte 9 = the
-                        // prefixed doc key, exit 0). The #145 tolerance is
+                        // IEMESSAGE default (live-probed: byte 9 = the
+                        // prefixed doc key, exit 0; the full stray set is
+                        // 2/9/10/11/13/14/15/-1/-2). The #145 tolerance is
                         // gone on this loop like the end loop's (#329).
                         Ok(_) => {
                             ctx.unknown_message = true;
@@ -1499,6 +1515,7 @@ impl Server {
             || ctx.unknown_message
             || ctx.client_terminated
             || ctx.ctrl_closed
+            || ctx.early_done
         {
             // #322 r1 F1: interrupts take the same abort — a wedged peer
             // holding sockets open must not park the joins (GT closes its
@@ -1778,6 +1795,7 @@ impl Server {
         if !ctx.client_terminated
             && !ctx.unknown_message
             && !ctx.ctrl_closed
+            && !ctx.early_done
             && ctx.interrupted.is_none()
             && ctx.server_error.is_none()
         {


### PR DESCRIPTION
Refs #330 (the ctrl-EOF + stray-parity half; the issue keeps the generic-arm/-J-doc remainder — scoping comment posted there).

The server's remaining message-surface parity, live-probed against GT 3.21 on every window:

- **Control EOF, mid-test and end-loop** (`iperf_server_api.c:249-254`): the BARE read-site sentence `the client has unexpectedly closed the connection` (direct `iperf_err` — no `error - ` prefix) rides the `-J` doc / prints once on stderr in text; IPERF_DONE, exit 0, persistent keeps serving. Mid-test takes the bare `end: {}` (no summary — GT's reporter never ran); the end-loop fast-close (EOF instead of IperfDone) keeps the POPULATED end with the error key, replacing the old silent-clean break. A distinct `ControlSocketClosed` return routes exactly this doc'd class to the serve-loop print; pre-test EOFs (port scans) stay on the quiet arm.
- **Mid-test known strays → IEMESSAGE**: GT's ONE message switch serves every phase — byte 9 mid-test probes identical to byte 99 (`error - `-prefixed key, exit 0). The `#145` mid-test tolerance is gone like the end loop's (#329); TEST_START keeps GT's no-op arm (`:266-267`), pinned through a full clean round.
- **Teardown**: `ctrl_closed` joins both abort gates (a peer may EOF control while holding data sockets) and the exchange skip.
- **Table cleanup**: `Role::Server` is dead — the server's loops are arm-explicit like GT's switch; `legal_next` is client-diagnostics-only now.

Not in scope (scoping comment on the issue lists all four residuals with probes): the generic-arm/-J-doc remainder incl. the exchange-phase IERECVRESULTS class, pre-test-phase docs, the client doc body, and the half-close cleanup relay.

Six pins (five red-first; the no-op arm is a keep-behavior pin). Full gate: 732 tests, clippy/fmt clean.


**r1 additions**: mid-test IPERF_DONE takes GT's explicit CLEAN arm (`iperf_server_api.c:287-288` — no error key, no stderr, bare end, exit 0; live-probed) instead of the IEMESSAGE default — the one wrong cell in the stray sweep. The dead serve-loop `PeerDisconnected` arm is removed (both server `recv_state` sites convert EOF now; port scans ride the generic Io arm like GT's per-scan cookie error). `run_once`/`error.rs` document the new `ControlSocketClosed` return. New pins: the byte-16 clean cells (json+text), the `-J` twin of the known-stray cell, and the ctrl-EOF-with-data-held bound (the cell the both-sockets pins can't discriminate).
