### PR TITLE
fix(compat): SERVER_ERROR wire-back on exchange/IEMESSAGE failures + --timestamps stamps on stderr error lines (#342, #344)

### DIFF
--- a/riperf3-cli/tests/self_terminate.rs
+++ b/riperf3-cli/tests/self_terminate.rs
@@ -702,3 +702,82 @@ fn refusal_skeleton_carries_the_client_target_bitrate() {
         );
     }
 }
+
+// ---------------------------------------------------------------------------
+// #344: iperf_err stamps its stderr lines with the --timestamps prefix
+// (iperf_error.c:51-57, :77) — GT's self-terminate line rides iperf_err
+// directly (server_timer_proc, iperf_server_api.c:328) and both refusal
+// kinds reach main.c:174's iperf_err via the -1 return. A literal strftime
+// format keeps the pins deterministic on unix; Windows uses the documented
+// HH:MM:SS fallback and ignores the format, so the byte-exact half is
+// unix-only (the #339 lesson).
+// ---------------------------------------------------------------------------
+
+/// Portable half: a nonempty prefix precedes the expected line somewhere in
+/// stderr. Unix half: the literal format renders verbatim.
+fn assert_stamped_line(serr: &str, bare: &str) {
+    let line = serr
+        .lines()
+        .find(|l| l.ends_with(bare))
+        .unwrap_or_else(|| panic!("no line ending with {bare:?} in {serr:?}"));
+    assert!(
+        line.len() > bare.len(),
+        "a nonempty timestamp prefix precedes the line: {line:?}"
+    );
+    #[cfg(unix)]
+    assert_eq!(
+        line,
+        &format!("XTSX {bare}"),
+        "the literal format renders verbatim: {line:?}"
+    );
+}
+
+/// The runtime breach line (the handle_one_test server_error emit site).
+#[test]
+fn bitrate_limit_line_carries_the_timestamps_prefix() {
+    let ps = common::free_port().to_string();
+    let server = spawn_server(&["--server-bitrate-limit", "1K", "--timestamps=XTSX "], &ps);
+    std::thread::sleep(Duration::from_millis(300));
+    let _ = common::run_client(
+        &["-c", "127.0.0.1", "-p", &ps, "-t", "5"],
+        Duration::from_secs(40),
+        "client",
+    );
+    let (_sout, serr, scode) = finish(server, Duration::from_secs(10), "server");
+    assert_eq!(scode, 0);
+    assert_stamped_line(&serr, &format!("riperf3: error - {BITRATE_MSG}"));
+}
+
+/// The upfront total-rate refusal line (refuse_total_rate's text emit — the
+/// message matches the runtime breach, so the scenario picks the site: a
+/// refused param exchange never starts the test).
+#[test]
+fn upfront_total_rate_line_carries_the_timestamps_prefix() {
+    let ps = common::free_port().to_string();
+    let server = spawn_server(&["--server-bitrate-limit", "1M", "--timestamps=XTSX "], &ps);
+    std::thread::sleep(Duration::from_millis(300));
+    let _ = common::run_client(
+        &["-c", "127.0.0.1", "-p", &ps, "-b", "2M", "-t", "2"],
+        Duration::from_secs(20),
+        "refused client",
+    );
+    let (_sout, serr, scode) = finish(server, Duration::from_secs(10), "server");
+    assert_eq!(scode, 0);
+    assert_stamped_line(&serr, &format!("riperf3: error - {BITRATE_MSG}"));
+}
+
+/// The upfront max-duration refusal line (refuse_max_duration's text emit).
+#[test]
+fn upfront_max_duration_line_carries_the_timestamps_prefix() {
+    let ps = common::free_port().to_string();
+    let server = spawn_server(&["--server-max-duration", "2", "--timestamps=XTSX "], &ps);
+    std::thread::sleep(Duration::from_millis(300));
+    let _ = common::run_client(
+        &["-c", "127.0.0.1", "-p", &ps, "-t", "6"],
+        Duration::from_secs(20),
+        "refused client",
+    );
+    let (_sout, serr, scode) = finish(server, Duration::from_secs(10), "server");
+    assert_eq!(scode, 0);
+    assert_stamped_line(&serr, &format!("riperf3: error - {MAXDUR_MSG}"));
+}

--- a/riperf3-cli/tests/wire_shape.rs
+++ b/riperf3-cli/tests/wire_shape.rs
@@ -1699,11 +1699,15 @@ fn generic_arm_failure_json_is_silent_stderr_with_skeleton_doc() {
 // ---------------------------------------------------------------------------
 // #342: GT's cleanup_server best-effort relays SERVER_ERROR(-2) + htonl(i_errno)
 // + htonl(errno) to a still-live peer before closing (iperf_server_api.c:
-// 460-473). Live-probed (iperf 3.21): an unknown control byte wires back
-// fe 0000006e 00000000 (IEMESSAGE=110); a failed results read wires back
-// fe 00000075 00000000 (IERECVRESULTS=117). The mock reads the frame and then
-// closes — GT itself parks >10 s post-error while the peer holds, so the pin
-// must not wait for the server's close to observe the bytes.
+// 460-473 — it keys on the i_errno GLOBAL at the run loop's exit, :1001,
+// regardless of return path). Live-probed (iperf 3.21): an unknown control
+// byte wires back fe 0000006e 00000000 (IEMESSAGE=110); a failed results read
+// fe 00000075 00000000 (IERECVRESULTS=117); a ctrl half-close
+// fe 0000006d 00000000 (IECTRLCLOSE=109, r1 F2); CLIENT_TERMINATE
+// fe 00000077 (IECLIENTTERM=119, r1 F1 — value/errno deviations on the
+// terminate pin). The mock reads the frame rather than waiting for the
+// server's close, so the pin observes the bytes regardless of close timing
+// (r1 F3: GT sends the frame and closes at once).
 // ---------------------------------------------------------------------------
 
 /// The 9-byte SERVER_ERROR relay: state(-2) + htonl(i_errno) + htonl(errno=0).
@@ -1728,9 +1732,12 @@ fn read_wireback(ctrl: &mut std::net::TcpStream) -> Vec<u8> {
     got
 }
 
-/// Like [`run_holding_scenario`], but after the final byte the mock READS the
-/// control socket for the #342 relay frame (then closes), returning the bytes.
-fn run_wireback_scenario(final_byte: u8, junk_mid_test: bool) -> Vec<u8> {
+/// Like [`run_holding_scenario`], but after the final action the mock READS
+/// the control socket for the #342 relay frame (then closes), returning the
+/// bytes. `final_action`: Some(byte) sends the byte; None HALF-closes the
+/// write side (`shutdown(SHUT_WR)`) and keeps the read half open — the EOF
+/// cells, where a full drop would discard the relay before the pin sees it.
+fn run_wireback_scenario(final_action: Option<u8>, junk_mid_test: bool) -> Vec<u8> {
     let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind");
     let port = listener.local_addr().unwrap().port();
     drop(listener);
@@ -1765,7 +1772,10 @@ fn run_wireback_scenario(final_byte: u8, junk_mid_test: bool) -> Vec<u8> {
             read_json_blob(&mut ctrl); // server results
             assert_eq!(read_exact(&mut ctrl, 1)[0], 14); // DisplayResults
         }
-        ctrl.write_all(&[final_byte]).unwrap();
+        match final_action {
+            Some(b) => ctrl.write_all(&[b]).unwrap(),
+            None => ctrl.shutdown(std::net::Shutdown::Write).unwrap(),
+        }
         let frame = read_wireback(&mut ctrl);
         drop((ctrl, data));
         frame
@@ -1782,7 +1792,7 @@ fn run_wireback_scenario(final_byte: u8, junk_mid_test: bool) -> Vec<u8> {
 #[test]
 fn mid_test_unknown_byte_wires_back_iemessage() {
     assert_eq!(
-        run_wireback_scenario(99, true),
+        run_wireback_scenario(Some(99), true),
         wireback_frame(110),
         "SERVER_ERROR + htonl(IEMESSAGE) + htonl(0), like GT's cleanup_server"
     );
@@ -1794,7 +1804,7 @@ fn mid_test_unknown_byte_wires_back_iemessage() {
 #[test]
 fn mid_test_known_stray_wires_back_iemessage() {
     assert_eq!(
-        run_wireback_scenario(9, true),
+        run_wireback_scenario(Some(9), true),
         wireback_frame(110),
         "the known-stray arm relays like the unmapped-byte arm"
     );
@@ -1804,25 +1814,61 @@ fn mid_test_known_stray_wires_back_iemessage() {
 #[test]
 fn end_loop_unknown_byte_wires_back_iemessage() {
     assert_eq!(
-        run_wireback_scenario(99, false),
+        run_wireback_scenario(Some(99), false),
         wireback_frame(110),
         "the end-loop arm shares GT's handle_message default relay"
     );
 }
 
-/// RECORDED DEVIATION: no relay on CLIENT_TERMINATE. GT's terminate arm
-/// (iperf_server_api.c:289-307) sets IECLIENTTERM, prints, closes the stream
-/// sockets, and returns 0 — no error return — yet a live GT wires back
-/// fe 000000ce (IESTREAMREAD=206): its post-teardown stream reads CLOBBER
-/// i_errno before cleanup_server reads it. That relay is bug noise, not
-/// behavior (the ethos ruling: implement cleanly, document, don't mirror) —
-/// riperf3 sends nothing and closes.
+/// CLIENT_TERMINATE relays IECLIENTTERM(119): the terminate arm sets the
+/// i_errno global (iperf_server_api.c:290) and cleanup_server relays it at
+/// the loop's normal exit (:1001, :466) — the relay does NOT key on an error
+/// return (r1 F1; live mid-test majority fe 00000077 00000000). TWO RECORDED
+/// DEVIATIONS, both value-level: (i) GT's mid-test value RACES 119 vs 206
+/// (~2/10 live — post-teardown stream reads clobber the plain global);
+/// riperf3 pins the intended 119. (ii) GT's end-loop frame carries a
+/// LEFTOVER errno word (fe 00000077 00000009 live — EBADF from its own
+/// closed-socket reads); riperf3 pins errno 0, the #336 honest-errno-0
+/// convention.
 #[test]
-fn end_loop_client_terminate_wires_back_nothing() {
+fn end_loop_client_terminate_wires_back_ieclientterm() {
     assert_eq!(
-        run_wireback_scenario(12, false),
-        Vec::<u8>::new(),
-        "clean EOF, no SERVER_ERROR frame, on the terminate path"
+        run_wireback_scenario(Some(12), false),
+        wireback_frame(119),
+        "SERVER_ERROR + htonl(IECLIENTTERM) + htonl(0) on the end-loop terminate"
+    );
+}
+
+/// The mid-test terminate arm relays the same frame (GT's arm is shared;
+/// riperf3's two sites are distinct).
+#[test]
+fn mid_test_client_terminate_wires_back_ieclientterm() {
+    assert_eq!(
+        run_wireback_scenario(Some(12), true),
+        wireback_frame(119),
+        "SERVER_ERROR + htonl(IECLIENTTERM) + htonl(0) on the mid-test terminate"
+    );
+}
+
+/// A ctrl HALF-close (shutdown(SHUT_WR), read half open) mid-test: GT's
+/// rval==0 arm sets IECTRLCLOSE (iperf_server_api.c:251-254) and
+/// cleanup_server relays fe 0000006d 00000000, deterministic live (r1 F2).
+#[test]
+fn mid_test_ctrl_half_close_wires_back_iectrlclose() {
+    assert_eq!(
+        run_wireback_scenario(None, true),
+        wireback_frame(109),
+        "SERVER_ERROR + htonl(IECTRLCLOSE) + htonl(0) on the mid-test EOF"
+    );
+}
+
+/// The same half-close where IperfDone was due — the end loop's EOF arm.
+#[test]
+fn end_loop_ctrl_half_close_wires_back_iectrlclose() {
+    assert_eq!(
+        run_wireback_scenario(None, false),
+        wireback_frame(109),
+        "SERVER_ERROR + htonl(IECTRLCLOSE) + htonl(0) on the end-loop EOF"
     );
 }
 

--- a/riperf3-cli/tests/wire_shape.rs
+++ b/riperf3-cli/tests/wire_shape.rs
@@ -1823,9 +1823,10 @@ fn end_loop_unknown_byte_wires_back_iemessage() {
 /// CLIENT_TERMINATE relays IECLIENTTERM(119): the terminate arm sets the
 /// i_errno global (iperf_server_api.c:290) and cleanup_server relays it at
 /// the loop's normal exit (:1001, :466) — the relay does NOT key on an error
-/// return (r1 F1; live mid-test majority fe 00000077 00000000). TWO RECORDED
-/// DEVIATIONS, both value-level: (i) GT's mid-test value RACES 119 vs 206
-/// (~2/10 live — post-teardown stream reads clobber the plain global);
+/// return (r1 F1). TWO RECORDED DEVIATIONS, both value-level: (i) GT's
+/// mid-test value is NONDETERMINISTIC — 119 vs a 206 IESTREAMREAD clobber
+/// (post-teardown stream reads overwrite the plain global; either value can
+/// dominate depending on timing — r1 and r2 observed opposite majorities);
 /// riperf3 pins the intended 119. (ii) GT's end-loop frame carries a
 /// LEFTOVER errno word (fe 00000077 00000009 live — EBADF from its own
 /// closed-socket reads); riperf3 pins errno 0, the #336 honest-errno-0
@@ -1869,6 +1870,29 @@ fn end_loop_ctrl_half_close_wires_back_iectrlclose() {
         run_wireback_scenario(None, false),
         wireback_frame(109),
         "SERVER_ERROR + htonl(IECTRLCLOSE) + htonl(0) on the end-loop EOF"
+    );
+}
+
+/// The NEGATIVE half of the relay matrix (r2 F1): IPERF_DONE is GT's CLEAN
+/// arm — i_errno stays IENONE, so cleanup_server relays NOTHING (live ×5).
+/// Without this pin a spurious relay at the clean arm survives every test
+/// (the clean-cell suites never read ctrl after the final byte).
+#[test]
+fn mid_test_iperf_done_wires_back_nothing() {
+    assert_eq!(
+        run_wireback_scenario(Some(16), true),
+        Vec::<u8>::new(),
+        "clean EOF, no SERVER_ERROR frame, on the mid-test IPERF_DONE"
+    );
+}
+
+/// The end-loop clean cell — a conforming client's normal finish.
+#[test]
+fn end_loop_iperf_done_wires_back_nothing() {
+    assert_eq!(
+        run_wireback_scenario(Some(16), false),
+        Vec::<u8>::new(),
+        "clean EOF, no SERVER_ERROR frame, on the normal completion"
     );
 }
 

--- a/riperf3-cli/tests/wire_shape.rs
+++ b/riperf3-cli/tests/wire_shape.rs
@@ -173,12 +173,23 @@ fn drive_server_scenario(
     json: bool,
     mock: impl FnOnce(u16) + Send + 'static,
 ) -> (String, String, std::process::ExitStatus) {
+    drive_server_scenario_with(&[], json, mock)
+}
+
+/// [`drive_server_scenario`] with extra server flags — the #344 timestamp
+/// pins arm `--timestamps` on the same mock rounds.
+fn drive_server_scenario_with(
+    extra_args: &[&str],
+    json: bool,
+    mock: impl FnOnce(u16) + Send + 'static,
+) -> (String, String, std::process::ExitStatus) {
     let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind");
     let port = listener.local_addr().unwrap().port();
     drop(listener);
     let port_s = port.to_string();
 
     let mut args = vec!["-s", "-1", "-p", &port_s];
+    args.extend_from_slice(extra_args);
     if json {
         args.push("-J");
     }
@@ -1683,4 +1694,301 @@ fn generic_arm_failure_json_is_silent_stderr_with_skeleton_doc() {
         "skeleton bare end{{}}"
     );
     assert!(status.success());
+}
+
+// ---------------------------------------------------------------------------
+// #342: GT's cleanup_server best-effort relays SERVER_ERROR(-2) + htonl(i_errno)
+// + htonl(errno) to a still-live peer before closing (iperf_server_api.c:
+// 460-473). Live-probed (iperf 3.21): an unknown control byte wires back
+// fe 0000006e 00000000 (IEMESSAGE=110); a failed results read wires back
+// fe 00000075 00000000 (IERECVRESULTS=117). The mock reads the frame and then
+// closes — GT itself parks >10 s post-error while the peer holds, so the pin
+// must not wait for the server's close to observe the bytes.
+// ---------------------------------------------------------------------------
+
+/// The 9-byte SERVER_ERROR relay: state(-2) + htonl(i_errno) + htonl(errno=0).
+fn wireback_frame(i_errno: u8) -> Vec<u8> {
+    vec![0xfe, 0, 0, 0, i_errno, 0, 0, 0, 0]
+}
+
+/// Bounded read of whatever the server sends after the failure: up to the
+/// 9-byte relay frame, EOF, or a 6 s timeout (a server that relays nothing
+/// yields an empty read — the red shape, and the terminate deviation's pin).
+fn read_wireback(ctrl: &mut std::net::TcpStream) -> Vec<u8> {
+    ctrl.set_read_timeout(Some(Duration::from_secs(6)))
+        .expect("set_read_timeout");
+    let mut got = Vec::new();
+    let mut buf = [0u8; 9];
+    while got.len() < 9 {
+        match ctrl.read(&mut buf) {
+            Ok(0) | Err(_) => break,
+            Ok(n) => got.extend_from_slice(&buf[..n]),
+        }
+    }
+    got
+}
+
+/// Like [`run_holding_scenario`], but after the final byte the mock READS the
+/// control socket for the #342 relay frame (then closes), returning the bytes.
+fn run_wireback_scenario(final_byte: u8, junk_mid_test: bool) -> Vec<u8> {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind");
+    let port = listener.local_addr().unwrap().port();
+    drop(listener);
+    let port_s = port.to_string();
+
+    let mut server = common::ChildGuard(
+        std::process::Command::new(env!("CARGO_BIN_EXE_riperf3"))
+            .args(["-s", "-1", "-p", &port_s])
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .spawn()
+            .expect("spawn server"),
+    );
+    std::thread::sleep(std::time::Duration::from_millis(400));
+
+    let mock = std::thread::spawn(move || {
+        let cookie = [b'x'; 37];
+        let mut ctrl = std::net::TcpStream::connect(("127.0.0.1", port)).expect("ctrl");
+        ctrl.write_all(&cookie).unwrap();
+        assert_eq!(read_exact(&mut ctrl, 1)[0], 9);
+        write_json_blob(&mut ctrl, MOCK_PARAMS);
+        assert_eq!(read_exact(&mut ctrl, 1)[0], 10);
+        let mut data = std::net::TcpStream::connect(("127.0.0.1", port)).expect("data");
+        data.write_all(&cookie).unwrap();
+        assert_eq!(read_exact(&mut ctrl, 1)[0], 1);
+        assert_eq!(read_exact(&mut ctrl, 1)[0], 2);
+        data.write_all(&[0u8; 4096]).unwrap();
+        if !junk_mid_test {
+            ctrl.write_all(&[4u8]).unwrap(); // TestEnd
+            assert_eq!(read_exact(&mut ctrl, 1)[0], 13);
+            write_json_blob(&mut ctrl, MOCK_RESULTS);
+            read_json_blob(&mut ctrl); // server results
+            assert_eq!(read_exact(&mut ctrl, 1)[0], 14); // DisplayResults
+        }
+        ctrl.write_all(&[final_byte]).unwrap();
+        let frame = read_wireback(&mut ctrl);
+        drop((ctrl, data));
+        frame
+    });
+
+    let frame = mock.join().expect("mock");
+    riperf3_test_support::wait_bounded(&mut server.0, std::time::Duration::from_secs(8))
+        .expect("server exits");
+    frame
+}
+
+/// An unmapped byte during the data phase relays IEMESSAGE(110) — the
+/// Err(UnknownControlMessage) arm.
+#[test]
+fn mid_test_unknown_byte_wires_back_iemessage() {
+    assert_eq!(
+        run_wireback_scenario(99, true),
+        wireback_frame(110),
+        "SERVER_ERROR + htonl(IEMESSAGE) + htonl(0), like GT's cleanup_server"
+    );
+}
+
+/// A KNOWN state that is a stray here (ParamExchange mid-test) takes the same
+/// relay — GT's default: arm switches on the byte value, mapped or not; the
+/// riperf3 Ok(_) arm is a separate code site from the unmapped-byte arm.
+#[test]
+fn mid_test_known_stray_wires_back_iemessage() {
+    assert_eq!(
+        run_wireback_scenario(9, true),
+        wireback_frame(110),
+        "the known-stray arm relays like the unmapped-byte arm"
+    );
+}
+
+/// The end loop's IEMESSAGE (junk where IperfDone was due) relays too.
+#[test]
+fn end_loop_unknown_byte_wires_back_iemessage() {
+    assert_eq!(
+        run_wireback_scenario(99, false),
+        wireback_frame(110),
+        "the end-loop arm shares GT's handle_message default relay"
+    );
+}
+
+/// RECORDED DEVIATION: no relay on CLIENT_TERMINATE. GT's terminate arm
+/// (iperf_server_api.c:289-307) sets IECLIENTTERM, prints, closes the stream
+/// sockets, and returns 0 — no error return — yet a live GT wires back
+/// fe 000000ce (IESTREAMREAD=206): its post-teardown stream reads CLOBBER
+/// i_errno before cleanup_server reads it. That relay is bug noise, not
+/// behavior (the ethos ruling: implement cleanly, document, don't mirror) —
+/// riperf3 sends nothing and closes.
+#[test]
+fn end_loop_client_terminate_wires_back_nothing() {
+    assert_eq!(
+        run_wireback_scenario(12, false),
+        Vec::<u8>::new(),
+        "clean EOF, no SERVER_ERROR frame, on the terminate path"
+    );
+}
+
+/// A zero-size results prefix from a peer that HOLDS its socket: GT wires
+/// back fe 00000075 00000000 (IERECVRESULTS=117, live-probed) — riperf3's
+/// exchange_recv_failed arm must relay before the finalize phases.
+#[test]
+fn exchange_failure_wires_back_recv_results() {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind");
+    let port = listener.local_addr().unwrap().port();
+    drop(listener);
+    let port_s = port.to_string();
+
+    let mut server = common::ChildGuard(
+        std::process::Command::new(env!("CARGO_BIN_EXE_riperf3"))
+            .args(["-s", "-1", "-p", &port_s])
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .spawn()
+            .expect("spawn server"),
+    );
+    std::thread::sleep(std::time::Duration::from_millis(400));
+
+    let mock = std::thread::spawn(move || {
+        let cookie = [b'x'; 37];
+        let mut ctrl = std::net::TcpStream::connect(("127.0.0.1", port)).expect("ctrl");
+        ctrl.write_all(&cookie).unwrap();
+        assert_eq!(read_exact(&mut ctrl, 1)[0], 9);
+        write_json_blob(&mut ctrl, MOCK_PARAMS);
+        assert_eq!(read_exact(&mut ctrl, 1)[0], 10);
+        let mut data = std::net::TcpStream::connect(("127.0.0.1", port)).expect("data");
+        data.write_all(&cookie).unwrap();
+        assert_eq!(read_exact(&mut ctrl, 1)[0], 1);
+        assert_eq!(read_exact(&mut ctrl, 1)[0], 2);
+        data.write_all(&[0u8; 4096]).unwrap();
+        ctrl.write_all(&[4u8]).unwrap(); // TestEnd
+        assert_eq!(read_exact(&mut ctrl, 1)[0], 13); // ExchangeResults
+        ctrl.write_all(&0u32.to_be_bytes()).unwrap(); // zero-size prefix, HOLD
+        let frame = read_wireback(&mut ctrl);
+        drop((ctrl, data));
+        frame
+    });
+
+    let frame = mock.join().expect("mock");
+    riperf3_test_support::wait_bounded(&mut server.0, std::time::Duration::from_secs(8))
+        .expect("server exits");
+    assert_eq!(
+        frame,
+        wireback_frame(117),
+        "SERVER_ERROR + htonl(IERECVRESULTS) + htonl(0), like GT's cleanup_server"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// #344: iperf_err stamps EVERY stderr error line with the --timestamps prefix
+// (iperf_error.c:51-57, :77) — the serve-loop arms must ride the same
+// output_timestamp_prefix() the pre-test emit gained in #339. GT's warning()
+// lines stay BARE (live-probed) — the exchange pin discriminates the two.
+// A literal strftime format keeps the pins deterministic on unix; Windows
+// uses the documented HH:MM:SS fallback and ignores the format, so the
+// byte-exact half of each pin is unix-only (the #339 lesson).
+// ---------------------------------------------------------------------------
+
+const TS_ARGS: &[&str] = &["--timestamps=XTSX "];
+
+/// Portable half: a nonempty prefix precedes the expected line. Unix half:
+/// the literal format renders verbatim.
+fn assert_stamped(line: &str, bare: &str) {
+    assert!(
+        line.ends_with(bare) && line.len() > bare.len(),
+        "a nonempty timestamp prefix precedes the line: {line:?}"
+    );
+    #[cfg(unix)]
+    assert_eq!(
+        line,
+        &format!("XTSX {bare}"),
+        "the literal format renders verbatim: {line:?}"
+    );
+}
+
+/// The mid-test ctrl-EOF arm (IECTRLCLOSE sentence).
+#[test]
+fn mid_test_eof_line_carries_the_timestamps_prefix() {
+    let (_sout, serr, status) = drive_server_scenario_with(TS_ARGS, false, |port| {
+        drive_mock_round_full(port, None, true, MOCK_PARAMS)
+    });
+    assert!(status.success());
+    assert_stamped(
+        serr.trim_end_matches('\n'),
+        &format!("riperf3: {CTRL_CLOSED}"),
+    );
+}
+
+/// The client-terminated arm (bare IECLIENTTERM sentence, no "error - ").
+#[test]
+fn end_loop_client_terminate_line_carries_the_timestamps_prefix() {
+    let (_sout, serr, status) = drive_server_scenario_with(TS_ARGS, false, |port| {
+        drive_mock_round_full(port, Some(12), false, MOCK_PARAMS)
+    });
+    assert!(status.success());
+    assert_stamped(
+        serr.trim_end_matches('\n'),
+        "riperf3: the client has terminated",
+    );
+}
+
+/// The recv-results arm: the ERROR line is stamped, the read-site warning()
+/// line above it stays BARE like GT's (iperf_error.c has no stamp in
+/// warning-class output; live-probed).
+#[test]
+fn exchange_eof_error_line_stamped_warning_stays_bare() {
+    let (_sout, serr, status) = drive_server_scenario_with(TS_ARGS, false, |port| {
+        let cookie = [b'x'; 37];
+        let mut ctrl = std::net::TcpStream::connect(("127.0.0.1", port)).expect("ctrl");
+        ctrl.write_all(&cookie).unwrap();
+        assert_eq!(read_exact(&mut ctrl, 1)[0], 9);
+        write_json_blob(&mut ctrl, MOCK_PARAMS);
+        assert_eq!(read_exact(&mut ctrl, 1)[0], 10);
+        let mut data = std::net::TcpStream::connect(("127.0.0.1", port)).expect("data");
+        data.write_all(&cookie).unwrap();
+        assert_eq!(read_exact(&mut ctrl, 1)[0], 1);
+        assert_eq!(read_exact(&mut ctrl, 1)[0], 2);
+        data.write_all(&[0u8; 4096]).unwrap();
+        ctrl.write_all(&[4u8]).unwrap(); // TestEnd
+        assert_eq!(read_exact(&mut ctrl, 1)[0], 13); // ExchangeResults
+        drop((ctrl, data)); // EOF where the results were due
+        std::thread::sleep(std::time::Duration::from_millis(300));
+    });
+    assert!(status.success());
+    let lines: Vec<&str> = serr.lines().collect();
+    assert_eq!(lines.len(), 2, "warning then the error line: {serr:?}");
+    assert_eq!(
+        lines[0], "warning: Failed to read JSON data size - read returned 0; errno=0",
+        "the warning-class line stays BARE like GT's"
+    );
+    assert_stamped(lines[1], &format!("riperf3: {RECV_RESULTS_ERR}"));
+}
+
+/// The unknown-message arm (end loop; the mid-test arm shares the print site).
+#[test]
+fn end_loop_unknown_byte_line_carries_the_timestamps_prefix() {
+    let (_sout, serr, status) = drive_server_scenario_with(TS_ARGS, false, |port| {
+        drive_mock_round_full(port, Some(99), false, MOCK_PARAMS)
+    });
+    assert!(status.success());
+    assert_stamped(
+        serr.trim_end_matches('\n'),
+        &format!("riperf3: error - {IEMESSAGE}"),
+    );
+}
+
+/// The serve loop's residual generic arm (#188-class rejection wording is
+/// riperf3's own, so the pin is on the PREFIX, not the sentence).
+#[test]
+fn generic_arm_failure_line_carries_the_timestamps_prefix() {
+    let (_sout, serr, status) =
+        drive_server_scenario_with(TS_ARGS, false, drive_generic_arm_failure);
+    assert!(status.success());
+    let line = serr.trim_end_matches('\n');
+    assert!(
+        line.contains("riperf3: error - ") && !line.starts_with("riperf3:"),
+        "a nonempty timestamp prefix precedes the residual-arm line: {line:?}"
+    );
+    #[cfg(unix)]
+    assert!(
+        line.starts_with("XTSX riperf3: error - "),
+        "the literal format renders verbatim: {line:?}"
+    );
 }

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -480,8 +480,15 @@ impl Server {
                     // Pre-test EOFs like port scans are caught earlier by the
                     // cookie read and take GT's IERECVCOOKIE surface via the
                     // RecvCookieFailed arm below (#330), not this mid-test one.)
+                    // #344: iperf_err stamps its stderr lines with the
+                    // --timestamps prefix (iperf_error.c:51-57, :77) — every
+                    // arm below rides output_timestamp_prefix() like the
+                    // pre-test emit (#339) and the stdout banner.
                     if !json && !crate::macros::output_quiet() {
-                        eprintln!("riperf3: {CTRL_CLOSED_MSG}");
+                        eprintln!(
+                            "{}riperf3: {CTRL_CLOSED_MSG}",
+                            crate::macros::output_timestamp_prefix()
+                        );
                     }
                 }
                 Err(RiperfError::ClientTerminated) => {
@@ -491,7 +498,11 @@ impl Server {
                     // modes the doc/event carried it — stderr stays silent
                     // like iperf_err (review r1 f1/f3).
                     if !json && !crate::macros::output_quiet() {
-                        eprintln!("riperf3: {}", RiperfError::ClientTerminated);
+                        eprintln!(
+                            "{}riperf3: {}",
+                            crate::macros::output_timestamp_prefix(),
+                            RiperfError::ClientTerminated
+                        );
                     }
                 }
                 Err(RiperfError::RecvResultsFailed) => {
@@ -501,7 +512,11 @@ impl Server {
                     // under -J the doc carried it and stderr keeps only
                     // the read-site warning.
                     if !json && !crate::macros::output_quiet() {
-                        eprintln!("riperf3: error - {}: ", RiperfError::RecvResultsFailed);
+                        eprintln!(
+                            "{}riperf3: error - {}: ",
+                            crate::macros::output_timestamp_prefix(),
+                            RiperfError::RecvResultsFailed
+                        );
                     }
                 }
                 Err(RiperfError::UnknownControlMessage) => {
@@ -512,7 +527,11 @@ impl Server {
                     // Under -J iperf_err's sink carried it in the doc —
                     // stderr stays silent, like the terminate arm above.
                     if !json && !crate::macros::output_quiet() {
-                        eprintln!("riperf3: error - {}", RiperfError::UnknownControlMessage);
+                        eprintln!(
+                            "{}riperf3: error - {}",
+                            crate::macros::output_timestamp_prefix(),
+                            RiperfError::UnknownControlMessage
+                        );
                     }
                 }
                 // #330: the pre-test control failures. Unlike the classes
@@ -532,7 +551,10 @@ impl Server {
                     if json {
                         self.emit_pretest_error_doc(&format!("error - {e}"));
                     } else if !crate::macros::output_quiet() {
-                        eprintln!("riperf3: error - {e}");
+                        eprintln!(
+                            "{}riperf3: error - {e}",
+                            crate::macros::output_timestamp_prefix()
+                        );
                     }
                 }
             }
@@ -1492,6 +1514,12 @@ impl Server {
                             // partial results in the finalize phases (the old
                             // early return leaked the reporter — the #147
                             // class — and skipped the dump iperf3 performs).
+                            // #342 RECORDED DEVIATION: NO SERVER_ERROR relay
+                            // here. GT's terminate arm returns 0 (no error),
+                            // yet a live GT wires back fe 000000ce
+                            // (IESTREAMREAD=206): its post-teardown stream
+                            // reads clobber i_errno before cleanup_server
+                            // reads it — bug noise, not behavior.
                             ctx.client_terminated = true;
                             break;
                         }
@@ -1512,7 +1540,12 @@ impl Server {
                         // prefixed doc key, exit 0; the full stray set is
                         // 2/9/10/11/13/14/15/-1/-2). The #145 tolerance is
                         // gone on this loop like the end loop's (#329).
+                        // #342: cleanup_server's best-effort relay —
+                        // SERVER_ERROR + htonl(IEMESSAGE=110) + htonl(errno)
+                        // to a still-live peer (iperf_server_api.c:460-473;
+                        // live: fe 0000006e 00000000).
                         Ok(_) => {
+                            let _ = protocol::send_server_error(&mut ctx.ctrl, 110).await;
                             ctx.unknown_message = true;
                             ctx.bare_end = true;
                             break;
@@ -1527,6 +1560,10 @@ impl Server {
                         // convention); GT's reporter dies with only whole
                         // ticks in the doc.
                         Err(RiperfError::UnknownControlMessage) => {
+                            // #342: the unmapped-byte arm relays like the
+                            // known-stray arm above — GT's default: switches
+                            // on the byte value, mapped or not.
+                            let _ = protocol::send_server_error(&mut ctx.ctrl, 110).await;
                             ctx.unknown_message = true;
                             ctx.bare_end = true;
                             break;
@@ -1655,7 +1692,12 @@ impl Server {
         // returning an error from this path (#224).
         if let Some(msg) = ctx.server_error {
             if !self.json_output && !self.json_stream && !crate::macros::output_quiet() {
-                eprintln!("riperf3: error - {msg}");
+                // #344: iperf_err's --timestamps stamp (server_timer_proc
+                // prints through iperf_err directly).
+                eprintln!(
+                    "{}riperf3: error - {msg}",
+                    crate::macros::output_timestamp_prefix()
+                );
             }
         }
 
@@ -1934,7 +1976,12 @@ impl Server {
                     // the doc. (The rendered error KEY is IERECVRESULTS on
                     // every close-type here — a deliberate deviation from
                     // GT's RST→IESENDMESSAGE flip; see the field's docs.)
+                    // #342: cleanup_server's relay — SERVER_ERROR +
+                    // htonl(IERECVRESULTS=117) + htonl(errno) to a peer that
+                    // still holds the socket (live: fe 00000075 00000000);
+                    // best-effort, a vanished peer just fails the write.
                     Err(_) => {
+                        let _ = protocol::send_server_error(&mut ctx.ctrl, 117).await;
                         ctx.exchange_recv_failed = true;
                         return Ok(());
                     }
@@ -1976,6 +2023,9 @@ impl Server {
                     // full blocks). riperf3 prints one dump; -J is identical
                     // on both (single doc, error key).
                     Ok(TestState::ClientTerminate) => {
+                        // #342: no relay — the mid-test terminate arm's
+                        // recorded deviation (GT's fe 000000ce is i_errno
+                        // clobber noise).
                         ctx.client_terminated = true;
                         return Ok(());
                     }
@@ -1993,6 +2043,10 @@ impl Server {
                     // would wedge both sides; it takes the IEMESSAGE class
                     // instead.
                     Ok(_) | Err(RiperfError::UnknownControlMessage) => {
+                        // #342: the same cleanup_server relay as the
+                        // mid-test arms — GT routes both loops through one
+                        // handle_message_server switch.
+                        let _ = protocol::send_server_error(&mut ctx.ctrl, 110).await;
                         ctx.unknown_message = true;
                         return Ok(());
                     }
@@ -2848,7 +2902,12 @@ impl Server {
         }
         match serde_json::to_string_pretty(report) {
             Ok(s) => println!("{s}"),
-            Err(e) => eprintln!("riperf3: error - failed to serialize JSON: {e}"),
+            // #344: stamped for sink consistency (riperf3-internal class —
+            // GT has no serialize-fail arm to match).
+            Err(e) => eprintln!(
+                "{}riperf3: error - failed to serialize JSON: {e}",
+                crate::macros::output_timestamp_prefix()
+            ),
         }
     }
 
@@ -2874,7 +2933,12 @@ impl Server {
                 );
             }
         } else if !crate::macros::output_quiet() {
-            eprintln!("riperf3: error - {MSG}");
+            // #344: iperf_err's --timestamps stamp (the refusal reaches
+            // main.c:174's iperf_err via the -1 return).
+            eprintln!(
+                "{}riperf3: error - {MSG}",
+                crate::macros::output_timestamp_prefix()
+            );
         }
         Ok(())
     }
@@ -2950,7 +3014,11 @@ impl Server {
                 );
             }
         } else if !crate::macros::output_quiet() {
-            eprintln!("riperf3: error - {MSG}");
+            // #344: iperf_err's --timestamps stamp, like the total-rate twin.
+            eprintln!(
+                "{}riperf3: error - {MSG}",
+                crate::macros::output_timestamp_prefix()
+            );
         }
         Ok(())
     }

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -1514,12 +1514,16 @@ impl Server {
                             // partial results in the finalize phases (the old
                             // early return leaked the reporter — the #147
                             // class — and skipped the dump iperf3 performs).
-                            // #342 RECORDED DEVIATION: NO SERVER_ERROR relay
-                            // here. GT's terminate arm returns 0 (no error),
-                            // yet a live GT wires back fe 000000ce
-                            // (IESTREAMREAD=206): its post-teardown stream
-                            // reads clobber i_errno before cleanup_server
-                            // reads it — bug noise, not behavior.
+                            // #342 (r1 F1): the terminate arm sets the
+                            // i_errno GLOBAL (iperf_server_api.c:290) and
+                            // cleanup_server relays it at the loop's normal
+                            // exit (:1001, :466) — the relay does not key on
+                            // an error return. RECORDED DEVIATION
+                            // (value-level): GT's live value RACES 119 vs a
+                            // 206 clobber (~2/10 — post-teardown stream
+                            // reads overwrite the plain global); riperf3
+                            // pins the intended IECLIENTTERM(119).
+                            let _ = protocol::send_server_error(&mut ctx.ctrl, 119).await;
                             ctx.client_terminated = true;
                             break;
                         }
@@ -1571,7 +1575,14 @@ impl Server {
                         // #330: control EOF mid-test — GT's IECTRLCLOSE
                         // read-site surface, a CLEAN round (IPERF_DONE):
                         // bare sentence in the doc, no summary, exit 0.
+                        // #342 (r1 F2): the rval==0 arm sets IECTRLCLOSE
+                        // (iperf_server_api.c:251-254) and cleanup_server
+                        // relays it — observable by a half-closed peer whose
+                        // read half is still open (deterministic live:
+                        // fe 0000006d 00000000); best-effort no-op on a
+                        // full close.
                         Err(RiperfError::PeerDisconnected) => {
+                            let _ = protocol::send_server_error(&mut ctx.ctrl, 109).await;
                             ctx.ctrl_closed = true;
                             ctx.bare_end = true;
                             break;
@@ -2023,9 +2034,13 @@ impl Server {
                     // full blocks). riperf3 prints one dump; -J is identical
                     // on both (single doc, error key).
                     Ok(TestState::ClientTerminate) => {
-                        // #342: no relay — the mid-test terminate arm's
-                        // recorded deviation (GT's fe 000000ce is i_errno
-                        // clobber noise).
+                        // #342 (r1 F1): IECLIENTTERM(119) relay like the
+                        // mid-test terminate arm. RECORDED DEVIATION
+                        // (value-level): GT's end-loop frame carries a
+                        // LEFTOVER errno word (fe 00000077 00000009 live —
+                        // EBADF from its own closed-socket reads); riperf3
+                        // pins errno 0, the #336 honest-errno-0 convention.
+                        let _ = protocol::send_server_error(&mut ctx.ctrl, 119).await;
                         ctx.client_terminated = true;
                         return Ok(());
                     }
@@ -2054,7 +2069,10 @@ impl Server {
                     // cell. GT prints its read-site sentence and the doc
                     // keeps the error key over the POPULATED end (the
                     // exchange completed; live-probed).
+                    // #342 (r1 F2): IECTRLCLOSE(109) relay like the
+                    // mid-test EOF arm — observable on a half-close only.
                     Err(RiperfError::PeerDisconnected) => {
+                        let _ = protocol::send_server_error(&mut ctx.ctrl, 109).await;
                         ctx.ctrl_closed = true;
                         break;
                     }

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -1519,10 +1519,12 @@ impl Server {
                             // cleanup_server relays it at the loop's normal
                             // exit (:1001, :466) — the relay does not key on
                             // an error return. RECORDED DEVIATION
-                            // (value-level): GT's live value RACES 119 vs a
-                            // 206 clobber (~2/10 — post-teardown stream
-                            // reads overwrite the plain global); riperf3
-                            // pins the intended IECLIENTTERM(119).
+                            // (value-level): GT's live value is
+                            // NONDETERMINISTIC — 119 vs a 206 IESTREAMREAD
+                            // clobber (post-teardown stream reads overwrite
+                            // the plain global; either value can dominate
+                            // depending on timing); riperf3 pins the
+                            // intended IECLIENTTERM(119).
                             let _ = protocol::send_server_error(&mut ctx.ctrl, 119).await;
                             ctx.client_terminated = true;
                             break;


### PR DESCRIPTION
Closes #342, closes #344.

Two serve-loop error-surface fidelity fixes, batched because they share the surface and the test harness.

## #342 — SERVER_ERROR wire-back on server error paths

GT's `cleanup_server` best-effort relays `SERVER_ERROR(-2)` + `htonl(i_errno)` + `htonl(errno)` to a still-live peer before closing (iperf_server_api.c:460-473). Key mechanism (r1 F1): it keys on the **i_errno global** at the run loop's exit (:1001), NOT on an error return — so arms that "return 0" still relay whatever i_errno holds. Live-probed (3.21):

| Scenario | GT wire-back | riperf3 (before) |
|---|---|---|
| results-exchange failure (zero-size prefix, peer holds) | `fe 00000075 00000000` (IERECVRESULTS=117) | nothing |
| unknown control byte (mid-test or end loop) | `fe 0000006e 00000000` (IEMESSAGE=110) | nothing |
| ctrl half-close (SHUT_WR, read half open) | `fe 0000006d 00000000` (IECTRLCLOSE=109) | nothing |
| CLIENT_TERMINATE mid-test | always relays; VALUE races 119 vs 206 clobber (timing-dependent — r1 saw mostly 119, r2 mostly 206) | nothing |
| CLIENT_TERMINATE end loop | `fe 00000077 00000009` (119 + leftover errno) 3/3 | nothing |

Fix: best-effort `let _ = protocol::send_server_error(...)` (the #339 pattern) at all 8 failure arms:

- exchange `recv_results_server` failure → 117
- mid-test known-stray (`Ok(_)`), mid-test unmapped byte, end-loop unknown arm → 110 (GT's `default:` switches on the byte value, mapped or not)
- mid-test + end-loop `PeerDisconnected` (ctrl EOF) → 109 (observable by a half-closed peer; best-effort no-op on a full close)
- mid-test + end-loop `ClientTerminate` → 119

**RECORDED DEVIATIONS (both value-level, on the terminate arms):**
1. GT's mid-test terminate value is NONDETERMINISTIC — 119 vs a 206 IESTREAMREAD clobber (post-teardown stream reads overwrite the plain `i_errno` global; either value can dominate depending on timing — r1 and r2 observed opposite majorities). riperf3 pins the intended IECLIENTTERM(119). (r1 corrected the original draft, which read the clobber outcome as "GT doesn't relay" — GT always relays; only the VALUE races.)
2. GT's end-loop terminate frame carries a LEFTOVER errno word (9/EBADF from its own closed-socket reads). riperf3 pins errno 0 — the #336 honest-errno-0 convention.

Scope confirmations from r1: interrupt paths need no relay (iperf_got_sigend sends only the bare SERVER_TERMINATE byte, no cleanup_server — iperf_api.c:5144-5168; riperf3 matches); IERECVMESSAGE (rval<0) unreachable with a readable peer, relay unobservable after RST.

## #344 — --timestamps prefix on stderr error lines

GT's `iperf_err` stamps its stderr lines with the `--timestamps` strftime prefix (iperf_error.c:51-57, :77); `warning:`-class lines stay bare (live-probed). The pre-test emit gained the stamp in #339; this PR completes the server family — verified per-arm against GT source:

| Site | GT print path |
|---|---|
| ctrl-closed sentence | `iperf_err` direct (iperf_server_api.c:251) |
| client-terminated sentence | `iperf_err` direct (:301) |
| recv-results error line | main.c:174 `iperf_err` |
| unknown-message error line | main.c:174 `iperf_err` |
| residual generic arm | same main.c sink shape |
| self-terminate line (rate/duration) | `server_timer_proc` → `iperf_err` (:328) |
| max-duration refusal text line | main.c:174 via the -1 return |
| total-rate refusal text line | main.c:174 via the -1 return |

The internal serialize-fail line is stamped for sink consistency but unpinned (riperf3-internal class, no GT shape to match).

**Follow-up filed:** #348 — the client half (GT's `iperf_errexit` stamps too; live-probed).

## Review round 1 (cold, adversarial, GT-fidelity)

REQUEST-CHANGES → all findings addressed:

- **F1 (BLOCKER)**: the original "no relay on CLIENT_TERMINATE" deviation misread GT — cleanup_server keys on the i_errno global, and live GT relays deterministically (majority 119). Fixed: relay 119 at both terminate arms; deviation records rewritten to the two honest value-level deviations above; pin flipped to assert the 119 frame.
- **F2 (HIGH)**: IECTRLCLOSE relay hole at both ctrl-EOF arms — same class, GT deterministic on half-close. Fixed: relay 109 at both + two half-close pins.
- **F3 (LOW)**: harness comment falsely claimed GT parks >10s post-error while the peer holds; GT sends the frame and closes at once. Comment corrected.
- **F4 (LOW)**: r1 observed a pre-existing full-suite flake twice in 7 runs (`mid_test_client_terminate_exits_bounded_while_peer_holds` once, consistent with the bind-then-drop ephemeral-port race; targeted hammers 10x + 2-core-pinned 6x all green). Untouched code path, no change in this PR — disclosed for the gate record.
- **F5 (NIT)**: test count corrected (below).
- **F6 (NIT)**: two out-of-scope GT observations filed as follow-up issues (GT double-relays the runtime IETOTALRATE breach; riperf3 lacks GT's data-idle IENOMSG=144 restart path).

r1 verified byte-fidelity of every shipped relay against GT source + live probes, confirmed errno word 0 in the non-terminate paths, confirmed the holding-peer bounded-exit pins hold with the new awaits, and killed 5 independent mutations of its own.

## Review round 2 (cold, independent)

APPROVE — re-derived the full relay matrix live (9 cells, all byte-identical at bc9fde9); verified both deviations are unobservable by conforming clients (GT's SIGINT client never reads the relay — iperf_api.c:5144-5187 — and GT renders 206 as the nonsense "unable to read from stream" while 119+errno-0 renders the clean terminate sentence); GT-interop live runs (normal / SIGINT / kill-9, text and -J) masked-identical to a GT server; independently re-verified the #344 stamp routing + a missed-site sweep; ran 5 own mutations. Three LOW findings, fixed in 8687a79:

- **F1**: the negative relay cells were unpinned — r2's spurious-relay-at-IperfDone mutant survived all 802 tests. Fixed: two clean-cell pins (mid-test + end-loop IPERF_DONE → zero bytes on ctrl), both red-verified against that exact mutant (M18/M19).
- **F2**: the deviation records overstated the terminate-race rate (r1's ~8/2 majority-119 did not replicate; r2 saw 10/12 clobber). Both comment sites + this body softened to "nondeterministic, timing-dependent".
- **F3**: the shared client/server interrupt line (main.rs:660) is GT-stamped on both roles but bare in riperf3 — explicitly noted on #348 (whose fix needs a public prefix accessor; out of this server.rs-scoped PR).

r2 also confirmed the pre-existing clean-teardown hold >6s on a data-socket-holding peer reproduces on BASE — that is exactly open issue #331 (next in the train).

## Tests (18 new, TDD red-first)

- 10 wire-back pins (wire_shape.rs): mock reads the 9-byte relay frame after triggering each failure, then closes. The EOF cells use a half-close (`shutdown(SHUT_WR)`, read half open) so the pin can observe the relay; the two IPERF_DONE clean cells pin the NEGATIVE half of the matrix (zero bytes).
- 5 serve-loop timestamp pins (wire_shape.rs) with `--timestamps=XTSX ` literal format: portable nonempty-prefix assert + byte-exact `XTSX ` under `cfg(unix)` (Windows HH:MM:SS fallback ignores custom formats — the #339 lesson). The exchange pin also asserts the read-site `warning:` line stays BARE, discriminating iperf_err-class from warning-class output.
- 3 self_terminate.rs timestamp pins: runtime bitrate breach, upfront total-rate refusal, upfront max-duration refusal (the upfront scenarios pick the refusal sites — same message text as the runtime breach, different code path).

## Mutation table (19 rounds, each restored from the committed tree)

| # | Mutation | Killing test | Result |
|---|---|---|---|
| M1 | remove mid-test `Ok(_)` relay | mid_test_known_stray_wires_back_iemessage | RED |
| M2 | remove mid-test unmapped-byte relay | mid_test_unknown_byte_wires_back_iemessage | RED |
| M3 | remove exchange relay | exchange_failure_wires_back_recv_results | RED |
| M4 | remove end-loop unknown relay | end_loop_unknown_byte_wires_back_iemessage | RED |
| M5 | (superseded by r1 F1 — original no-relay pin; replaced by M14/M16) | — | — |
| M6 | blank ctrl-closed stamp | mid_test_eof_line_carries_the_timestamps_prefix | RED |
| M7 | blank client-terminated stamp | end_loop_client_terminate_line_carries_the_timestamps_prefix | RED |
| M8 | blank recv-results stamp | exchange_eof_error_line_stamped_warning_stays_bare | RED |
| M9 | blank unknown-message stamp | end_loop_unknown_byte_line_carries_the_timestamps_prefix | RED |
| M10 | blank residual-arm stamp | generic_arm_failure_line_carries_the_timestamps_prefix | RED |
| M11 | blank self-terminate stamp | bitrate_limit_line_carries_the_timestamps_prefix | RED |
| M12 | blank total-rate refusal stamp | upfront_total_rate_line_carries_the_timestamps_prefix | RED |
| M13 | blank max-duration refusal stamp | upfront_max_duration_line_carries_the_timestamps_prefix | RED |
| M14 | remove mid-test terminate relay | mid_test_client_terminate_wires_back_ieclientterm | RED |
| M15 | remove mid-test EOF relay | mid_test_ctrl_half_close_wires_back_iectrlclose | RED |
| M16 | remove end-loop terminate relay | end_loop_client_terminate_wires_back_ieclientterm | RED |
| M17 | remove end-loop EOF relay | end_loop_ctrl_half_close_wires_back_iectrlclose | RED |
| M18 | spurious relay at mid-test IPERF_DONE clean arm | mid_test_iperf_done_wires_back_nothing | RED |
| M19 | spurious relay at end-loop IPERF_DONE clean arm | end_loop_iperf_done_wires_back_nothing | RED |

## Gates

- workspace tests: 804 passed, 0 failed (786 + 18 new)
- clippy `-D warnings`: clean; fmt: clean
- xcheck 7/7 targets
- CI + per-merge compat 52/52 before merge
