### PR TITLE
fix: bound the CREATE_STREAMS wait — ctrl-EOF and GT's rcv-timeout IENOMSG surface (#338)

### DIFF
--- a/riperf3-cli/src/cli.rs
+++ b/riperf3-cli/src/cli.rs
@@ -887,6 +887,12 @@ impl Cli {
         if let Some(secs) = self.server_max_duration {
             builder = builder.server_max_duration(u32::try_from(secs).unwrap_or(u32::MAX));
         }
+        if let Some(ms) = self.rcv_timeout {
+            // #338: the server half of --rcv-timeout (GT uses it as the
+            // no-progress bound on both roles). IERCVTIMEOUT range enforced
+            // pre-sink in main.rs (#328).
+            builder = builder.rcv_timeout(u64::try_from(ms).unwrap_or(0));
+        }
         if self.forceflush {
             builder = builder.forceflush(true);
         }

--- a/riperf3-cli/src/cli.rs
+++ b/riperf3-cli/src/cli.rs
@@ -2398,6 +2398,21 @@ mod cli_tests {
         }
 
         #[test]
+        fn server_rcv_timeout_wired() {
+            // #356 r1 F10: the SERVER glue for --rcv-timeout (#338), the
+            // builder-compare convention like the client's rcv_timeout_wired.
+            let cli = Cli::parse_from(["riperf3", "-s", "--rcv-timeout", "3000"]);
+            let s = build_server_from_cli(&cli);
+            assert_eq!(
+                s,
+                riperf3::ServerBuilder::new()
+                    .rcv_timeout(3000)
+                    .build()
+                    .unwrap()
+            );
+        }
+
+        #[test]
         fn server_idle_timeout_wired() {
             let cli = Cli::parse_from(["riperf3", "-s", "--idle-timeout", "30"]);
             let s = build_server_from_cli(&cli);

--- a/riperf3-cli/tests/wire_shape.rs
+++ b/riperf3-cli/tests/wire_shape.rs
@@ -2314,3 +2314,408 @@ fn setup_phase_ctrl_hold_takes_gt_doc_shape_in_json() {
         "bare end{{}}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// #356 r1 F1: GT dispatches setup-phase ctrl bytes through the SAME
+// handle_message_server switch as mid-test (iperf_server_api.c:236-311) —
+// the CREATE_STREAMS wait is inside its event loop. Live-probed (GT 3.21,
+// probe356b.py on issue #338):
+//
+// - 0x0c CLIENT_TERMINATE: instant; relay fe 00000077 00000000 (119, errno
+//   0 — deterministic in this cell, no post-teardown clobber); text stderr
+//   the bare "the client has terminated" + the report-skeleton pair on
+//   stdout (separator + plain header, reporter_callback at DISPLAY_RESULTS
+//   with zero streams); -J = the setup start + a FULL-zeros end (streams:[],
+//   zero sum_sent/sum_received, real host cpu_utilization_percent) + the
+//   bare error key; --json-stream = error event + zeros-end end event.
+//   GT also closes every accepted data socket at once (r1 F7).
+// - 0x10 IPERF_DONE: instant clean exit — NO relay, NO stderr; -J = the
+//   errorless setup doc (bare end{}); --json-stream = one bare end event.
+// - 0x01 TEST_START: GT's no-op arm — the wait continues (and the byte
+//   resets GT's no-progress clock: last_receive_time semantics).
+// - anything else: the IEMESSAGE default — relay fe 0000006e 00000000,
+//   prefixed doc key, bare end.
+// - 0x04 TEST_END: RECORDED DEVIATION — GT runs its ghost end processing
+//   (report headers, an EXCHANGE_RESULTS byte, then a stale-errno
+//   IERECVRESULTS tangle: "unable to receive results: Bad file
+//   descriptor"); riperf3 takes the IEMESSAGE arm above.
+// ---------------------------------------------------------------------------
+
+const CLIENT_TERMINATED_MSG: &str = "the client has terminated";
+const UNKNOWN_CTRL_MSG: &str =
+    "received an unknown control message (ensure other side is iperf3 and not iperf)";
+
+/// Dispatch-cell driver: park in CREATE_STREAMS, send one ctrl byte, read
+/// the relay until EOF (empty = no relay, the IPERF_DONE shape).
+fn run_setup_byte_scenario(
+    extra_args: &[&str],
+    byte: u8,
+) -> (Vec<u8>, String, String, std::process::ExitStatus) {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind");
+    let port = listener.local_addr().unwrap().port();
+    drop(listener);
+    let port_s = port.to_string();
+
+    let mut args = vec!["-s", "-1", "-p", &port_s, "--rcv-timeout", "3000"];
+    args.extend_from_slice(extra_args);
+    let mut server = common::ChildGuard(
+        std::process::Command::new(env!("CARGO_BIN_EXE_riperf3"))
+            .args(&args)
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .spawn()
+            .expect("spawn server"),
+    );
+    let sout_reader =
+        riperf3_test_support::drain_reader(server.0.stdout.take().expect("piped stdout"));
+    let serr_reader =
+        riperf3_test_support::drain_reader(server.0.stderr.take().expect("piped stderr"));
+    std::thread::sleep(std::time::Duration::from_millis(400));
+
+    let mock = std::thread::spawn(move || {
+        let mut ctrl = std::net::TcpStream::connect(("127.0.0.1", port)).expect("ctrl");
+        ctrl.write_all(&[b'x'; 37]).unwrap();
+        assert_eq!(read_exact(&mut ctrl, 1)[0], 9, "ParamExchange");
+        write_json_blob(&mut ctrl, INCOMPLETE_PARAMS);
+        assert_eq!(read_exact(&mut ctrl, 1)[0], 10, "CreateStreams");
+        ctrl.write_all(&[byte]).unwrap();
+        let frame = read_wireback(&mut ctrl);
+        drop(ctrl);
+        frame
+    });
+
+    let frame = mock.join().expect("mock");
+    let status =
+        riperf3_test_support::wait_bounded(&mut server.0, std::time::Duration::from_secs(8))
+            .expect("server exits promptly on the dispatched byte");
+    (
+        frame,
+        sout_reader.join().expect("stdout"),
+        serr_reader.join().expect("stderr"),
+        status,
+    )
+}
+
+/// CLIENT_TERMINATE mid-setup, text: the 119 relay, GT's bare sentence, the
+/// report-skeleton pair on stdout — NOT the rcv-timeout park's IENOMSG.
+#[test]
+fn setup_phase_client_terminate_dispatches_instantly_in_text() {
+    let (frame, sout, serr, status) = run_setup_byte_scenario(&[], 0x0c);
+    assert_eq!(
+        frame,
+        wireback_frame(119),
+        "SERVER_ERROR + htonl(IECLIENTTERM) + htonl(0), like GT's cleanup_server"
+    );
+    assert!(status.success(), "one-off exits 0 like GT");
+    assert_eq!(
+        serr.trim(),
+        format!("riperf3: {CLIENT_TERMINATED_MSG}"),
+        "GT's bare IECLIENTTERM sentence, not the IENOMSG park: {serr:?}"
+    );
+    assert!(
+        sout.contains("- - - - - - - - - - - - - - - - - - - - - - - - -"),
+        "the terminate skeleton's separator: {sout:?}"
+    );
+    assert!(
+        sout.contains("[ ID] Interval           Transfer     Bitrate"),
+        "the terminate skeleton's header: {sout:?}"
+    );
+}
+
+/// CLIENT_TERMINATE mid-setup, -J: the setup doc with GT's FULL-zeros end.
+#[test]
+fn setup_phase_client_terminate_takes_gt_doc_shape_in_json() {
+    let (frame, sout, serr, status) = run_setup_byte_scenario(&["-J"], 0x0c);
+    assert_eq!(frame, wireback_frame(119));
+    assert!(status.success());
+    assert!(serr.trim().is_empty(), "-J keeps stderr silent: {serr:?}");
+    let doc: serde_json::Value =
+        serde_json::from_str(sout.trim()).unwrap_or_else(|e| panic!("one -J doc ({e}): {sout}"));
+    assert_eq!(
+        doc["error"].as_str(),
+        Some(CLIENT_TERMINATED_MSG),
+        "bare sentence key: {doc}"
+    );
+    let end = &doc["end"];
+    assert_eq!(
+        end["streams"].as_array().map(Vec::len),
+        Some(0),
+        "streams:[] present and empty: {end}"
+    );
+    for sum in ["sum_sent", "sum_received"] {
+        assert_eq!(
+            end[sum]["bytes"].as_u64(),
+            Some(0),
+            "{sum} zeros block present: {end}"
+        );
+        assert_eq!(end[sum]["sender"].as_bool(), Some(false), "{sum}.sender");
+    }
+    assert!(
+        end["cpu_utilization_percent"]["host_total"].is_number(),
+        "real host cpu figures like GT: {end}"
+    );
+    assert_eq!(
+        end["cpu_utilization_percent"]["remote_total"].as_f64(),
+        Some(0.0),
+        "remote zeros like GT: {end}"
+    );
+    assert!(
+        !doc["start"]["accepted_connection"].is_null(),
+        "setup-phase start populated: {doc}"
+    );
+}
+
+/// CLIENT_TERMINATE mid-setup, --json-stream: GT's error + zeros-end pair.
+#[test]
+fn setup_phase_client_terminate_stream_events() {
+    let (frame, sout, serr, status) = run_setup_byte_scenario(&["--json-stream"], 0x0c);
+    assert_eq!(frame, wireback_frame(119));
+    assert!(status.success());
+    assert!(
+        serr.trim().is_empty(),
+        "--json-stream keeps stderr silent: {serr:?}"
+    );
+    let events: Vec<serde_json::Value> = sout
+        .lines()
+        .filter(|l| !l.trim().is_empty())
+        .map(|l| serde_json::from_str(l).unwrap_or_else(|e| panic!("event line ({e}): {l}")))
+        .collect();
+    assert_eq!(events.len(), 2, "error + end pair: {sout:?}");
+    assert_eq!(events[0]["event"].as_str(), Some("error"));
+    assert_eq!(events[0]["data"].as_str(), Some(CLIENT_TERMINATED_MSG));
+    assert_eq!(events[1]["event"].as_str(), Some("end"));
+    assert_eq!(
+        events[1]["data"]["streams"].as_array().map(Vec::len),
+        Some(0),
+        "zeros-end event data like GT: {}",
+        events[1]
+    );
+}
+
+/// A stray byte mid-setup takes GT's IEMESSAGE default, not the park.
+#[test]
+fn setup_phase_stray_byte_takes_iemessage_surface_in_text() {
+    let (frame, sout, serr, status) = run_setup_byte_scenario(&[], 0x63);
+    assert_eq!(
+        frame,
+        wireback_frame(110),
+        "SERVER_ERROR + htonl(IEMESSAGE) + htonl(0)"
+    );
+    assert!(status.success());
+    assert_eq!(
+        serr.trim(),
+        format!("riperf3: error - {UNKNOWN_CTRL_MSG}"),
+        "GT's prefixed IEMESSAGE line: {serr:?}"
+    );
+    assert!(
+        !sout.contains("- - - - -"),
+        "no report skeleton in the stray cell (GT prints none): {sout:?}"
+    );
+}
+
+/// A stray byte mid-setup, -J: the prefixed key over the bare-end setup doc.
+#[test]
+fn setup_phase_stray_byte_prefixed_key_in_json() {
+    let (frame, sout, serr, status) = run_setup_byte_scenario(&["-J"], 0x63);
+    assert_eq!(frame, wireback_frame(110));
+    assert!(status.success());
+    assert!(serr.trim().is_empty(), "-J keeps stderr silent: {serr:?}");
+    let doc: serde_json::Value =
+        serde_json::from_str(sout.trim()).unwrap_or_else(|e| panic!("one -J doc ({e}): {sout}"));
+    assert_eq!(
+        doc["error"].as_str(),
+        Some(format!("error - {UNKNOWN_CTRL_MSG}").as_str()),
+        "prefixed IEMESSAGE key: {doc}"
+    );
+    assert!(
+        doc["end"].as_object().expect("end").is_empty(),
+        "bare end{{}} in the stray cell: {doc}"
+    );
+}
+
+/// IPERF_DONE mid-setup is GT's clean arm: no relay, no stderr, an
+/// errorless setup doc, exit 0.
+#[test]
+fn setup_phase_iperf_done_is_clean_and_errorless_in_json() {
+    let (frame, sout, serr, status) = run_setup_byte_scenario(&["-J"], 0x10);
+    assert!(
+        frame.is_empty(),
+        "GT's IPERF_DONE arm relays nothing: {frame:?}"
+    );
+    assert!(status.success());
+    assert!(
+        serr.trim().is_empty(),
+        "clean exit keeps stderr silent: {serr:?}"
+    );
+    let doc: serde_json::Value =
+        serde_json::from_str(sout.trim()).unwrap_or_else(|e| panic!("one -J doc ({e}): {sout}"));
+    assert!(
+        doc.get("error").is_none(),
+        "NO error key in the clean-done doc: {doc}"
+    );
+    assert!(
+        doc["end"].as_object().expect("end").is_empty(),
+        "bare end{{}}: {doc}"
+    );
+    assert!(
+        !doc["start"]["accepted_connection"].is_null(),
+        "setup-phase start populated: {doc}"
+    );
+}
+
+/// IPERF_DONE mid-setup, --json-stream: GT emits a single bare end event.
+#[test]
+fn setup_phase_iperf_done_stream_events() {
+    let (frame, sout, serr, status) = run_setup_byte_scenario(&["--json-stream"], 0x10);
+    assert!(frame.is_empty());
+    assert!(status.success());
+    assert!(serr.trim().is_empty());
+    let events: Vec<&str> = sout.lines().filter(|l| !l.trim().is_empty()).collect();
+    assert_eq!(events.len(), 1, "one bare end event: {sout:?}");
+    let ev: serde_json::Value = serde_json::from_str(events[0]).expect("end event");
+    assert_eq!(ev["event"].as_str(), Some("end"));
+    assert_eq!(ev["data"], serde_json::json!({}), "bare data: {ev}");
+}
+
+/// TEST_START mid-setup is GT's no-op arm — the watch survives it and a
+/// later EOF still takes the IECTRLCLOSE surface.
+#[test]
+fn setup_phase_test_start_byte_is_gt_noop() {
+    let (_sout, serr, status) =
+        drive_server_scenario_with(&["--rcv-timeout", "3000"], false, |port| {
+            let mut ctrl = std::net::TcpStream::connect(("127.0.0.1", port)).expect("ctrl");
+            ctrl.write_all(&[b'x'; 37]).unwrap();
+            assert_eq!(read_exact(&mut ctrl, 1)[0], 9, "ParamExchange");
+            write_json_blob(&mut ctrl, INCOMPLETE_PARAMS);
+            assert_eq!(read_exact(&mut ctrl, 1)[0], 10, "CreateStreams");
+            ctrl.write_all(&[0x01]).unwrap(); // TEST_START: GT's no-op
+            std::thread::sleep(std::time::Duration::from_millis(700));
+            drop(ctrl); // now EOF — the watch must still be armed
+            std::thread::sleep(std::time::Duration::from_millis(300));
+        });
+    assert!(status.success());
+    assert_eq!(
+        serr.trim(),
+        format!("riperf3: {CTRL_CLOSED}"),
+        "the no-op byte left the EOF watch armed: {serr:?}"
+    );
+}
+
+/// r1 F7: the terminate return closes already-accepted data streams like
+/// GT's cleanup_server — the peer's data socket sees EOF bounded, not a
+/// detached task holding it until the peer gives up.
+#[test]
+fn setup_phase_terminate_closes_accepted_streams() {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind");
+    let port = listener.local_addr().unwrap().port();
+    drop(listener);
+    let port_s = port.to_string();
+
+    let mut server = common::ChildGuard(
+        std::process::Command::new(env!("CARGO_BIN_EXE_riperf3"))
+            .args(["-s", "-1", "-p", &port_s, "--rcv-timeout", "3000", "-J"])
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .spawn()
+            .expect("spawn server"),
+    );
+    let sout_reader =
+        riperf3_test_support::drain_reader(server.0.stdout.take().expect("piped stdout"));
+    let serr_reader =
+        riperf3_test_support::drain_reader(server.0.stderr.take().expect("piped stderr"));
+    std::thread::sleep(std::time::Duration::from_millis(400));
+
+    let mock = std::thread::spawn(move || {
+        let mut ctrl = std::net::TcpStream::connect(("127.0.0.1", port)).expect("ctrl");
+        ctrl.write_all(&[b'x'; 37]).unwrap();
+        assert_eq!(read_exact(&mut ctrl, 1)[0], 9, "ParamExchange");
+        write_json_blob(&mut ctrl, r#"{"tcp":true,"parallel":2}"#);
+        assert_eq!(read_exact(&mut ctrl, 1)[0], 10, "CreateStreams");
+        // Connect ONE of the two promised streams (correct cookie), then
+        // terminate on ctrl.
+        let mut data = std::net::TcpStream::connect(("127.0.0.1", port)).expect("data");
+        data.write_all(&[b'x'; 37]).unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(300));
+        ctrl.write_all(&[0x0c]).unwrap();
+        let frame = read_wireback(&mut ctrl);
+        // The server must close the accepted data socket (GT closes every
+        // stream socket in its terminate arm) — bounded EOF, not a park.
+        data.set_read_timeout(Some(std::time::Duration::from_secs(2)))
+            .expect("set_read_timeout");
+        let mut buf = [0u8; 16];
+        let data_read = data.read(&mut buf);
+        (frame, data_read.map_err(|e| e.kind()))
+    });
+
+    let (frame, data_read) = mock.join().expect("mock");
+    assert_eq!(frame, wireback_frame(119));
+    assert_eq!(
+        data_read,
+        Ok(0),
+        "the accepted data socket sees EOF bounded (GT closes stream socks)"
+    );
+    let status =
+        riperf3_test_support::wait_bounded(&mut server.0, std::time::Duration::from_secs(8))
+            .expect("server exits");
+    assert!(status.success());
+    drop(sout_reader.join().expect("stdout"));
+    drop(serr_reader.join().expect("stderr"));
+}
+
+/// r1 F4: the setup doc's timestamp is GT's wait-start stamp (on-connect
+/// metadata), not the emit time — at the default 120 s bound those differ
+/// by two minutes.
+#[test]
+fn setup_phase_doc_timestamp_is_stamped_at_accept_not_emit() {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind");
+    let port = listener.local_addr().unwrap().port();
+    drop(listener);
+    let port_s = port.to_string();
+
+    let mut server = common::ChildGuard(
+        std::process::Command::new(env!("CARGO_BIN_EXE_riperf3"))
+            .args(["-s", "-1", "-p", &port_s, "--rcv-timeout", "3000", "-J"])
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .spawn()
+            .expect("spawn server"),
+    );
+    let sout_reader =
+        riperf3_test_support::drain_reader(server.0.stdout.take().expect("piped stdout"));
+    let serr_reader =
+        riperf3_test_support::drain_reader(server.0.stderr.take().expect("piped stderr"));
+    std::thread::sleep(std::time::Duration::from_millis(400));
+
+    let mock = std::thread::spawn(move || {
+        let mut ctrl = std::net::TcpStream::connect(("127.0.0.1", port)).expect("ctrl");
+        ctrl.write_all(&[b'x'; 37]).unwrap();
+        assert_eq!(read_exact(&mut ctrl, 1)[0], 9, "ParamExchange");
+        write_json_blob(&mut ctrl, INCOMPLETE_PARAMS);
+        assert_eq!(read_exact(&mut ctrl, 1)[0], 10, "CreateStreams");
+        let t_cs = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_millis() as u64;
+        // HOLD to the 3 s bound.
+        let _ = read_wireback(&mut ctrl);
+        t_cs
+    });
+
+    let t_cs = mock.join().expect("mock");
+    let status =
+        riperf3_test_support::wait_bounded(&mut server.0, std::time::Duration::from_secs(8))
+            .expect("server exits at the bound");
+    assert!(status.success());
+    let sout = sout_reader.join().expect("stdout");
+    drop(serr_reader.join().expect("stderr"));
+    let doc: serde_json::Value =
+        serde_json::from_str(sout.trim()).unwrap_or_else(|e| panic!("one -J doc ({e}): {sout}"));
+    let stamped = doc["start"]["timestamp"]["timemillisecs"]
+        .as_u64()
+        .expect("timemillisecs");
+    assert!(
+        stamped <= t_cs + 500,
+        "stamped at the wait start like GT (accept metadata), not at emit \
+         ({stamped} vs CREATE_STREAMS at {t_cs} — emit would be ~+3000)"
+    );
+}

--- a/riperf3-cli/tests/wire_shape.rs
+++ b/riperf3-cli/tests/wire_shape.rs
@@ -2603,7 +2603,10 @@ fn setup_phase_test_start_byte_is_gt_noop() {
 
 /// r1 F7: the terminate return closes already-accepted data streams like
 /// GT's cleanup_server — the peer's data socket sees EOF bounded, not a
-/// detached task holding it until the peer gives up.
+/// detached task holding it until the peer gives up. PERSISTENT server on
+/// purpose: a one-off's process exit closes every socket and would pass
+/// with the abort removed — only a still-running server discriminates
+/// abort from detach (the mutation-vacuous first draft of this pin).
 #[test]
 fn setup_phase_terminate_closes_accepted_streams() {
     let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind");
@@ -2613,15 +2616,15 @@ fn setup_phase_terminate_closes_accepted_streams() {
 
     let mut server = common::ChildGuard(
         std::process::Command::new(env!("CARGO_BIN_EXE_riperf3"))
-            .args(["-s", "-1", "-p", &port_s, "--rcv-timeout", "3000", "-J"])
+            .args(["-s", "-p", &port_s, "--rcv-timeout", "3000", "-J"])
             .stdout(std::process::Stdio::piped())
             .stderr(std::process::Stdio::piped())
             .spawn()
             .expect("spawn server"),
     );
-    let sout_reader =
+    let _sout_reader =
         riperf3_test_support::drain_reader(server.0.stdout.take().expect("piped stdout"));
-    let serr_reader =
+    let _serr_reader =
         riperf3_test_support::drain_reader(server.0.stderr.take().expect("piped stderr"));
     std::thread::sleep(std::time::Duration::from_millis(400));
 
@@ -2639,7 +2642,8 @@ fn setup_phase_terminate_closes_accepted_streams() {
         ctrl.write_all(&[0x0c]).unwrap();
         let frame = read_wireback(&mut ctrl);
         // The server must close the accepted data socket (GT closes every
-        // stream socket in its terminate arm) — bounded EOF, not a park.
+        // stream socket in its terminate arm) — bounded EOF while the
+        // server keeps serving, not a detached task holding it.
         data.set_read_timeout(Some(std::time::Duration::from_secs(2)))
             .expect("set_read_timeout");
         let mut buf = [0u8; 16];
@@ -2654,12 +2658,11 @@ fn setup_phase_terminate_closes_accepted_streams() {
         Ok(0),
         "the accepted data socket sees EOF bounded (GT closes stream socks)"
     );
-    let status =
-        riperf3_test_support::wait_bounded(&mut server.0, std::time::Duration::from_secs(8))
-            .expect("server exits");
-    assert!(status.success());
-    drop(sout_reader.join().expect("stdout"));
-    drop(serr_reader.join().expect("stderr"));
+    // Persistent server: still alive and serving — ChildGuard kills it.
+    assert!(
+        server.0.try_wait().expect("try_wait").is_none(),
+        "the persistent server kept serving after the terminate round"
+    );
 }
 
 /// r1 F4: the setup doc's timestamp is GT's wait-start stamp (on-connect

--- a/riperf3-cli/tests/wire_shape.rs
+++ b/riperf3-cli/tests/wire_shape.rs
@@ -2577,10 +2577,13 @@ fn setup_phase_iperf_done_stream_events() {
     assert_eq!(ev["data"], serde_json::json!({}), "bare data: {ev}");
 }
 
-/// TEST_START mid-setup is GT's no-op arm — the watch survives it and a
-/// later EOF still takes the IECTRLCLOSE surface.
+/// TEST_START mid-setup keeps the wait alive — the watch survives it and
+/// a later EOF still takes the IECTRLCLOSE surface (this byte-then-EOF
+/// sub-cell matches GT). RECORDED DEVIATION (r2 F2): in the accepts-after
+/// sub-cell GT's Nread has overwritten test->state, so GT ACCESS_DENIED's
+/// a subsequent correct-cookie connect; riperf3 keeps accepting.
 #[test]
-fn setup_phase_test_start_byte_is_gt_noop() {
+fn setup_phase_test_start_byte_keeps_waiting() {
     let (_sout, serr, status) =
         drive_server_scenario_with(&["--rcv-timeout", "3000"], false, |port| {
             let mut ctrl = std::net::TcpStream::connect(("127.0.0.1", port)).expect("ctrl");
@@ -2721,4 +2724,109 @@ fn setup_phase_doc_timestamp_is_stamped_at_accept_not_emit() {
         "stamped at the wait start like GT (accept metadata), not at emit \
          ({stamped} vs CREATE_STREAMS at {t_cs} — emit would be ~+3000)"
     );
+}
+
+/// r2 F1: the setup-phase ctrl-EOF relays IECTRLCLOSE(109) like its
+/// mid-test and end-loop siblings (#342; GT cleanup_server,
+/// iperf_server_api.c:466-473) — observable by a HALF-closed peer whose
+/// read half is still open; best-effort no-op on a full close.
+#[test]
+fn setup_phase_ctrl_eof_relays_iectrlclose_on_half_close() {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind");
+    let port = listener.local_addr().unwrap().port();
+    drop(listener);
+    let port_s = port.to_string();
+
+    let mut server = common::ChildGuard(
+        std::process::Command::new(env!("CARGO_BIN_EXE_riperf3"))
+            .args(["-s", "-1", "-p", &port_s, "--rcv-timeout", "3000"])
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .spawn()
+            .expect("spawn server"),
+    );
+    let _sout = riperf3_test_support::drain_reader(server.0.stdout.take().expect("piped stdout"));
+    let _serr = riperf3_test_support::drain_reader(server.0.stderr.take().expect("piped stderr"));
+    std::thread::sleep(std::time::Duration::from_millis(400));
+
+    let mock = std::thread::spawn(move || {
+        let mut ctrl = std::net::TcpStream::connect(("127.0.0.1", port)).expect("ctrl");
+        ctrl.write_all(&[b'x'; 37]).unwrap();
+        assert_eq!(read_exact(&mut ctrl, 1)[0], 9, "ParamExchange");
+        write_json_blob(&mut ctrl, INCOMPLETE_PARAMS);
+        assert_eq!(read_exact(&mut ctrl, 1)[0], 10, "CreateStreams");
+        // HALF-close: EOF on the server's read, our read half stays open
+        // for the relay frame.
+        ctrl.shutdown(std::net::Shutdown::Write)
+            .expect("shutdown WR");
+        read_wireback(&mut ctrl)
+    });
+
+    let frame = mock.join().expect("mock");
+    assert_eq!(
+        frame,
+        wireback_frame(109),
+        "SERVER_ERROR + htonl(IECTRLCLOSE) + htonl(0), like GT's cleanup_server"
+    );
+    let status =
+        riperf3_test_support::wait_bounded(&mut server.0, std::time::Duration::from_secs(8))
+            .expect("server exits");
+    assert!(status.success());
+}
+
+/// r2 F3: the rcv-timeout is a NO-PROGRESS clock, not an absolute setup
+/// deadline — each accepted stream (and each dispatched ctrl byte) resets
+/// it, GT's last_receive_time semantics. A -P2 peer connecting one stream
+/// every ~2 s under --rcv-timeout 3000 must reach TEST_START, though the
+/// whole setup takes longer than 3 s.
+#[test]
+fn setup_phase_rcv_timeout_resets_on_stream_progress() {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind");
+    let port = listener.local_addr().unwrap().port();
+    drop(listener);
+    let port_s = port.to_string();
+
+    let mut server = common::ChildGuard(
+        std::process::Command::new(env!("CARGO_BIN_EXE_riperf3"))
+            .args(["-s", "-1", "-p", &port_s, "--rcv-timeout", "3000"])
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .spawn()
+            .expect("spawn server"),
+    );
+    let _sout = riperf3_test_support::drain_reader(server.0.stdout.take().expect("piped stdout"));
+    let _serr = riperf3_test_support::drain_reader(server.0.stderr.take().expect("piped stderr"));
+    std::thread::sleep(std::time::Duration::from_millis(400));
+
+    let mock = std::thread::spawn(move || {
+        let mut ctrl = std::net::TcpStream::connect(("127.0.0.1", port)).expect("ctrl");
+        ctrl.write_all(&[b'x'; 37]).unwrap();
+        assert_eq!(read_exact(&mut ctrl, 1)[0], 9, "ParamExchange");
+        write_json_blob(&mut ctrl, r#"{"tcp":true,"parallel":2}"#);
+        assert_eq!(read_exact(&mut ctrl, 1)[0], 10, "CreateStreams");
+        // Slow-but-progressing: one stream per ~2 s. Total setup ~4 s,
+        // every gap under the 3 s bound.
+        std::thread::sleep(std::time::Duration::from_millis(2000));
+        let mut d1 = std::net::TcpStream::connect(("127.0.0.1", port)).expect("data1");
+        d1.write_all(&[b'x'; 37]).unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(2000));
+        let mut d2 = std::net::TcpStream::connect(("127.0.0.1", port)).expect("data2");
+        d2.write_all(&[b'x'; 37]).unwrap();
+        // The next ctrl byte decides: TEST_START(1) = survived (green);
+        // a SERVER_ERROR frame (0xfe = IENOMSG at ~t+3 s) = an absolute
+        // deadline killed the progressing peer (red).
+        let first = read_exact(&mut ctrl, 1)[0];
+        drop((d1, d2, ctrl));
+        first
+    });
+
+    let first = mock.join().expect("mock");
+    assert_eq!(
+        first, 1,
+        "a progressing -P2 peer reaches TEST_START; 0xfe means the bound \
+         fired mid-progress (absolute-deadline regression)"
+    );
+    // The mock vanished mid-test; the server's own machinery bounds the
+    // round — only the reached-TEST_START byte is under test here.
+    let _ = riperf3_test_support::wait_bounded(&mut server.0, std::time::Duration::from_secs(20));
 }

--- a/riperf3-cli/tests/wire_shape.rs
+++ b/riperf3-cli/tests/wire_shape.rs
@@ -2814,7 +2814,11 @@ fn setup_phase_rcv_timeout_resets_on_stream_progress() {
         d2.write_all(&[b'x'; 37]).unwrap();
         // The next ctrl byte decides: TEST_START(1) = survived (green);
         // a SERVER_ERROR frame (0xfe = IENOMSG at ~t+3 s) = an absolute
-        // deadline killed the progressing peer (red).
+        // deadline killed the progressing peer (red). Bounded read (r3
+        // nit): a regression that silences the socket entirely must fail
+        // the pin, not park the join.
+        ctrl.set_read_timeout(Some(std::time::Duration::from_secs(8)))
+            .expect("set_read_timeout");
         let first = read_exact(&mut ctrl, 1)[0];
         drop((d1, d2, ctrl));
         first

--- a/riperf3-cli/tests/wire_shape.rs
+++ b/riperf3-cli/tests/wire_shape.rs
@@ -2114,3 +2114,203 @@ fn generic_arm_failure_line_carries_the_timestamps_prefix() {
         "the literal format renders verbatim: {line:?}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// #338: the CREATE_STREAMS wait must watch the control socket and carry GT's
+// no-progress bound. Live-probed (GT 3.21, probe338.py on the issue):
+//
+// EOF variant ({"tcp":true} params, ctrl closed, no data conns): GT notices
+// the EOF at once (dt~0.00s) — text stderr = the bare IECTRLCLOSE sentence;
+// -J = a POPULATED setup-phase start (empty connected:[], listener bufsizes,
+// timestamp, accepted_connection, cookie, tcp_mss_default/target_bitrate/
+// fq_rate zeros) + intervals:[] + bare end:{} + the bare error key; exit 0.
+//
+// HOLD variant (ctrl held open, no data conns): GT bounds at rcv_timeout
+// (--rcv-timeout, default 120000 ms) — wire-back SERVER_ERROR + IENOMSG(144)
+// + errno 0 on the held ctrl, text stderr `iperf3: error - idle timeout for
+// receiving data`, -J error key `error - idle timeout for receiving data`
+// (prefixed), exit 0. Pre-fix riperf3 parked unbounded in BOTH variants.
+// ---------------------------------------------------------------------------
+
+/// Valid JSON that deserializes via serde defaults but promises data streams
+/// the peer never connects.
+const INCOMPLETE_PARAMS: &str = r#"{"tcp":true}"#;
+
+fn drive_setup_eof(port: u16) {
+    let mut ctrl = std::net::TcpStream::connect(("127.0.0.1", port)).expect("ctrl");
+    ctrl.write_all(&[b'x'; 37]).unwrap();
+    assert_eq!(read_exact(&mut ctrl, 1)[0], 9, "ParamExchange");
+    write_json_blob(&mut ctrl, INCOMPLETE_PARAMS);
+    assert_eq!(read_exact(&mut ctrl, 1)[0], 10, "CreateStreams");
+    drop(ctrl); // EOF with no data connections
+    std::thread::sleep(std::time::Duration::from_millis(300));
+}
+
+/// EOF variant, text: the server exits bounded with GT's IECTRLCLOSE line.
+#[test]
+fn setup_phase_ctrl_eof_exits_bounded_in_text() {
+    let (_sout, serr, status) = drive_server_scenario(false, drive_setup_eof);
+    assert!(status.success(), "one-off exits 0 like GT");
+    assert_eq!(
+        serr.trim(),
+        format!("riperf3: {CTRL_CLOSED}"),
+        "GT's bare read-site sentence: {serr:?}"
+    );
+}
+
+/// EOF variant, -J: the setup-phase doc — populated start, empty shells,
+/// bare error key, silent stderr.
+#[test]
+fn setup_phase_ctrl_eof_takes_gt_doc_shape_in_json() {
+    let (sout, serr, status) = drive_server_scenario(true, drive_setup_eof);
+    assert!(status.success());
+    assert!(serr.trim().is_empty(), "-J keeps stderr silent: {serr:?}");
+    let doc: serde_json::Value =
+        serde_json::from_str(sout.trim()).unwrap_or_else(|e| panic!("one -J doc ({e}): {sout}"));
+    assert_eq!(
+        doc["error"].as_str(),
+        Some(CTRL_CLOSED),
+        "bare IECTRLCLOSE key: {doc}"
+    );
+    let start = &doc["start"];
+    assert_eq!(
+        start["connected"].as_array().map(Vec::len),
+        Some(0),
+        "connected:[] present and EMPTY: {start}"
+    );
+    assert_eq!(
+        start["accepted_connection"]["host"].as_str(),
+        Some("127.0.0.1"),
+        "accepted_connection present: {start}"
+    );
+    // 36, not 37: the doc drops the wire cookie's trailing NUL slot (the
+    // shipped convention at server.rs's other cookie-render sites; a real
+    // iperf3 cookie is 36 chars + NUL, so both tools render identically for
+    // conforming clients — only this mock's 37 non-NUL bytes differ).
+    assert_eq!(
+        start["cookie"].as_str(),
+        Some("x".repeat(36).as_str()),
+        "cookie present: {start}"
+    );
+    for key in ["sndbuf_actual", "rcvbuf_actual", "timestamp"] {
+        assert!(
+            !start[key].is_null(),
+            "{key} present in the setup-phase start: {start}"
+        );
+    }
+    for key in [
+        "sock_bufsize",
+        "tcp_mss_default",
+        "target_bitrate",
+        "fq_rate",
+    ] {
+        assert_eq!(
+            start[key].as_u64(),
+            Some(0),
+            "{key} present as 0 like GT: {start}"
+        );
+    }
+    assert!(
+        doc["intervals"].as_array().expect("intervals").is_empty(),
+        "intervals:[]"
+    );
+    assert!(
+        doc["end"].as_object().expect("end").is_empty(),
+        "bare end{{}}"
+    );
+}
+
+const IDLE_TIMEOUT_MSG: &str = "idle timeout for receiving data";
+
+/// HOLD-variant driver: park in CREATE_STREAMS with the ctrl open, read the
+/// wire-back frame, return it with the captured streams.
+fn run_setup_hold_scenario(json: bool) -> (Vec<u8>, String, String, std::process::ExitStatus) {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind");
+    let port = listener.local_addr().unwrap().port();
+    drop(listener);
+    let port_s = port.to_string();
+
+    let mut args = vec!["-s", "-1", "-p", &port_s, "--rcv-timeout", "3000"];
+    if json {
+        args.push("-J");
+    }
+    let mut server = common::ChildGuard(
+        std::process::Command::new(env!("CARGO_BIN_EXE_riperf3"))
+            .args(&args)
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .spawn()
+            .expect("spawn server"),
+    );
+    let sout_reader =
+        riperf3_test_support::drain_reader(server.0.stdout.take().expect("piped stdout"));
+    let serr_reader =
+        riperf3_test_support::drain_reader(server.0.stderr.take().expect("piped stderr"));
+    std::thread::sleep(std::time::Duration::from_millis(400));
+
+    let mock = std::thread::spawn(move || {
+        let mut ctrl = std::net::TcpStream::connect(("127.0.0.1", port)).expect("ctrl");
+        ctrl.write_all(&[b'x'; 37]).unwrap();
+        assert_eq!(read_exact(&mut ctrl, 1)[0], 9, "ParamExchange");
+        write_json_blob(&mut ctrl, INCOMPLETE_PARAMS);
+        assert_eq!(read_exact(&mut ctrl, 1)[0], 10, "CreateStreams");
+        // HOLD: no data connections, ctrl stays open. The wire-back should
+        // arrive at the ~3 s bound; the pre-fix park never sends it.
+        let frame = read_wireback(&mut ctrl);
+        drop(ctrl);
+        frame
+    });
+
+    let frame = mock.join().expect("mock");
+    let status =
+        riperf3_test_support::wait_bounded(&mut server.0, std::time::Duration::from_secs(8))
+            .expect("server exits at the rcv-timeout bound while the peer holds");
+    (
+        frame,
+        sout_reader.join().expect("stdout"),
+        serr_reader.join().expect("stderr"),
+        status,
+    )
+}
+
+/// HOLD variant, text: bounded at --rcv-timeout with GT's IENOMSG surface —
+/// the wire-back frame, the stderr line, exit 0.
+#[test]
+fn setup_phase_ctrl_hold_bounds_at_rcv_timeout_in_text() {
+    let (frame, _sout, serr, status) = run_setup_hold_scenario(false);
+    assert_eq!(
+        frame,
+        wireback_frame(144),
+        "SERVER_ERROR + htonl(IENOMSG) + htonl(0), like GT's cleanup_server"
+    );
+    assert!(status.success(), "one-off exits 0 like GT");
+    assert_eq!(
+        serr.trim(),
+        format!("riperf3: error - {IDLE_TIMEOUT_MSG}"),
+        "GT's IENOMSG line: {serr:?}"
+    );
+}
+
+/// HOLD variant, -J: the prefixed error key over the setup-phase doc.
+#[test]
+fn setup_phase_ctrl_hold_takes_gt_doc_shape_in_json() {
+    let (frame, sout, serr, status) = run_setup_hold_scenario(true);
+    assert_eq!(frame, wireback_frame(144));
+    assert!(status.success());
+    assert!(serr.trim().is_empty(), "-J keeps stderr silent: {serr:?}");
+    let doc: serde_json::Value =
+        serde_json::from_str(sout.trim()).unwrap_or_else(|e| panic!("one -J doc ({e}): {sout}"));
+    assert_eq!(
+        doc["error"].as_str(),
+        Some(format!("error - {IDLE_TIMEOUT_MSG}").as_str()),
+        "the prefixed IENOMSG key: {doc}"
+    );
+    assert!(
+        !doc["start"]["accepted_connection"].is_null(),
+        "setup-phase start populated: {doc}"
+    );
+    assert!(
+        doc["end"].as_object().expect("end").is_empty(),
+        "bare end{{}}"
+    );
+}

--- a/riperf3/src/error.rs
+++ b/riperf3/src/error.rs
@@ -81,6 +81,16 @@ pub enum RiperfError {
     #[error("unable to receive parameters from client")]
     RecvParamsFailed,
 
+    /// iperf3's IENOMSG(144): the server's no-progress watchdog fired — no
+    /// messages/data received within `--rcv-timeout` (default 120000 ms, GT's
+    /// DEFAULT_NO_MSG_RCVD_TIMEOUT, iperf_api.h:70). First wired at the
+    /// CREATE_STREAMS wait (#338; the TEST_RUNNING half is #351). GT relays
+    /// SERVER_ERROR + 144 via cleanup_server and keeps serving: text
+    /// `iperf3: error - <sentence>`, -J `error - `-prefixed doc key, exit 0.
+    /// GT's sentence (#151 convention).
+    #[error("idle timeout for receiving data")]
+    DataIdleTimeout,
+
     /// iperf3's IEMESSAGE (#325): an unhandled control byte. GT's end-loop
     /// switch has arms for only TEST_START / TEST_END / IPERF_DONE /
     /// CLIENT_TERMINATE — every other value, known state or not, hits

--- a/riperf3/src/json_report.rs
+++ b/riperf3/src/json_report.rs
@@ -224,6 +224,88 @@ pub(crate) struct SetupPhaseDoc {
 /// lands at listen time (iperf_tcp.c:373-377), BEFORE timestamp — the
 /// shared Start serializer's client-derived order is #355.
 pub(crate) fn setup_error_document(d: &SetupPhaseDoc, error: &str) -> String {
+    setup_phase_document(d, &BareEnd {}, Some(error))
+}
+
+/// #356 r1 F1: GT's CLIENT_TERMINATE-at-setup document — its
+/// reporter_callback runs under DISPLAY_RESULTS with zero streams
+/// (iperf_server_api.c:292-297), so the end block is the FULL-zeros shape:
+/// `streams:[]`, zero sum blocks, and REAL host cpu figures with remote
+/// zeros (live-probed 3.21). The error key is the bare sentence, like the
+/// mid-test terminate arm's.
+pub(crate) fn setup_terminate_document(
+    d: &SetupPhaseDoc,
+    error: &str,
+    cpu: &CpuUtilization,
+) -> String {
+    setup_phase_document(d, &zeros_end(cpu), Some(error))
+}
+
+/// #356 r1 F1: GT's IPERF_DONE-at-setup document — the clean arm exits the
+/// run loop with no error at all, so the accumulated doc is the setup start
+/// over a bare `end:{}` and NO error key (live-probed 3.21).
+pub(crate) fn setup_done_document(d: &SetupPhaseDoc) -> String {
+    setup_phase_document(d, &BareEnd {}, None)
+}
+
+/// #356 r1 F1: the `--json-stream` terminate-at-setup pair — GT emits the
+/// bare-sentence error event, then an `end` event whose data is the same
+/// FULL-zeros end block the -J doc carries (live-probed 3.21).
+pub(crate) fn terminate_stream_events(error: &str, cpu: &CpuUtilization) -> String {
+    format!(
+        "{}\n{}",
+        json_stream_event("error", &error),
+        json_stream_event("end", &zeros_end(cpu))
+    )
+}
+
+/// #356 r1 F1: the `--json-stream` IPERF_DONE-at-setup tail — GT emits one
+/// bare `end` event and nothing else (live-probed 3.21).
+pub(crate) fn done_stream_events() -> String {
+    json_stream_event("end", &serde_json::json!({}))
+}
+
+#[derive(Serialize)]
+struct BareEnd {}
+
+/// GT's zero sum block: exactly the six keys its reporter renders for a
+/// stream-less summary (no retransmits — the sender extras never arm).
+#[derive(Serialize)]
+struct ZeroSum {
+    start: u64,
+    end: u64,
+    seconds: u64,
+    bytes: u64,
+    bits_per_second: u64,
+    sender: bool,
+}
+
+#[derive(Serialize)]
+struct ZerosEnd {
+    streams: [(); 0],
+    sum_sent: ZeroSum,
+    sum_received: ZeroSum,
+    cpu_utilization_percent: CpuUtilization,
+}
+
+fn zeros_end(cpu: &CpuUtilization) -> ZerosEnd {
+    let zero = || ZeroSum {
+        start: 0,
+        end: 0,
+        seconds: 0,
+        bytes: 0,
+        bits_per_second: 0,
+        sender: false,
+    };
+    ZerosEnd {
+        streams: [],
+        sum_sent: zero(),
+        sum_received: zero(),
+        cpu_utilization_percent: cpu.clone(),
+    }
+}
+
+fn setup_phase_document<E: Serialize>(d: &SetupPhaseDoc, end: &E, error: Option<&str>) -> String {
     #[derive(Serialize)]
     struct SetupStart<'a> {
         connected: [(); 0],
@@ -242,11 +324,12 @@ pub(crate) fn setup_error_document(d: &SetupPhaseDoc, error: &str) -> String {
         fq_rate: u64,
     }
     #[derive(Serialize)]
-    struct Doc<'a> {
+    struct Doc<'a, E: Serialize> {
         start: SetupStart<'a>,
         intervals: [(); 0],
-        end: serde_json::Map<String, serde_json::Value>,
-        error: &'a str,
+        end: &'a E,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        error: Option<&'a str>,
     }
     let secs = d.timemillisecs / 1000;
     serde_json::to_string_pretty(&Doc {
@@ -272,7 +355,7 @@ pub(crate) fn setup_error_document(d: &SetupPhaseDoc, error: &str) -> String {
             fq_rate: d.fq_rate,
         },
         intervals: [],
-        end: serde_json::Map::new(),
+        end,
         error,
     })
     .unwrap()
@@ -3713,6 +3796,107 @@ mod tests {
                 "receiver_tcp_congestion"
             ],
             "end key order drifted from the frozen 0.8.0 wire shape: {raw}"
+        );
+    }
+
+    /// #356 r1 F8 (+#355): the setup-phase doc's start keys are GT's SERVER
+    /// insertion order — the bufsize trio at listen time, BEFORE timestamp
+    /// (iperf_tcp.c:373-377), unlike the client-derived order the shared
+    /// Start serializer pins above. Parsed-Value asserts are order-blind;
+    /// read the raw string. The terminate variant's zeros end rides along.
+    #[test]
+    fn setup_document_key_order_is_gt_server_order() {
+        let d = SetupPhaseDoc {
+            sock_bufsize: 0,
+            sndbuf_actual: Some(16384),
+            rcvbuf_actual: Some(131072),
+            timemillisecs: 1_700_000_000_000,
+            accepted_host: "127.0.0.1".into(),
+            accepted_port: 5201,
+            cookie: "c".repeat(36),
+            target_bitrate: 0,
+            fq_rate: 0,
+        };
+        let raw = setup_terminate_document(
+            &d,
+            "the client has terminated",
+            &CpuUtilization {
+                host_total: 1.0,
+                host_user: 0.5,
+                host_system: 0.5,
+                remote_total: 0.0,
+                remote_user: 0.0,
+                remote_system: 0.0,
+            },
+        );
+
+        let keys = |obj: &str| -> Vec<String> {
+            let from = raw.find(&format!("\"{obj}\":")).unwrap() + obj.len() + 3;
+            let bytes = raw.as_bytes();
+            let mut depth = 0i32;
+            let mut i = from;
+            let mut out = Vec::new();
+            while i < bytes.len() {
+                match bytes[i] {
+                    b'{' | b'[' => depth += 1,
+                    b'}' | b']' => {
+                        depth -= 1;
+                        if depth == 0 {
+                            break;
+                        }
+                    }
+                    b'"' => {
+                        let close = raw[i + 1..].find('"').unwrap() + i + 1;
+                        if depth == 1 && bytes.get(close + 1) == Some(&b':') {
+                            out.push(raw[i + 1..close].to_string());
+                        }
+                        i = close;
+                    }
+                    _ => {}
+                }
+                i += 1;
+            }
+            out
+        };
+        assert_eq!(
+            keys("start"),
+            [
+                "connected",
+                "version",
+                "system_info",
+                "sock_bufsize",
+                "sndbuf_actual",
+                "rcvbuf_actual",
+                "timestamp",
+                "accepted_connection",
+                "cookie",
+                "tcp_mss_default",
+                "target_bitrate",
+                "fq_rate"
+            ],
+            "setup start key order drifted from GT's server order: {raw}"
+        );
+        assert_eq!(
+            keys("end"),
+            [
+                "streams",
+                "sum_sent",
+                "sum_received",
+                "cpu_utilization_percent"
+            ],
+            "terminate zeros-end key order drifted: {raw}"
+        );
+        assert_eq!(
+            keys("sum_sent"),
+            [
+                "start",
+                "end",
+                "seconds",
+                "bytes",
+                "bits_per_second",
+                "sender"
+            ],
+            "zero sum block keys drifted from GT's six: {raw}"
         );
     }
 

--- a/riperf3/src/json_report.rs
+++ b/riperf3/src/json_report.rs
@@ -200,6 +200,84 @@ pub(crate) fn refusal_document(error: &str, target_bitrate: Option<u64>) -> Stri
     .unwrap()
 }
 
+/// Inputs for the #338 setup-phase document, gathered at the CREATE_STREAMS
+/// wait (the control connection and the listener are live; no data streams).
+pub(crate) struct SetupPhaseDoc {
+    pub sock_bufsize: u64,
+    pub sndbuf_actual: Option<u64>,
+    pub rcvbuf_actual: Option<u64>,
+    pub timemillisecs: u64,
+    pub accepted_host: String,
+    pub accepted_port: u16,
+    pub cookie: String,
+    pub target_bitrate: u64,
+    pub fq_rate: u64,
+}
+
+/// #338: the setup-phase (CREATE_STREAMS) error document — by then GT's
+/// server has the on_connect metadata AND the listener's buffer fields, so
+/// the start is POPULATED (live-probed 3.21): empty `connected:[]`, the
+/// bufsize trio, timestamp, accepted_connection, cookie, `tcp_mss_default`
+/// 0 (the server never reads the ctrl MSS, the #50 convention),
+/// target_bitrate, fq_rate — over `intervals:[]`, a bare `end:{}`, and the
+/// error key. KEY ORDER is GT's SERVER insertion order: the bufsize trio
+/// lands at listen time (iperf_tcp.c:373-377), BEFORE timestamp — the
+/// shared Start serializer's client-derived order is #355.
+pub(crate) fn setup_error_document(d: &SetupPhaseDoc, error: &str) -> String {
+    #[derive(Serialize)]
+    struct SetupStart<'a> {
+        connected: [(); 0],
+        version: String,
+        system_info: String,
+        sock_bufsize: u64,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        sndbuf_actual: Option<u64>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        rcvbuf_actual: Option<u64>,
+        timestamp: Timestamp,
+        accepted_connection: ConnectingTo,
+        cookie: &'a str,
+        tcp_mss_default: u32,
+        target_bitrate: u64,
+        fq_rate: u64,
+    }
+    #[derive(Serialize)]
+    struct Doc<'a> {
+        start: SetupStart<'a>,
+        intervals: [(); 0],
+        end: serde_json::Map<String, serde_json::Value>,
+        error: &'a str,
+    }
+    let secs = d.timemillisecs / 1000;
+    serde_json::to_string_pretty(&Doc {
+        start: SetupStart {
+            connected: [],
+            version: format!("riperf3 {}", env!("CARGO_PKG_VERSION")),
+            system_info: crate::utils::system_info(),
+            sock_bufsize: d.sock_bufsize,
+            sndbuf_actual: d.sndbuf_actual,
+            rcvbuf_actual: d.rcvbuf_actual,
+            timestamp: Timestamp {
+                time: http_date(secs),
+                timesecs: secs,
+                timemillisecs: d.timemillisecs,
+            },
+            accepted_connection: ConnectingTo {
+                host: d.accepted_host.clone(),
+                port: d.accepted_port,
+            },
+            cookie: &d.cookie,
+            tcp_mss_default: 0,
+            target_bitrate: d.target_bitrate,
+            fq_rate: d.fq_rate,
+        },
+        intervals: [],
+        end: serde_json::Map::new(),
+        error,
+    })
+    .unwrap()
+}
+
 /// The `--json-stream` pre-test error tail (#198): an `error` event followed
 /// by an empty `end` event, iperf3's JSONStream_Output order on errexit.
 pub fn error_stream_events(error: &str) -> String {

--- a/riperf3/src/reporter.rs
+++ b/riperf3/src/reporter.rs
@@ -262,6 +262,17 @@ pub fn print_separator() {
     ));
 }
 
+/// #356 r1 F1: GT's terminate-at-setup text skeleton — its
+/// reporter_callback runs under DISPLAY_RESULTS with zero streams
+/// (iperf_server_api.c:292-297), printing just the separator and the plain
+/// TCP header (live-probed 3.21).
+pub fn print_terminate_skeleton() {
+    print_separator();
+    titled(format_args!(
+        "[ ID] Interval           Transfer     Bitrate"
+    ));
+}
+
 /// GT's final-partial-interval keep rule (iperf_print_intermediate,
 /// iperf_api.c:3853-3880, #264): a run's trailing sub-interval survives iff
 /// it spans at least 10% of the stats interval OR it actually moved bytes —

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -688,9 +688,11 @@ impl Server {
     /// Peer-caused test endings surface as errors AFTER the report was
     /// rendered to the active sink: a CLIENT_TERMINATE returns
     /// [`RiperfError::ClientTerminated`], an unhandled control byte
-    /// returns [`RiperfError::UnknownControlMessage`] (#325), and a
+    /// returns [`RiperfError::UnknownControlMessage`] (#325), a
     /// control-connection EOF returns [`RiperfError::ControlSocketClosed`]
-    /// (#330) — all mirror GT rounds its one-off still exits 0 on.
+    /// (#330), and a setup phase that makes no progress for `--rcv-timeout`
+    /// returns [`RiperfError::DataIdleTimeout`] (#338) — all mirror GT
+    /// rounds its one-off still exits 0 on.
     pub async fn run_once(&self) -> Result<crate::json_report::Report> {
         let listener = self.listen().await?;
         self.serve_once(&listener).await
@@ -734,8 +736,10 @@ impl Server {
         let _quiet_guard = (!self.emit_output).then(crate::macros::OutputQuietGuard::set);
         match self.handle_one_test(listener).await? {
             Some(report) => Ok(report),
-            // Reachable only with an interrupt watch set (e.g. the CLI's signal
-            // handling): interrupted while idle, before any client connected.
+            // The no-report rounds: interrupted while idle (an interrupt
+            // watch), a refused test, or IPERF_DONE mid-setup (#356). The
+            // interrupt-flavored message for all three is a recorded
+            // #293/#294 candidate.
             None => Err(RiperfError::Aborted(
                 "interrupted before a test started".into(),
             )),
@@ -1294,9 +1298,13 @@ impl Server {
                                 // EOF: the peer closed without connecting its
                                 // data streams — GT's read-site surface. The
                                 // -J doc emits here (the serve loop's arm
-                                // prints the text sentence).
+                                // prints the text sentence). #342 relay like
+                                // the mid-test/end-loop EOF siblings —
+                                // observable by a half-closed peer,
+                                // best-effort no-op on a full close (r2 F1).
                                 Ok(CtrlActivity::Eof) => {
                                     abort_setup_streams(ctx).await;
+                                    let _ = protocol::send_server_error(&mut ctx.ctrl, 109).await;
                                     self.emit_setup_phase_error(ctx, listener, CTRL_CLOSED_MSG);
                                     return Err(RiperfError::ControlSocketClosed);
                                 }
@@ -3130,7 +3138,8 @@ impl Server {
     /// #356 r1 F1: a state byte arrived during the CREATE_STREAMS wait —
     /// dispatch it through GT's handle_message_server arms
     /// (iperf_server_api.c:236-311; each cell live-probed on issue #338):
-    /// TEST_START is a no-op, CLIENT_TERMINATE relays 119 and takes the
+    /// TEST_START keeps waiting (see the arm's deviation record — GT's
+    /// state-write quirk is not mirrored), CLIENT_TERMINATE relays 119 and takes the
     /// terminate surfaces, IPERF_DONE is the clean errorless arm, and
     /// everything else is the IEMESSAGE default with the 110 relay.
     /// RECORDED DEVIATION: "everything else" includes TEST_END, where GT
@@ -3145,7 +3154,13 @@ impl Server {
     ) -> Result<SetupFlow> {
         match protocol::recv_state(&mut ctx.ctrl).await {
             // GT's no-op arm — keep waiting (the recreated sleep IS the
-            // clock reset: a received byte is progress).
+            // clock reset: a received byte is progress). RECORDED DEVIATION
+            // (r2 F2): GT's Nread writes the byte INTO test->state
+            // (iperf_server_api.c:249), so after a 0x01 GT is no longer in
+            // CREATE_STREAMS and ACCESS_DENIED's a subsequent correct-cookie
+            // data connect (live-probed); riperf3 keeps accepting — the
+            // liveness-preserving reading of "no-op", not a mirror of the
+            // state-variable quirk. The byte-then-EOF sub-cell matches GT.
             Ok(TestState::TestStart) => Ok(SetupFlow::Proceed),
             Ok(TestState::ClientTerminate) => {
                 abort_setup_streams(ctx).await;
@@ -3169,9 +3184,11 @@ impl Server {
                 Err(RiperfError::UnknownControlMessage)
             }
             // The byte vanished between the readiness watch and the read —
-            // only a racing EOF does that; take the EOF surface.
+            // only a racing EOF does that; take the EOF surface (with the
+            // #342 relay, like the watch's own EOF arm — r2 F1).
             Err(RiperfError::PeerDisconnected) => {
                 abort_setup_streams(ctx).await;
+                let _ = protocol::send_server_error(&mut ctx.ctrl, 109).await;
                 self.emit_setup_phase_error(ctx, listener, CTRL_CLOSED_MSG);
                 Err(RiperfError::ControlSocketClosed)
             }
@@ -3246,6 +3263,11 @@ impl Server {
         let cpu = crate::json_report::CpuUtilization {
             // Like build_report: only the server's own figures — GT never
             // surfaces the remote side here (no exchange happened at all).
+            // RECORDED DEVIATION (r2 F4, value-level): GT's cpu_util
+            // baseline arms just before TEST_START (iperf_server_api.c:925),
+            // so in this pre-TEST_START cell GT measures against zeroed
+            // statics (an epoch window, ~1e-05 live); riperf3 reports the
+            // honest round window.
             host_total: measured.host_total,
             host_user: measured.host_user,
             host_system: measured.host_system,

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -201,6 +201,10 @@ struct TestRunCtx {
     /// mapped_v4_to_regular_v4.
     accepted_host: String,
     accepted_port: u16,
+    /// Wall-clock millis at ctx creation — GT's setup-doc `timestamp` is
+    /// the on-connect stamp, not the emit time (#356 r1 F4): at the default
+    /// 120 s rcv-timeout those differ by two minutes.
+    accepted_millis: u64,
     cookie: [u8; protocol::COOKIE_SIZE],
     params: TestParams,
     cfg: TestConfig,
@@ -394,12 +398,40 @@ fn demux_local_addr_for(
     ))
 }
 
+/// GT's DEFAULT_NO_MSG_RCVD_TIMEOUT (iperf_api.h:70): the server-side
+/// no-progress bound applied when `--rcv-timeout` is unset (#338).
+const DEFAULT_RCV_TIMEOUT_MS: u64 = 120_000;
+
+/// How the #338 setup phase ended when it didn't produce data streams.
+enum SetupFlow {
+    /// All streams accepted — run the test.
+    Proceed,
+    /// The client sent IPERF_DONE mid-setup — GT's clean arm: the round
+    /// ends with no error surface, like a refusal (#356 r1 F1).
+    ClientDone,
+}
+
 /// What the #338 setup-phase ctrl watch saw.
 enum CtrlActivity {
     /// The peer closed the control connection (read-half EOF).
     Eof,
     /// A state byte is waiting; it stays OS-buffered for the mid-test loop.
     Data,
+}
+
+/// #356 r1 F7: GT's cleanup_server closes every accepted stream socket on
+/// the setup-phase error paths (iperf_server_api.c:460-473); riperf3's
+/// spawned tasks would otherwise detach into the runtime parked in read()
+/// until the peer closes — an accumulating leak under a persistent server.
+/// Abort drops each task's socket at its next await; no counts exist yet,
+/// so there is nothing to freeze (the #352 join-site concern doesn't apply).
+async fn abort_setup_streams(ctx: &mut TestRunCtx) {
+    for s in &ctx.streams {
+        s.task.abort();
+    }
+    for s in ctx.streams.drain(..) {
+        let _ = s.task.await;
+    }
 }
 
 /// #338: wait for control-socket activity without consuming it. This must
@@ -767,6 +799,10 @@ impl Server {
             ctrl,
             accepted_host,
             accepted_port,
+            accepted_millis: std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_millis() as u64)
+                .unwrap_or(0),
             cookie,
             params,
             cfg,
@@ -801,7 +837,11 @@ impl Server {
         let _done_guard = stream::DoneOnDrop(ctx.done.clone());
 
         // ---- CreateStreams ----
-        self.setup_data_streams(&mut ctx, listener).await?;
+        if let SetupFlow::ClientDone = self.setup_data_streams(&mut ctx, listener).await? {
+            // #356 r1 F1: GT's clean IPERF_DONE arm — the round ends with
+            // no error surface, keep-serving like a refusal (Ok(None)).
+            return Ok(None);
+        }
 
         // ---- TestStart / TestRunning ----
         self.start_test(&mut ctx).await?;
@@ -1191,7 +1231,7 @@ impl Server {
         &self,
         ctx: &mut TestRunCtx,
         listener: &tokio::net::TcpListener,
-    ) -> Result<()> {
+    ) -> Result<SetupFlow> {
         // Determine how many streams to accept and their roles.
         // Normal: server receives. Reverse: server sends. Bidir: both.
         let recv_count = if ctx.cfg.reverse && !ctx.cfg.bidir {
@@ -1234,36 +1274,38 @@ impl Server {
                 // #338: GT's CREATE_STREAMS wait runs inside its select()
                 // event loop, so a ctrl-EOF is noticed at once (IECTRLCLOSE,
                 // iperf_server_api.c:249-254) and a no-progress round is
-                // bounded at rcv_timeout (IENOMSG=144, :663-678; default =
-                // DEFAULT_NO_MSG_RCVD_TIMEOUT 120000 ms, iperf_api.h:70).
-                // The bare accept parked unbounded on both. The ctrl watch
-                // is readiness-only (see ctrl_activity for why it must not
-                // be TcpStream::peek) — a state byte arriving mid-setup
-                // stays OS-buffered for the mid-test loop's arms (pre-#338
-                // semantics; GT would dispatch it here — recorded residual
-                // on the issue), and once one is seen the arm disarms so
-                // the select can't spin.
-                let rcv_timeout = std::time::Duration::from_millis(self.rcv_timeout.unwrap_or(
-                    120_000, // GT DEFAULT_NO_MSG_RCVD_TIMEOUT
-                ));
-                let mut watch_ctrl = true;
+                // bounded at rcv_timeout (IENOMSG=144, :663-678). The bare
+                // accept parked unbounded on both. The ctrl watch is
+                // readiness-only (see ctrl_activity for why it must not be
+                // TcpStream::peek); a waiting state byte is then DISPATCHED
+                // through GT's handle_message_server arms below (:236-311,
+                // #356 r1 F1) — consuming it keeps the no-progress clock
+                // honest (each byte is receive progress, GT's
+                // last_receive_time semantics) and a byte can never wedge
+                // the select in a ready-spin.
+                let rcv_timeout = std::time::Duration::from_millis(
+                    self.rcv_timeout.unwrap_or(DEFAULT_RCV_TIMEOUT_MS),
+                );
                 for i in 0..total {
                     let (mut data_stream, _) = loop {
                         tokio::select! {
                             accepted = listener.accept() => break accepted?,
-                            activity = ctrl_activity(&ctx.ctrl), if watch_ctrl => match activity {
+                            activity = ctrl_activity(&ctx.ctrl) => match activity {
                                 // EOF: the peer closed without connecting its
                                 // data streams — GT's read-site surface. The
                                 // -J doc emits here (the serve loop's arm
                                 // prints the text sentence).
                                 Ok(CtrlActivity::Eof) => {
+                                    abort_setup_streams(ctx).await;
                                     self.emit_setup_phase_error(ctx, listener, CTRL_CLOSED_MSG);
                                     return Err(RiperfError::ControlSocketClosed);
                                 }
-                                // A state byte mid-setup: left buffered;
-                                // disarm the watch.
                                 Ok(CtrlActivity::Data) => {
-                                    watch_ctrl = false;
+                                    if let SetupFlow::ClientDone =
+                                        self.dispatch_setup_ctrl_byte(ctx, listener).await?
+                                    {
+                                        return Ok(SetupFlow::ClientDone);
+                                    }
                                 }
                                 Err(e) => return Err(e.into()),
                             },
@@ -1272,6 +1314,7 @@ impl Server {
                                 // SERVER_ERROR + IENOMSG(144) + errno 0
                                 // (live: fe 00000090 00000000), the doc with
                                 // the prefixed key, exit-0 keep-serving.
+                                abort_setup_streams(ctx).await;
                                 let _ = protocol::send_server_error(&mut ctx.ctrl, 144).await;
                                 self.emit_setup_phase_error(
                                     ctx,
@@ -1284,6 +1327,7 @@ impl Server {
                     };
                     let stream_cookie = protocol::recv_cookie(&mut data_stream).await?;
                     if stream_cookie != ctx.cookie {
+                        abort_setup_streams(ctx).await;
                         return Err(RiperfError::CookieMismatch);
                     }
                     // Apply socket options (nodelay, MSS, window, congestion) to each stream
@@ -1429,7 +1473,7 @@ impl Server {
                 }
             }
         }
-        Ok(())
+        Ok(SetupFlow::Proceed)
     }
 
     /// TestStart / TestRunning: the #222 preamble prints, the start-barrier
@@ -3083,6 +3127,84 @@ impl Server {
         }
     }
 
+    /// #356 r1 F1: a state byte arrived during the CREATE_STREAMS wait —
+    /// dispatch it through GT's handle_message_server arms
+    /// (iperf_server_api.c:236-311; each cell live-probed on issue #338):
+    /// TEST_START is a no-op, CLIENT_TERMINATE relays 119 and takes the
+    /// terminate surfaces, IPERF_DONE is the clean errorless arm, and
+    /// everything else is the IEMESSAGE default with the 110 relay.
+    /// RECORDED DEVIATION: "everything else" includes TEST_END, where GT
+    /// instead runs its end processing against streams that never existed
+    /// (live: the report skeleton, an EXCHANGE_RESULTS byte, then a
+    /// stale-errno IERECVRESULTS "Bad file descriptor" tangle) —
+    /// nonconforming-only, not mirrored.
+    async fn dispatch_setup_ctrl_byte(
+        &self,
+        ctx: &mut TestRunCtx,
+        listener: &tokio::net::TcpListener,
+    ) -> Result<SetupFlow> {
+        match protocol::recv_state(&mut ctx.ctrl).await {
+            // GT's no-op arm — keep waiting (the recreated sleep IS the
+            // clock reset: a received byte is progress).
+            Ok(TestState::TestStart) => Ok(SetupFlow::Proceed),
+            Ok(TestState::ClientTerminate) => {
+                abort_setup_streams(ctx).await;
+                let _ = protocol::send_server_error(&mut ctx.ctrl, 119).await;
+                self.emit_setup_phase_terminate(ctx, listener);
+                Err(RiperfError::ClientTerminated)
+            }
+            Ok(TestState::IperfDone) => {
+                abort_setup_streams(ctx).await;
+                self.emit_setup_phase_done(ctx, listener);
+                Ok(SetupFlow::ClientDone)
+            }
+            Ok(_) | Err(RiperfError::UnknownControlMessage) => {
+                abort_setup_streams(ctx).await;
+                let _ = protocol::send_server_error(&mut ctx.ctrl, 110).await;
+                self.emit_setup_phase_error(
+                    ctx,
+                    listener,
+                    &format!("error - {}", RiperfError::UnknownControlMessage),
+                );
+                Err(RiperfError::UnknownControlMessage)
+            }
+            // The byte vanished between the readiness watch and the read —
+            // only a racing EOF does that; take the EOF surface.
+            Err(RiperfError::PeerDisconnected) => {
+                abort_setup_streams(ctx).await;
+                self.emit_setup_phase_error(ctx, listener, CTRL_CLOSED_MSG);
+                Err(RiperfError::ControlSocketClosed)
+            }
+            Err(e) => Err(e),
+        }
+    }
+
+    /// The setup-phase (CREATE_STREAMS) doc input: GT's bufsize trio comes
+    /// off the LISTENER at listen time (iperf_tcp.c:337-377) — read the
+    /// same socket (best-effort: a failed getsockopt omits the key rather
+    /// than inventing one). The timestamp is the on-connect stamp carried
+    /// on ctx, not the emit time (#356 r1 F4).
+    fn setup_phase_doc_input(
+        &self,
+        ctx: &TestRunCtx,
+        listener: &tokio::net::TcpListener,
+    ) -> crate::json_report::SetupPhaseDoc {
+        let sock = socket2::SockRef::from(listener);
+        crate::json_report::SetupPhaseDoc {
+            sock_bufsize: ctx.cfg.window.map(|w| w as u64).unwrap_or(0),
+            sndbuf_actual: sock.send_buffer_size().ok().map(|v| v as u64),
+            rcvbuf_actual: sock.recv_buffer_size().ok().map(|v| v as u64),
+            timemillisecs: ctx.accepted_millis,
+            accepted_host: ctx.accepted_host.clone(),
+            accepted_port: ctx.accepted_port,
+            // The wire cookie is 37 bytes with a trailing NUL; the -J
+            // string drops it (the :1092/:2925 convention).
+            cookie: String::from_utf8_lossy(&ctx.cookie[..protocol::COOKIE_SIZE - 1]).to_string(),
+            target_bitrate: ctx.cfg.bandwidth,
+            fq_rate: ctx.cfg.fq_rate,
+        }
+    }
+
     /// #338: render a setup-phase (CREATE_STREAMS) error in GT's sink shape.
     /// Under -J: the POPULATED setup doc (on_connect + listener metadata,
     /// live-probed — see json_report::setup_error_document); --json-stream:
@@ -3102,31 +3224,63 @@ impl Server {
                 doc_error,
             ));
         } else if self.json_output {
-            // GT's bufsize trio comes off the LISTENER at listen time
-            // (iperf_tcp.c:337-377); read the same socket. Best-effort — a
-            // failed getsockopt omits the key rather than inventing one.
-            let sock = socket2::SockRef::from(listener);
-            let timemillisecs = std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .map(|d| d.as_millis() as u64)
-                .unwrap_or(0);
             let doc = crate::json_report::setup_error_document(
-                &crate::json_report::SetupPhaseDoc {
-                    sock_bufsize: ctx.cfg.window.map(|w| w as u64).unwrap_or(0),
-                    sndbuf_actual: sock.send_buffer_size().ok().map(|v| v as u64),
-                    rcvbuf_actual: sock.recv_buffer_size().ok().map(|v| v as u64),
-                    timemillisecs,
-                    accepted_host: ctx.accepted_host.clone(),
-                    accepted_port: ctx.accepted_port,
-                    // The wire cookie is 37 bytes with a trailing NUL; the -J
-                    // string drops it (the :1092/:2925 convention).
-                    cookie: String::from_utf8_lossy(&ctx.cookie[..protocol::COOKIE_SIZE - 1])
-                        .to_string(),
-                    target_bitrate: ctx.cfg.bandwidth,
-                    fq_rate: ctx.cfg.fq_rate,
-                },
+                &self.setup_phase_doc_input(ctx, listener),
                 doc_error,
             );
+            println!("{doc}");
+        }
+    }
+
+    /// #356 r1 F1: the CLIENT_TERMINATE-at-setup surfaces. -J carries GT's
+    /// FULL-zeros end (real host cpu, remote zeros — the reporter_callback
+    /// ran); --json-stream the error + zeros-end pair; text prints the
+    /// report skeleton on stdout here (the serve loop's arm adds the
+    /// stderr sentence).
+    fn emit_setup_phase_terminate(&self, ctx: &TestRunCtx, listener: &tokio::net::TcpListener) {
+        if crate::macros::output_quiet() {
+            return;
+        }
+        let error = RiperfError::ClientTerminated.to_string();
+        let measured = crate::cpu::CpuSnapshot::now().utilization_since(&ctx.cpu_start);
+        let cpu = crate::json_report::CpuUtilization {
+            // Like build_report: only the server's own figures — GT never
+            // surfaces the remote side here (no exchange happened at all).
+            host_total: measured.host_total,
+            host_user: measured.host_user,
+            host_system: measured.host_system,
+            remote_total: 0.0,
+            remote_user: 0.0,
+            remote_system: 0.0,
+        };
+        if self.json_stream {
+            crate::reporter::emit_json_stream_line(&crate::json_report::terminate_stream_events(
+                &error, &cpu,
+            ));
+        } else if self.json_output {
+            let doc = crate::json_report::setup_terminate_document(
+                &self.setup_phase_doc_input(ctx, listener),
+                &error,
+                &cpu,
+            );
+            println!("{doc}");
+        } else {
+            crate::reporter::print_terminate_skeleton();
+        }
+    }
+
+    /// #356 r1 F1: the IPERF_DONE-at-setup surfaces — GT's clean arm: the
+    /// errorless setup doc under -J, one bare end event under
+    /// --json-stream, silence in text.
+    fn emit_setup_phase_done(&self, ctx: &TestRunCtx, listener: &tokio::net::TcpListener) {
+        if crate::macros::output_quiet() {
+            return;
+        }
+        if self.json_stream {
+            crate::reporter::emit_json_stream_line(&crate::json_report::done_stream_events());
+        } else if self.json_output {
+            let doc =
+                crate::json_report::setup_done_document(&self.setup_phase_doc_input(ctx, listener));
             println!("{doc}");
         }
     }
@@ -3596,6 +3750,14 @@ impl ServerBuilder {
 
 #[cfg(test)]
 mod tests {
+
+    /// #356 r1 F9: the unset-`--rcv-timeout` bound is GT's
+    /// DEFAULT_NO_MSG_RCVD_TIMEOUT (iperf_api.h:70). The 120 s value can't
+    /// be exercised by the suite, so the constant is the pin.
+    #[test]
+    fn default_rcv_timeout_is_gt_default() {
+        assert_eq!(super::DEFAULT_RCV_TIMEOUT_MS, 120_000);
+    }
 
     /// #316: the server adopts the client's exchanged GSO/GRO request
     /// (GT iperf_api.c:2599-2619), including the zero-dg_size recompute

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -335,6 +335,10 @@ pub struct Server {
     pub(crate) one_off: bool,
     pub(crate) verbose: bool,
     pub(crate) idle_timeout: Option<u32>,
+    /// `--rcv-timeout` (ms): the no-progress bound on waits that GT caps at
+    /// rcv_timeout (#338 CREATE_STREAMS; default 120000 = GT's
+    /// DEFAULT_NO_MSG_RCVD_TIMEOUT, iperf_api.h:70).
+    pub(crate) rcv_timeout: Option<u64>,
     pub(crate) server_bitrate_limit: Option<u64>,
     pub(crate) server_max_duration: Option<u32>,
     pub(crate) forceflush: bool,
@@ -531,6 +535,19 @@ impl Server {
                             "{}riperf3: error - {}",
                             crate::macros::output_timestamp_prefix(),
                             RiperfError::UnknownControlMessage
+                        );
+                    }
+                }
+                Err(RiperfError::DataIdleTimeout) => {
+                    // #338: GT's rcv_timeout no-progress bound at the
+                    // CREATE_STREAMS wait — IENOMSG(144). The doc emitted at
+                    // the setup site; text prints iperf_err's stamped line.
+                    // Keep-serving, exit 0 (GT's rc -1 class, like IEMESSAGE).
+                    if !json && !crate::macros::output_quiet() {
+                        eprintln!(
+                            "{}riperf3: error - {}",
+                            crate::macros::output_timestamp_prefix(),
+                            RiperfError::DataIdleTimeout
                         );
                     }
                 }
@@ -1180,8 +1197,56 @@ impl Server {
             TransportProtocol::Tcp => {
                 protocol::send_state(&mut ctx.ctrl, TestState::CreateStreams).await?;
 
+                // #338: GT's CREATE_STREAMS wait runs inside its select()
+                // event loop, so a ctrl-EOF is noticed at once (IECTRLCLOSE,
+                // iperf_server_api.c:249-254) and a no-progress round is
+                // bounded at rcv_timeout (IENOMSG=144, :663-678; default =
+                // DEFAULT_NO_MSG_RCVD_TIMEOUT 120000 ms, iperf_api.h:70).
+                // The bare accept parked unbounded on both. The ctrl watch
+                // PEEKs — a state byte arriving mid-setup stays buffered for
+                // the mid-test loop's arms (pre-#338 semantics; GT would
+                // dispatch it here — recorded residual on the issue), and
+                // once one is seen the arm disarms so the select can't spin.
+                let rcv_timeout = std::time::Duration::from_millis(self.rcv_timeout.unwrap_or(
+                    120_000, // GT DEFAULT_NO_MSG_RCVD_TIMEOUT
+                ));
+                let mut watch_ctrl = true;
                 for i in 0..total {
-                    let (mut data_stream, _) = listener.accept().await?;
+                    let mut peek_buf = [0u8; 1];
+                    let (mut data_stream, _) = loop {
+                        tokio::select! {
+                            accepted = listener.accept() => break accepted?,
+                            peeked = ctx.ctrl.peek(&mut peek_buf), if watch_ctrl => match peeked {
+                                // EOF: the peer closed without connecting its
+                                // data streams — GT's read-site surface. The
+                                // -J doc emits here (the serve loop's arm
+                                // prints the text sentence).
+                                Ok(0) => {
+                                    self.emit_setup_phase_error(ctx, listener, CTRL_CLOSED_MSG);
+                                    return Err(RiperfError::ControlSocketClosed);
+                                }
+                                // A state byte mid-setup: leave it buffered
+                                // (peek) and disarm the watch.
+                                Ok(_) => {
+                                    watch_ctrl = false;
+                                }
+                                Err(e) => return Err(e.into()),
+                            },
+                            _ = tokio::time::sleep(rcv_timeout) => {
+                                // GT's no-progress bound: wire-back
+                                // SERVER_ERROR + IENOMSG(144) + errno 0
+                                // (live: fe 00000090 00000000), the doc with
+                                // the prefixed key, exit-0 keep-serving.
+                                let _ = protocol::send_server_error(&mut ctx.ctrl, 144).await;
+                                self.emit_setup_phase_error(
+                                    ctx,
+                                    listener,
+                                    &format!("error - {}", RiperfError::DataIdleTimeout),
+                                );
+                                return Err(RiperfError::DataIdleTimeout);
+                            }
+                        }
+                    };
                     let stream_cookie = protocol::recv_cookie(&mut data_stream).await?;
                     if stream_cookie != ctx.cookie {
                         return Err(RiperfError::CookieMismatch);
@@ -2983,6 +3048,54 @@ impl Server {
         }
     }
 
+    /// #338: render a setup-phase (CREATE_STREAMS) error in GT's sink shape.
+    /// Under -J: the POPULATED setup doc (on_connect + listener metadata,
+    /// live-probed — see json_report::setup_error_document); --json-stream:
+    /// the same error+end event pair GT emits here (live-probed, no start
+    /// event); text: nothing — the serve loop's arms print the stderr line.
+    fn emit_setup_phase_error(
+        &self,
+        ctx: &TestRunCtx,
+        listener: &tokio::net::TcpListener,
+        doc_error: &str,
+    ) {
+        if crate::macros::output_quiet() {
+            return;
+        }
+        if self.json_stream {
+            crate::reporter::emit_json_stream_line(&crate::json_report::error_stream_events(
+                doc_error,
+            ));
+        } else if self.json_output {
+            // GT's bufsize trio comes off the LISTENER at listen time
+            // (iperf_tcp.c:337-377); read the same socket. Best-effort — a
+            // failed getsockopt omits the key rather than inventing one.
+            let sock = socket2::SockRef::from(listener);
+            let timemillisecs = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_millis() as u64)
+                .unwrap_or(0);
+            let doc = crate::json_report::setup_error_document(
+                &crate::json_report::SetupPhaseDoc {
+                    sock_bufsize: ctx.cfg.window.map(|w| w as u64).unwrap_or(0),
+                    sndbuf_actual: sock.send_buffer_size().ok().map(|v| v as u64),
+                    rcvbuf_actual: sock.recv_buffer_size().ok().map(|v| v as u64),
+                    timemillisecs,
+                    accepted_host: ctx.accepted_host.clone(),
+                    accepted_port: ctx.accepted_port,
+                    // The wire cookie is 37 bytes with a trailing NUL; the -J
+                    // string drops it (the :1092/:2925 convention).
+                    cookie: String::from_utf8_lossy(&ctx.cookie[..protocol::COOKIE_SIZE - 1])
+                        .to_string(),
+                    target_bitrate: ctx.cfg.bandwidth,
+                    fq_rate: ctx.cfg.fq_rate,
+                },
+                doc_error,
+            );
+            println!("{doc}");
+        }
+    }
+
     /// #330: render a pre-test control error (IERECVCOOKIE / IERECVPARAMS) in
     /// GT's iperf_err sink shape — silent stderr under -J with the message in
     /// the skeleton doc, one text line otherwise. Both codes are perr=1, so the
@@ -3139,6 +3252,7 @@ pub struct ServerBuilder {
     one_off: bool,
     verbose: bool,
     idle_timeout: Option<u32>,
+    rcv_timeout: Option<u64>,
     server_bitrate_limit: Option<u64>,
     server_max_duration: Option<u32>,
     forceflush: bool,
@@ -3166,6 +3280,7 @@ impl Default for ServerBuilder {
             one_off: false,
             verbose: false,
             idle_timeout: None,
+            rcv_timeout: None,
             server_bitrate_limit: None,
             server_max_duration: None,
             forceflush: false,
@@ -3259,6 +3374,13 @@ impl ServerBuilder {
     /// `secs` seconds (with `-1/--one-off`, exit instead).
     pub fn idle_timeout(mut self, secs: u32) -> Self {
         self.idle_timeout = Some(secs);
+        self
+    }
+
+    /// `--rcv-timeout` (ms): the server's no-progress bound (#338). Unset:
+    /// GT's DEFAULT_NO_MSG_RCVD_TIMEOUT (120000 ms).
+    pub fn rcv_timeout(mut self, ms: u64) -> Self {
+        self.rcv_timeout = Some(ms);
         self
     }
 
@@ -3410,6 +3532,7 @@ impl ServerBuilder {
             one_off: self.one_off,
             verbose: self.verbose,
             idle_timeout: self.idle_timeout,
+            rcv_timeout: self.rcv_timeout,
             server_bitrate_limit: self.server_bitrate_limit,
             server_max_duration: self.server_max_duration,
             forceflush: self.forceflush,

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -394,6 +394,40 @@ fn demux_local_addr_for(
     ))
 }
 
+/// What the #338 setup-phase ctrl watch saw.
+enum CtrlActivity {
+    /// The peer closed the control connection (read-half EOF).
+    Eof,
+    /// A state byte is waiting; it stays OS-buffered for the mid-test loop.
+    Data,
+}
+
+/// #338: wait for control-socket activity without consuming it. This must
+/// NOT be `TcpStream::peek` — tokio's poll_peek path leaves winsock
+/// readiness corrupted so LATER reads on the same socket never wake (the
+/// mid-test loop missed TEST_END forever; deterministic on Windows even
+/// with the peek arm never resolving — reproduced natively on Windows 11,
+/// see PR #356).
+/// `ready()` performs no syscall on the socket, so in the common case
+/// (setup completes with no ctrl activity) the socket is untouched; the
+/// classifying peek goes straight to the OS via `SockRef`, with `try_io`
+/// keeping tokio's WouldBlock/clear-readiness discipline. Cancel-safe: the
+/// only await is `ready()`, which holds no I/O state.
+async fn ctrl_activity(ctrl: &tokio::net::TcpStream) -> std::io::Result<CtrlActivity> {
+    loop {
+        ctrl.ready(tokio::io::Interest::READABLE).await?;
+        let mut buf = [std::mem::MaybeUninit::<u8>::uninit()];
+        match ctrl.try_io(tokio::io::Interest::READABLE, || {
+            socket2::SockRef::from(ctrl).peek(&mut buf)
+        }) {
+            Ok(0) => return Ok(CtrlActivity::Eof),
+            Ok(_) => return Ok(CtrlActivity::Data),
+            Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => continue,
+            Err(e) => return Err(e),
+        }
+    }
+}
+
 impl Server {
     /// Chainable form of [`ServerBuilder::interrupt`] for an already-built
     /// server (#210).
@@ -1203,31 +1237,32 @@ impl Server {
                 // bounded at rcv_timeout (IENOMSG=144, :663-678; default =
                 // DEFAULT_NO_MSG_RCVD_TIMEOUT 120000 ms, iperf_api.h:70).
                 // The bare accept parked unbounded on both. The ctrl watch
-                // PEEKs — a state byte arriving mid-setup stays buffered for
-                // the mid-test loop's arms (pre-#338 semantics; GT would
-                // dispatch it here — recorded residual on the issue), and
-                // once one is seen the arm disarms so the select can't spin.
+                // is readiness-only (see ctrl_activity for why it must not
+                // be TcpStream::peek) — a state byte arriving mid-setup
+                // stays OS-buffered for the mid-test loop's arms (pre-#338
+                // semantics; GT would dispatch it here — recorded residual
+                // on the issue), and once one is seen the arm disarms so
+                // the select can't spin.
                 let rcv_timeout = std::time::Duration::from_millis(self.rcv_timeout.unwrap_or(
                     120_000, // GT DEFAULT_NO_MSG_RCVD_TIMEOUT
                 ));
                 let mut watch_ctrl = true;
                 for i in 0..total {
-                    let mut peek_buf = [0u8; 1];
                     let (mut data_stream, _) = loop {
                         tokio::select! {
                             accepted = listener.accept() => break accepted?,
-                            peeked = ctx.ctrl.peek(&mut peek_buf), if watch_ctrl => match peeked {
+                            activity = ctrl_activity(&ctx.ctrl), if watch_ctrl => match activity {
                                 // EOF: the peer closed without connecting its
                                 // data streams — GT's read-site surface. The
                                 // -J doc emits here (the serve loop's arm
                                 // prints the text sentence).
-                                Ok(0) => {
+                                Ok(CtrlActivity::Eof) => {
                                     self.emit_setup_phase_error(ctx, listener, CTRL_CLOSED_MSG);
                                     return Err(RiperfError::ControlSocketClosed);
                                 }
-                                // A state byte mid-setup: leave it buffered
-                                // (peek) and disarm the watch.
-                                Ok(_) => {
+                                // A state byte mid-setup: left buffered;
+                                // disarm the watch.
+                                Ok(CtrlActivity::Data) => {
                                     watch_ctrl = false;
                                 }
                                 Err(e) => return Err(e.into()),


### PR DESCRIPTION
Closes #338.

## The wedge (both variants live-proven, spec banked on the issue)

The CREATE_STREAMS accept loop ran a bare `listener.accept().await` — it watched neither the control socket nor a clock. A peer sending valid-but-incomplete params (`{"tcp":true}`, deserializes via serde defaults) and then either closing the control socket (EOF variant) or holding it open without connecting data streams (HOLD variant) parked the server unbounded (>12 s / >50 s observed). GT is bounded on both: its CREATE_STREAMS wait runs inside the select() event loop, so ctrl-EOF is noticed at once (IECTRLCLOSE, iperf_server_api.c:249-254), and a no-progress round trips rcv_timeout (IENOMSG=144, :663-678; default DEFAULT_NO_MSG_RCVD_TIMEOUT = 120000 ms, iperf_api.h:70).

## The fix

The accept wait is now a `select!` over three arms:

- **accept** (existing body unchanged);
- **ctrl peek**: `Ok(0)`/EOF → emit the setup-phase `-J` doc at the site and return `ControlSocketClosed` (the serve loop's existing arm prints the stamped text sentence; exit-0 keep-serving). A state BYTE arriving mid-setup stays buffered (peek, not read) for the mid-test loop's arms — pre-existing semantics preserved; GT would dispatch it at once via handle_message_server, recorded as a residual on the issue. Once a byte is seen the arm disarms so the select cannot spin.
- **rcv_timeout deadline**: wire-back `SERVER_ERROR + htonl(IENOMSG=144) + htonl(0)` (live GT: `fe 00000090 00000000`), the doc with the `error - `-prefixed key, new `RiperfError::DataIdleTimeout` → serve-loop arm prints GT's stamped `riperf3: error - idle timeout for receiving data`; exit-0 keep-serving.

`--rcv-timeout` gains its server half: the flag existed but was client-wired only. `ServerBuilder::rcv_timeout(ms)` + CLI glue; unset defaults to GT's 120000 ms. (#351 — the TEST_RUNNING watchdog — will reuse this knob and the IENOMSG machinery.)

## The setup-phase document

GT's doc here is NOT the minimal skeleton — by CREATE_STREAMS its json_start carries the on_connect metadata and the LISTENER's buffer fields (live-probed, banked on the issue): empty `connected:[]`, `sock_bufsize`/`sndbuf_actual`/`rcvbuf_actual` (read off the listener — iperf_tcp.c:337-377), `timestamp`, `accepted_connection`, `cookie`, `tcp_mss_default` 0 (the server never reads the ctrl MSS), `target_bitrate`, `fq_rate`, over `intervals:[]` + bare `end:{}` + the error key (bare sentence for IECTRLCLOSE; `error - `-prefixed for IENOMSG). New `json_report::setup_error_document` mirrors it, including GT's SERVER key order (bufsizes before timestamp).

`--json-stream`: live-probed — GT emits exactly the existing error+end event pair (no start event); the emit reuses `error_stream_events`.

**Discovered and filed separately: #355** — riperf3's shared Start serializer emits the bufsize trio AFTER fq_rate on the server role in ALL runs, where GT's server emits them before timestamp (insertion order at listen time). Pre-existing, general, byte-order-only; the new setup doc is born with GT's order.

## Tests (4 new, TDD red-first — all four parked past the harness bounds pre-fix)

- `setup_phase_ctrl_eof_exits_bounded_in_text` — bounded exit, exit 0, the bare stamped sentence.
- `setup_phase_ctrl_eof_takes_gt_doc_shape_in_json` — populated start (empty connected, accepted_connection, cookie, bufsize presence, zeros where GT has zeros), bare end, bare error key, silent stderr.
- `setup_phase_ctrl_hold_bounds_at_rcv_timeout_in_text` — with `--rcv-timeout 3000`: the mock reads the exact 9-byte IENOMSG wire-back at the ~3 s bound; exit 0; GT's stderr line.
- `setup_phase_ctrl_hold_takes_gt_doc_shape_in_json` — the prefixed error key over the populated start.

## Mutation table (5 rounds, each restored from the committed tree)

| # | Mutation | Killing test | Result |
|---|---|---|---|
| M1 | remove the IENOMSG wire-back | setup_phase_ctrl_hold_bounds_at_rcv_timeout_in_text | RED |
| M2 | remove the EOF-path doc emit | setup_phase_ctrl_eof_takes_gt_doc_shape_in_json | RED |
| M3 | neuter the --rcv-timeout knob (flag no longer reaches the deadline) | setup_phase_ctrl_hold_bounds_at_rcv_timeout_in_text | RED |
| M4 | disable the ctrl-peek arm | setup_phase_ctrl_eof_exits_bounded_in_text | RED |
| M5 | delete the serve-loop DataIdleTimeout stderr line | setup_phase_ctrl_hold_bounds_at_rcv_timeout_in_text | RED |

## Gates

- workspace tests: 810 passed, 0 failed (806 + 4 new)
- clippy `-D warnings`: clean; fmt: clean
- xcheck 7/7 targets
- CI + per-merge compat 52/52 before merge

## Round record

### Windows CI red → root-caused + fixed (8521860)

The 6b605c3 head hung both `bound_server.rs` in-process e2e tests on Windows: the server received the whole transfer, then never saw TEST_END. Mechanism (reproduced natively red→green on a Windows 11 host): **tokio `TcpStream::peek` in the setup select corrupts winsock readiness for ALL later reads on that socket, even when the peek arm never resolves**. Fix: `ctrl_activity()` — a readiness-only `ready(READABLE)` wait (no syscall touches the socket in the common case) with a classifying direct `MSG_PEEK` via `socket2::SockRef` under `try_io` (keeping the WouldBlock/clear discipline). Same EOF/Data/Err surface, one cross-platform path. Full native Windows suite: 718 green (sole failure = the known VM-environment `rate_limiter_high_rate_precision` timer-resolution limit, green on GitHub's runner).

### r1 (cold, adversarial) → REQUEST-CHANGES → fixed (605cdaf, 4ccfa70)

r1 verified the core byte-exact GT-faithful in every probed cell (EOF/HOLD × text/-J/--json-stream, the IENOMSG wire-back, -P4 progress semantics, keep-serving) and found:

- **F1 (HIGH): the ctrl-Data disarm misclassified vs GT and was mutation-invisible** — a client Ctrl-C'd mid-setup (CLIENT_TERMINATE then EOF) parked to the rcv-timeout and misreported IENOMSG; removing the disarm left all tests green with an *unbounded* park as the silent regression. FIXED by implementing GT's dispatch: setup-phase ctrl bytes now go through the same `handle_message_server` arms as mid-test (each cell live-probed on GT 3.21): terminate → relay 119 + report skeleton (text) / FULL-zeros end with real host cpu (-J) / error+zeros-end pair (--json-stream); IPERF_DONE → clean errorless doc, round ends keep-serving like a refusal; TEST_START → no-op (byte = clock reset, GT's last_receive_time); default → IEMESSAGE + relay 110. RECORDED DEVIATION: TEST_END-at-setup takes the IEMESSAGE arm (GT ghost-runs end processing into a stale-errno IERECVRESULTS tangle; nonconforming-only).
- **F4: setup-doc timestamp now stamps at on-connect (ctx creation), not emit** — pinned (red at +3 s, green at the stamp).
- **F7: every setup-phase error return (and the pre-existing CookieMismatch sibling) aborts+joins accepted stream tasks** like GT's cleanup_server; pinned with a PERSISTENT server (a one-off's exit closes sockets either way — the first draft of this pin was mutation-vacuous, caught in the kill-check round).
- **F8: raw key-order pin** for the setup doc (GT server order, bufsizes before timestamp) + the terminate zeros-end shape.
- **F9: 120 s default hoisted to `DEFAULT_RCV_TIMEOUT_MS`** + constant pin.
- **F10: server-side `--rcv-timeout` builder-compare glue test.**
- **F2 (records): filed #358** (UDP setup: ctrl-EOF unnoticed 30 s, --rcv-timeout ignored, non-GT surface — never unbounded, pre-existing 30 s cap), **#357** (-w sndbuf/rcvbuf actuals vs GT's re-listen), **amended #355** (GT emits `target_bitrate` twice in the -b cell — unmatchable by serde_json, recorded deviation), **noted on #353** (setup-phase family fixed here; exchange-phase `?` remains).
- **F5 (RST cell)**: GT's own surface is degenerate (stale IESENDMESSAGE + garbage getpeername line); riperf3's immediate generic arm kept — deviation noted here.

### Dispatch verification

10 new pins red-first → green (terminate/stray/done/no-op × text/-J/--json-stream + F4 + F7). Live A/B vs GT: wire frames byte-identical (`fe…77…`, `fe…6e…`), dt 0.01 both cells, sentences byte-identical, terminate -J doc **shape-identical** (every key path/type/array length). Mutation kill-round (one at a time from the committed tree, anchors uniqueness-verified after two first-occurrence mistargets hit the mid-test arms): terminate-arm, relay-119, abort, done-arm, no-op-arm, stamp-at-emit — all RED. Native Windows leg: all 14 setup_phase pins + bound_server green with verified rebuilds.

### r2 (cold, independent) → REQUEST-CHANGES → fixed (a364590)

r2 independently re-derived the dispatch matrix byte-identical, proved the round leak-free (30 terminate-rounds, flat fd count), spin-free (0.00 s CPU over a 10 s hold), flake-free (70/70 pinned runs), and regression-free (masked A/B vs a6e1b59 across 9 healthy scenarios), then found:

- **F1: the two new setup-phase EOF sites skipped the #342 IECTRLCLOSE(109) relay** their mid-test/end-loop siblings send (GT live: `fe 0000006d 00000000` under half-close; head sent nothing). FIXED — both sites relay best-effort; pinned via SHUT_WR half-close (red→green, mutation-killed at the watch arm; the dispatch-arm twin is a race-window structural sibling with no deterministic driver).
- **F2: the TEST_START "GT no-op" claim was false in the accepts-after sub-cell** — GT's Nread poisons `test->state`, so GT ACCESS_DENIED's later correct-cookie connects while riperf3 keeps accepting. RECORDED DEVIATION (per the don't-mirror-GT-bugs ruling): arm comment + dispatch doc + test renamed `setup_phase_test_start_byte_keeps_waiting`; the byte-then-EOF sub-cell still matches GT and stays pinned.
- **F3: the no-progress clock-reset semantics were mutation-invisible** (an absolute-deadline hoist survived all 14 pins while it would kill a slow-but-progressing peer GT keeps). PINNED: -P2 peer, one stream per ~2 s under `--rcv-timeout 3000`, must reach TEST_START — red under the deadline-hoist mutation, green on head.
- **F4 (record): terminate-cell cpu figures** — GT's cpu_util baseline arms only at TEST_START, so its pre-TEST_START figures are an epoch-window degenerate (~1e-05); riperf3 reports the honest round window. Deviation comment at the computation.
- **F5: filed #359** (pre-existing, baseline-identical: wrong-cookie / silent data connects kill the round where GT ACCESS_DENIED-denies and continues).
- **F6: doc drift fixed** — serve_once's None arm lists all three no-report classes; run_once rustdoc gains the DataIdleTimeout ending.

Delta gate: 16 pins green (F1 red→first), full workspace green, clippy/fmt clean, xcheck 7/7, native Windows leg green with verified rebuilds (incl. the half-close relay pin on winsock).

### r3 (focused, delta 4ccfa70..a364590) → APPROVE

All six r2 findings verified resolved: the 109 relay live byte-identical to GT under half-close (mutation re-run red at the watch arm; the dispatch-arm twin proven driverless — recv_state maps only a 0-byte read to PeerDisconnected, and any cell reaching it has a dying socket, so symmetry + `let _ =` is the whole story); the F2 record source-verified (GT's Nread-into-state + the ACCESS_DENIED knock path) and record-not-mirror endorsed; MUT6 re-run red against the new F3 pin (5/5 green under 2-core pinning); F4/F6 records accurate; masked A/B vs 4ccfa70 shows the relays don't leak into healthy rounds. Two nits applied post-approve: the #359 GT cite corrected (deny = iperf_tcp.c:161-166, guard = iperf_server_api.c:786), and the F3 pin's decisive read bounded (7c7965b, test-only).

## Residuals

- **UDP setup path: filed #358** (bounded today by the pre-existing 30 s UDP connect cap; ctrl-EOF/rcv-timeout/surface fidelity gaps recorded there).
- Terminate-mid-setup with already-accepted streams: riperf3 emits the no-streams doc shape; GT lists the accepted stream as a zeros row (+`receiver_tcp_congestion`, populated `connected[]`). Behavior matches (sockets closed at once, F7); the doc-shape divergence in this adversarial-only sub-cell is a recorded deviation (probe capture `gt-stream-term.json` in the r1 record).
- The lib `run_once`/`BoundServer::run_once` surface for the IPERF_DONE cell rides the established `Ok(None)` refusal path, which `serve_once` maps to the pre-existing `Aborted("interrupted before a test started")` — a lib-facing message nit shared with refusals; candidate for the #293/#294 API pass.

