### PR TITLE
fix(compat): exchange-phase results failures take GT's IERECVRESULTS surface (#330)

### DIFF
--- a/riperf3-cli/tests/wire_shape.rs
+++ b/riperf3-cli/tests/wire_shape.rs
@@ -958,6 +958,156 @@ fn exchange_short_blob_prints_gt_length_warning() {
     assert!(status.success(), "one-off exits 0 like GT");
 }
 
+/// Make the drop of this socket send a real RST. A plain close after the
+/// peer has drained everything sends FIN (a clean EOF); SO_LINGER(0) forces
+/// the abortive close so the server's in-flight read returns ECONNRESET,
+/// not Ok(0). Mirrors setup_retry.rs. (std has no stable `set_linger`.)
+#[cfg(unix)]
+fn force_rst_on_drop(sock: &std::net::TcpStream) {
+    use std::os::fd::AsRawFd;
+    let linger = libc::linger {
+        l_onoff: 1,
+        l_linger: 0,
+    };
+    let rc = unsafe {
+        libc::setsockopt(
+            sock.as_raw_fd(),
+            libc::SOL_SOCKET,
+            libc::SO_LINGER,
+            std::ptr::from_ref(&linger).cast(),
+            std::mem::size_of::<libc::linger>() as libc::socklen_t,
+        )
+    };
+    assert_eq!(rc, 0, "SO_LINGER setsockopt failed");
+}
+#[cfg(not(unix))]
+fn force_rst_on_drop(_sock: &std::net::TcpStream) {}
+
+/// #336 r1 F1: a HARD read error mid-blob (an RST arriving after the SIZE
+/// was read and the server is blocked on the blob) takes GT's rc<0 arm
+/// "JSON data read failed; errno={e}" (iperf_api.c:3078) — NOT the
+/// expected/received short-read arm (that one is for a clean partial+EOF,
+/// where GT's Nread returned rc>=0). The mock promises 500 bytes, lets the
+/// server consume the size and block, then RST-closes.
+#[test]
+fn exchange_blob_rst_takes_gt_read_failed_arm() {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind");
+    let port = listener.local_addr().unwrap().port();
+    drop(listener);
+    let port_s = port.to_string();
+
+    let mut server = common::ChildGuard(
+        std::process::Command::new(env!("CARGO_BIN_EXE_riperf3"))
+            .args(["-s", "-1", "-p", &port_s])
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::piped())
+            .spawn()
+            .expect("spawn server"),
+    );
+    let serr_reader =
+        riperf3_test_support::drain_reader(server.0.stderr.take().expect("piped stderr"));
+    std::thread::sleep(std::time::Duration::from_millis(400));
+
+    std::thread::spawn(move || {
+        let cookie = [b'x'; 37];
+        let mut ctrl = std::net::TcpStream::connect(("127.0.0.1", port)).expect("ctrl");
+        ctrl.write_all(&cookie).unwrap();
+        assert_eq!(read_exact(&mut ctrl, 1)[0], 9);
+        write_json_blob(&mut ctrl, MOCK_PARAMS);
+        assert_eq!(read_exact(&mut ctrl, 1)[0], 10);
+        let mut data = std::net::TcpStream::connect(("127.0.0.1", port)).expect("data");
+        data.write_all(&cookie).unwrap();
+        assert_eq!(read_exact(&mut ctrl, 1)[0], 1);
+        assert_eq!(read_exact(&mut ctrl, 1)[0], 2);
+        data.write_all(&[0u8; 4096]).unwrap();
+        ctrl.write_all(&[4u8]).unwrap(); // TestEnd
+        assert_eq!(read_exact(&mut ctrl, 1)[0], 13); // ExchangeResults
+        ctrl.write_all(&500u32.to_be_bytes()).unwrap(); // promise 500, send none
+                                                        // Let the server read the size and block in the blob read, THEN abort.
+        std::thread::sleep(std::time::Duration::from_millis(500));
+        force_rst_on_drop(&ctrl);
+        drop((ctrl, data));
+    });
+
+    let status =
+        riperf3_test_support::wait_bounded(&mut server.0, std::time::Duration::from_secs(10))
+            .expect("server exits on the reset");
+    assert!(status.success(), "one-off exits 0 like GT");
+    let serr = serr_reader.join().expect("stderr");
+    assert!(
+        serr.contains("warning: JSON data read failed; errno="),
+        "a hard read error takes GT's rc<0 arm: {serr}"
+    );
+    assert!(
+        !serr.contains("does not correspond to offered length"),
+        "must NOT fall through to the expected/received short-read arm: {serr}"
+    );
+}
+
+/// #336 r1 F4: a zero JSON size fails GT's hsize>0 gate
+/// (iperf_api.c:3038/:3068) and warns the overflow line verbatim.
+#[test]
+fn exchange_zero_size_takes_gt_overflow_warning() {
+    let (_sout, serr, status) = run_exchange_fail_scenario(false, Some((0, b"")));
+    assert!(
+        serr.contains("warning: JSON data length overflow - 0 bytes JSON size is not allowed"),
+        "a zero JSON size warns GT's overflow line: {serr}"
+    );
+    assert!(status.success(), "one-off exits 0 like GT");
+}
+
+/// #330: a HARD read error during the SIZE read (an RST before the 4-byte
+/// length arrives) takes GT's rc<0 size arm "read returned -1; errno={e}"
+/// — the size-stage twin of the blob rc<0 arm above.
+#[test]
+fn exchange_size_rst_takes_gt_read_failed_size_arm() {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind");
+    let port = listener.local_addr().unwrap().port();
+    drop(listener);
+    let port_s = port.to_string();
+
+    let mut server = common::ChildGuard(
+        std::process::Command::new(env!("CARGO_BIN_EXE_riperf3"))
+            .args(["-s", "-1", "-p", &port_s])
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::piped())
+            .spawn()
+            .expect("spawn server"),
+    );
+    let serr_reader =
+        riperf3_test_support::drain_reader(server.0.stderr.take().expect("piped stderr"));
+    std::thread::sleep(std::time::Duration::from_millis(400));
+
+    std::thread::spawn(move || {
+        let cookie = [b'x'; 37];
+        let mut ctrl = std::net::TcpStream::connect(("127.0.0.1", port)).expect("ctrl");
+        ctrl.write_all(&cookie).unwrap();
+        assert_eq!(read_exact(&mut ctrl, 1)[0], 9);
+        write_json_blob(&mut ctrl, MOCK_PARAMS);
+        assert_eq!(read_exact(&mut ctrl, 1)[0], 10);
+        let mut data = std::net::TcpStream::connect(("127.0.0.1", port)).expect("data");
+        data.write_all(&cookie).unwrap();
+        assert_eq!(read_exact(&mut ctrl, 1)[0], 1);
+        assert_eq!(read_exact(&mut ctrl, 1)[0], 2);
+        data.write_all(&[0u8; 4096]).unwrap();
+        ctrl.write_all(&[4u8]).unwrap(); // TestEnd
+        assert_eq!(read_exact(&mut ctrl, 1)[0], 13); // ExchangeResults
+                                                     // No size bytes at all — abort before the length arrives.
+        force_rst_on_drop(&ctrl);
+        drop((ctrl, data));
+    });
+
+    let status =
+        riperf3_test_support::wait_bounded(&mut server.0, std::time::Duration::from_secs(10))
+            .expect("server exits on the reset");
+    assert!(status.success(), "one-off exits 0 like GT");
+    let serr = serr_reader.join().expect("stderr");
+    assert!(
+        serr.contains("warning: Failed to read JSON data size - read returned -1; errno="),
+        "an RST at the size read takes GT's rc<0 size arm: {serr}"
+    );
+}
+
 /// #325 r2 F6: the CLIENT side of the same default — GT's client message
 /// handler IEMESSAGEs an unmapped byte too (iperf_client_api.c:409-411).
 /// The byte replaces ExchangeResults(13) at the client's direct state wait

--- a/riperf3-cli/tests/wire_shape.rs
+++ b/riperf3-cli/tests/wire_shape.rs
@@ -931,9 +931,10 @@ fn exchange_half_size_then_hold_exits_bounded() {
         drop((ctrl, data));
     });
 
-    // The 10 s idle bound fires; well inside the 15 s assert window.
+    // The 10 s idle bound fires; the 20 s assert window leaves slack for a
+    // loaded 2-core CI runner (r2 finding 7).
     let status =
-        riperf3_test_support::wait_bounded(&mut server.0, std::time::Duration::from_secs(15))
+        riperf3_test_support::wait_bounded(&mut server.0, std::time::Duration::from_secs(20))
             .expect("server exits on GT's read bound while the peer holds");
     assert!(status.success(), "one-off exits 0 like GT");
     let serr = serr_reader.join().expect("stderr");
@@ -1057,8 +1058,9 @@ fn exchange_zero_size_takes_gt_overflow_warning() {
 }
 
 /// #330: a HARD read error during the SIZE read (an RST before the 4-byte
-/// length arrives) takes GT's rc<0 size arm "read returned -1; errno={e}"
-/// — the size-stage twin of the blob rc<0 arm above.
+/// length arrives) takes GT's rc<0 size arm "read returned -2; errno={e}"
+/// (GT's Nrecv returns NET_HARDERROR=-2, echoed raw; r2 finding 1) — the
+/// size-stage twin of the blob rc<0 arm above.
 #[test]
 fn exchange_size_rst_takes_gt_read_failed_size_arm() {
     let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind");
@@ -1103,7 +1105,7 @@ fn exchange_size_rst_takes_gt_read_failed_size_arm() {
     assert!(status.success(), "one-off exits 0 like GT");
     let serr = serr_reader.join().expect("stderr");
     assert!(
-        serr.contains("warning: Failed to read JSON data size - read returned -1; errno="),
+        serr.contains("warning: Failed to read JSON data size - read returned -2; errno="),
         "an RST at the size read takes GT's rc<0 size arm: {serr}"
     );
 }

--- a/riperf3-cli/tests/wire_shape.rs
+++ b/riperf3-cli/tests/wire_shape.rs
@@ -773,6 +773,137 @@ fn mid_test_ctrl_eof_with_data_held_exits_bounded() {
     );
 }
 
+/// #330 exchange-phase cells: full protocol through TestEnd; after the
+/// server's ExchangeResults(13), `blob`: None = EOF before the results,
+/// Some((promised_len, partial)) = a short blob then EOF.
+fn run_exchange_fail_scenario(
+    json: bool,
+    blob: Option<(u32, &'static [u8])>,
+) -> (String, String, std::process::ExitStatus) {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind");
+    let port = listener.local_addr().unwrap().port();
+    drop(listener);
+    let port_s = port.to_string();
+
+    let mut args = vec!["-s", "-1", "-p", &port_s];
+    if json {
+        args.push("-J");
+    }
+    let mut server = common::ChildGuard(
+        std::process::Command::new(env!("CARGO_BIN_EXE_riperf3"))
+            .args(&args)
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .spawn()
+            .expect("spawn server"),
+    );
+    let sout_reader =
+        riperf3_test_support::drain_reader(server.0.stdout.take().expect("piped stdout"));
+    let serr_reader =
+        riperf3_test_support::drain_reader(server.0.stderr.take().expect("piped stderr"));
+    std::thread::sleep(std::time::Duration::from_millis(400));
+
+    let mock = std::thread::spawn(move || {
+        let cookie = [b'x'; 37];
+        let mut ctrl = std::net::TcpStream::connect(("127.0.0.1", port)).expect("ctrl");
+        ctrl.write_all(&cookie).unwrap();
+        assert_eq!(read_exact(&mut ctrl, 1)[0], 9);
+        write_json_blob(&mut ctrl, MOCK_PARAMS);
+        assert_eq!(read_exact(&mut ctrl, 1)[0], 10);
+        let mut data = std::net::TcpStream::connect(("127.0.0.1", port)).expect("data");
+        data.write_all(&cookie).unwrap();
+        assert_eq!(read_exact(&mut ctrl, 1)[0], 1);
+        assert_eq!(read_exact(&mut ctrl, 1)[0], 2);
+        data.write_all(&[0u8; 4096]).unwrap();
+        ctrl.write_all(&[4u8]).unwrap(); // TestEnd
+        assert_eq!(read_exact(&mut ctrl, 1)[0], 13); // ExchangeResults
+        if let Some((promised, partial)) = blob {
+            ctrl.write_all(&promised.to_be_bytes()).unwrap();
+            ctrl.write_all(partial).unwrap();
+        }
+        drop((ctrl, data)); // EOF where the results were due
+        std::thread::sleep(std::time::Duration::from_millis(300));
+    });
+
+    mock.join().expect("mock");
+    let status =
+        riperf3_test_support::wait_bounded(&mut server.0, std::time::Duration::from_secs(8))
+            .expect("server exits");
+    (
+        sout_reader.join().expect("stdout"),
+        serr_reader.join().expect("stderr"),
+        status,
+    )
+}
+
+const RECV_RESULTS_ERR: &str = "error - unable to receive results: ";
+
+/// #330: EOF where the client's results were due — GT's IERECVRESULTS
+/// (live-probed): the Nread_json warning on stderr EVEN under -J (GT's
+/// warning() bypasses every sink), the doc's error key in the #248
+/// dangling-`: ` errno-0 perr form (RECORDED DEVIATION: GT appends a
+/// STALE errno's strerror), POPULATED end, exit 0.
+#[test]
+fn exchange_eof_takes_gt_recv_results_shape_in_json() {
+    let (sout, serr, status) = run_exchange_fail_scenario(true, None);
+    let doc: serde_json::Value =
+        serde_json::from_str(sout.trim()).unwrap_or_else(|e| panic!("one -J doc ({e}): {sout}"));
+    assert_eq!(
+        doc["error"].as_str(),
+        Some(RECV_RESULTS_ERR),
+        "the IERECVRESULTS key in the errno-0 perr form: {doc}"
+    );
+    assert!(
+        doc["end"]["streams"]
+            .as_array()
+            .is_some_and(|a| !a.is_empty()),
+        "TEST_END processing ran — populated end: {doc}"
+    );
+    assert_eq!(
+        serr.trim(),
+        "warning: Failed to read JSON data size - read returned 0; errno=0",
+        "GT's read-site warning, sink-bypassing, and nothing else: {serr}"
+    );
+    assert!(status.success(), "one-off exits 0 like GT");
+}
+
+/// #330, text half: the warning, the error line, and the summary.
+#[test]
+fn exchange_eof_prints_warning_line_and_summary_in_text() {
+    let (sout, serr, status) = run_exchange_fail_scenario(false, None);
+    // No whole-string trim: the error line's dangling `: ` IS the pin.
+    let lines: Vec<&str> = serr.lines().collect();
+    assert_eq!(
+        lines,
+        vec![
+            "warning: Failed to read JSON data size - read returned 0; errno=0",
+            &format!("riperf3: {RECV_RESULTS_ERR}") as &str,
+        ],
+        "warning then the error line, once each: {serr}"
+    );
+    assert_eq!(
+        sout.matches(SUMMARY_SEPARATOR).count(),
+        1,
+        "the completed round prints its summary: {sout}"
+    );
+    assert!(status.success(), "one-off exits 0 like GT");
+}
+
+/// #330: a short results blob then EOF — GT's expected/received warning
+/// verbatim (live: "expected 500 bytes but received 5; errno=0").
+#[test]
+fn exchange_short_blob_prints_gt_length_warning() {
+    let (_sout, serr, status) = run_exchange_fail_scenario(false, Some((500, b"{\"cp")));
+    assert!(
+        serr.contains(
+            "warning: JSON size of data read does not correspond to offered length - \
+             expected 500 bytes but received 4; errno=0"
+        ),
+        "GT's short-blob warning with the real counts: {serr}"
+    );
+    assert!(status.success(), "one-off exits 0 like GT");
+}
+
 /// #325 r2 F6: the CLIENT side of the same default — GT's client message
 /// handler IEMESSAGEs an unmapped byte too (iperf_client_api.c:409-411).
 /// The byte replaces ExchangeResults(13) at the client's direct state wait

--- a/riperf3-cli/tests/wire_shape.rs
+++ b/riperf3-cli/tests/wire_shape.rs
@@ -945,7 +945,8 @@ fn exchange_half_size_then_hold_exits_bounded() {
 }
 
 /// #330: a short results blob then EOF — GT's expected/received warning
-/// verbatim (live: "expected 500 bytes but received 5; errno=0").
+/// verbatim (this cell sends 4 blob bytes: "expected 500 bytes but
+/// received 4; errno=0").
 #[test]
 fn exchange_short_blob_prints_gt_length_warning() {
     let (_sout, serr, status) = run_exchange_fail_scenario(false, Some((500, b"{\"cp")));
@@ -981,15 +982,23 @@ fn force_rst_on_drop(sock: &std::net::TcpStream) {
     };
     assert_eq!(rc, 0, "SO_LINGER setsockopt failed");
 }
-#[cfg(not(unix))]
-fn force_rst_on_drop(_sock: &std::net::TcpStream) {}
+// (No non-unix stub: the only callers are the two RST pins below, both
+// #[cfg(unix)] — forcing an RST needs SO_LINGER(0), which is unix-only.)
 
 /// #336 r1 F1: a HARD read error mid-blob (an RST arriving after the SIZE
 /// was read and the server is blocked on the blob) takes GT's rc<0 arm
-/// "JSON data read failed; errno={e}" (iperf_api.c:3078) — NOT the
+/// "JSON data read failed; errno={e}" (iperf_api.c:3061) — NOT the
 /// expected/received short-read arm (that one is for a clean partial+EOF,
 /// where GT's Nread returned rc>=0). The mock promises 500 bytes, lets the
 /// server consume the size and block, then RST-closes.
+///
+/// Unix-only (r3 finding 1): the mock leaves NO unread data before it drops
+/// (the server already consumed the size), so the cross-platform
+/// unread-data→RST path doesn't apply — a real RST needs SO_LINGER(0). The
+/// warning arm itself is platform-independent Rust, exercised on every unix
+/// CI target (Linux/macOS/*BSD); Windows would send a clean FIN and hit the
+/// EOF arm instead.
+#[cfg(unix)]
 #[test]
 fn exchange_blob_rst_takes_gt_read_failed_arm() {
     let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind");
@@ -1060,7 +1069,9 @@ fn exchange_zero_size_takes_gt_overflow_warning() {
 /// #330: a HARD read error during the SIZE read (an RST before the 4-byte
 /// length arrives) takes GT's rc<0 size arm "read returned -2; errno={e}"
 /// (GT's Nrecv returns NET_HARDERROR=-2, echoed raw; r2 finding 1) — the
-/// size-stage twin of the blob rc<0 arm above.
+/// size-stage twin of the blob rc<0 arm above. Unix-only for the same
+/// reason (r3 finding 1): the SO_LINGER(0) RST is unix-only.
+#[cfg(unix)]
 #[test]
 fn exchange_size_rst_takes_gt_read_failed_size_arm() {
     let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind");

--- a/riperf3-cli/tests/wire_shape.rs
+++ b/riperf3-cli/tests/wire_shape.rs
@@ -889,6 +889,60 @@ fn exchange_eof_prints_warning_line_and_summary_in_text() {
     assert!(status.success(), "one-off exits 0 like GT");
 }
 
+/// #336 r1 F3: a peer that half-sends the SIZE and then HOLDS the socket
+/// — GT's Nrecv self-recovers via its 10 s idle / 30 s overall read
+/// bounds (net.c:75-76) and warns with the partial count; the exchange
+/// must not park forever.
+#[test]
+fn exchange_half_size_then_hold_exits_bounded() {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind");
+    let port = listener.local_addr().unwrap().port();
+    drop(listener);
+    let port_s = port.to_string();
+
+    let mut server = common::ChildGuard(
+        std::process::Command::new(env!("CARGO_BIN_EXE_riperf3"))
+            .args(["-s", "-1", "-p", &port_s])
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::piped())
+            .spawn()
+            .expect("spawn server"),
+    );
+    let serr_reader =
+        riperf3_test_support::drain_reader(server.0.stderr.take().expect("piped stderr"));
+    std::thread::sleep(std::time::Duration::from_millis(400));
+
+    std::thread::spawn(move || {
+        let cookie = [b'x'; 37];
+        let mut ctrl = std::net::TcpStream::connect(("127.0.0.1", port)).expect("ctrl");
+        ctrl.write_all(&cookie).unwrap();
+        assert_eq!(read_exact(&mut ctrl, 1)[0], 9);
+        write_json_blob(&mut ctrl, MOCK_PARAMS);
+        assert_eq!(read_exact(&mut ctrl, 1)[0], 10);
+        let mut data = std::net::TcpStream::connect(("127.0.0.1", port)).expect("data");
+        data.write_all(&cookie).unwrap();
+        assert_eq!(read_exact(&mut ctrl, 1)[0], 1);
+        assert_eq!(read_exact(&mut ctrl, 1)[0], 2);
+        data.write_all(&[0u8; 4096]).unwrap();
+        ctrl.write_all(&[4u8]).unwrap(); // TestEnd
+        assert_eq!(read_exact(&mut ctrl, 1)[0], 13); // ExchangeResults
+        ctrl.write_all(&[0u8, 0u8]).unwrap(); // 2 of 4 size bytes, then HOLD
+        std::thread::sleep(std::time::Duration::from_secs(40));
+        drop((ctrl, data));
+    });
+
+    // The 10 s idle bound fires; well inside the 15 s assert window.
+    let status =
+        riperf3_test_support::wait_bounded(&mut server.0, std::time::Duration::from_secs(15))
+            .expect("server exits on GT's read bound while the peer holds");
+    assert!(status.success(), "one-off exits 0 like GT");
+    let serr = serr_reader.join().expect("stderr");
+    assert!(
+        serr.contains("warning: Failed to read JSON data size - read returned 2; errno=0"),
+        "the timed-out read warns with the partial count: {serr}"
+    );
+}
+
 /// #330: a short results blob then EOF — GT's expected/received warning
 /// verbatim (live: "expected 500 bytes but received 5; errno=0").
 #[test]

--- a/riperf3/src/protocol.rs
+++ b/riperf3/src/protocol.rs
@@ -591,8 +591,23 @@ fn gt_warning(msg: std::fmt::Arguments<'_>) {
 const NREAD_IDLE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
 const NREAD_OVERALL_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
 
+/// GT's `NET_HARDERROR` (net.h:50): the value `Nrecv` returns on a hard read
+/// error, echoed verbatim into the size-read warning's `read returned %d`
+/// (iperf_api.c:3074). It is -2, NOT -1 (`NET_SOFTERROR`, which `Nrecv`
+/// never emits) — r2 finding 1, live-confirmed GT prints `-2`.
+const NET_HARDERROR: i32 = -2;
+
 /// One GT-bounded read step: Ok(Some(n)) = n bytes, Ok(None) = EOF or a
 /// timeout (GT's Nrecv returns the partial), Err = hard read error.
+///
+/// RECORDED DEVIATION (r2 finding 5): the 10 s idle bound is fresh PER read
+/// step (idle-since-last-progress). GT-on-Linux instead threads ONE
+/// `select(2)` timeout that the kernel decrements in place across a single
+/// `Nread` (net.c:422), i.e. a cumulative-per-Nread budget; GT-on-BSD/macOS
+/// (where `select` leaves the timeout untouched, per POSIX) matches our
+/// per-step reset. Divergence is adversarial-only (a byte-dripping peer:
+/// GT-Linux gives up at ~10 s cumulative, we at up to the 30 s overall) and
+/// the real results blob is one atomic write; both paths stay bounded.
 async fn nread_step(
     stream: &mut TcpStream,
     buf: &mut [u8],
@@ -610,7 +625,7 @@ async fn nread_step(
 }
 
 /// The SERVER's results read (#330): a malformed read gets GT's Nread_json
-/// warning surface (iperf_api.c:3036-3080 — all four arms, deterministic
+/// warning surface (iperf_api.c:3036-3080 — all five arms, deterministic
 /// text and counts, live-probed under -J and text) and maps to the
 /// IERECVRESULTS class the caller renders into the doc. Reads are bounded
 /// like GT's Nrecv. The client keeps the plain [`recv_results`]: its
@@ -630,9 +645,12 @@ pub async fn recv_results_server(stream: &mut TcpStream) -> Result<TestResultsJs
                 return Err(crate::error::RiperfError::RecvResultsFailed);
             }
             Ok(Some(n)) => got += n,
+            // A hard read error: GT's Nrecv returns NET_HARDERROR and the
+            // size warning echoes that raw rc (iperf_api.c:3074) — so the
+            // literal is -2, not -1 (r2 finding 1).
             Err(e) => {
                 gt_warning(format_args!(
-                    "Failed to read JSON data size - read returned -1; errno={}",
+                    "Failed to read JSON data size - read returned {NET_HARDERROR}; errno={}",
                     e.raw_os_error().unwrap_or(0)
                 ));
                 return Err(crate::error::RiperfError::RecvResultsFailed);
@@ -641,14 +659,23 @@ pub async fn recv_results_server(stream: &mut TcpStream) -> Result<TestResultsJs
     }
     let len = u32::from_be_bytes(len_buf) as usize;
     if len == 0 {
-        // GT's hsize>0 gate (iperf_api.c:3038/:3068): a zero size warns
+        // GT's hsize>0 gate (iperf_api.c:3038/:3069): a zero size warns
         // the overflow line — live-probed wording (r1 F4).
         gt_warning(format_args!(
             "JSON data length overflow - 0 bytes JSON size is not allowed"
         ));
         return Err(crate::error::RiperfError::RecvResultsFailed);
     }
-    let mut buf = vec![0u8; len];
+    // GT calloc's the buffer and NULL-guards it (iperf_api.c:3042-3043),
+    // degrading to IERECVRESULTS with NO warning on alloc failure. `len` is
+    // an unbounded peer-controlled u32 (max_size=0 → no cap, like GT), so a
+    // fallible reserve is the faithful match: an infallible `vec![0u8; len]`
+    // would abort the process on a hostile 4 GB prefix (r2 finding 4).
+    let mut buf = Vec::new();
+    if buf.try_reserve_exact(len).is_err() {
+        return Err(crate::error::RiperfError::RecvResultsFailed);
+    }
+    buf.resize(len, 0);
     let mut got = 0usize;
     while got < len {
         match nread_step(stream, &mut buf[got..], deadline).await {
@@ -663,8 +690,8 @@ pub async fn recv_results_server(stream: &mut TcpStream) -> Result<TestResultsJs
                 return Err(crate::error::RiperfError::RecvResultsFailed);
             }
             Ok(Some(n)) => got += n,
-            // A hard read error is GT's rc<0 arm (r1 F1 — live RST probe:
-            // "JSON data read failed; errno=104").
+            // A hard read error is GT's rc<0 arm (iperf_api.c:3061; r1 F1 —
+            // live RST probe: "JSON data read failed; errno=104").
             Err(e) => {
                 gt_warning(format_args!(
                     "JSON data read failed; errno={}",

--- a/riperf3/src/protocol.rs
+++ b/riperf3/src/protocol.rs
@@ -574,48 +574,104 @@ fn validate_results(value: serde_json::Value) -> Result<TestResultsJson> {
     Ok(results)
 }
 
+/// GT's Nread_json warning lines bypass every sink (warning() is a raw
+/// fprintf(stderr), iperf_api.c:126-129) — but the #290 quiet-guard
+/// contract wins for embedded library runs (r1 F6 decision): a quiet
+/// caller gets silence, everyone else gets GT's exact line.
+fn gt_warning(msg: std::fmt::Arguments<'_>) {
+    if !crate::macros::output_quiet() {
+        eprintln!("warning: {msg}");
+    }
+}
+
+/// GT's Nrecv read bounds (net.c:75-76): 10 s of idle silence or 30 s
+/// overall ends the read with the partial count — the warnings then carry
+/// that count like any short read (r1 F3: without these a peer that
+/// half-sends and HOLDS parked the exchange forever; GT self-recovers).
+const NREAD_IDLE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+const NREAD_OVERALL_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+
+/// One GT-bounded read step: Ok(Some(n)) = n bytes, Ok(None) = EOF or a
+/// timeout (GT's Nrecv returns the partial), Err = hard read error.
+async fn nread_step(
+    stream: &mut TcpStream,
+    buf: &mut [u8],
+    deadline: tokio::time::Instant,
+) -> std::result::Result<Option<usize>, std::io::Error> {
+    tokio::select! {
+        r = stream.read(buf) => match r {
+            Ok(0) => Ok(None),
+            Ok(n) => Ok(Some(n)),
+            Err(e) => Err(e),
+        },
+        _ = tokio::time::sleep(NREAD_IDLE_TIMEOUT) => Ok(None),
+        _ = tokio::time::sleep_until(deadline) => Ok(None),
+    }
+}
+
 /// The SERVER's results read (#330): a malformed read gets GT's Nread_json
-/// warning surface — deterministic `warning: ...` lines on STDERR in every
-/// mode (GT's warning() bypasses all sinks; live-probed under -J) — and
-/// maps to the IERECVRESULTS class the caller renders into the doc. The
-/// client keeps the plain [`recv_results`]: its warning parity needs its
-/// own GT probes (noted on #330).
+/// warning surface (iperf_api.c:3036-3080 — all four arms, deterministic
+/// text and counts, live-probed under -J and text) and maps to the
+/// IERECVRESULTS class the caller renders into the doc. Reads are bounded
+/// like GT's Nrecv. The client keeps the plain [`recv_results`]: its
+/// warning parity needs its own GT probes (noted on #330).
 pub async fn recv_results_server(stream: &mut TcpStream) -> Result<TestResultsJson> {
+    let deadline = tokio::time::Instant::now() + NREAD_OVERALL_TIMEOUT;
     let mut len_buf = [0u8; 4];
     let mut got = 0usize;
     while got < 4 {
-        match stream.read(&mut len_buf[got..]).await {
-            // GT's Nread returns the partial count on EOF; the warning
-            // echoes it verbatim (live: "read returned 0; errno=0").
-            Ok(0) => {
-                eprintln!("warning: Failed to read JSON data size - read returned {got}; errno=0");
+        match nread_step(stream, &mut len_buf[got..], deadline).await {
+            // GT's Nread returns the partial count on EOF/timeout; the
+            // warning echoes it verbatim (live: "read returned 0; errno=0").
+            Ok(None) => {
+                gt_warning(format_args!(
+                    "Failed to read JSON data size - read returned {got}; errno=0"
+                ));
                 return Err(crate::error::RiperfError::RecvResultsFailed);
             }
-            Ok(n) => got += n,
+            Ok(Some(n)) => got += n,
             Err(e) => {
-                eprintln!(
-                    "warning: Failed to read JSON data size - read returned -1; errno={}",
+                gt_warning(format_args!(
+                    "Failed to read JSON data size - read returned -1; errno={}",
                     e.raw_os_error().unwrap_or(0)
-                );
+                ));
                 return Err(crate::error::RiperfError::RecvResultsFailed);
             }
         }
     }
     let len = u32::from_be_bytes(len_buf) as usize;
+    if len == 0 {
+        // GT's hsize>0 gate (iperf_api.c:3038/:3068): a zero size warns
+        // the overflow line — live-probed wording (r1 F4).
+        gt_warning(format_args!(
+            "JSON data length overflow - 0 bytes JSON size is not allowed"
+        ));
+        return Err(crate::error::RiperfError::RecvResultsFailed);
+    }
     let mut buf = vec![0u8; len];
     let mut got = 0usize;
     while got < len {
-        match stream.read(&mut buf[got..]).await {
-            Ok(0) | Err(_) => {
-                // GT's short-blob warning, expected/received verbatim
-                // (live: "expected 500 bytes but received 5; errno=0").
-                eprintln!(
-                    "warning: JSON size of data read does not correspond to offered length - \
+        match nread_step(stream, &mut buf[got..], deadline).await {
+            // EOF/timeout: GT's Nread returned the partial (rc >= 0) — the
+            // expected/received arm (live: "expected 500 bytes but
+            // received 5; errno=0").
+            Ok(None) => {
+                gt_warning(format_args!(
+                    "JSON size of data read does not correspond to offered length - \
                      expected {len} bytes but received {got}; errno=0"
-                );
+                ));
                 return Err(crate::error::RiperfError::RecvResultsFailed);
             }
-            Ok(n) => got += n,
+            Ok(Some(n)) => got += n,
+            // A hard read error is GT's rc<0 arm (r1 F1 — live RST probe:
+            // "JSON data read failed; errno=104").
+            Err(e) => {
+                gt_warning(format_args!(
+                    "JSON data read failed; errno={}",
+                    e.raw_os_error().unwrap_or(0)
+                ));
+                return Err(crate::error::RiperfError::RecvResultsFailed);
+            }
         }
     }
     let value: serde_json::Value =

--- a/riperf3/src/protocol.rs
+++ b/riperf3/src/protocol.rs
@@ -554,6 +554,11 @@ pub async fn send_results(stream: &mut TcpStream, results: &TestResultsJson) -> 
 /// Receive test results from length-prefixed JSON (no size limit).
 pub async fn recv_results(stream: &mut TcpStream) -> Result<TestResultsJson> {
     let value = json_read(stream, 0).await?;
+    validate_results(value)
+}
+
+/// The #271 shape validation shared by both results readers.
+fn validate_results(value: serde_json::Value) -> Result<TestResultsJson> {
     let results: TestResultsJson = serde_json::from_value(value)?;
     // #271: GT accepts BOTH omitted_* keys (>=3.14 peer) or NEITHER (old
     // peer), and fails the exchange with IERECVRESULTS when exactly one is
@@ -567,6 +572,55 @@ pub async fn recv_results(stream: &mut TcpStream) -> Result<TestResultsJson> {
         return Err(crate::error::RiperfError::RecvResultsFailed);
     }
     Ok(results)
+}
+
+/// The SERVER's results read (#330): a malformed read gets GT's Nread_json
+/// warning surface — deterministic `warning: ...` lines on STDERR in every
+/// mode (GT's warning() bypasses all sinks; live-probed under -J) — and
+/// maps to the IERECVRESULTS class the caller renders into the doc. The
+/// client keeps the plain [`recv_results`]: its warning parity needs its
+/// own GT probes (noted on #330).
+pub async fn recv_results_server(stream: &mut TcpStream) -> Result<TestResultsJson> {
+    let mut len_buf = [0u8; 4];
+    let mut got = 0usize;
+    while got < 4 {
+        match stream.read(&mut len_buf[got..]).await {
+            // GT's Nread returns the partial count on EOF; the warning
+            // echoes it verbatim (live: "read returned 0; errno=0").
+            Ok(0) => {
+                eprintln!("warning: Failed to read JSON data size - read returned {got}; errno=0");
+                return Err(crate::error::RiperfError::RecvResultsFailed);
+            }
+            Ok(n) => got += n,
+            Err(e) => {
+                eprintln!(
+                    "warning: Failed to read JSON data size - read returned -1; errno={}",
+                    e.raw_os_error().unwrap_or(0)
+                );
+                return Err(crate::error::RiperfError::RecvResultsFailed);
+            }
+        }
+    }
+    let len = u32::from_be_bytes(len_buf) as usize;
+    let mut buf = vec![0u8; len];
+    let mut got = 0usize;
+    while got < len {
+        match stream.read(&mut buf[got..]).await {
+            Ok(0) | Err(_) => {
+                // GT's short-blob warning, expected/received verbatim
+                // (live: "expected 500 bytes but received 5; errno=0").
+                eprintln!(
+                    "warning: JSON size of data read does not correspond to offered length - \
+                     expected {len} bytes but received {got}; errno=0"
+                );
+                return Err(crate::error::RiperfError::RecvResultsFailed);
+            }
+            Ok(n) => got += n,
+        }
+    }
+    let value: serde_json::Value =
+        serde_json::from_slice(&buf).map_err(|_| crate::error::RiperfError::RecvResultsFailed)?;
+    validate_results(value)
 }
 
 // ---------------------------------------------------------------------------

--- a/riperf3/src/reporter.rs
+++ b/riperf3/src/reporter.rs
@@ -268,6 +268,13 @@ pub fn print_separator() {
 /// GT drops only the short empty tail its comment attributes to control
 /// messages queuing behind data. With `-i 0` the threshold is zero, so the
 /// whole-run flush is unconditionally kept.
+///
+/// RECORDED DEVIATION (#330 item 5, #333 r2 N2): on ERROR-truncated rounds
+/// (mid-test IEMESSAGE/EOF) and sub-tick complete rounds, this flush emits
+/// one partial interval GT never shows — GT's reporter is timer-driven and
+/// dead by then, so its doc carries whole ticks only (live: byte-9 cell =
+/// GT intervals [], riperf3 [1]). Kept: the flush is the #210 terminate
+/// convention and load-bearing for every interrupt dump shape.
 fn keep_final_interval(len_secs: f64, interval_secs: f64, residual_bytes: u64) -> bool {
     len_secs >= interval_secs * 0.10 || residual_bytes > 0
 }

--- a/riperf3/src/reporter.rs
+++ b/riperf3/src/reporter.rs
@@ -269,12 +269,17 @@ pub fn print_separator() {
 /// messages queuing behind data. With `-i 0` the threshold is zero, so the
 /// whole-run flush is unconditionally kept.
 ///
-/// RECORDED DEVIATION (#330 item 5, #333 r2 N2): on ERROR-truncated rounds
-/// (mid-test IEMESSAGE/EOF) and sub-tick complete rounds, this flush emits
-/// one partial interval GT never shows — GT's reporter is timer-driven and
-/// dead by then, so its doc carries whole ticks only (live: byte-9 cell =
-/// GT intervals [], riperf3 [1]). Kept: the flush is the #210 terminate
-/// convention and load-bearing for every interrupt dump shape.
+/// RECORDED DEVIATION (#330 item 5; scope corrected by #336 r1 F2): on
+/// ERROR-TRUNCATED rounds only (mid-test IEMESSAGE/EOF) this flush emits
+/// one partial interval GT never shows — GT's reporter genuinely never
+/// runs there (live: byte-9 cell = GT intervals [], riperf3 [1]).
+/// Sub-tick COMPLETE rounds are PARITY (live-refuted: `-n 4K` → both
+/// docs carry intervals [1]; GT's TEST_END arm runs the reporter and its
+/// keep-rule is this one). Where mock cells showed GT [] on complete
+/// rounds, the mechanism was byte accounting — GT's canceled stream
+/// threads had counted 0 bytes, so this same rule dropped its tail —
+/// not a dead reporter. Kept: the flush is the #210 terminate convention
+/// and load-bearing for every interrupt dump shape.
 fn keep_final_interval(len_secs: f64, interval_secs: f64, residual_bytes: u64) -> bool {
     len_secs >= interval_secs * 0.10 || residual_bytes > 0
 }

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -270,12 +270,28 @@ struct TestRunCtx {
     /// #330: the exchange-phase results read failed — GT's IERECVRESULTS
     /// surface (live-probed): the Nread_json warning already printed to
     /// stderr, the doc keeps the POPULATED end (TEST_END processing ran)
-    /// plus `error - unable to receive results: ` (the dangling `: ` is
-    /// the #248 perr form at errno 0 — RECORDED DEVIATION: GT appends
-    /// strerror of a STALE errno here, "Transport endpoint is not
-    /// connected" on Linux, while its own warning reports errno=0; we
-    /// print the honest errno-0 form instead of reproducing the stale
-    /// read), exit 0, persistent keeps serving.
+    /// plus `error - unable to receive results: `, exit 0, persistent keeps
+    /// serving.
+    ///
+    /// RECORDED DEVIATION (the dangling `: ` is the #248 perr form at
+    /// errno 0): GT appends `strerror` of a leftover errno here — on Linux
+    /// deterministically `Transport endpoint is not connected` (ENOTCONN)
+    /// across every clean-close probe — while its own warning reports
+    /// errno=0. The tail is a semantically-meaningless errno from the
+    /// best-effort cleanup path, so we print the honest errno-0 form.
+    ///
+    /// RECORDED DEVIATION (r2 finding 2 — close-type message flip): GT's
+    /// BASE message is not uniformly IERECVRESULTS. On a clean FIN the
+    /// half-closed socket still accepts `cleanup_server`'s best-effort
+    /// `SERVER_ERROR` write, so `i_errno` stays IERECVRESULTS ("unable to
+    /// receive results"). On an RST that write fails and
+    /// `iperf_set_send_state` overwrites `i_errno` to IESENDMESSAGE
+    /// (iperf_server_api.c:466-472), flipping the rendered key to "unable
+    /// to send control message - port may not be available...". That
+    /// message MISDESCRIBES the failure (the receive is what failed, not a
+    /// send), so per the faithful-ethos ruling we keep the honest
+    /// IERECVRESULTS surface for every close-type and file upstream rather
+    /// than reproduce the misleading flip.
     exchange_recv_failed: bool,
     /// #330 r1 F1: a mid-test IPERF_DONE — GT's switch has an EXPLICIT
     /// no-error arm for it (iperf_server_api.c:287-288) and Nread wrote
@@ -1876,9 +1892,12 @@ impl Server {
             let _client_results = tokio::select! {
                 r = protocol::recv_results_server(&mut ctx.ctrl) => match r {
                     Ok(v) => v,
-                    // #330: any malformed results read is GT's
-                    // IERECVRESULTS — the warning printed at the read
-                    // site; the finalize phases render the doc.
+                    // #330: a malformed results read routes to the
+                    // exchange_recv_failed surface — the Nread_json warning
+                    // printed at the read site; the finalize phases render
+                    // the doc. (The rendered error KEY is IERECVRESULTS on
+                    // every close-type here — a deliberate deviation from
+                    // GT's RST→IESENDMESSAGE flip; see the field's docs.)
                     Err(_) => {
                         ctx.exchange_recv_failed = true;
                         return Ok(());

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -1542,13 +1542,15 @@ impl Server {
         // the next await); the UDP runners are spawn_blocking, where abort
         // is a no-op once running — their joins stay bounded anyway by the
         // 500 ms read-timeout + `done` polling in the blocking loops.
+        // (exchange_recv_failed is NOT here — this phase runs before the
+        // exchange, so the flag can't be set yet; its abort lives at the
+        // post-emit gate. r1 F5.)
         if ctx.server_error.is_some()
             || ctx.interrupted.is_some()
             || ctx.unknown_message
             || ctx.client_terminated
             || ctx.ctrl_closed
             || ctx.early_done
-            || ctx.exchange_recv_failed
         {
             // #322 r1 F1: interrupts take the same abort — a wedged peer
             // holding sockets open must not park the joins (GT closes its

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -267,6 +267,16 @@ struct TestRunCtx {
     /// Mid-test rides bare_end (no final dump); end-loop keeps the
     /// populated end (the exchange completed) — both live-probed.
     ctrl_closed: bool,
+    /// #330: the exchange-phase results read failed — GT's IERECVRESULTS
+    /// surface (live-probed): the Nread_json warning already printed to
+    /// stderr, the doc keeps the POPULATED end (TEST_END processing ran)
+    /// plus `error - unable to receive results: ` (the dangling `: ` is
+    /// the #248 perr form at errno 0 — RECORDED DEVIATION: GT appends
+    /// strerror of a STALE errno here, "Transport endpoint is not
+    /// connected" on Linux, while its own warning reports errno=0; we
+    /// print the honest errno-0 form instead of reproducing the stale
+    /// read), exit 0, persistent keeps serving.
+    exchange_recv_failed: bool,
     /// #330 r1 F1: a mid-test IPERF_DONE — GT's switch has an EXPLICIT
     /// no-error arm for it (iperf_server_api.c:287-288) and Nread wrote
     /// the byte into test->state, so its run loop exits CLEAN: no error
@@ -467,6 +477,16 @@ impl Server {
                         eprintln!("riperf3: {}", RiperfError::ClientTerminated);
                     }
                 }
+                Err(RiperfError::RecvResultsFailed) => {
+                    // #330: GT text prints `iperf3: error - unable to
+                    // receive results: ` once (the #248 dangling perr form
+                    // at errno 0 — see the ctx field's deviation record);
+                    // under -J the doc carried it and stderr keeps only
+                    // the read-site warning.
+                    if !json && !crate::macros::output_quiet() {
+                        eprintln!("riperf3: error - {}: ", RiperfError::RecvResultsFailed);
+                    }
+                }
                 Err(RiperfError::UnknownControlMessage) => {
                     // #325: GT main.c:174 prints `iperf3: error - <IEMESSAGE
                     // sentence>` once and keeps serving; a failed test is
@@ -664,6 +684,7 @@ impl Server {
             unknown_message: false,
             ctrl_closed: false,
             early_done: false,
+            exchange_recv_failed: false,
             bare_end: false,
             interrupted: None,
         };
@@ -737,6 +758,10 @@ impl Server {
                 // #330: IECTRLCLOSE's read-site line is a DIRECT iperf_err
                 // — bare, no prefix (live-probed both windows).
                 end.report_error = Some(CTRL_CLOSED_MSG.to_string());
+            } else if ctx.exchange_recv_failed {
+                // #330: the perr dangling `: ` at errno 0 (#248 form; see
+                // the field's deviation record).
+                end.report_error = Some(format!("error - {}: ", RiperfError::RecvResultsFailed));
             }
         }
 
@@ -776,6 +801,7 @@ impl Server {
             || ctx.client_terminated
             || ctx.ctrl_closed
             || ctx.early_done
+            || ctx.exchange_recv_failed
         {
             for s in &ctx.streams {
                 s.task.abort();
@@ -811,6 +837,12 @@ impl Server {
             // loop prints GT's read-site line for exactly this class (the
             // doc'd mid/end-loop EOF), while pre-test EOFs stay quiet.
             return Err(RiperfError::ControlSocketClosed);
+        }
+        if ctx.exchange_recv_failed {
+            // #330: the doc rendered above; the caller prints GT's text
+            // line (json keeps stderr to the warning alone) and keeps
+            // serving — a failed test is rc -1, one-off exit 0.
+            return Err(RiperfError::RecvResultsFailed);
         }
         Ok(Some(report))
     }
@@ -1516,6 +1548,7 @@ impl Server {
             || ctx.client_terminated
             || ctx.ctrl_closed
             || ctx.early_done
+            || ctx.exchange_recv_failed
         {
             // #322 r1 F1: interrupts take the same abort — a wedged peer
             // holding sockets open must not park the joins (GT closes its
@@ -1839,7 +1872,16 @@ impl Server {
             // iperf3's server reports only its own measured bytes and a 0 remote
             // CPU (#50).
             let _client_results = tokio::select! {
-                r = protocol::recv_results(&mut ctx.ctrl) => r?,
+                r = protocol::recv_results_server(&mut ctx.ctrl) => match r {
+                    Ok(v) => v,
+                    // #330: any malformed results read is GT's
+                    // IERECVRESULTS — the warning printed at the read
+                    // site; the finalize phases render the doc.
+                    Err(_) => {
+                        ctx.exchange_recv_failed = true;
+                        return Ok(());
+                    }
+                },
                 msg = crate::client::wait_interrupt(exchange_interrupt.as_mut()) => {
                     let _ = protocol::send_state(&mut ctx.ctrl, TestState::ServerTerminate).await;
                     ctx.interrupted = Some(msg);


### PR DESCRIPTION
Refs #330 (the exchange-phase half of remainder item 1).

Live-probed against GT 3.21 (EOF where the client's results were due; a short blob then EOF; a half-sent length that HOLDS; an RST mid-blob — `probe330c.py`). `recv_results_server` reproduces GT's `Nread_json` surface (`iperf_api.c:3036-3080`): all five warning strings, the read-bound recovery, and the IERECVRESULTS doc.

- **GT's five Nread_json warning strings**, printed to stderr in EVERY mode (GT's `warning()` is a raw `fprintf(stderr)` that bypasses all sinks, confirmed under `-J`), text and counts verbatim:
  - `Failed to read JSON data size - read returned {n}; errno=0` (size EOF/timeout)
  - `Failed to read JSON data size - read returned -1; errno={e}` (size hard error, e.g. RST)
  - `JSON data length overflow - 0 bytes JSON size is not allowed` (`hsize<=0` gate)
  - `JSON size of data read does not correspond to offered length - expected {N} bytes but received {M}; errno=0` (blob short read / EOF)
  - `JSON data read failed; errno={e}` (blob hard error)
- **GT's Nrecv read bounds** (`net.c:75-76`): 10 s idle / 30 s overall end the read with the partial count. Without them a peer that half-sends the length and then HOLDS its socket parked the exchange forever; GT self-recovers, so we do too (`nread_step`).
- **The IERECVRESULTS doc**: POPULATED end (TEST_END processing ran) + the error key, exit 0 one-off, persistent keeps serving — routed through the finalize machinery like the `#325`/`#333` classes.
- **RECORDED DEVIATION** (ethos ruling): GT's error suffix is `strerror` of a **stale** errno — `Transport endpoint is not connected` on Linux while its own warning reports `errno=0`. riperf3 prints the honest errno-0 perr form (`error - unable to receive results: `, the `#248` dangling `: ` convention).
- **Quiet-guard** (`#290`): an embedded library caller that asked for quiet gets silence; everyone else gets GT's exact line. GT has no such knob (its `warning()` is unconditional) — a deliberate, documented library-ergonomics deviation.

### r1 review fixes (this branch, on top of the original commit)
1. **F1** — a hard read error mid-blob now takes the rc<0 `JSON data read failed` arm, not the expected/received arm with a fabricated `errno=0`.
2. **F2** — corrected the item-5 partial-interval deviation: **sub-tick COMPLETE rounds are PARITY** (live-refuted with `-n 4K`: both docs carry `intervals [1]`). Only **error-truncated** rounds emit a partial GT's dead reporter never shows. Where mock cells showed GT `[]` on complete rounds, the mechanism was byte accounting (canceled threads counted 0 bytes), not a dead reporter.
3. **F3** — bounded the reads (above); new pin `exchange_half_size_then_hold_exits_bounded`.
4. **F4** — zero JSON size now warns GT's overflow line.
5. **F5** — dropped `exchange_recv_failed` from the `shutdown_and_flush` gate: that phase runs before the exchange, so the flag can't be set yet. Its abort lives only at the post-emit gate.
6. **F6** — routed the warnings through the quiet guard (above).

Still open on #330 after this: pre-test-phase docs, the client doc body + client warning parity, the send-side exchange failure and rare Io/IERECVMESSAGE classes, and the generic-arm gating that waits on those docs.

Seven exchange pins covering all five warning strings + the bounded-hold recovery + the text/JSON summary shapes. F1/F3/F4 red-proven against reverted arms; the RST pins reuse `setup_retry.rs`'s `SO_LINGER(0)` and assert the errno by prefix so they hold on every CI platform. Full workspace gate green (clippy `-D warnings`, fmt, all tests).

### r2 review fixes
1. **BLOCKER** — the size-read hard-error warning printed `read returned -1`; GT's `Nrecv` returns `NET_HARDERROR=-2` (net.h:50) and `JSON_read` echoes that raw `rc` (iperf_api.c:3074). Fixed to `-2` (named const), pin corrected, live-confirmed.
2. **SHOULD-FIX** — recorded the close-type message flip as a deviation: GT's base key is not uniformly IERECVRESULTS — an RST makes `cleanup_server`'s best-effort `SERVER_ERROR` write fail, overwriting `i_errno` → IESENDMESSAGE (iperf_server_api.c:466-472). That message misdescribes the failure, so we keep the honest IERECVRESULTS surface for every close-type and file upstream. Corrected the false code comment.
3. NIT — tightened the strerror-tail deviation wording (GT's appended ENOTCONN is deterministic on Linux, not "stale").
4. NIT — fallible reserve for the results blob (`try_reserve_exact` → RecvResultsFailed silently, matching GT's `calloc`-NULL guard) so a hostile 4 GB length prefix can't abort the process.
5. NIT — recorded the idle-timeout deviation (per-read 10s reset = GT-BSD/macOS; GT-Linux decrements one `select` per Nread).
6. NIT — corrected GT line citations.
7. NIT — bumped the half-size-then-hold assert window 15s→20s for loaded CI.

All r2 fixes red-proven where pinnable (the `-2` literal). Full workspace gate green.

### r3 review
r3 verified all four r2 fixes correct + byte-exact warning strings + read-loop correctness, and caught a **Windows-CI blocker** r1/r2 missed: the two SO_LINGER(0) RST pins can't force an RST on Windows (clean FIN → EOF arm), so they're now `#[cfg(unix)]` (the arms are platform-independent Rust, exercised on every unix CI target). Non-unix stub dropped; two stale comment references corrected. r3's standing verdict: approve once Windows CI is green.
