### PR TITLE
fix(compat): unit_atof/unit_atof_rate fidelity for -w, -b, --fq-rate + -u -F reject (#334, #335)

### DIFF
--- a/riperf3-cli/src/cli.rs
+++ b/riperf3-cli/src/cli.rs
@@ -648,8 +648,17 @@ impl Cli {
             // #334: GT's -w is unit_atof (1024-based) → `(int) farg`
             // (iperf_api.c:1438-1452). The IEUNITVAL parse error and the
             // `> MAX_TCP_BUFFER` IEBUFSIZE check run pre-sink in main.rs; this
-            // maps the accepted double to the socket_bufsize int. A negative
-            // (via `-w -5`) casts straight through like GT's (int) farg.
+            // maps the accepted double to the socket_bufsize int. GT's cast is
+            // a DIRECT double→int32 (cvttsd2si), so `farg as i32` matches it
+            // exactly on every reachable value: `-w -5` → -5, and an
+            // out-of-i32-range negative (`-w -3G`) saturates to i32::MIN on
+            // both (GT's cvttsd2si also yields INT_MIN); positive overflow is
+            // unreachable (IEBUFSIZE catches anything > MAX_TCP_BUFFER first).
+            // RECORDED DEVIATION (unobservable): the sole literal that
+            // diverges is `-w nan` — `nan as i32` = 0, GT's `(int)nan` =
+            // INT_MIN. socket_bufsize is not a wire/output field and `-w nan`
+            // never connects, so the value is never observable; not worth a
+            // special-case for an absurd input.
             let farg = unit_atoi_os(s)?;
             builder = builder.window(farg as i32);
         }

--- a/riperf3-cli/src/cli.rs
+++ b/riperf3-cli/src/cli.rs
@@ -193,8 +193,13 @@ pub struct Cli {
     pub bidir: bool,
 
     /// Set socket buffer sizes (indirectly sets TCP window size)
-    #[arg(short = 'w', long, value_name = "size")]
-    pub window: Option<String>,
+    // #334: GT parses -w with unit_atof (iperf_api.c:1438-1452) — a 1024-based
+    // size returning a double, then `> MAX_TCP_BUFFER` (536870912) → IEBUFSIZE,
+    // else `(int) farg`. The IEUNITVAL/IEBUFSIZE surface runs pre-sink in
+    // main.rs; raw OsString so invalid-UTF-8 argv echoes byte-for-byte like GT.
+    // allow_hyphen: a negative casts straight through like GT's (int) farg.
+    #[arg(short = 'w', long, value_name = "size", allow_hyphen_values = true)]
+    pub window: Option<std::ffi::OsString>,
 
     /// Set TCP congestion control algorithm
     #[arg(short = 'C', long, value_name = "algo")]
@@ -212,8 +217,18 @@ pub struct Cli {
     pub no_delay: bool,
 
     /// Target bitrate in bits/sec (0 = unlimited; default: unlimited TCP, 1M UDP)
-    #[arg(short = 'b', long, value_name = "rate[/burst]")]
-    pub bitrate: Option<String>,
+    // #334: GT parses -b `rate[/burst]` (iperf_api.c:1347-1365) — slash-split
+    // FIRST: if a '/' is present, burst = atoi(after) with `<= 0 || >
+    // MAX_BURST` (1000) → IEBURST; THEN rate = unit_atof_rate(before)
+    // (1000-based) → IEUNITVAL. Both run pre-sink in main.rs. allow_hyphen: a
+    // negative rate wraps huge (iperf_size_t) and GT proceeds.
+    #[arg(
+        short = 'b',
+        long,
+        value_name = "rate[/burst]",
+        allow_hyphen_values = true
+    )]
+    pub bitrate: Option<std::ffi::OsString>,
 
     /// Set the IP type of service (0-255; decimal, 0x hex, or 0 octal)
     // String, parsed by the builder's `tos_str` with iperf3's strtol-base-0
@@ -290,8 +305,11 @@ pub struct Cli {
     pub bind_dev: Option<String>,
 
     /// Enable fair-queuing based socket pacing (bits/sec, Linux only)
-    #[arg(long, value_name = "rate")]
-    pub fq_rate: Option<String>,
+    // #334: GT parses --fq-rate with unit_atof_rate (iperf_api.c:1726-1737),
+    // 1000-based → IEUNITVAL pre-sink in main.rs. allow_hyphen: a negative rate
+    // wraps huge (iperf_size_t) and GT proceeds.
+    #[arg(long, value_name = "rate", allow_hyphen_values = true)]
+    pub fq_rate: Option<std::ffi::OsString>,
 
     /// Set the IPv6 flow label (Linux only)
     #[arg(short = 'L', long, value_name = "N")]
@@ -627,7 +645,13 @@ impl Cli {
             builder = builder.bidir(true);
         }
         if let Some(ref s) = self.window {
-            builder = builder.window_str(s)?;
+            // #334: GT's -w is unit_atof (1024-based) → `(int) farg`
+            // (iperf_api.c:1438-1452). The IEUNITVAL parse error and the
+            // `> MAX_TCP_BUFFER` IEBUFSIZE check run pre-sink in main.rs; this
+            // maps the accepted double to the socket_bufsize int. A negative
+            // (via `-w -5`) casts straight through like GT's (int) farg.
+            let farg = unit_atoi_os(s)?;
+            builder = builder.window(farg as i32);
         }
         if let Some(ref algo) = self.congestion {
             builder = builder.congestion(algo);
@@ -641,7 +665,26 @@ impl Cli {
             builder = builder.no_delay(true);
         }
         if let Some(ref s) = self.bitrate {
-            builder = builder.bandwidth_str(s)?;
+            // #334: GT's -b `rate[/burst]` (iperf_api.c:1347-1365) — burst =
+            // atoi(after the FIRST '/') then rate = unit_atof_rate(before),
+            // 1000-based. The IEBURST/IEUNITVAL surface is enforced pre-sink
+            // in main.rs; here we wire the resolved rate (iperf_size_t) and
+            // burst. A negative rate wraps huge via c_double_to_u64 like GT.
+            let (rate, burst) = split_rate_interval(s);
+            let bps = unit_atof_rate_like_bytes(rate).map_err(|()| {
+                format!(
+                    "invalid unit value or suffix: '{}'",
+                    String::from_utf8_lossy(rate)
+                )
+            })?;
+            builder = builder.bandwidth(c_double_to_u64(bps));
+            if let Some(burst) = burst {
+                // The IEBURST range (1..=1000) is enforced pre-sink; a direct
+                // caller's out-of-range burst folds through u32, and the lib's
+                // build() re-checks `> MAX_BURST` for those callers.
+                let n = atoi_like_bytes(burst);
+                builder = builder.burst(u32::try_from(n).unwrap_or(0));
+            }
         }
         if let Some(ref s) = self.tos {
             builder = builder.tos_str(s)?;
@@ -720,7 +763,12 @@ impl Cli {
             builder = builder.bind_dev(dev);
         }
         if let Some(ref s) = self.fq_rate {
-            builder = builder.fq_rate_str(s)?;
+            // #334: GT's --fq-rate is unit_atof_rate (1000-based),
+            // iperf_api.c:1728 → IEUNITVAL pre-sink in main.rs; wire the
+            // resolved rate (iperf_size_t). A negative wraps huge like GT.
+            let bps = unit_atof_rate_like_bytes(s.as_encoded_bytes())
+                .map_err(|()| format!("invalid unit value or suffix: '{}'", s.to_string_lossy()))?;
+            builder = builder.fq_rate(c_double_to_u64(bps));
         }
         if let Some(label) = self.flowlabel {
             builder = builder.flowlabel(label);
@@ -1455,7 +1503,7 @@ mod cli_tests {
             assert!(cli.bidir);
             assert!(cli.no_delay);
             assert_eq!(cli.length, Some("1460".into()));
-            assert_eq!(cli.bitrate, Some("100M".to_string()));
+            assert_eq!(cli.bitrate, Some("100M".into()));
         }
 
         #[test]
@@ -1472,7 +1520,7 @@ mod cli_tests {
             let cli = Cli::parse_from([
                 "riperf3", "-c", "host", "-w", "512K", "-M", "1400", "-C", "bbr",
             ]);
-            assert_eq!(cli.window, Some("512K".to_string()));
+            assert_eq!(cli.window, Some("512K".into()));
             assert_eq!(cli.mss, Some(1400));
             assert_eq!(cli.congestion, Some("bbr".to_string()));
         }

--- a/riperf3-cli/src/main.rs
+++ b/riperf3-cli/src/main.rs
@@ -217,6 +217,14 @@ fn main() -> std::process::ExitCode {
     // client-only flag's bad value beats IECLIENTONLY (live-probed:
     // `-s -b abc` is IEUNITVAL, not client-only). GT echoes the RAW argv
     // bytes in the IEUNITVAL quotes, so those lines are written byte-for-byte.
+    //
+    // RECORDED DEVIATION (systemic, shared with the #328/#270 pre-sinks):
+    // clap fully parses argv before we see it, erasing option order, so
+    // these checks run in FIXED field order (w, then b, then --fq-rate),
+    // not getopt/argv order. With TWO simultaneously-invalid unit flags GT
+    // reports the argv-first one and we report the field-first one — same
+    // class (IEUNITVAL) and exit (1), only the quoted errarg differs. A
+    // single bad flag (the realistic case) is byte-identical.
 
     // -w/--window (iperf_api.c:1438-1452): unit_atof (1024-based) → IEUNITVAL,
     // then `farg > (double) MAX_TCP_BUFFER` (512*MB = 536870912) → IEBUFSIZE,

--- a/riperf3-cli/src/main.rs
+++ b/riperf3-cli/src/main.rs
@@ -212,6 +212,68 @@ fn main() -> std::process::ExitCode {
         }
     }
 
+    // #334: -w/-b/--fq-rate wire through GT's unit parsers with their own
+    // error classes, all in-loop — BEFORE the post-loop role checks, so a
+    // client-only flag's bad value beats IECLIENTONLY (live-probed:
+    // `-s -b abc` is IEUNITVAL, not client-only). GT echoes the RAW argv
+    // bytes in the IEUNITVAL quotes, so those lines are written byte-for-byte.
+
+    // -w/--window (iperf_api.c:1438-1452): unit_atof (1024-based) → IEUNITVAL,
+    // then `farg > (double) MAX_TCP_BUFFER` (512*MB = 536870912) → IEBUFSIZE,
+    // else `(int) farg`.
+    const MAX_TCP_BUFFER: f64 = 536_870_912.0;
+    if let Some(spec) = cli.window.as_deref() {
+        match cli::unit_atoi_like_bytes(spec.as_encoded_bytes()) {
+            Err(()) => {
+                print_unit_val_error(spec.as_encoded_bytes());
+                return std::process::ExitCode::FAILURE;
+            }
+            Ok(farg) if farg > MAX_TCP_BUFFER => {
+                eprintln!(
+                    "riperf3: parameter error - socket buffer size too large \
+                     (maximum = 536870912 bytes)"
+                );
+                print_usage_trailer();
+                return std::process::ExitCode::FAILURE;
+            }
+            Ok(_) => {}
+        }
+    }
+
+    // -b/--bitrate (iperf_api.c:1347-1365): slash-split FIRST — if a '/' is
+    // present, burst = atoi(after) with `<= 0 || > MAX_BURST` (1000) →
+    // IEBURST; THEN rate = unit_atof_rate(before) → IEUNITVAL. The burst
+    // check precedes the rate parse (GT's code order), and the IEUNITVAL
+    // errarg is the RATE part only (the slash was NUL'd).
+    const MAX_BURST: i64 = 1000;
+    if let Some(spec) = cli.bitrate.as_deref() {
+        let (rate, burst) = cli::split_rate_interval(spec);
+        if let Some(burst) = burst {
+            let n = cli::atoi_like_bytes(burst);
+            if n <= 0 || n > MAX_BURST {
+                eprintln!("riperf3: parameter error - invalid burst count (maximum = 1000)");
+                print_usage_trailer();
+                return std::process::ExitCode::FAILURE;
+            }
+        }
+        if cli::unit_atof_rate_like_bytes(rate).is_err() {
+            print_unit_val_error(rate);
+            return std::process::ExitCode::FAILURE;
+        }
+    }
+
+    // --fq-rate (iperf_api.c:1726-1737): unit_atof_rate (1000-based) →
+    // IEUNITVAL. (GT gates the whole case on HAVE_SO_MAX_PACING_RATE, else
+    // IEUNIMP; riperf3 applies fq-pacing best-effort on every platform, so it
+    // validates the value uniformly — this is the value class the Linux
+    // reference reaches.)
+    if let Some(spec) = cli.fq_rate.as_deref() {
+        if cli::unit_atof_rate_like_bytes(spec.as_encoded_bytes()).is_err() {
+            print_unit_val_error(spec.as_encoded_bytes());
+            return std::process::ExitCode::FAILURE;
+        }
+    }
+
     if let Some(msg) = parse_class_rejection(&cli) {
         // #270: GT routes the parse-error class through 'parameter error - '
         // with the usage trailer (live-probed for all three classes here:
@@ -358,6 +420,17 @@ fn parse_class_rejection(cli: &Cli) -> Option<String> {
         // part of the live-probed line (errno 0 at parse time).
         if cli.rcv_timeout.is_some() && !cli.reverse && !cli.bidir {
             return Some("client receive timeout is valid only in receiving mode: ".to_string());
+        }
+        // #335: GT rejects `-F` under UDP with IEUDPFILETRANSFER
+        // (iperf_api.c:1919-1923) — a UDP datagram carries its own header
+        // (packet number, etc.), so a file transfer can't ride it. This sits
+        // AFTER the rvrs-rcv-timeout leg (:1880) and BEFORE the blksize block
+        // (:1926) in GT's post-loop, so it BEATS the -l/blksize rejection
+        // below (live-probed: `-u -F x -l 70000` is IEUDPFILETRANSFER, not
+        // IEUDPBLOCKSIZE). `-u` is client-only, so on a server it takes
+        // IECLIENTONLY first — this leg only matters for a client.
+        if cli.file.is_some() && cli.udp {
+            return Some("cannot transfer file using UDP".to_string());
         }
         // #328 (r1 F1): GT's -l range checks sit BETWEEN the rvrs-rcv check
         // (:1881) and the end-conditions check (:1992) in the parse

--- a/riperf3-cli/tests/error_format.rs
+++ b/riperf3-cli/tests/error_format.rs
@@ -1062,3 +1062,164 @@ fn debug_level_parses_like_atoi() {
         );
     }
 }
+
+// ---------------------------------------------------------------------------
+// #334: -w (unit_atof, 1024-based), -b (rate[/burst], unit_atof_rate +
+// atoi), and --fq-rate (unit_atof_rate) wire through GT's own unit parsers
+// with GT's error classes (IEUNITVAL / IEBUFSIZE / IEBURST), all in-loop —
+// before the post-loop client-only role check. Every expectation below was
+// live-probed against iperf 3.21.
+// ---------------------------------------------------------------------------
+
+/// #334: the accept surface — every GT-accepted form parses and the run
+/// proceeds to CONNECT (dead port 9), never a parse error. Live-probed:
+/// `-w 10Kx` (K scales, trailing x ignored, = 10240), `-w 512K`, `-b 1Mx`
+/// (rate 1M, x ignored), `-b 100M`, `-b 10M/5` (burst 5), `--fq-rate 1Mx`,
+/// `--fq-rate 1M`. riperf3 previously rejected the `x`-suffixed forms with
+/// clap's "invalid value for number".
+#[test]
+fn unit_atof_family_accept_gt_forms_and_proceed() {
+    for args in [
+        &["-w", "10Kx"][..],
+        &["-w", "512K"][..],
+        &["-b", "1Mx"][..],
+        &["-b", "100M"][..],
+        &["-b", "10M/5"][..],
+        &["--fq-rate", "1Mx"][..],
+        &["--fq-rate", "1M"][..],
+    ] {
+        let out = std::process::Command::new(env!("CARGO_BIN_EXE_riperf3"))
+            .args(["-c", "127.0.0.1", "-p", "9"])
+            .args(args)
+            .output()
+            .expect("spawn riperf3");
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        assert!(
+            stderr.contains("unable to connect")
+                && !stderr.contains("parameter error")
+                && !stderr.contains("error: invalid value")
+                && !stderr.contains("invalid value for number"),
+            "{args:?} parses via GT's unit semantics and proceeds: {stderr}"
+        );
+    }
+}
+
+/// #334: the reject surface — GT's exact sentences + usage trailer + exit 1
+/// (live-probed). -w: unit_atof (iperf_api.c:1438-1452) → IEUNITVAL on a bad
+/// unit, then `> MAX_TCP_BUFFER` (536870912) → IEBUFSIZE (`-w 1G` is
+/// 1073741824). -b: slash-split FIRST (iperf_api.c:1347-1365) — burst =
+/// atoi(after) with `<= 0 || > MAX_BURST` (1000) → IEBURST, checked BEFORE
+/// the rate's unit_atof_rate → IEUNITVAL (so `-b abc/0` is IEBURST, not
+/// IEUNITVAL); the IEUNITVAL errarg is the RATE part (before the slash).
+/// --fq-rate: unit_atof_rate (iperf_api.c:1726-1737) → IEUNITVAL.
+#[test]
+fn unit_atof_family_reject_bad_values_with_gt_classes() {
+    let cases: &[(&[&str], &str)] = &[
+        (
+            &["-c", "127.0.0.1", "-w", "abc"],
+            "parameter error - invalid unit value or suffix: 'abc'",
+        ),
+        (
+            &["-c", "127.0.0.1", "-w", "1G"],
+            "parameter error - socket buffer size too large (maximum = 536870912 bytes)",
+        ),
+        (
+            &["-c", "127.0.0.1", "-b", "abc"],
+            "parameter error - invalid unit value or suffix: 'abc'",
+        ),
+        (
+            &["-c", "127.0.0.1", "-b", "10M/0"],
+            "parameter error - invalid burst count (maximum = 1000)",
+        ),
+        (
+            &["-c", "127.0.0.1", "-b", "10M/1001"],
+            "parameter error - invalid burst count (maximum = 1000)",
+        ),
+        // Burst check precedes the rate parse (GT's code order): a bad rate
+        // WITH a bad burst reports IEBURST, and the IEUNITVAL errarg on a
+        // sliced spec is the rate part only.
+        (
+            &["-c", "127.0.0.1", "-b", "abc/0"],
+            "parameter error - invalid burst count (maximum = 1000)",
+        ),
+        (
+            &["-c", "127.0.0.1", "-b", "abc/5"],
+            "parameter error - invalid unit value or suffix: 'abc'",
+        ),
+        (
+            &["-c", "127.0.0.1", "--fq-rate", "abc"],
+            "parameter error - invalid unit value or suffix: 'abc'",
+        ),
+        // In-loop value parse beats the post-loop client-only role check:
+        // `-s -b abc` is IEUNITVAL, not IECLIENTONLY (live-probed).
+        (
+            &["-s", "-b", "abc"],
+            "parameter error - invalid unit value or suffix: 'abc'",
+        ),
+    ];
+    for (args, want) in cases {
+        let out = std::process::Command::new(env!("CARGO_BIN_EXE_riperf3"))
+            .args(*args)
+            .output()
+            .expect("spawn riperf3");
+        assert_eq!(out.status.code(), Some(1), "{args:?} exits 1 like GT");
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        assert!(
+            stderr.starts_with(&format!("riperf3: {want}")),
+            "{args:?}: GT wording expected, got: {stderr}"
+        );
+        assert!(
+            stderr.contains("Usage:") && stderr.contains("--help"),
+            "the usage trailer rides parameter errors (GT shape): {stderr}"
+        );
+    }
+}
+
+/// #335: GT rejects `-F <file>` with UDP (`-u`) via IEUDPFILETRANSFER
+/// (iperf_api.c:1919-1923; iperf_error.c:396-397) — `cannot transfer file
+/// using UDP`, a UDP datagram carries its own header so a file can't ride
+/// it. Placement is load-bearing: the check sits AFTER the reverse-only
+/// rcv-timeout leg and BEFORE the blksize block in GT's post-loop, so it
+/// BEATS the -l range rejection. Live-probed: `-u -F x -l 70000` is
+/// IEUDPFILETRANSFER, NOT IEUDPBLOCKSIZE (riperf3's -l check used to win).
+#[test]
+fn udp_file_transfer_rejects_before_blocksize() {
+    let cases: &[&[&str]] = &[
+        &["-c", "127.0.0.1", "-u", "-F", "x"],
+        // The load-bearing ordering cell: a UDP block size that would trip
+        // IEUDPBLOCKSIZE must still report IEUDPFILETRANSFER first.
+        &["-c", "127.0.0.1", "-u", "-F", "x", "-l", "70000"],
+    ];
+    for args in cases {
+        let out = std::process::Command::new(env!("CARGO_BIN_EXE_riperf3"))
+            .args(*args)
+            .output()
+            .expect("spawn riperf3");
+        assert_eq!(out.status.code(), Some(1), "{args:?} exits 1 like GT");
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        assert!(
+            stderr.starts_with("riperf3: parameter error - cannot transfer file using UDP"),
+            "{args:?}: IEUDPFILETRANSFER expected (before the blksize block), got: {stderr}"
+        );
+        assert!(
+            stderr.contains("Usage:") && stderr.contains("--help"),
+            "the usage trailer rides parameter errors: {stderr}"
+        );
+    }
+    // TCP `-F` is fine (no UDP), and UDP without `-F` is fine — neither trips
+    // IEUDPFILETRANSFER (they fail later, on connect).
+    for args in [
+        &["-c", "127.0.0.1", "-p", "9", "-F", "/dev/null"][..],
+        &["-c", "127.0.0.1", "-p", "9", "-u"][..],
+    ] {
+        let out = std::process::Command::new(env!("CARGO_BIN_EXE_riperf3"))
+            .args(args)
+            .output()
+            .expect("spawn riperf3");
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        assert!(
+            !stderr.contains("cannot transfer file using UDP"),
+            "{args:?} must not trip IEUDPFILETRANSFER: {stderr}"
+        );
+    }
+}


### PR DESCRIPTION
Wires `-w`, `-b`, and `--fq-rate` through GT's own unit parsers with GT's exact error classes, and makes `-u -F <file>` reject like GT. Both issues land as one PR; the CLI-boundary pattern mirrors the existing `--server-bitrate-limit` handling (`OsString` field → parse pre-sink in `main.rs` / `build_client` → resolved number into a lib numeric setter). No clap in the lib.

## #334 — `-w` / `-b` / `--fq-rate` fidelity

The three fields become `Option<OsString>` (raw non-UTF-8 argv handled like GT), parsed pre-sink in `main.rs` with GT's classes, all **in-loop** — i.e. before the post-loop role checks, so a client-only flag's bad value beats `IECLIENTONLY`.

GT source:
- **`-w/--window`** (`iperf_api.c:1438-1452`, `iperf.h:464`): `farg = unit_atof(optarg)` (1024-based) → `IEUNITVAL`; then `farg > MAX_TCP_BUFFER` (`512*MB` = 536870912) → `IEBUFSIZE`; else `(int) farg`.
- **`-b/--bitrate`** (`iperf_api.c:1347-1365`, `iperf.h:474`): slash-split FIRST. With a `/`: `burst = atoi(after)`, `burst <= 0 || burst > MAX_BURST` (1000) → `IEBURST`. THEN `rate = unit_atof_rate(before)` (1000-based) → `IEUNITVAL`. Burst check precedes the rate parse; the `IEUNITVAL` errarg is the rate part only.
- **`--fq-rate`** (`iperf_api.c:1726-1737`): `unit_atof_rate(optarg)` → `IEUNITVAL`.

Reused the GT-validated parsers already in `cli.rs`: `unit_atoi_like_bytes` (`unit_atof`, for `-w`), `unit_atof_rate_like_bytes` (`unit_atof_rate`, for `-b` rate + `--fq-rate`), `atoi_like_bytes` (`atoi`, for `-b` burst), and `split_rate_interval` (first-`/` split). Error rendering reuses the existing `print_unit_val_error` / usage-trailer path, identical to the other `IEUNITVAL` flags.

Pinned live cells (iperf 3.21):
- `-w 10Kx` → proceeds (K scales, trailing x ignored); `-w 512K` → ok; `-w 1G` → `IEBUFSIZE`; `-w abc` → `IEUNITVAL`.
- `-b 1Mx` → proceeds; `-b 100M` → ok; `-b 10M/5` → ok (burst 5); `-b abc` → `IEUNITVAL 'abc'`; `-b 10M/0` and `-b 10M/1001` → `IEBURST`; `-b abc/0` → `IEBURST` (burst before rate); `-b abc/5` → `IEUNITVAL 'abc'` (errarg = rate part).
- `--fq-rate 1Mx` → proceeds; `--fq-rate 1M` → ok; `--fq-rate abc` → `IEUNITVAL`.
- `-s -b abc` → `IEUNITVAL`, not `IECLIENTONLY` (in-loop beats the post-loop role check).

This fixes riperf3 previously rejecting `10Kx`/`1Mx` with clap's "invalid value for number", mis-classing `abc`, and silently accepting `-w 1G` (no `IEBUFSIZE`).

## #335 — `-u -F <file>` → `IEUDPFILETRANSFER`

GT (`iperf_api.c:1919-1923`, `iperf_error.c:396-397`): `diskfile_name != 0 && protocol == Pudp` → `IEUDPFILETRANSFER`, text `cannot transfer file using UDP` (no `perr`, so no trailing colon). Placement is load-bearing: it sits AFTER the reverse-only rcv-timeout leg and BEFORE the blksize block. Added at the GT-faithful slot in `parse_class_rejection` — before the `-l`/blksize rejection — so it wins:

- `-u -F x -l 70000` → `IEUDPFILETRANSFER`, not `IEUDPBLOCKSIZE` (riperf3's `-l` check used to fire first).

`-u` is client-only, so on a server it takes `IECLIENTONLY` first; this leg only matters for a client (matching GT's comment that Pudp here implies the client side).

## Deviations

- `-w`/`-b`/`--fq-rate` take `allow_hyphen_values` so GT's accepted negatives (which wrap huge via `iperf_size_t` / cast straight through `(int) farg` and proceed) aren't rejected by clap. Consistent with `-n`/`-l`/`--server-bitrate-limit`.
- `--fq-rate`: GT gates the whole case on `HAVE_SO_MAX_PACING_RATE` (else `IEUNIMP`). riperf3 already applies fq-pacing best-effort on every platform, so it validates the value uniformly — this is the value class the Linux reference reaches. Pre-existing accept-everywhere stance preserved.
- The lib keeps its `window_str`/`bandwidth_str`/`fq_rate_str` convenience methods for embedders (unchanged); the CLI now uses the numeric setters + `cli.rs` parsing, same split as `-n`/`-k`/`-l`.

## Tests

New in `riperf3-cli/tests/error_format.rs`:
- `unit_atof_family_accept_gt_forms_and_proceed` — the accept surface.
- `unit_atof_family_reject_bad_values_with_gt_classes` — `IEUNITVAL`/`IEBUFSIZE`/`IEBURST` sentences + trailer + exit 1, incl. burst-before-rate ordering and the `-s -b abc` in-loop-beats-role cell.
- `udp_file_transfer_rejects_before_blocksize` — `IEUDPFILETRANSFER` incl. the load-bearing `-l 70000` ordering cell, plus TCP-`-F`/UDP-no-`-F` negatives.

TDD (red first), then each new arm red-proofed (revert arm → specific cell goes red → restore), including the #335 placement (relocating it below the `-l` block flips the `-l 70000` cell to `IEUDPBLOCKSIZE`).

Gate: `cargo clippy --workspace --all-targets -- -D warnings` clean, `cargo fmt --check` clean, `cargo test --workspace` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014cFED59mYjR6nUcepyiq4n
