### PR TITLE
fix(compat): server pre-test errors take GT's iperf_err sink shape (#330)

### DIFF
--- a/riperf3-cli/tests/wire_shape.rs
+++ b/riperf3-cli/tests/wire_shape.rs
@@ -1469,10 +1469,19 @@ fn pretest_error_line_carries_the_timestamps_prefix() {
             .expect("server exits");
     assert!(status.success(), "one-off exits 0 like GT");
     let serr = serr_reader.join().expect("stderr");
+    let suffix = format!("riperf3: error - {RECV_COOKIE_MSG}: \n");
+    assert!(
+        serr.ends_with(&suffix) && serr.len() > suffix.len(),
+        "a nonempty timestamp prefix precedes the iperf_err line: {serr:?}"
+    );
+    // Unix renders the literal strftime format verbatim; Windows uses the
+    // documented HH:MM:SS fallback (macros.rs render_timestamp) and ignores
+    // the format, so the byte-exact pin is unix-only.
+    #[cfg(unix)]
     assert_eq!(
         serr,
-        format!("XTSX riperf3: error - {RECV_COOKIE_MSG}: \n"),
-        "iperf_err's stderr line carries the timestamp prefix: {serr:?}"
+        format!("XTSX {suffix}"),
+        "the literal format renders verbatim: {serr:?}"
     );
 }
 

--- a/riperf3-cli/tests/wire_shape.rs
+++ b/riperf3-cli/tests/wire_shape.rs
@@ -1349,6 +1349,133 @@ fn cookie_failure_wire_back_is_server_error_ierecvcookie() {
     assert!(status.success());
 }
 
+/// #339 r2b F1: GT bounds EVERY Nread (net.c:75-76) — the cookie read
+/// included; iperf_server_api.c:194-200's own comment names the timeout case
+/// ("the inability to read the correct amount of data (i.e. timed out)"),
+/// and live GT self-recovers from a connect-and-hold peer in ~20 s with the
+/// IERECVCOOKIE surface. Unbounded, riperf3's serial serve loop parked
+/// forever behind one hostile peer.
+#[test]
+fn pretest_cookie_hold_exits_bounded_with_ierecvcookie() {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind");
+    let port = listener.local_addr().unwrap().port();
+    drop(listener);
+    let port_s = port.to_string();
+
+    let mut server = common::ChildGuard(
+        std::process::Command::new(env!("CARGO_BIN_EXE_riperf3"))
+            .args(["-s", "-1", "-p", &port_s])
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::piped())
+            .spawn()
+            .expect("spawn server"),
+    );
+    let serr_reader =
+        riperf3_test_support::drain_reader(server.0.stderr.take().expect("piped stderr"));
+    std::thread::sleep(std::time::Duration::from_millis(400));
+
+    // Detached holder: connects and sends NOTHING. The server must not wait
+    // for it (the thread outlives the assert; the process exit reaps it).
+    std::thread::spawn(move || {
+        let ctrl = std::net::TcpStream::connect(("127.0.0.1", port)).expect("ctrl");
+        std::thread::sleep(std::time::Duration::from_secs(40));
+        drop(ctrl);
+    });
+
+    // The 10 s idle bound fires; the 20 s assert window leaves slack for a
+    // loaded 2-core CI runner (the exchange_half_size hold precedent).
+    let status =
+        riperf3_test_support::wait_bounded(&mut server.0, std::time::Duration::from_secs(20))
+            .expect("server exits on GT's read bound while the peer holds");
+    assert!(status.success(), "one-off exits 0 like GT");
+    let serr = serr_reader.join().expect("stderr");
+    assert_eq!(
+        serr,
+        format!("riperf3: error - {RECV_COOKIE_MSG}: \n"),
+        "the bounded cookie read takes the IERECVCOOKIE surface: {serr:?}"
+    );
+}
+
+/// #339 r2b F1, params half: full cookie, then 2 of the 4 length-prefix
+/// bytes and a HOLD. GT's get_parameters Nread times out and IERECVPARAMS
+/// renders; riperf3 previously parked in the unbounded json_read.
+#[test]
+fn pretest_params_hold_exits_bounded_with_ierecvparams() {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind");
+    let port = listener.local_addr().unwrap().port();
+    drop(listener);
+    let port_s = port.to_string();
+
+    let mut server = common::ChildGuard(
+        std::process::Command::new(env!("CARGO_BIN_EXE_riperf3"))
+            .args(["-s", "-1", "-p", &port_s])
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::piped())
+            .spawn()
+            .expect("spawn server"),
+    );
+    let serr_reader =
+        riperf3_test_support::drain_reader(server.0.stderr.take().expect("piped stderr"));
+    std::thread::sleep(std::time::Duration::from_millis(400));
+
+    std::thread::spawn(move || {
+        let mut ctrl = std::net::TcpStream::connect(("127.0.0.1", port)).expect("ctrl");
+        ctrl.write_all(&[b'x'; 37]).unwrap();
+        assert_eq!(read_exact(&mut ctrl, 1)[0], 9, "ParamExchange");
+        ctrl.write_all(&[0u8, 0u8]).unwrap(); // 2 of 4 size bytes, then HOLD
+        std::thread::sleep(std::time::Duration::from_secs(40));
+        drop(ctrl);
+    });
+
+    let status =
+        riperf3_test_support::wait_bounded(&mut server.0, std::time::Duration::from_secs(20))
+            .expect("server exits on GT's read bound while the peer holds");
+    assert!(status.success(), "one-off exits 0 like GT");
+    let serr = serr_reader.join().expect("stderr");
+    assert_eq!(
+        serr,
+        format!("riperf3: error - {RECV_PARAMS_MSG}: \n"),
+        "the bounded params read takes the IERECVPARAMS surface: {serr:?}"
+    );
+}
+
+/// #339 r2b F2: iperf_err prefixes its stderr line with the --timestamps
+/// stamp (iperf_error.c:51-57, :77) — the pre-test emit site must ride the
+/// same output_timestamp_prefix() the stdout banner does. A literal strftime
+/// format keeps the pin deterministic (formats pass through verbatim, #202).
+#[test]
+fn pretest_error_line_carries_the_timestamps_prefix() {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind");
+    let port = listener.local_addr().unwrap().port();
+    drop(listener);
+    let port_s = port.to_string();
+
+    let mut server = common::ChildGuard(
+        std::process::Command::new(env!("CARGO_BIN_EXE_riperf3"))
+            .args(["-s", "-1", "-p", &port_s, "--timestamps=XTSX "])
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::piped())
+            .spawn()
+            .expect("spawn server"),
+    );
+    let serr_reader =
+        riperf3_test_support::drain_reader(server.0.stderr.take().expect("piped stderr"));
+    std::thread::sleep(std::time::Duration::from_millis(400));
+
+    let mock = std::thread::spawn(move || drive_cookie_failure(port));
+    mock.join().expect("mock");
+    let status =
+        riperf3_test_support::wait_bounded(&mut server.0, std::time::Duration::from_secs(5))
+            .expect("server exits");
+    assert!(status.success(), "one-off exits 0 like GT");
+    let serr = serr_reader.join().expect("stderr");
+    assert_eq!(
+        serr,
+        format!("XTSX riperf3: error - {RECV_COOKIE_MSG}: \n"),
+        "iperf_err's stderr line carries the timestamp prefix: {serr:?}"
+    );
+}
+
 // ---------------------------------------------------------------------------
 // #330 (r1 F1): the serve loop's RESIDUAL generic Err arm rides the same
 // iperf_err sink. A #188-class validation rejection (valid JSON that

--- a/riperf3-cli/tests/wire_shape.rs
+++ b/riperf3-cli/tests/wire_shape.rs
@@ -1321,3 +1321,90 @@ fn param_failure_wire_back_is_server_error_ierecvparams() {
     });
     assert!(status.success());
 }
+
+/// r1 F2 / M4: the cookie-path SERVER_ERROR wire-back i_errno (106). The two
+/// cookie tests above close before reading it; here the mock half-closes its
+/// write side (a FIN so the server's cookie read EOFs) but keeps the read side
+/// open, so it can observe the wire-back bytes.
+#[test]
+fn cookie_failure_wire_back_is_server_error_ierecvcookie() {
+    let (_sout, _serr, status) = drive_server_scenario(false, |port| {
+        let mut ctrl = std::net::TcpStream::connect(("127.0.0.1", port)).expect("ctrl");
+        ctrl.set_read_timeout(Some(Duration::from_secs(5))).unwrap();
+        ctrl.write_all(b"short").unwrap(); // < 37 cookie bytes
+        ctrl.shutdown(std::net::Shutdown::Write).unwrap(); // FIN, keep read open
+        let back = read_exact(&mut ctrl, 9);
+        assert_eq!(back[0], 0xfe, "SERVER_ERROR state (-2): {back:?}");
+        assert_eq!(
+            u32::from_be_bytes(back[1..5].try_into().unwrap()),
+            106,
+            "IERECVCOOKIE i_errno"
+        );
+        assert_eq!(
+            u32::from_be_bytes(back[5..9].try_into().unwrap()),
+            0,
+            "honest errno 0"
+        );
+    });
+    assert!(status.success());
+}
+
+// ---------------------------------------------------------------------------
+// #330 (r1 F1): the serve loop's RESIDUAL generic Err arm rides the same
+// iperf_err sink. A #188-class validation rejection (valid JSON that
+// deserializes but fails config derivation — a negative block size) reaches
+// that arm; under -J it must be silent on stderr with the message in a
+// skeleton doc, not the raw stderr line GT never emits in JSON mode. The
+// wording is riperf3's own #188 deviation (not a GT class), so the pin is on
+// the SINK SHAPE.
+// ---------------------------------------------------------------------------
+
+/// Valid JSON, deserializes, but `len: -5` fails config derivation (#188).
+const GENERIC_ARM_PARAMS: &str = r#"{"tcp":true,"omit":0,"time":1,"num":0,"blockcount":0,"parallel":1,"len":-5,"pacing_timer":1000,"client_version":"riperf3 0.0.0"}"#;
+
+fn drive_generic_arm_failure(port: u16) {
+    let mut ctrl = std::net::TcpStream::connect(("127.0.0.1", port)).expect("ctrl");
+    ctrl.write_all(&[b'x'; 37]).unwrap();
+    assert_eq!(read_exact(&mut ctrl, 1)[0], 9, "ParamExchange");
+    write_json_blob(&mut ctrl, GENERIC_ARM_PARAMS);
+    std::thread::sleep(std::time::Duration::from_millis(400));
+}
+
+#[test]
+fn generic_arm_failure_text_prints_one_error_line() {
+    let (_sout, serr, status) = drive_server_scenario(false, drive_generic_arm_failure);
+    assert!(
+        serr.starts_with("riperf3: error - ") && serr.lines().count() == 1,
+        "one iperf_err text line: {serr:?}"
+    );
+    assert!(
+        status.success(),
+        "one-off server exits 0 after a rejected test"
+    );
+}
+
+#[test]
+fn generic_arm_failure_json_is_silent_stderr_with_skeleton_doc() {
+    let (sout, serr, status) = drive_server_scenario(true, drive_generic_arm_failure);
+    assert!(
+        serr.trim().is_empty(),
+        "-J routes the residual error to the doc, not stderr: {serr:?}"
+    );
+    let doc: serde_json::Value =
+        serde_json::from_str(sout.trim()).unwrap_or_else(|e| panic!("one -J doc ({e}): {sout}"));
+    assert!(
+        doc["error"]
+            .as_str()
+            .is_some_and(|e| e.starts_with("error - ")),
+        "the skeleton doc carries the error key: {doc}"
+    );
+    assert!(
+        doc["intervals"].as_array().expect("intervals").is_empty(),
+        "skeleton intervals:[]"
+    );
+    assert!(
+        doc["end"].as_object().expect("end").is_empty(),
+        "skeleton bare end{{}}"
+    );
+    assert!(status.success());
+}

--- a/riperf3-cli/tests/wire_shape.rs
+++ b/riperf3-cli/tests/wire_shape.rs
@@ -160,6 +160,19 @@ fn run_scenario_full(
     mid_test: bool,
     params: &'static str,
 ) -> (String, String, std::process::ExitStatus) {
+    drive_server_scenario(json, move |port| {
+        drive_mock_round_full(port, final_action, mid_test, params)
+    })
+}
+
+/// Spawn a one-off (`-s -1`) server, run an arbitrary `mock` against it on the
+/// bound port, and capture `(stdout, stderr, exit status)`. The shared spawn
+/// body for [`run_scenario_full`] and the #330 pre-test-error scenarios (which
+/// drive a mock that never reaches a real test).
+fn drive_server_scenario(
+    json: bool,
+    mock: impl FnOnce(u16) + Send + 'static,
+) -> (String, String, std::process::ExitStatus) {
     let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind");
     let port = listener.local_addr().unwrap().port();
     drop(listener);
@@ -183,8 +196,7 @@ fn run_scenario_full(
         riperf3_test_support::drain_reader(server.0.stderr.take().expect("piped stderr"));
     std::thread::sleep(std::time::Duration::from_millis(400));
 
-    let mock =
-        std::thread::spawn(move || drive_mock_round_full(port, final_action, mid_test, params));
+    let mock = std::thread::spawn(move || mock(port));
     mock.join().expect("mock");
     let status =
         riperf3_test_support::wait_bounded(&mut server.0, std::time::Duration::from_secs(5))
@@ -1164,4 +1176,148 @@ fn client_state_wait_unknown_byte_takes_gt_iemessage() {
         "GT's client IEMESSAGE line"
     );
     assert_eq!(client.status.code(), Some(1), "GT's client errexits 1");
+}
+
+// ---------------------------------------------------------------------------
+// #330: the pre-test SERVER generic-error surface (cookie + params).
+//
+// GT 3.21 live-probed: a control-connection that fails the cookie read or the
+// param read/parse errors out through iperf_err's json sink — silent stderr
+// under -J with the message in a SKELETON accumulated doc, one stderr line in
+// text — plus a best-effort SERVER_ERROR(-2) + (i_errno, errno) wire-back via
+// cleanup_server. One-off servers keep exit 0. riperf3 previously surfaced the
+// raw "early eof" / serde class on stderr with no -J doc at all.
+// ---------------------------------------------------------------------------
+
+/// IERECVCOOKIE(106) — iperf_error.c: "unable to receive cookie at server".
+const RECV_COOKIE_MSG: &str = "unable to receive cookie at server";
+/// IERECVPARAMS(114) — iperf_error.c: "unable to receive parameters from client".
+const RECV_PARAMS_MSG: &str = "unable to receive parameters from client";
+
+/// Cookie failure: connect, send a truncated cookie, then EOF. GT's
+/// iperf_accept read fails -> IERECVCOOKIE.
+fn drive_cookie_failure(port: u16) {
+    let mut ctrl = std::net::TcpStream::connect(("127.0.0.1", port)).expect("ctrl");
+    ctrl.write_all(b"short").unwrap(); // < 37 cookie bytes, then close
+    drop(ctrl);
+    std::thread::sleep(std::time::Duration::from_millis(400));
+}
+
+/// Params failure: full cookie, read ParamExchange(9), then send a
+/// length-prefixed blob that is not valid JSON. GT's get_parameters ->
+/// JSON_read cJSON_Parse fails -> IERECVPARAMS.
+fn drive_param_failure(port: u16) {
+    let mut ctrl = std::net::TcpStream::connect(("127.0.0.1", port)).expect("ctrl");
+    ctrl.write_all(&[b'x'; 37]).unwrap();
+    assert_eq!(read_exact(&mut ctrl, 1)[0], 9, "ParamExchange");
+    write_json_blob(&mut ctrl, "this is not json");
+    std::thread::sleep(std::time::Duration::from_millis(400));
+}
+
+#[test]
+fn cookie_failure_text_prints_the_ierecvcookie_line() {
+    let (_sout, serr, status) = drive_server_scenario(false, drive_cookie_failure);
+    // The #248 perr dangling ": " at errno 0 — GT's honest form (its own
+    // stale-errno strerror is a recorded deviation, like #336).
+    assert_eq!(
+        serr,
+        format!("riperf3: error - {RECV_COOKIE_MSG}: \n"),
+        "{serr:?}"
+    );
+    assert!(
+        status.success(),
+        "one-off server exits 0 after a cookie failure"
+    );
+}
+
+#[test]
+fn cookie_failure_json_emits_the_skeleton_doc_silent_stderr() {
+    let (sout, serr, status) = drive_server_scenario(true, drive_cookie_failure);
+    assert!(
+        serr.trim().is_empty(),
+        "-J silences the error line: {serr:?}"
+    );
+    let doc: serde_json::Value =
+        serde_json::from_str(sout.trim()).unwrap_or_else(|e| panic!("one -J doc ({e}): {sout}"));
+    assert_eq!(
+        doc["error"].as_str(),
+        Some(format!("error - {RECV_COOKIE_MSG}: ").as_str()),
+        "the -J error key carries GT's IERECVCOOKIE sentence: {doc}"
+    );
+    assert_eq!(
+        doc["start"]["connected"].as_array().map(Vec::len),
+        Some(0),
+        "skeleton start.connected is empty"
+    );
+    assert!(doc["start"]["version"].is_string());
+    assert!(doc["start"]["system_info"].is_string());
+    assert!(doc["intervals"].as_array().expect("intervals").is_empty());
+    assert!(
+        doc["end"].as_object().expect("end").is_empty(),
+        "bare end{{}}"
+    );
+    assert!(status.success());
+}
+
+#[test]
+fn param_failure_text_prints_the_ierecvparams_line() {
+    let (_sout, serr, status) = drive_server_scenario(false, drive_param_failure);
+    assert_eq!(
+        serr,
+        format!("riperf3: error - {RECV_PARAMS_MSG}: \n"),
+        "{serr:?}"
+    );
+    assert!(
+        status.success(),
+        "one-off server exits 0 after a param failure"
+    );
+}
+
+#[test]
+fn param_failure_json_emits_the_skeleton_doc_silent_stderr() {
+    let (sout, serr, status) = drive_server_scenario(true, drive_param_failure);
+    assert!(
+        serr.trim().is_empty(),
+        "-J silences the error line: {serr:?}"
+    );
+    let doc: serde_json::Value =
+        serde_json::from_str(sout.trim()).unwrap_or_else(|e| panic!("one -J doc ({e}): {sout}"));
+    assert_eq!(
+        doc["error"].as_str(),
+        Some(format!("error - {RECV_PARAMS_MSG}: ").as_str()),
+        "the -J error key carries GT's IERECVPARAMS sentence: {doc}"
+    );
+    assert!(doc["intervals"].as_array().expect("intervals").is_empty());
+    assert!(
+        doc["end"].as_object().expect("end").is_empty(),
+        "bare end{{}}"
+    );
+    assert!(status.success());
+}
+
+/// The wire-back: GT's cleanup_server sends SERVER_ERROR(-2), then
+/// htonl(i_errno), then htonl(errno). riperf3 mirrors it with errno pinned to
+/// 0 (honest, like #336). Observable only for the param case — a
+/// cookie-failure peer has already closed.
+#[test]
+fn param_failure_wire_back_is_server_error_ierecvparams() {
+    let (_sout, _serr, status) = drive_server_scenario(false, |port| {
+        let mut ctrl = std::net::TcpStream::connect(("127.0.0.1", port)).expect("ctrl");
+        ctrl.write_all(&[b'x'; 37]).unwrap();
+        assert_eq!(read_exact(&mut ctrl, 1)[0], 9, "ParamExchange");
+        write_json_blob(&mut ctrl, "this is not json");
+        let back = read_exact(&mut ctrl, 9);
+        assert_eq!(back[0], 0xfe, "SERVER_ERROR state (-2): {back:?}");
+        assert_eq!(
+            u32::from_be_bytes(back[1..5].try_into().unwrap()),
+            114,
+            "IERECVPARAMS i_errno"
+        );
+        assert_eq!(
+            u32::from_be_bytes(back[5..9].try_into().unwrap()),
+            0,
+            "honest errno 0"
+        );
+    });
+    assert!(status.success());
 }

--- a/riperf3/src/error.rs
+++ b/riperf3/src/error.rs
@@ -62,7 +62,9 @@ pub enum RiperfError {
 
     /// iperf3's IERECVCOOKIE(106): the server's initial cookie read failed —
     /// a truncated or absent cookie, a port scan, a peer that closed before
-    /// the 37-byte cookie arrived. GT's iperf_accept sets it, cleanup_server
+    /// the 37-byte cookie arrived, or a timed-out read (GT bounds every
+    /// Nread, net.c:75-76; its IERECVCOOKIE comment names the timeout case,
+    /// iperf_server_api.c:194-200). GT's iperf_accept sets it, cleanup_server
     /// relays SERVER_ERROR(-2) + the code, and the surface is exit-0
     /// keep-serving with the message in the -J skeleton doc / one text line
     /// (#330). GT's sentence, no "protocol violation" wrapper (#151), perr=1
@@ -71,8 +73,9 @@ pub enum RiperfError {
     RecvCookieFailed,
 
     /// iperf3's IERECVPARAMS(114): the server could not read or parse the
-    /// client's ParamExchange blob — malformed JSON, or a short/absent
-    /// length-prefixed body. GT's get_parameters sets it whenever JSON_read
+    /// client's ParamExchange blob — malformed JSON, a short/absent
+    /// length-prefixed body, or a timed-out read (bounded like every GT
+    /// Nread). GT's get_parameters sets it whenever JSON_read
     /// returns NULL (a read failure OR a cJSON parse failure alike); the
     /// surface mirrors IERECVCOOKIE (#330). GT's sentence (#151), perr=1.
     #[error("unable to receive parameters from client")]

--- a/riperf3/src/error.rs
+++ b/riperf3/src/error.rs
@@ -60,6 +60,24 @@ pub enum RiperfError {
     #[error("unable to receive results")]
     RecvResultsFailed,
 
+    /// iperf3's IERECVCOOKIE(106): the server's initial cookie read failed —
+    /// a truncated or absent cookie, a port scan, a peer that closed before
+    /// the 37-byte cookie arrived. GT's iperf_accept sets it, cleanup_server
+    /// relays SERVER_ERROR(-2) + the code, and the surface is exit-0
+    /// keep-serving with the message in the -J skeleton doc / one text line
+    /// (#330). GT's sentence, no "protocol violation" wrapper (#151), perr=1
+    /// so the emit sites carry the #248 dangling ": ".
+    #[error("unable to receive cookie at server")]
+    RecvCookieFailed,
+
+    /// iperf3's IERECVPARAMS(114): the server could not read or parse the
+    /// client's ParamExchange blob — malformed JSON, or a short/absent
+    /// length-prefixed body. GT's get_parameters sets it whenever JSON_read
+    /// returns NULL (a read failure OR a cJSON parse failure alike); the
+    /// surface mirrors IERECVCOOKIE (#330). GT's sentence (#151), perr=1.
+    #[error("unable to receive parameters from client")]
+    RecvParamsFailed,
+
     /// iperf3's IEMESSAGE (#325): an unhandled control byte. GT's end-loop
     /// switch has arms for only TEST_START / TEST_END / IPERF_DONE /
     /// CLIENT_TERMINATE — every other value, known state or not, hits

--- a/riperf3/src/protocol.rs
+++ b/riperf3/src/protocol.rs
@@ -184,10 +184,16 @@ pub async fn send_cookie(stream: &mut TcpStream, cookie: &[u8; COOKIE_SIZE]) -> 
     Ok(())
 }
 
-/// Read a 37-byte cookie from a TCP stream.
+/// Read a 37-byte cookie from a TCP stream. Bounded like every GT Nread
+/// (net.c:75-76) — iperf_server_api.c:194-200's IERECVCOOKIE comment names
+/// the timed-out read explicitly, and live GT self-recovers from a
+/// connect-and-hold peer in ~20 s. Unbounded, one hostile peer parked the
+/// serial serve loop forever (#339 r2b F1). Both call sites are server-side
+/// (the control cookie and the data-stream cookie).
 pub async fn recv_cookie(stream: &mut TcpStream) -> Result<[u8; COOKIE_SIZE]> {
+    let deadline = tokio::time::Instant::now() + NREAD_OVERALL_TIMEOUT;
     let mut cookie = [0u8; COOKIE_SIZE];
-    stream.read_exact(&mut cookie).await?;
+    nread_exact(stream, &mut cookie, deadline).await?;
     Ok(cookie)
 }
 
@@ -538,9 +544,11 @@ pub async fn send_params(stream: &mut TcpStream, params: &TestParams) -> Result<
     json_write(stream, &value).await
 }
 
-/// Receive test parameters from length-prefixed JSON.
+/// Receive test parameters from length-prefixed JSON. Bounded like every GT
+/// Nread (#339 r2b F1): a peer that holds mid-prefix or mid-body times out
+/// into the IERECVPARAMS surface instead of parking the serve loop.
 pub async fn recv_params(stream: &mut TcpStream) -> Result<TestParams> {
-    let value = json_read(stream, MAX_PARAMS_JSON_LEN).await?;
+    let value = json_read_bounded(stream, MAX_PARAMS_JSON_LEN).await?;
     let params: TestParams = serde_json::from_value(value)?;
     Ok(params)
 }
@@ -622,6 +630,48 @@ async fn nread_step(
         _ = tokio::time::sleep(NREAD_IDLE_TIMEOUT) => Ok(None),
         _ = tokio::time::sleep_until(deadline) => Ok(None),
     }
+}
+
+/// GT-bounded read_exact on top of [`nread_step`]: fills `buf` fully or
+/// fails — EOF, the idle bound, and the overall deadline all collapse to
+/// `UnexpectedEof` (GT's Nread returns the partial count and every
+/// exact-size caller treats a short read as the failure; the pre-test
+/// callers have no warning surface — that parity is a #330 residual).
+async fn nread_exact(
+    stream: &mut TcpStream,
+    buf: &mut [u8],
+    deadline: tokio::time::Instant,
+) -> std::result::Result<(), std::io::Error> {
+    let mut got = 0usize;
+    while got < buf.len() {
+        match nread_step(stream, &mut buf[got..], deadline).await? {
+            None => return Err(std::io::ErrorKind::UnexpectedEof.into()),
+            Some(n) => got += n,
+        }
+    }
+    Ok(())
+}
+
+/// GT-bounded [`json_read`] (#339 r2b F1): the server's params read gets
+/// Nread's idle/overall bounds so a holding peer can't park the serial
+/// serve loop. Client-side reads keep the plain [`json_read`] — their
+/// bound/warning parity is a separate surface (noted on #330).
+async fn json_read_bounded(stream: &mut TcpStream, max_len: usize) -> Result<serde_json::Value> {
+    let deadline = tokio::time::Instant::now() + NREAD_OVERALL_TIMEOUT;
+    let mut len_buf = [0u8; 4];
+    nread_exact(stream, &mut len_buf, deadline).await?;
+    let len = u32::from_be_bytes(len_buf) as usize;
+
+    if max_len > 0 && len > max_len {
+        return Err(RiperfError::Protocol(format!(
+            "JSON payload too large: {len} bytes (max {max_len})"
+        )));
+    }
+
+    let mut buf = vec![0u8; len];
+    nread_exact(stream, &mut buf, deadline).await?;
+    let value: serde_json::Value = serde_json::from_slice(&buf)?;
+    Ok(value)
 }
 
 /// The SERVER's results read (#330): a malformed read gets GT's Nread_json

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -2908,7 +2908,13 @@ impl Server {
         if self.json_output || self.json_stream {
             self.emit_pretest_error_doc(&doc_error);
         } else if !crate::macros::output_quiet() {
-            eprintln!("riperf3: {doc_error}");
+            // #339 r2b F2: iperf_err stamps its stderr line with the
+            // --timestamps prefix (iperf_error.c:51-57, :77) — same
+            // output_timestamp_prefix() the stdout banner rides.
+            eprintln!(
+                "{}riperf3: {doc_error}",
+                crate::macros::output_timestamp_prefix()
+            );
         }
     }
 

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -514,8 +514,23 @@ impl Server {
                         eprintln!("riperf3: error - {}", RiperfError::UnknownControlMessage);
                     }
                 }
+                // #330: the pre-test control failures. Unlike the classes
+                // above — which build a partial report inside handle_one_test
+                // and carried the error in it — these error BEFORE any report
+                // exists, so the serve loop emits GT's iperf_err sink shape
+                // directly: silent stderr + a SKELETON accumulated doc under
+                // -J, one text line otherwise.
+                Err(e @ RiperfError::RecvCookieFailed) | Err(e @ RiperfError::RecvParamsFailed) => {
+                    self.emit_pretest_error(&e);
+                }
                 Err(e) => {
-                    if !crate::macros::output_quiet() {
+                    // Any residual pre-report error rides the same sink: under
+                    // -J iperf_err stays silent and puts the message in a
+                    // skeleton doc, rather than the raw stderr line GT never
+                    // emits in JSON mode (#330 divergence 1).
+                    if json {
+                        self.emit_pretest_error_doc(&format!("error - {e}"));
+                    } else if !crate::macros::output_quiet() {
                         eprintln!("riperf3: error - {e}");
                     }
                 }
@@ -914,11 +929,31 @@ impl Server {
         ctrl: &mut tokio::net::TcpStream,
     ) -> Result<Option<([u8; protocol::COOKIE_SIZE], TestParams, TestConfig)>> {
         // ---- Cookie ----
-        let cookie = protocol::recv_cookie(ctrl).await?;
+        // #330: a failed cookie read is GT's IERECVCOOKIE(106) — iperf_accept
+        // errors and cleanup_server relays SERVER_ERROR(-2) + the code before
+        // the serve loop renders the exit-0 keep-serving surface (skeleton -J
+        // doc / one text line). The wire-back is best-effort: a peer that
+        // already closed (a port scan) just no-ops the send, like GT's Nwrite.
+        let cookie = match protocol::recv_cookie(ctrl).await {
+            Ok(cookie) => cookie,
+            Err(_) => {
+                let _ = protocol::send_server_error(ctrl, 106).await;
+                return Err(RiperfError::RecvCookieFailed);
+            }
+        };
 
         // ---- ParamExchange ----
         protocol::send_state(ctrl, TestState::ParamExchange).await?;
-        let mut params = protocol::recv_params(ctrl).await?;
+        // #330: GT's get_parameters sets IERECVPARAMS(114) whenever JSON_read
+        // returns NULL — a short/absent body OR a cJSON parse failure alike —
+        // and relays SERVER_ERROR(-2) + the code through cleanup_server.
+        let mut params = match protocol::recv_params(ctrl).await {
+            Ok(params) => params,
+            Err(_) => {
+                let _ = protocol::send_server_error(ctrl, 114).await;
+                return Err(RiperfError::RecvParamsFailed);
+            }
+        };
         // iperf3 sends num/blockcount = 0 for a plain `-t` run; treat 0 as
         // unlimited so the byte-limit checks below don't misread a duration test
         // as byte-limited (#119).
@@ -2841,6 +2876,39 @@ impl Server {
             eprintln!("riperf3: error - {MSG}");
         }
         Ok(())
+    }
+
+    /// #330: the JSON half of a pre-test error's iperf_err sink — the -J
+    /// skeleton document (populated `start`/`intervals:[]`/`end:{}` + `error`)
+    /// or the --json-stream error+empty-end event pair. No-op in text mode and
+    /// under the #290 console-quiet scope. Shared by [`Self::emit_pretest_error`]
+    /// and the serve loop's residual generic arm.
+    fn emit_pretest_error_doc(&self, doc_error: &str) {
+        if crate::macros::output_quiet() {
+            return;
+        }
+        if self.json_stream {
+            crate::reporter::emit_json_stream_line(&crate::json_report::error_stream_events(
+                doc_error,
+            ));
+        } else if self.json_output {
+            println!("{}", crate::json_report::error_document(doc_error));
+        }
+    }
+
+    /// #330: render a pre-test control error (IERECVCOOKIE / IERECVPARAMS) in
+    /// GT's iperf_err sink shape — silent stderr under -J with the message in
+    /// the skeleton doc, one text line otherwise. Both codes are perr=1, so the
+    /// #248 dangling ": " rides along; riperf3 pins errno 0, leaving the suffix
+    /// bare where GT would append a (often stale) strerror — the same honest
+    /// deviation as #336.
+    fn emit_pretest_error(&self, err: &RiperfError) {
+        let doc_error = format!("error - {err}: ");
+        if self.json_output || self.json_stream {
+            self.emit_pretest_error_doc(&doc_error);
+        } else if !crate::macros::output_quiet() {
+            eprintln!("riperf3: {doc_error}");
+        }
     }
 
     /// #230: refuse a test at param exchange (GT's upfront requested-duration

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -477,8 +477,9 @@ impl Server {
                     // it (sink rule). (r1 F3: the old PeerDisconnected arm
                     // is gone — both server recv_state sites convert EOF to
                     // this class now, so it had no constructor left.
-                    // Pre-test EOFs like port scans ride the generic Io arm
-                    // below, same as GT's per-scan cookie-read error line.)
+                    // Pre-test EOFs like port scans are caught earlier by the
+                    // cookie read and take GT's IERECVCOOKIE surface via the
+                    // RecvCookieFailed arm below (#330), not this mid-test one.)
                     if !json && !crate::macros::output_quiet() {
                         eprintln!("riperf3: {CTRL_CLOSED_MSG}");
                     }


### PR DESCRIPTION
## What

The server's pre-test control failures (cookie read, param read/parse) surfaced riperf3's raw `early eof` / serde class on stderr with **no `-J` document at all**. GT routes every such failure through `iperf_err`'s json sink — silent stderr under `-J` with the message in a **skeleton accumulated doc**, one text line otherwise — plus a best-effort `SERVER_ERROR(-2)` + `(i_errno, errno)` wire-back via `cleanup_server`. One-off servers keep exit 0.

Closes #330.

## GT ground truth (live-probed, iperf 3.21)

| case | GT class | text stderr | `-J` stderr | `-J` doc |
|---|---|---|---|---|
| bad-JSON params | IERECVPARAMS(114) | `error - unable to receive parameters from client: ` | silent | skeleton + error key |
| cookie-then-EOF | IERECVPARAMS(114) | (warning line) + `error - …parameters…: ` | silent¹ | skeleton + error key |
| portscan / short cookie | IERECVCOOKIE(106) | `error - unable to receive cookie at server: ` | silent | skeleton + error key |

`get_parameters` sets IERECVPARAMS whenever `JSON_read` returns NULL — a short/absent body **or** a `cJSON_Parse` failure alike. Cookie-then-EOF classifies as IERECVPARAMS (the cookie read succeeds; the params size-read EOFs), matching GT.

Wire-back (both classes): `cleanup_server` sends `SERVER_ERROR(-2)` + `htonl(i_errno)` + `htonl(errno)`. riperf3 pins `errno` to 0 → **byte-identical** to GT on the bad-JSON case (GT's errno is 0 there); an honest bare `: ` where GT appends an often-stale strerror otherwise — the same deviation as #336/#248 (both codes are perr=1).

**riperf3 before:** every case → `riperf3: error - early eof` on stderr, no `-J` doc.
**riperf3 after:** matches the table above, wire-back included.

## Changes

- `error.rs`: `RecvCookieFailed` / `RecvParamsFailed` variants (GT's IERECVCOOKIE / IERECVPARAMS sentences, no `protocol violation` wrapper, perr=1).
- `server.rs` `negotiate_test`: catch the cookie / param read failures, best-effort `send_server_error(106/114)`, return the typed class.
- `server.rs` serve loop: new arms → `emit_pretest_error` (skeleton `-J` doc + silent stderr / one text line; the pre-report classes carry no built report so the loop emits the doc directly, unlike the RecvResults/terminate classes). The residual generic arm now also `-J`-gates through the same skeleton-doc sink (divergence 1) instead of the raw stderr line GT never emits in JSON mode.

## Scope notes

- **Divergence 3** (mid-test TEST_RUNNING stray → IEMESSAGE) already landed in #333 (`Ok(_) => unknown_message`); the #330 body predates it.
- **CLI error sink** is already `-J`-gated (emits a doc); the two new classes are server-side reads a client never receives, so they never reach it.
- **Recorded residual (follow-up, not this PR):** GT's `JSON_read` read-failure `warning:` diagnostic lines (a `warning()` mechanism distinct from the `iperf_err` sink #330 targets) are not replicated — they appear only for read-failure subcases, never for a cJSON parse failure.

¹ GT keeps the `warning:` line on stderr under `-J`; only the `iperf_err` error line is silenced. See the residual note.

## Verification

- New `wire_shape` pins (mock client vs riperf3 server, text + `-J`): the line, the skeleton doc + silent stderr, and the param `SERVER_ERROR` wire-back bytes, for both classes.
- `cargo test --workspace`: 777 green, 0 failing. `clippy --all-targets -D warnings` clean, `fmt` clean.
- `xcheck` 7/7 incl. `x86_64-pc-windows-msvc`.
- Live re-probe: riperf3 vs GT byte-identical on bad-JSON (incl. wire-back); IERECVPARAMS vs IERECVCOOKIE split matches GT across cookie-eof / portscan / short-cookie.


## Review round 2 (two independent cold reviews)

**r2a: APPROVE.** Live side-by-side byte-diff vs GT 3.21 (wire-backs `fe 0000006a/72 00000000` identical; `-J` skeleton keys/order match; `--json-stream` error+end pair byte-identical; exit 0 keep-serving). 4 mutations red (code flips, sink un-gating, `": "` drop, arm removal). Deviations confirmed correctly scoped. NIT noted: no `--json-stream` variant pin for the pre-test path (verified correct by construction — GT emits no `start` event before `iperf_on_test_start`).

**r2b: REQUEST-CHANGES → fixed in `d27303f`.**
- **F1 (HIGH): pre-test control reads were unbounded** — a connect-and-hold peer parked the serial serve loop forever, while GT self-recovers in ~20 s via its universal Nread bounds (net.c:75-76; iperf_server_api.c:194-200 names the timeout case). Fix: `nread_exact` on top of the #336 `nread_step` bounds — `recv_cookie` (both server call sites) and a bounded `json_read` for the server's params read. Client-side reads stay plain (their bound/warning parity is the recorded #330 residual). Red-first hold pins for both classes (bounded exit + correct surface).
- **F2 (LOW): the new stderr emit site dropped the `--timestamps` prefix** GT's iperf_err applies (iperf_error.c:51-57, :77). Fixed + deterministic literal-format pin. The same gap on the older serve-loop arms is pre-existing → #344.
- F3/F4 NITs filed as #345/#346.

r2b's live probe matrix (cookie-hold / partial-cookie / length-prefix-hold / persistent-3-failures / healthy-run) all GT-matched after the fix; its mutation table (7 rows) all red. Post-fix gate: workspace green (780 tests), clippy/fmt clean, xcheck 7/7.
