### PR TITLE
fix: IESENDMESSAGE on the post-cookie state-write failure + the idle-interrupt skeleton doc (#345, #346)

### DIFF
--- a/riperf3-cli/tests/signal_terminate.rs
+++ b/riperf3-cli/tests/signal_terminate.rs
@@ -963,8 +963,8 @@ fn server_sigterm_mid_test_emits_exactly_one_doc() {
     assert_eq!(scode, 0, "signal-normal exit");
     assert!(serr.trim().is_empty(), "-J keeps stderr silent: {serr:?}");
     // from_str on the WHOLE stdout: a second appended doc fails the parse.
-    let doc: serde_json::Value = serde_json::from_str(sout.trim())
-        .expect("server stdout is EXACTLY ONE JSON document");
+    let doc: serde_json::Value =
+        serde_json::from_str(sout.trim()).expect("server stdout is EXACTLY ONE JSON document");
     assert!(
         doc["error"].is_string(),
         "the single doc carries the interrupt/terminate key: {doc}"

--- a/riperf3-cli/tests/signal_terminate.rs
+++ b/riperf3-cli/tests/signal_terminate.rs
@@ -938,3 +938,35 @@ fn server_survives_a_mid_exchange_client_wedge() {
         "the sigend dump carries the interrupt error key: {doc}"
     );
 }
+
+/// #346 (M4 gate): a server SIGTERM'd MID-TEST emits EXACTLY ONE document —
+/// the round's partial report already carried the message (#210), and the
+/// serve loop's idle-interrupt skeleton (#346) must NOT append a second doc
+/// when the interrupted round produced a report. Two concatenated docs
+/// break every JSON consumer.
+#[cfg(unix)]
+#[test]
+fn server_sigterm_mid_test_emits_exactly_one_doc() {
+    let ps = free_port().to_string();
+    let server = spawn(&["-s", "-1", "-p", &ps, "-J"]);
+    std::thread::sleep(Duration::from_millis(300));
+    let client = spawn(&["-c", "127.0.0.1", "-p", &ps, "-t", "8", "-J"]);
+    std::thread::sleep(Duration::from_secs(2));
+
+    let spid = server.0.id() as i32;
+    unsafe {
+        libc::kill(spid, libc::SIGTERM);
+    }
+    let (sout, serr, scode) = wait_with_output_bounded(server, Duration::from_secs(8), "server");
+    let _ = wait_with_output_bounded(client, Duration::from_secs(8), "client");
+
+    assert_eq!(scode, 0, "signal-normal exit");
+    assert!(serr.trim().is_empty(), "-J keeps stderr silent: {serr:?}");
+    // from_str on the WHOLE stdout: a second appended doc fails the parse.
+    let doc: serde_json::Value = serde_json::from_str(sout.trim())
+        .expect("server stdout is EXACTLY ONE JSON document");
+    assert!(
+        doc["error"].is_string(),
+        "the single doc carries the interrupt/terminate key: {doc}"
+    );
+}

--- a/riperf3-cli/tests/signal_terminate.rs
+++ b/riperf3-cli/tests/signal_terminate.rs
@@ -970,3 +970,55 @@ fn server_sigterm_mid_test_emits_exactly_one_doc() {
         "the single doc carries the interrupt/terminate key: {doc}"
     );
 }
+
+/// #346 (PR #360 r1 F1): a SIGTERM landing DURING a refused round must not
+/// append the idle-interrupt skeleton after the refusal doc — the refusal
+/// round returns Ok(None) after emitting its own document. Deterministic:
+/// the signal lands while the server is blocked in recv_params (which does
+/// not watch the interrupt), then the violating params complete the
+/// refusal round with the interrupt already pending.
+#[cfg(unix)]
+#[test]
+fn sigterm_during_refused_round_emits_exactly_one_doc() {
+    use std::io::{Read, Write};
+    let ps = free_port();
+    let server = spawn(&[
+        "-s",
+        "-1",
+        "-p",
+        &ps.to_string(),
+        "-J",
+        "--server-max-duration",
+        "5",
+    ]);
+    std::thread::sleep(Duration::from_millis(400));
+
+    let mut ctrl = std::net::TcpStream::connect(("127.0.0.1", ps)).expect("ctrl");
+    ctrl.write_all(&[b'x'; 37]).unwrap();
+    let mut b = [0u8; 1];
+    ctrl.read_exact(&mut b).unwrap();
+    assert_eq!(b[0], 9, "ParamExchange");
+    // Signal while the server is parked in recv_params.
+    let spid = server.0.id() as i32;
+    unsafe {
+        libc::kill(spid, libc::SIGTERM);
+    }
+    std::thread::sleep(Duration::from_millis(100));
+    // Violating params (time 100 > max 5) complete the REFUSED round.
+    let params = br#"{"tcp":true,"time":100}"#;
+    ctrl.write_all(&(params.len() as u32).to_be_bytes())
+        .unwrap();
+    ctrl.write_all(params).unwrap();
+
+    let (sout, serr, scode) = wait_with_output_bounded(server, Duration::from_secs(8), "server");
+    drop(ctrl);
+    assert_eq!(scode, 0, "signal-normal exit");
+    assert!(serr.trim().is_empty(), "-J keeps stderr silent: {serr:?}");
+    // Whole-stdout parse: an appended skeleton doc fails it.
+    let doc: serde_json::Value = serde_json::from_str(sout.trim())
+        .expect("server stdout is EXACTLY ONE JSON document (the refusal's)");
+    assert!(
+        doc["error"].is_string(),
+        "the single doc is the refusal's: {doc}"
+    );
+}

--- a/riperf3-cli/tests/wire_shape.rs
+++ b/riperf3-cli/tests/wire_shape.rs
@@ -2850,8 +2850,12 @@ const SENDMSG_SENTENCE: &str =
     "unable to send control message - port may not be available, the other side may have stopped running, etc.";
 
 /// One #345 attempt: cookie, then an immediate SO_LINGER(0) RST. Returns
-/// (stdout, stderr, exit).
-#[cfg(unix)]
+/// (stdout, stderr, exit). LINUX-ONLY (the #339 SO_LINGER lesson, refined):
+/// on macOS/FreeBSD the RST surfaces through an EARLIER syscall (CI: a
+/// kind-only InvalidInput via the generic pre-test arm, deterministic on
+/// FreeBSD) and the send-write race is essentially never won — the mapping
+/// under test is platform-independent; only Linux timing exercises it.
+#[cfg(target_os = "linux")]
 fn drive_cookie_then_rst(json: bool) -> (String, String, std::process::ExitStatus) {
     drive_server_scenario(json, |port| {
         let mut ctrl = std::net::TcpStream::connect(("127.0.0.1", port)).expect("ctrl");
@@ -2881,7 +2885,7 @@ fn drive_cookie_then_rst(json: bool) -> (String, String, std::process::ExitStatu
 /// #345 text: within a bounded number of race attempts, the send-failure
 /// class must appear with GT's IESENDMESSAGE sentence (red = it never
 /// appears; pre-fix the path takes a raw Io message via the generic arm).
-#[cfg(unix)]
+#[cfg(target_os = "linux")]
 #[test]
 fn pretest_send_state_failure_takes_iesendmessage_text() {
     let mut seen = Vec::new();
@@ -2903,7 +2907,7 @@ fn pretest_send_state_failure_takes_iesendmessage_text() {
 
 /// #345 -J: same race loop; when the send class hits, the skeleton doc
 /// carries the prefixed key with the live strerror (no dangling ": ").
-#[cfg(unix)]
+#[cfg(target_os = "linux")]
 #[test]
 fn pretest_send_state_failure_takes_iesendmessage_json() {
     let mut seen = Vec::new();

--- a/riperf3-cli/tests/wire_shape.rs
+++ b/riperf3-cli/tests/wire_shape.rs
@@ -2834,3 +2834,202 @@ fn setup_phase_rcv_timeout_resets_on_stream_progress() {
     // round — only the reached-TEST_START byte is under test here.
     let _ = riperf3_test_support::wait_bounded(&mut server.0, std::time::Duration::from_secs(20));
 }
+
+// ---------------------------------------------------------------------------
+// #345: post-cookie send_state(ParamExchange) failure = GT's IESENDMESSAGE
+// (111) — iperf_error.c:305-308 sentence + a LIVE deterministic strerror
+// (ENOTCONN; the peer's RST broke the write). GT live-probed (N=12/mode):
+// text deterministic; -J silent stderr + skeleton doc with the prefixed key;
+// 4/12 the RST lost the race and the run took the IERECVPARAMS class
+// instead — BOTH classes stay reachable, so these pins retry-classify.
+// The SERVER_ERROR+111 relay is best-effort and unobservable (the peer
+// RST'd) — unpinned by design, like #347's try_reserve guard.
+// ---------------------------------------------------------------------------
+
+const SENDMSG_SENTENCE: &str =
+    "unable to send control message - port may not be available, the other side may have stopped running, etc.";
+
+/// One #345 attempt: cookie, then an immediate SO_LINGER(0) RST. Returns
+/// (stdout, stderr, exit).
+#[cfg(unix)]
+fn drive_cookie_then_rst(json: bool) -> (String, String, std::process::ExitStatus) {
+    drive_server_scenario(json, |port| {
+        let mut ctrl = std::net::TcpStream::connect(("127.0.0.1", port)).expect("ctrl");
+        // SO_LINGER(0): the drop sends a real RST (the setup_retry.rs
+        // helper's pattern — unix-only, which is why these pins are).
+        let linger = libc::linger {
+            l_onoff: 1,
+            l_linger: 0,
+        };
+        let rc = unsafe {
+            use std::os::fd::AsRawFd;
+            libc::setsockopt(
+                ctrl.as_raw_fd(),
+                libc::SOL_SOCKET,
+                libc::SO_LINGER,
+                std::ptr::from_ref(&linger).cast(),
+                std::mem::size_of::<libc::linger>() as libc::socklen_t,
+            )
+        };
+        assert_eq!(rc, 0, "SO_LINGER setsockopt failed");
+        ctrl.write_all(&[b'x'; 37]).unwrap();
+        drop(ctrl); // RST races the server's ParamExchange state write
+        std::thread::sleep(std::time::Duration::from_millis(200));
+    })
+}
+
+/// #345 text: within a bounded number of race attempts, the send-failure
+/// class must appear with GT's IESENDMESSAGE sentence (red = it never
+/// appears; pre-fix the path takes a raw Io message via the generic arm).
+#[cfg(unix)]
+#[test]
+fn pretest_send_state_failure_takes_iesendmessage_text() {
+    let mut seen = Vec::new();
+    for _ in 0..12 {
+        let (_sout, serr, status) = drive_cookie_then_rst(false);
+        assert!(status.success(), "keep-serving one-off exits 0: {serr:?}");
+        let line = serr.trim().to_string();
+        if line.contains(SENDMSG_SENTENCE) {
+            assert!(
+                line.starts_with(&format!("riperf3: error - {SENDMSG_SENTENCE}: ")),
+                "GT's sentence + live strerror suffix: {line:?}"
+            );
+            return;
+        }
+        seen.push(line);
+    }
+    panic!("IESENDMESSAGE never surfaced in 12 RST races; saw: {seen:#?}");
+}
+
+/// #345 -J: same race loop; when the send class hits, the skeleton doc
+/// carries the prefixed key with the live strerror (no dangling ": ").
+#[cfg(unix)]
+#[test]
+fn pretest_send_state_failure_takes_iesendmessage_json() {
+    let mut seen = Vec::new();
+    for _ in 0..12 {
+        let (sout, serr, status) = drive_cookie_then_rst(true);
+        assert!(status.success());
+        assert!(serr.trim().is_empty(), "-J keeps stderr silent: {serr:?}");
+        let doc: serde_json::Value = serde_json::from_str(sout.trim())
+            .unwrap_or_else(|e| panic!("one -J doc ({e}): {sout}"));
+        let key = doc["error"].as_str().unwrap_or_default().to_string();
+        if key.contains(SENDMSG_SENTENCE) {
+            assert!(
+                key.starts_with(&format!("error - {SENDMSG_SENTENCE}: ")),
+                "prefixed key + live strerror: {key:?}"
+            );
+            assert!(
+                !key.ends_with(": "),
+                "the live-strerror class must NOT carry the errno-0 dangling suffix: {key:?}"
+            );
+            assert!(
+                doc["end"].as_object().expect("end").is_empty(),
+                "skeleton bare end: {doc}"
+            );
+            return;
+        }
+        seen.push(key);
+    }
+    panic!("IESENDMESSAGE never surfaced in 12 RST races; saw: {seen:#?}");
+}
+
+// ---------------------------------------------------------------------------
+// #346: SIGTERM while LISTENING (no client ever). GT live-probed: -J =
+// skeleton doc with the interrupt-class key (NO "error - " prefix), silent
+// stderr, exit 0; --json-stream = the error+bare-end event pair; text =
+// stderr `iperf3: interrupt - the server has terminated by signal
+// Terminated(15)`, exit 0. riperf3 pre-fix emitted NOTHING in the JSON
+// modes on this path.
+// ---------------------------------------------------------------------------
+
+const SIGTERM_KEY: &str = "interrupt - the server has terminated by signal Terminated(15)";
+
+#[cfg(unix)]
+fn drive_sigterm_listening(args: &[&str]) -> (String, String, std::process::ExitStatus) {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind");
+    let port = listener.local_addr().unwrap().port();
+    drop(listener);
+    let port_s = port.to_string();
+    let mut all = vec!["-s", "-p", &port_s];
+    all.extend_from_slice(args);
+    let mut server = common::ChildGuard(
+        std::process::Command::new(env!("CARGO_BIN_EXE_riperf3"))
+            .args(&all)
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .spawn()
+            .expect("spawn server"),
+    );
+    let sout = riperf3_test_support::drain_reader(server.0.stdout.take().expect("piped stdout"));
+    let serr = riperf3_test_support::drain_reader(server.0.stderr.take().expect("piped stderr"));
+    std::thread::sleep(std::time::Duration::from_millis(600));
+    // SIGTERM to the LISTENING server — no client ever connected.
+    unsafe { libc::kill(server.0.id() as i32, libc::SIGTERM) };
+    let status =
+        riperf3_test_support::wait_bounded(&mut server.0, std::time::Duration::from_secs(8))
+            .expect("signal-normal exit");
+    (
+        sout.join().expect("stdout"),
+        serr.join().expect("stderr"),
+        status,
+    )
+}
+
+/// #346 -J: the skeleton doc with the interrupt key, silent stderr, exit 0.
+#[cfg(unix)]
+#[test]
+fn sigterm_while_listening_emits_skeleton_doc_in_json() {
+    let (sout, serr, status) = drive_sigterm_listening(&["-J"]);
+    assert!(status.success(), "GT signormalexit exits 0");
+    assert!(serr.trim().is_empty(), "-J keeps stderr silent: {serr:?}");
+    let doc: serde_json::Value =
+        serde_json::from_str(sout.trim()).unwrap_or_else(|e| panic!("one -J doc ({e}): {sout:?}"));
+    assert_eq!(
+        doc["error"].as_str(),
+        Some(SIGTERM_KEY),
+        "the interrupt-class key, NO error- prefix: {doc}"
+    );
+    assert_eq!(
+        doc["start"]["connected"].as_array().map(Vec::len),
+        Some(0),
+        "skeleton start: {doc}"
+    );
+    assert!(
+        doc["end"].as_object().expect("end").is_empty(),
+        "bare end: {doc}"
+    );
+}
+
+/// #346 --json-stream: GT's error + bare-end event pair.
+#[cfg(unix)]
+#[test]
+fn sigterm_while_listening_stream_events() {
+    let (sout, serr, status) = drive_sigterm_listening(&["--json-stream"]);
+    assert!(status.success());
+    assert!(serr.trim().is_empty(), "silent stderr: {serr:?}");
+    let events: Vec<serde_json::Value> = sout
+        .lines()
+        .filter(|l| !l.trim().is_empty())
+        .map(|l| serde_json::from_str(l).unwrap_or_else(|e| panic!("event ({e}): {l}")))
+        .collect();
+    assert_eq!(events.len(), 2, "error + end pair: {sout:?}");
+    assert_eq!(events[0]["event"].as_str(), Some("error"));
+    assert_eq!(events[0]["data"].as_str(), Some(SIGTERM_KEY));
+    assert_eq!(events[1]["event"].as_str(), Some("end"));
+    assert_eq!(events[1]["data"], serde_json::json!({}));
+}
+
+/// #346 text: the stderr interrupt line + exit 0 (the pre-fix-green
+/// baseline half of the cell, pinned against regressions).
+#[cfg(unix)]
+#[test]
+fn sigterm_while_listening_text_line_and_exit_zero() {
+    let (_sout, serr, status) = drive_sigterm_listening(&[]);
+    assert!(status.success(), "GT signormalexit exits 0");
+    assert_eq!(
+        serr.trim(),
+        format!("riperf3: {SIGTERM_KEY}"),
+        "the CLI's interrupt line: {serr:?}"
+    );
+}

--- a/riperf3/src/error.rs
+++ b/riperf3/src/error.rs
@@ -81,6 +81,17 @@ pub enum RiperfError {
     #[error("unable to receive parameters from client")]
     RecvParamsFailed,
 
+    /// iperf3's IESENDMESSAGE(111): a control-channel send failed — the
+    /// post-cookie ParamExchange state write (GT's iperf_set_send_state
+    /// failure path inside iperf_accept, #345). Unlike the errno-0 dangling
+    /// `: ` siblings above, GT's suffix here is a LIVE deterministic
+    /// strerror (ENOTCONN — the peer's RST is what broke the write), so the
+    /// wrapped io::Error rides the Display; its trailing "(os error N)" is
+    /// the recorded #151-class divergence. Relay + exit-0 keep-serving like
+    /// the sibling pre-test classes (#330).
+    #[error("unable to send control message - port may not be available, the other side may have stopped running, etc.: {0}")]
+    SendControlFailed(std::io::Error),
+
     /// iperf3's IENOMSG(144): the server's no-progress watchdog fired — no
     /// messages/data received within `--rcv-timeout` (default 120000 ms, GT's
     /// DEFAULT_NO_MSG_RCVD_TIMEOUT, iperf_api.h:70). First wired at the

--- a/riperf3/src/error.rs
+++ b/riperf3/src/error.rs
@@ -85,10 +85,12 @@ pub enum RiperfError {
     /// post-cookie ParamExchange state write (GT's iperf_set_send_state
     /// failure path inside iperf_accept, #345). Unlike the errno-0 dangling
     /// `: ` siblings above, GT's suffix here is a LIVE deterministic
-    /// strerror (ENOTCONN — the peer's RST is what broke the write), so the
-    /// wrapped io::Error rides the Display; its trailing "(os error N)" is
-    /// the recorded #151-class divergence. Relay + exit-0 keep-serving like
-    /// the sibling pre-test classes (#330).
+    /// strerror, so the wrapped io::Error rides the Display. RECORDED
+    /// DEVIATION (r1 F2): the errno CLASS itself diverges, not just the
+    /// "(os error N)" tail — GT's select loop sees the RST before its write
+    /// (ENOTCONN); riperf3's write_all is the first post-cookie op and eats
+    /// it (ECONNRESET). Both are honest live errnos for the same peer RST.
+    /// Relay + exit-0 keep-serving like the sibling pre-test classes (#330).
     #[error("unable to send control message - port may not be available, the other side may have stopped running, etc.: {0}")]
     SendControlFailed(std::io::Error),
 

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -533,13 +533,10 @@ impl Server {
             // (iperf_server_api.c:133-135) — no stderr line, no banner
             // re-print, no counter increment; the accept simply re-arms.
             let mut idle_restart = false;
-            let mut round_had_no_report = false;
             match self.handle_one_test(&listener).await {
                 // #137: the daemon loop discards each test's Report; library
-                // users who want it call `run_once`. A None round (idle
-                // interrupt, refusal, IPERF_DONE-at-setup) emitted no doc —
-                // the #346 idle-interrupt check below needs to know.
-                Ok(r) => round_had_no_report = r.is_none(),
+                // users who want it call `run_once`.
+                Ok(_) => {}
                 Err(RiperfError::Aborted(msg)) if msg == "idle timeout" => {
                     idle_restart = true;
                 }
@@ -648,20 +645,14 @@ impl Server {
             }
 
             // #210: an interrupted run stops serving — handle_one_test
-            // already dumped its stats and told the client; the caller owns
-            // the signal-normal exit. #346: EXCEPT when the interrupt landed
-            // while idle (a None round emitted no doc) — GT's signormalexit
-            // finishes the accumulated empty doc with the interrupt key
-            // (live: the skeleton -J doc / error+end event pair, silent
-            // stderr, exit 0); text keeps the caller's stderr line.
-            if let Some(rx) = interrupt_fired.as_mut() {
-                let msg = rx.borrow_and_update().clone();
-                if let Some(msg) = msg {
-                    if round_had_no_report {
-                        self.emit_pretest_error_doc(&msg);
-                    }
-                    return Ok(());
-                }
+            // already dumped its stats and told the client (or, interrupted
+            // while idle, emitted the #346 skeleton at the accept site);
+            // the caller owns the signal-normal exit.
+            if interrupt_fired
+                .as_mut()
+                .is_some_and(|rx| rx.borrow_and_update().is_some())
+            {
+                return Ok(());
             }
             if self.one_off {
                 break;
@@ -766,7 +757,21 @@ impl Server {
         let (mut ctrl, peer_addr) = match self.accept_control(listener).await? {
             Some(accepted) => accepted,
             // Interrupted while idle (no client): no test ran, so no report.
-            None => return Ok(None),
+            // #346: THIS is the only doc-less None — refusals and
+            // IPERF_DONE-at-setup rounds return None after emitting their
+            // own docs — so the idle-interrupt skeleton emits here, not at
+            // the serve loop (where it would double-emit in a
+            // signal-during-round race). GT's signormalexit shape,
+            // live-probed: skeleton doc / error+bare-end pair with the
+            // interrupt-class key (no prefix), silent stderr, exit 0.
+            None => {
+                if let Some(w) = &self.interrupt {
+                    if let Some(msg) = w.0.borrow().clone() {
+                        self.emit_pretest_error_doc(&msg);
+                    }
+                }
+                return Ok(None);
+            }
         };
         // (#222 r1 item 6: the Time/banner/Cookie/MSS block prints AFTER the
         // param exchange — GT's iperf_on_connect fires there — so a
@@ -1083,6 +1088,8 @@ impl Server {
             let _ = protocol::send_server_error(ctrl, 111).await;
             return Err(match e {
                 RiperfError::Io(io) => RiperfError::SendControlFailed(io),
+                // send_state is one write_all, so only Io reaches here today
+                // (r1 F3) — the arm fails safe if that ever changes.
                 other => other,
             });
         }

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -533,10 +533,13 @@ impl Server {
             // (iperf_server_api.c:133-135) — no stderr line, no banner
             // re-print, no counter increment; the accept simply re-arms.
             let mut idle_restart = false;
+            let mut round_had_no_report = false;
             match self.handle_one_test(&listener).await {
                 // #137: the daemon loop discards each test's Report; library
-                // users who want it call `run_once`.
-                Ok(_) => {}
+                // users who want it call `run_once`. A None round (idle
+                // interrupt, refusal, IPERF_DONE-at-setup) emitted no doc —
+                // the #346 idle-interrupt check below needs to know.
+                Ok(r) => round_had_no_report = r.is_none(),
                 Err(RiperfError::Aborted(msg)) if msg == "idle timeout" => {
                     idle_restart = true;
                 }
@@ -623,7 +626,9 @@ impl Server {
                 // exists, so the serve loop emits GT's iperf_err sink shape
                 // directly: silent stderr + a SKELETON accumulated doc under
                 // -J, one text line otherwise.
-                Err(e @ RiperfError::RecvCookieFailed) | Err(e @ RiperfError::RecvParamsFailed) => {
+                Err(e @ RiperfError::RecvCookieFailed)
+                | Err(e @ RiperfError::RecvParamsFailed)
+                | Err(e @ RiperfError::SendControlFailed(_)) => {
                     self.emit_pretest_error(&e);
                 }
                 Err(e) => {
@@ -644,12 +649,19 @@ impl Server {
 
             // #210: an interrupted run stops serving — handle_one_test
             // already dumped its stats and told the client; the caller owns
-            // the signal-normal exit.
-            if interrupt_fired
-                .as_mut()
-                .is_some_and(|rx| rx.borrow_and_update().is_some())
-            {
-                return Ok(());
+            // the signal-normal exit. #346: EXCEPT when the interrupt landed
+            // while idle (a None round emitted no doc) — GT's signormalexit
+            // finishes the accumulated empty doc with the interrupt key
+            // (live: the skeleton -J doc / error+end event pair, silent
+            // stderr, exit 0); text keeps the caller's stderr line.
+            if let Some(rx) = interrupt_fired.as_mut() {
+                let msg = rx.borrow_and_update().clone();
+                if let Some(msg) = msg {
+                    if round_had_no_report {
+                        self.emit_pretest_error_doc(&msg);
+                    }
+                    return Ok(());
+                }
             }
             if self.one_off {
                 break;
@@ -1063,7 +1075,17 @@ impl Server {
         };
 
         // ---- ParamExchange ----
-        protocol::send_state(ctrl, TestState::ParamExchange).await?;
+        // #345: a failed post-cookie state write is GT's IESENDMESSAGE(111)
+        // — iperf_accept's iperf_set_send_state failure path; cleanup_server
+        // relays SERVER_ERROR(-2)+111 (best-effort and usually unobservable:
+        // the peer's RST is what broke the write — unpinned by design).
+        if let Err(e) = protocol::send_state(ctrl, TestState::ParamExchange).await {
+            let _ = protocol::send_server_error(ctrl, 111).await;
+            return Err(match e {
+                RiperfError::Io(io) => RiperfError::SendControlFailed(io),
+                other => other,
+            });
+        }
         // #330: GT's get_parameters sets IERECVPARAMS(114) whenever JSON_read
         // returns NULL — a short/absent body OR a cJSON parse failure alike —
         // and relays SERVER_ERROR(-2) + the code through cleanup_server.
@@ -3314,7 +3336,13 @@ impl Server {
     /// bare where GT would append a (often stale) strerror — the same honest
     /// deviation as #336.
     fn emit_pretest_error(&self, err: &RiperfError) {
-        let doc_error = format!("error - {err}: ");
+        // #345: SendControlFailed's Display already carries the live
+        // strerror (GT perr with a real errno); the errno-0 siblings keep
+        // the #248 dangling ": ".
+        let doc_error = match err {
+            RiperfError::SendControlFailed(_) => format!("error - {err}"),
+            _ => format!("error - {err}: "),
+        };
         if self.json_output || self.json_stream {
             self.emit_pretest_error_doc(&doc_error);
         } else if !crate::macros::output_quiet() {


### PR DESCRIPTION
Closes #345, closes #346 — two pre-test server surfaces brought to GT shape, both live-probed on GT 3.21 first (probe records banked on the issues).

## #345 — IESENDMESSAGE on the post-cookie state-write failure

A peer RST racing the server's `send_state(ParamExchange)` write rode the serve loop's generic arm with a raw Io message. Now GT's IESENDMESSAGE(111):

- `RiperfError::SendControlFailed(io::Error)` renders iperf_error.c:305's sentence with the **live strerror** riding the io::Error Display — GT's suffix here is a real deterministic errno (ENOTCONN), not the stale class, so this variant deliberately skips the errno-0 dangling `": "` its #330 siblings carry. The trailing `"(os error N)"` is the recorded #151-class divergence.
- Best-effort `SERVER_ERROR + htonl(111) + htonl(0)` relay at the catch site — **unpinned by design**: the peer's RST is what broke the write, so the relay is unobservable (the #347 try_reserve precedent).
- Same skeleton-doc / stderr-line / exit-0 keep-serving sink as IERECVCOOKIE/IERECVPARAMS (#330).

**The race is inherent** (GT live: 8/12 send-class, 4/12 params-class — the state write sometimes lands before the RST). The pins retry-classify across 12 attempts and assert the send class appears with the exact sentence + a non-dangling suffix; both classes stay reachable. Pins are `cfg(unix)` (SO_LINGER(0) RST forcing — the #339 lesson).

## #346 — SIGTERM while listening emits the skeleton doc

The CLI's `Exit::Signal` arm assumes "the document already carried the message" — true mid-test (#210's report dump), false while idle: a listening `-J` server SIGTERM'd emitted **nothing**. The serve loop's interrupt exit now emits the skeleton doc with the interrupt-class key (bare, no `error - ` prefix) **only when the interrupted round produced no report** (`Ok(None)` — idle/refusal/clean-done rounds).

GT live-probed: `-J` = skeleton doc + `"error": "interrupt - the server has terminated by signal Terminated(15)"`, silent stderr, **exit 0**; `--json-stream` = error + bare-end event pair; text = the stderr line (already byte-identical, now pinned with the exit code).

### Post-open self-catch (537cc40)

The first cut gated the skeleton on `Ok(None)` rounds at the serve loop — but refusal and IPERF_DONE-at-setup rounds return `Ok(None)` *after emitting their own docs*, so a signal-during-round race could double-emit. The emit now lives at the accept-interrupted return (the only doc-less `None`), the serve-loop check is back to its original shape, and the race class is gone structurally. Side effect worth review: lib `run_once`/`BoundServer::run_once` with an interrupt watch now also emit the idle-interrupt doc (sink-consistent with the CLI; `emit_output(false)` still silences it).

### r1 (cold) → REQUEST-CHANGES → fixed (072eaec)

r1's blocker: **the self-catch restructure was never actually committed** — a mutation cycle's `git checkout --` restore wiped the uncommitted server.rs hunk, so 537cc40 shipped only the test and the racy serve-loop gate was live at head (r1 proved the double-emit deterministically: SIGTERM parked in `recv_params`, then a refused round → refusal doc + skeleton concatenated). Fixed at 072eaec: the restructure is landed (accept-site emit verified in the diff stat this time), with r1's deterministic construction as a red-first pin (`sigterm_during_refused_round_emits_exactly_one_doc`), plus the F2 errno-class deviation record (riperf3's live errno is ECONNRESET where GT's select-loop ordering yields ENOTCONN — both honest, now recorded beyond the `(os error N)` tail) and the F3 dead-arm comment. r1 also verified: the retry pins safe both directions (N=40 census: 37/40 send-class; P(12 misses) ≈ 3e-14, load shifts the safe way), the 111 relay's GT source route (errno-word 0 = the documented relay policy), persistent-server round-doc+skeleton concatenation is GT-parity (live), SIGINT/SIGHUP keys byte-identical, and masked A/B vs main clean.

### CI red on 072eaec → the RST-race pins are Linux-only (8b6aac5)

macOS/FreeBSD surfaced the RST through an earlier syscall (FreeBSD: ECONNABORTED at the accept/configure site, deterministic; macOS: a kind-only InvalidInput) and essentially never win the send-write race — the mapping under test is platform-independent, only Linux timing reaches it. The pins moved from `cfg(unix)` to `cfg(target_os = "linux")` (the #339 SO_LINGER lesson, refined). NOTE (r2 nit): the gating commit's comment swaps which platform saw which surface — one-line comment fix rides the next PR touching the file.

### r2 (cold, independent, full PR at the final head) → APPROVE

r2 verified the r1-blocker restructure is really in the head, enumerated every `Ok(None)`/Err × signal-timing cell live (the double-emit class is structurally dead; between-rounds concatenation is GT-parity, probed both tools), re-ran all five mutations from the committed tree with unique anchors (each killed by exactly its intended pin — M4's racy first-cut placement is uniquely discriminated by the r1 refusal pin), exercised the lib surfaces live (run_once + watch emits the skeleton then the Aborted error; `emit_output(false)` silences it), and closed the gates: suite 31/31, 7 pins × 5 runs 2-core-pinned 35/35, masked A/B vs main clean, CI 17/17 on 8b6aac5. Non-blocking findings: **#361 filed** (a wedged pre-cookie client + SIGTERM still exits doc-less where GT emits the skeleton — the pre-existing #158 interrupt-blind window, narrowed but not closed by this PR), **#362 filed** (non-Linux pre-test failures ride the generic arm with raw io messages where GT has accept-error classes — pre-existing, surfaced by the 072eaec CI logs), plus two doc touch-ups riding the next PR (the gating comment's platform swap; `send_server_error`'s errno-0 rationale now slightly stale for the #345 cause).

## Verification

- 6 new pins, red-first (4 behavior pins red pre-impl via stash; the text/exit-0 pin green-baseline by design; the mid-test single-doc pin added after its mutation proved the gap — see below).
- Live A/B vs GT: SIGTERM `-J` cell shape-identical (key, skeleton start, bare end, rc 0); the #345 cells classified live by the pins (sentence + strerror).
- Mutations (one at a time from the committed tree, anchors uniqueness-verified): send-class mapping removal → RED; dangling-suffix regression → RED; idle-gate removal → **initially SURVIVED both existing mid-test signal pins** (they SIGTERM the *client*; no server-mid-test-signal single-doc pin existed) → live-proven to double-emit → new pin `server_sigterm_mid_test_emits_exactly_one_doc` → RED; idle-emit removal → RED. The 111 relay stays unpinned by design (recorded above).
- Full workspace suite green; clippy `-D warnings` / fmt clean; xcheck 7/7.
- CI + compat 52/52 on the final head before merge.
