### PR TITLE
fix(compat): commit results-blob pages only as bytes arrive + GT's %d wrap (#340, #341)

### DIFF
--- a/riperf3-cli/src/main.rs
+++ b/riperf3-cli/src/main.rs
@@ -224,7 +224,11 @@ fn main() -> std::process::ExitCode {
     // not getopt/argv order. With TWO simultaneously-invalid unit flags GT
     // reports the argv-first one and we report the field-first one — same
     // class (IEUNITVAL) and exit (1), only the quoted errarg differs. A
-    // single bad flag (the realistic case) is byte-identical.
+    // single bad flag (the realistic case) is byte-identical. The same clap
+    // root also collapses REPEATED occurrences of one flag to the last
+    // value, so `-b abc -b 10M` runs where GT's in-loop per-occurrence
+    // check rejects the first `abc` (#340 audit N5) — error-vs-success, not
+    // just a different errarg; inherent to last-wins parsing (since #328).
 
     // -w/--window (iperf_api.c:1438-1452): unit_atof (1024-based) → IEUNITVAL,
     // then `farg > (double) MAX_TCP_BUFFER` (512*MB = 536870912) → IEBUFSIZE,

--- a/riperf3-cli/tests/wire_shape.rs
+++ b/riperf3-cli/tests/wire_shape.rs
@@ -1133,6 +1133,89 @@ fn exchange_size_rst_takes_gt_read_failed_size_arm() {
     );
 }
 
+/// #341: GT prints the expected size through `%d` (iperf_api.c:3057 — the
+/// uint32_t hsize two's-complement-wraps), so a hostile 0xFFFFFFF0 prefix
+/// warns "expected -16", not the unsigned 4294967280.
+#[test]
+fn exchange_huge_size_warning_wraps_like_gt_percent_d() {
+    let (_sout, serr, status) = run_exchange_fail_scenario(false, Some((0xFFFF_FFF0, b"")));
+    assert!(
+        serr.contains(
+            "warning: JSON size of data read does not correspond to offered length - \
+             expected -16 bytes but received 0; errno=0"
+        ),
+        "GT's %d wrap on the expected count: {serr}"
+    );
+    assert!(status.success(), "one-off exits 0 like GT");
+}
+
+/// #340: a hostile 4 GiB size prefix must not COMMIT the memory. GT callocs
+/// (lazy zero pages, ~4 MB RSS through the whole read window); riperf3's
+/// try_reserve+resize memset every page in (~4.2 GB RSS, unauthenticated,
+/// repeatable per round). The read loop must commit pages only as bytes
+/// arrive. Linux-only: samples the child's VmRSS from /proc.
+#[cfg(target_os = "linux")]
+#[test]
+fn exchange_huge_size_prefix_does_not_commit_rss() {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind");
+    let port = listener.local_addr().unwrap().port();
+    drop(listener);
+    let port_s = port.to_string();
+
+    let mut server = common::ChildGuard(
+        std::process::Command::new(env!("CARGO_BIN_EXE_riperf3"))
+            .args(["-s", "-1", "-p", &port_s])
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .spawn()
+            .expect("spawn server"),
+    );
+    let pid = server.0.id();
+    std::thread::sleep(std::time::Duration::from_millis(400));
+
+    // The full dance to ExchangeResults, then the hostile prefix + a HOLD so
+    // the blob read window stays open while RSS is sampled.
+    let mock = std::thread::spawn(move || {
+        let cookie = [b'x'; 37];
+        let mut ctrl = std::net::TcpStream::connect(("127.0.0.1", port)).expect("ctrl");
+        ctrl.write_all(&cookie).unwrap();
+        assert_eq!(read_exact(&mut ctrl, 1)[0], 9);
+        write_json_blob(&mut ctrl, MOCK_PARAMS);
+        assert_eq!(read_exact(&mut ctrl, 1)[0], 10);
+        let mut data = std::net::TcpStream::connect(("127.0.0.1", port)).expect("data");
+        data.write_all(&cookie).unwrap();
+        assert_eq!(read_exact(&mut ctrl, 1)[0], 1);
+        assert_eq!(read_exact(&mut ctrl, 1)[0], 2);
+        data.write_all(&[0u8; 4096]).unwrap();
+        ctrl.write_all(&[4u8]).unwrap(); // TestEnd
+        assert_eq!(read_exact(&mut ctrl, 1)[0], 13); // ExchangeResults
+        ctrl.write_all(&0xFFFF_FFF0u32.to_be_bytes()).unwrap(); // hostile prefix
+        std::thread::sleep(std::time::Duration::from_secs(3)); // hold the window
+        drop((ctrl, data));
+    });
+
+    // Sample peak RSS while the server sits in the bounded blob read.
+    let mut peak_kb = 0u64;
+    for _ in 0..20 {
+        std::thread::sleep(std::time::Duration::from_millis(100));
+        let status = std::fs::read_to_string(format!("/proc/{pid}/status")).unwrap_or_default();
+        if let Some(line) = status.lines().find(|l| l.starts_with("VmRSS:")) {
+            let kb: u64 = line
+                .split_whitespace()
+                .nth(1)
+                .and_then(|v| v.parse().ok())
+                .unwrap_or(0);
+            peak_kb = peak_kb.max(kb);
+        }
+    }
+    mock.join().expect("mock");
+    let _ = riperf3_test_support::wait_bounded(&mut server.0, std::time::Duration::from_secs(20));
+    assert!(
+        peak_kb < 262_144, // 256 MB — GT sits at ~4.5 MB, the defect at ~4.2 GB
+        "hostile prefix committed {peak_kb} kB RSS — pages must commit only as bytes arrive"
+    );
+}
+
 /// #325 r2 F6: the CLIENT side of the same default — GT's client message
 /// handler IEMESSAGEs an unmapped byte too (iperf_client_api.c:409-411).
 /// The byte replaces ExchangeResults(13) at the client's direct state wait

--- a/riperf3-cli/tests/wire_shape.rs
+++ b/riperf3-cli/tests/wire_shape.rs
@@ -1133,7 +1133,7 @@ fn exchange_size_rst_takes_gt_read_failed_size_arm() {
     );
 }
 
-/// #341: GT prints the expected size through `%d` (iperf_api.c:3057 — the
+/// #341: GT prints the expected size through `%d` (iperf_api.c:3056 — the
 /// uint32_t hsize two's-complement-wraps), so a hostile 0xFFFFFFF0 prefix
 /// warns "expected -16", not the unsigned 4294967280.
 #[test]
@@ -1145,6 +1145,63 @@ fn exchange_huge_size_warning_wraps_like_gt_percent_d() {
              expected -16 bytes but received 0; errno=0"
         ),
         "GT's %d wrap on the expected count: {serr}"
+    );
+    assert!(status.success(), "one-off exits 0 like GT");
+}
+
+/// #347 r2 F1: the chunk-loop bookkeeping (`take` cap + `extend ..n`) needs
+/// discriminating coverage — a paced >64 KiB blob with coalesced trailing
+/// junk. The mid-blob pause forces a partial chunk read (an `extend ..take`
+/// mutant appends stale garbage); the junk written together with the tail
+/// coalesces into the final read (a `take = chunk.len()` mutant over-reads
+/// past the promised length). Correct code reads exactly the promised
+/// length like GT (iperf_api.c:3044/:3053), completes the exchange, and the
+/// junk then lands in the END LOOP as GT's IEMESSAGE — proving it was never
+/// consumed by the blob read.
+#[test]
+fn exchange_multi_chunk_paced_blob_with_trailing_junk_completes() {
+    let (_sout, serr, status) = drive_server_scenario(false, |port| {
+        let cookie = [b'x'; 37];
+        let mut ctrl = std::net::TcpStream::connect(("127.0.0.1", port)).expect("ctrl");
+        ctrl.write_all(&cookie).unwrap();
+        assert_eq!(read_exact(&mut ctrl, 1)[0], 9);
+        write_json_blob(&mut ctrl, MOCK_PARAMS);
+        assert_eq!(read_exact(&mut ctrl, 1)[0], 10);
+        let mut data = std::net::TcpStream::connect(("127.0.0.1", port)).expect("data");
+        data.write_all(&cookie).unwrap();
+        assert_eq!(read_exact(&mut ctrl, 1)[0], 1);
+        assert_eq!(read_exact(&mut ctrl, 1)[0], 2);
+        data.write_all(&[0u8; 4096]).unwrap();
+        ctrl.write_all(&[4u8]).unwrap(); // TestEnd
+        assert_eq!(read_exact(&mut ctrl, 1)[0], 13); // ExchangeResults
+
+        // A valid 100 000-byte results doc: MOCK_RESULTS plus JSON-legal
+        // trailing spaces inside the promised length (spans 2 chunks).
+        let mut blob = MOCK_RESULTS.as_bytes().to_vec();
+        blob.resize(100_000, b' ');
+        ctrl.write_all(&(blob.len() as u32).to_be_bytes()).unwrap();
+        ctrl.write_all(&blob[..30_000]).unwrap();
+        // Pause mid-blob: the server's in-flight chunk read returns partial.
+        std::thread::sleep(std::time::Duration::from_millis(400));
+        // Tail + junk in ONE write so they coalesce into the final read.
+        let mut tail = blob[30_000..].to_vec();
+        tail.extend_from_slice(&[b'J'; 512]);
+        ctrl.write_all(&tail).unwrap();
+
+        // The exchange completes: the server's results + DisplayResults.
+        read_json_blob(&mut ctrl);
+        assert_eq!(read_exact(&mut ctrl, 1)[0], 14); // DisplayResults
+        std::thread::sleep(std::time::Duration::from_millis(300));
+        drop((ctrl, data));
+    });
+    assert!(
+        !serr.contains("warning:"),
+        "the paced multi-chunk blob parses clean — no warning arm fires: {serr}"
+    );
+    assert!(
+        serr.contains(IEMESSAGE),
+        "the junk stays queued past the blob read and lands in the end loop \
+         as GT's IEMESSAGE: {serr}"
     );
     assert!(status.success(), "one-off exits 0 like GT");
 }

--- a/riperf3/src/protocol.rs
+++ b/riperf3/src/protocol.rs
@@ -738,14 +738,16 @@ pub async fn recv_results_server(stream: &mut TcpStream) -> Result<TestResultsJs
         match nread_step(stream, &mut chunk[..take], deadline).await {
             // EOF/timeout: GT's Nread returned the partial (rc >= 0) — the
             // expected/received arm (live: "expected 500 bytes but
-            // received 5; errno=0"). GT prints the uint32_t hsize through
-            // %d (iperf_api.c:3057), so the expected count two's-complement
-            // wraps past INT_MAX (#341: 0xFFFFFFF0 → "expected -16").
+            // received 5; errno=0"). GT prints BOTH counts through %d
+            // (iperf_api.c:3056: hsize, rc), so each two's-complement wraps
+            // past INT_MAX (#341: 0xFFFFFFF0 → "expected -16"; the received
+            // arm needs a >2^31-byte transfer to diverge — r1's note; the
+            // cast is well-defined since got <= len <= u32::MAX).
             Ok(None) => {
                 gt_warning(format_args!(
                     "JSON size of data read does not correspond to offered length - \
-                     expected {} bytes but received {got}; errno=0",
-                    len as u32 as i32
+                     expected {} bytes but received {}; errno=0",
+                    len as u32 as i32, got as u32 as i32
                 ));
                 return Err(crate::error::RiperfError::RecvResultsFailed);
             }

--- a/riperf3/src/protocol.rs
+++ b/riperf3/src/protocol.rs
@@ -616,6 +616,11 @@ const NET_HARDERROR: i32 = -2;
 /// per-step reset. Divergence is adversarial-only (a byte-dripping peer:
 /// GT-Linux gives up at ~10 s cumulative, we at up to the 30 s overall) and
 /// the real results blob is one atomic write; both paths stay bounded.
+///
+/// The OTHER direction (#340 audit N6): callers thread one OVERALL deadline
+/// across BOTH the size and blob reads, where GT arms a fresh `ftimeout`
+/// per `Nread` (net.c:485-489) — GT's worst case is ~2×30 s, riperf3's is
+/// strictly tighter at 30 s total. Adversarial-only, same surface.
 async fn nread_step(
     stream: &mut TcpStream,
     buf: &mut [u8],
@@ -716,30 +721,41 @@ pub async fn recv_results_server(stream: &mut TcpStream) -> Result<TestResultsJs
         ));
         return Err(crate::error::RiperfError::RecvResultsFailed);
     }
-    // GT calloc's the buffer and NULL-guards it (iperf_api.c:3042-3043),
-    // degrading to IERECVRESULTS with NO warning on alloc failure. `len` is
-    // an unbounded peer-controlled u32 (max_size=0 → no cap, like GT), so a
-    // fallible reserve is the faithful match: an infallible `vec![0u8; len]`
-    // would abort the process on a hostile 4 GB prefix (r2 finding 4).
-    let mut buf = Vec::new();
-    if buf.try_reserve_exact(len).is_err() {
-        return Err(crate::error::RiperfError::RecvResultsFailed);
-    }
-    buf.resize(len, 0);
+    // GT calloc's the buffer upfront and NULL-guards it (iperf_api.c:3042-
+    // 3043), degrading to IERECVRESULTS with NO warning on alloc failure —
+    // and calloc's zero pages are LAZY. The previous try_reserve+resize here
+    // memset every page in, COMMITTING a hostile 4 GiB prefix as real RSS
+    // (#340, unauthenticated). riperf3 instead grows the buffer as bytes
+    // arrive (fallible reserve per chunk = GT's NULL-guard degrade class),
+    // so the hostile prefix costs nothing anywhere — a deliberate
+    // improvement over GT's upfront virtual reservation, same surface.
+    const READ_CHUNK: usize = 64 * 1024;
+    let mut buf: Vec<u8> = Vec::new();
+    let mut chunk = vec![0u8; READ_CHUNK.min(len)];
     let mut got = 0usize;
     while got < len {
-        match nread_step(stream, &mut buf[got..], deadline).await {
+        let take = chunk.len().min(len - got);
+        match nread_step(stream, &mut chunk[..take], deadline).await {
             // EOF/timeout: GT's Nread returned the partial (rc >= 0) — the
             // expected/received arm (live: "expected 500 bytes but
-            // received 5; errno=0").
+            // received 5; errno=0"). GT prints the uint32_t hsize through
+            // %d (iperf_api.c:3057), so the expected count two's-complement
+            // wraps past INT_MAX (#341: 0xFFFFFFF0 → "expected -16").
             Ok(None) => {
                 gt_warning(format_args!(
                     "JSON size of data read does not correspond to offered length - \
-                     expected {len} bytes but received {got}; errno=0"
+                     expected {} bytes but received {got}; errno=0",
+                    len as u32 as i32
                 ));
                 return Err(crate::error::RiperfError::RecvResultsFailed);
             }
-            Ok(Some(n)) => got += n,
+            Ok(Some(n)) => {
+                if buf.try_reserve(n).is_err() {
+                    return Err(crate::error::RiperfError::RecvResultsFailed);
+                }
+                buf.extend_from_slice(&chunk[..n]);
+                got += n;
+            }
             // A hard read error is GT's rc<0 arm (iperf_api.c:3061; r1 F1 —
             // live RST probe: "JSON data read failed; errno=104").
             Err(e) => {


### PR DESCRIPTION
## What

Two findings from the post-merge audit of the #336 exchange surface, plus its two doc notes.

**#340 (the release-blocker):** `recv_results_server`'s `try_reserve_exact` + `resize(len, 0)` memset the whole peer-controlled `u32` length, committing a hostile 4 GiB size prefix as real RSS (~4.2 GB observed vs GT's ~4.5 MB — GT `calloc`s and gets lazy zero pages; iperf_api.c:3042). Unauthenticated and repeatable per round; OOM-kills riperf3 on cgroup-limited hosts where iperf3 survives. Ironically introduced BY the r2-finding-4 DoS guard (the guard prevented the abort; the resize then committed the memory anyway).

Fix: chunked read (64 KiB) + fallible per-chunk `try_reserve` + `extend_from_slice`. Pages commit only for bytes actually received — the hostile prefix now costs nothing at all, on any platform. This is a deliberate improvement over GT's upfront virtual reservation (documented in-code): the degrade class on alloc failure (silent IERECVRESULTS) is unchanged, and all five pinned Nread_json warning arms are byte-identical (the partial-count bookkeeping is untouched — the pre-existing pins prove it).

**#341 (rider, same function):** GT prints the expected size through `%d` (iperf_api.c:3057), so past INT_MAX it two's-complement wraps: `expected -16 bytes` for a 0xFFFFFFF0 prefix, not `expected 4294967280 bytes`.

**Doc riders:** audit note N5 (the argv-order deviation record now also covers repeated-flag last-wins — `-b abc -b 10M` runs where GT rejects, error-vs-success) and N6 (the shared-overall-deadline direction vs GT's per-`Nread` `ftimeout`, net.c:485-489 — riperf3 is strictly tighter, 30 s vs GT's worst ~2×30 s).

## Tests (red-first)

- `exchange_huge_size_prefix_does_not_commit_rss` (linux-only, samples the child's `/proc/<pid>/status` VmRSS under a held 4 GiB prefix): red at ~720 MB mid-memset, green well under the 256 MB bound.
- `exchange_huge_size_warning_wraps_like_gt_percent_d`: red on the unsigned form, green on GT's `-16`.
- All 9 exchange pins green; full workspace green; clippy/fmt clean; xcheck 7/7.

Closes #340. Closes #341.

## Review round 1

**APPROVE** — live RSS re-probe (fix: 6.1 MB flat vs mutation's 716 MB; GT 4.4 MB), wrap byte-identical to GT, chunk loop exercised live at a 300 KB multi-chunk blob AND an exact-64 KiB boundary (both clean through DISPLAY_RESULTS), 3/3 mutations red. Max realistic blob sized: ~22 KB for -P 128 (MAX_STREAMS, iperf.h:476); multi-chunk is reachable only via --get-server-output or non-iperf3 peers. Perf: noise (one ≤64 KiB memcpy once per test, off the data path).

One LOW finding folded in (`5715e38`): GT prints BOTH warning counts through `%d` (iperf_api.c:3056: `hsize, rc` — Nread's `int` return), so the received arm now wraps too. Divergence needs a >2^31-byte transfer inside the 30 s bound — impractical as a CI pin; the cast is byte-identical for every test-reachable value (short-blob pin proves the positive range).

## Review round 2

**REQUEST-CHANGES → fixed in `06545ad`.** r2 (torture emphasis) verified the fixes themselves — slow-drip bounded at 30 s with RSS proportional to bytes; RST-mid-chunk byte-identical to GT; 65535/65536/65537/200000-byte blobs clean; all five warning arms live-driven side-by-side vs GT with zero pin-rot; degrade path faithful to GT's calloc-NULL (no warning, same IERECVRESULTS surface); both comment riders live-verified TRUE.

Its one blocker: the new chunk-loop bookkeeping had zero discriminating coverage — `take = chunk.len()` and `extend ..take` mutants both survived the full suite green while breaking real multi-read exchanges. Fixed with one pin (r2's own prescription): a paced >64 KiB blob (mid-blob pause → partial chunk read kills the extend mutant) with trailing junk coalesced into the final write (killed only by the take cap), asserting the exchange completes and the junk lands in the end loop as IEMESSAGE. Both mutations re-run RED against the pin, restored, tree clean. Also fixed the r2 NIT (`%d` cite is iperf_api.c:3056).

r2's acceptability calls, recorded: the `try_reserve` guard stays unpinned (CI can't force alloc failure; contract documented in-code) and the received-count wrap stays unpinned (needs a >2 GiB delivered transfer, contradicting the suite's own RSS envelope).
