### PR TITLE
fix: success-path stream joins no longer park on a socket-holding peer (#331)

### DIFF
--- a/riperf3-cli/tests/wire_shape.rs
+++ b/riperf3-cli/tests/wire_shape.rs
@@ -543,6 +543,22 @@ fn mid_test_client_terminate_exits_bounded_while_peer_holds() {
     );
 }
 
+/// #331: the SUCCESS path — a COMPLETED round (IperfDone received, results
+/// exchanged, doc emitted) against a peer that then HOLDS its sockets open.
+/// GT closes every stream socket at TEST_END (iperf_server_api.c:272-275)
+/// and its one-off exits on its own clock; riperf3's success-path joins
+/// parked in the receivers' read() for the peer's whole hold (live: >6 s,
+/// 3/3 on the pre-fix tree).
+#[test]
+fn clean_finish_exits_bounded_while_peer_holds() {
+    let (serr, status) = run_holding_scenario(16, false);
+    assert!(status.success(), "clean one-off exit 0");
+    assert!(
+        serr.trim().is_empty(),
+        "a completed round prints nothing to stderr: {serr:?}"
+    );
+}
+
 const CTRL_CLOSED: &str = "the client has unexpectedly closed the connection";
 
 /// #330: an abrupt EOF DURING the data phase is GT's IECTRLCLOSE read-site

--- a/riperf3-cli/tests/wire_shape.rs
+++ b/riperf3-cli/tests/wire_shape.rs
@@ -451,6 +451,21 @@ fn mid_test_unknown_byte_with_get_server_output_prints_no_summary() {
 /// which must arrive while the peer still holds. Detached mock thread;
 /// the sockets close when the test binary exits.
 fn run_holding_scenario(final_byte: u8, junk_mid_test: bool) -> (String, std::process::ExitStatus) {
+    run_holding_scenario_params(final_byte, junk_mid_test, MOCK_PARAMS, 0)
+}
+
+/// `pre_end_delay_ms`: dwell in TEST_RUNNING before sending TestEnd. The
+/// reverse (sender-park) cell needs the server's sender to FILL the
+/// unread-peer buffers and park in write_all() BEFORE `done` is set — an
+/// immediate TestEnd lets the sender exit via its done-check without ever
+/// parking, and the pin can't discriminate (buffers fill in ~ms at loopback
+/// speed; the dwell is ample).
+fn run_holding_scenario_params(
+    final_byte: u8,
+    junk_mid_test: bool,
+    params: &'static str,
+    pre_end_delay_ms: u64,
+) -> (String, std::process::ExitStatus) {
     let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind");
     let port = listener.local_addr().unwrap().port();
     drop(listener);
@@ -473,7 +488,7 @@ fn run_holding_scenario(final_byte: u8, junk_mid_test: bool) -> (String, std::pr
         let mut ctrl = std::net::TcpStream::connect(("127.0.0.1", port)).expect("ctrl");
         ctrl.write_all(&cookie).unwrap();
         assert_eq!(read_exact(&mut ctrl, 1)[0], 9);
-        write_json_blob(&mut ctrl, MOCK_PARAMS);
+        write_json_blob(&mut ctrl, params);
         assert_eq!(read_exact(&mut ctrl, 1)[0], 10);
         let mut data = std::net::TcpStream::connect(("127.0.0.1", port)).expect("data");
         data.write_all(&cookie).unwrap();
@@ -481,6 +496,9 @@ fn run_holding_scenario(final_byte: u8, junk_mid_test: bool) -> (String, std::pr
         assert_eq!(read_exact(&mut ctrl, 1)[0], 2);
         data.write_all(&[0u8; 4096]).unwrap();
         if !junk_mid_test {
+            if pre_end_delay_ms > 0 {
+                std::thread::sleep(std::time::Duration::from_millis(pre_end_delay_ms));
+            }
             ctrl.write_all(&[4u8]).unwrap(); // TestEnd
             assert_eq!(read_exact(&mut ctrl, 1)[0], 13);
             write_json_blob(&mut ctrl, MOCK_RESULTS);
@@ -556,6 +574,24 @@ fn clean_finish_exits_bounded_while_peer_holds() {
     assert!(
         serr.trim().is_empty(),
         "a completed round prints nothing to stderr: {serr:?}"
+    );
+}
+
+/// The reverse round's params — the server streams are SENDERS.
+const MOCK_PARAMS_REVERSE: &str = r#"{"tcp":true,"omit":0,"time":1,"num":0,"blockcount":0,"parallel":1,"len":131072,"pacing_timer":1000,"reverse":true,"client_version":"riperf3 0.0.0"}"#;
+
+/// #331 (r2 F2): the SENDER arm — a REVERSE round where the peer completes
+/// the protocol but never drains the data socket parks the server's sender
+/// in write_all() against the full buffers (pre-fix: wedged the peer's whole
+/// hold, live 12 s; post-fix: ms exit). The abort is direction-blind; this
+/// pin keeps the sender arm covered explicitly.
+#[test]
+fn clean_finish_reverse_exits_bounded_while_peer_holds() {
+    let (serr, status) = run_holding_scenario_params(16, false, MOCK_PARAMS_REVERSE, 500);
+    assert!(status.success(), "clean reverse one-off exit 0");
+    assert!(
+        serr.trim().is_empty(),
+        "a completed reverse round prints nothing to stderr: {serr:?}"
     );
 }
 

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -850,19 +850,21 @@ impl Server {
         // its own clock). Covers the pre-existing mid-test terminate too.
         // #330: ctrl_closed joins — a peer may EOF the control socket
         // while holding the DATA sockets open; GT's cleanup closes them.
-        if ctx.interrupted.is_some()
-            || ctx.unknown_message
-            || ctx.client_terminated
-            || ctx.ctrl_closed
-            || ctx.early_done
-            || ctx.exchange_recv_failed
-        {
-            for s in &ctx.streams {
-                s.task.abort();
-            }
-            if let Some(h) = &ctx.udp_demux_handle {
-                h.abort();
-            }
+        // #331: the SUCCESS path parks the same way — a completed peer that
+        // holds its data sockets leaves receivers in read(), so the old
+        // abnormal-end gate is now unconditional. GT closes every stream
+        // socket at TEST_END (iperf_server_api.c:272-275); closing at
+        // riperf3's literal TestEnd arm would race the #55/#159 catch-up
+        // window and drift byte counts, so the safe equivalent is here:
+        // counts are frozen at build_result_streams + the exchange, and
+        // every sink has emitted. Abort drops each tokio task's socket at
+        // its next await; the spawn_blocking UDP runners are bounded by the
+        // 500 ms read-timeout + `done` polling either way.
+        for s in &ctx.streams {
+            s.task.abort();
+        }
+        if let Some(h) = &ctx.udp_demux_handle {
+            h.abort();
         }
         for s in ctx.streams {
             let _ = s.task.await;


### PR DESCRIPTION
Closes #331.

## The wedge

The post-emit stream joins (`for s in ctx.streams { s.task.await }`) ran behind an abort gate listing only the six abnormal-end flags. On the SUCCESS path — a fully completed round (TestEnd, exchange, DisplayResults, IperfDone all done) — the joins ran bare, so a peer that completed the protocol and then HELD its data sockets open parked the server's TCP receivers in `read()` for the whole hold. Reproduced live at >6 s, 3/3, by PR #349's r2 on base; GT's one-off exits on its own clock (it closes every stream socket at TEST_END, iperf_server_api.c:272-275).

## The fix

The abort gate is now unconditional: abort every stream task + the UDP demux handle right before the joins, on every path.

Design notes, for the record:

- **Why not close at riperf3's literal TestEnd arm (GT's site)?** riperf3's async receivers may still be landing in-flight final bytes when TestEnd arrives on the control socket — the #55/#159 catch-up window exists precisely for that. Closing there would race the catch-up and drift byte counts. The join site is the safe equivalent: counts are frozen at build_result_streams + the exchange, and every sink has already emitted.
- **Why abort, not `shutdown(raw_fd)`?** `StreamMeta.raw_fd` is unix-only (`None` on Windows), so a shutdown-based unblocker would leave Windows wedged. Abort is cross-platform, proven at this exact site by the six abnormal-end paths, and equivalent in effect for TCP (the task's socket drops at the next await). For the spawn_blocking UDP runners both mechanisms are no-ops — those are bounded by the 500 ms read-timeout + `done` polling either way.

## Test (TDD red-first)

`clean_finish_exits_bounded_while_peer_holds` (wire_shape.rs): mock completes the full protocol through IperfDone, then holds both sockets 30 s; asserts bounded exit (<8 s), exit 0, empty stderr. Red on the pre-fix tree (parked past the bound), green after.

Mutation: restoring the old conditional gate reds EXACTLY this pin — the 7 sibling bounded-exit pins (terminate/IEMESSAGE/EOF holds) stay green, so the pin discriminates the success-path arm specifically.

## Review rounds

**r1 (cold, adversarial) — APPROVE, no blockers.** Re-derived the phase order (nothing reads a counter/stat/capture after the abort site); 60-round byte-count matrices (base/head vs GT, TCP fwd/rev/bidir/-P4, UDP) — every single-stream cell EXACT, -P4 deltas identical on base (pre-existing catch-up semantics); wedge reproduced on base (12.12 s on a 12 s hold) and dead on head (0.12 s vs a 30 s hold); UDP flavor bounded ~1 s on BOTH trees (the class never applied); persistent-server 7-round sweeps clean; get-server-output/json-stream/-J shapes identical; design call verified vs GT source (TEST_END close at iperf_server_api.c:265-286; the FIN-timing residual is recorded in the join-site comment); new pin 5/5 green 2-core-pinned; restore-the-gate mutation reds exactly the new pin. Its LOW (pre-existing: an Err from the exchange phase `?`-returns PAST the abort/join, detaching parked tasks — a persistent-server fd leak) is filed as **#353**.

**r2 (cold, independent) — APPROVE.** Complementary angles: signal-during-teardown races (21 timed SIGINT/SIGTERM runs inside the abort+join window — no panic, no double/lost dump); JoinError posture unchanged (cancellation and panics were already swallowed by `let _ =` on base); verified the pin's mock exercises the true success path (reads the server results + DisplayResults before IperfDone). Two findings:

- **F1 (LOW, out of scope)**: the CLIENT has the sibling wedge — bare joins, no abort; live-proven peer-bound exit (12 s hold → 12.002 s) where GT's client self-bounds at 10 s (net.c:75 read bound + pthread_cancel-then-join, iperf_client_api.c:817-841). Filed as **#354**.
- **F2 (NIT → adopted)**: the REVERSE cell — server SENDERS parked in write_all() against full buffers — also wedged on base (12.005 s) and is fixed by the same direction-blind abort (5 ms), but was unpinned. Added `clean_finish_reverse_exits_bounded_while_peer_holds` (469ba2c) with a 500 ms TEST_RUNNING dwell so the sender genuinely parks before `done` is set — the first draft without the dwell PASSED under the gate-restore mutation (the sender exited via its done-check before ever parking); the dwell version reds together with the forward pin under that mutation and is green 2-core-pinned.

## Gates

- workspace tests: 806 passed, 0 failed
- clippy `-D warnings`: clean; fmt: clean
- xcheck 7/7 targets
- CI + per-merge compat 52/52 before merge
