### PR TITLE
fix: stamp CLI-layer stderr lines with the --timestamps prefix (#348)

### DIFF
--- a/riperf3-cli/src/main.rs
+++ b/riperf3-cli/src/main.rs
@@ -326,6 +326,13 @@ fn main() -> std::process::ExitCode {
     let json = cli.json;
     let json_stream = cli.json_stream;
     let logfile = cli.logfile.clone();
+    // #348: the sink stamps like GT's iperf_errexit; the lib's prefix is
+    // run-scoped and already gone here, so render from the CLI's format.
+    let ts_prefix = cli
+        .timestamps
+        .clone()
+        .map(|f| riperf3::render_timestamp_prefix(&f))
+        .unwrap_or_default();
     match run(cli) {
         Ok(()) => std::process::ExitCode::SUCCESS,
         Err(e) => {
@@ -361,7 +368,9 @@ fn main() -> std::process::ExitCode {
                     println!("{}", riperf3::json_report::error_document(&e.to_string()));
                 }
             } else {
-                let line = format!("riperf3: error - {e}");
+                // #348: GT's iperf_errexit stamps this line like iperf_err
+                // (iperf_error.c:100-127).
+                let line = format!("{ts_prefix}riperf3: error - {e}");
                 let logged = logfile.as_deref().and_then(|path| {
                     use std::io::Write;
                     std::fs::OpenOptions::new()
@@ -574,6 +583,13 @@ fn run(cli: Cli) -> std::result::Result<(), Box<dyn std::error::Error>> {
     let pidfile = cli.pidfile.clone();
     let is_server = cli.server;
     let (json, json_stream) = (cli.json, cli.json_stream);
+    // #348: the interrupt notice prints after the run — render the stamp
+    // from the CLI's own format (the lib's prefix is run-scoped).
+    let ts_prefix = cli
+        .timestamps
+        .clone()
+        .map(|f| riperf3::render_timestamp_prefix(&f))
+        .unwrap_or_default();
     // #210: the first signal no longer cancels the run outright — it fires
     // this watch with iperf3's formatted message, and the lib dumps the
     // accumulated stats + tells the peer (CLIENT_TERMINATE /
@@ -657,7 +673,10 @@ fn run(cli: Cli) -> std::result::Result<(), Box<dyn std::error::Error>> {
             // there (#210 review r1 f3).
             if !json && !json_stream {
                 let role = if is_server { "server" } else { "client" };
-                eprintln!("riperf3: interrupt - the {role} has terminated by signal {sig}");
+                // #348: stamped on both roles (GT live).
+                eprintln!(
+                    "{ts_prefix}riperf3: interrupt - the {role} has terminated by signal {sig}"
+                );
             }
             Ok(())
         }

--- a/riperf3-cli/src/main.rs
+++ b/riperf3-cli/src/main.rs
@@ -327,12 +327,10 @@ fn main() -> std::process::ExitCode {
     let json_stream = cli.json_stream;
     let logfile = cli.logfile.clone();
     // #348: the sink stamps like GT's iperf_errexit; the lib's prefix is
-    // run-scoped and already gone here, so render from the CLI's format.
-    let ts_prefix = cli
-        .timestamps
-        .clone()
-        .map(|f| riperf3::render_timestamp_prefix(&f))
-        .unwrap_or_default();
+    // run-scoped and already gone here, so keep the CLI's format and render
+    // AT PRINT TIME — GT strftimes per line, and a stamp captured before a
+    // multi-second run would be stale on the exit line.
+    let ts_format = cli.timestamps.clone();
     match run(cli) {
         Ok(()) => std::process::ExitCode::SUCCESS,
         Err(e) => {
@@ -370,7 +368,13 @@ fn main() -> std::process::ExitCode {
             } else {
                 // #348: GT's iperf_errexit stamps this line like iperf_err
                 // (iperf_error.c:100-127).
-                let line = format!("{ts_prefix}riperf3: error - {e}");
+                let line = format!(
+                    "{}riperf3: error - {e}",
+                    ts_format
+                        .as_deref()
+                        .map(riperf3::render_timestamp_prefix)
+                        .unwrap_or_default()
+                );
                 let logged = logfile.as_deref().and_then(|path| {
                     use std::io::Write;
                     std::fs::OpenOptions::new()
@@ -583,13 +587,9 @@ fn run(cli: Cli) -> std::result::Result<(), Box<dyn std::error::Error>> {
     let pidfile = cli.pidfile.clone();
     let is_server = cli.server;
     let (json, json_stream) = (cli.json, cli.json_stream);
-    // #348: the interrupt notice prints after the run — render the stamp
-    // from the CLI's own format (the lib's prefix is run-scoped).
-    let ts_prefix = cli
-        .timestamps
-        .clone()
-        .map(|f| riperf3::render_timestamp_prefix(&f))
-        .unwrap_or_default();
+    // #348: the interrupt notice prints after the run — keep the CLI's
+    // format and render at print time (GT strftimes per line).
+    let ts_format = cli.timestamps.clone();
     // #210: the first signal no longer cancels the run outright — it fires
     // this watch with iperf3's formatted message, and the lib dumps the
     // accumulated stats + tells the peer (CLIENT_TERMINATE /
@@ -673,9 +673,13 @@ fn run(cli: Cli) -> std::result::Result<(), Box<dyn std::error::Error>> {
             // there (#210 review r1 f3).
             if !json && !json_stream {
                 let role = if is_server { "server" } else { "client" };
-                // #348: stamped on both roles (GT live).
+                // #348: stamped on both roles (GT live), rendered now.
                 eprintln!(
-                    "{ts_prefix}riperf3: interrupt - the {role} has terminated by signal {sig}"
+                    "{}riperf3: interrupt - the {role} has terminated by signal {sig}",
+                    ts_format
+                        .as_deref()
+                        .map(riperf3::render_timestamp_prefix)
+                        .unwrap_or_default()
                 );
             }
             Ok(())

--- a/riperf3-cli/tests/wire_shape.rs
+++ b/riperf3-cli/tests/wire_shape.rs
@@ -2851,10 +2851,12 @@ const SENDMSG_SENTENCE: &str =
 
 /// One #345 attempt: cookie, then an immediate SO_LINGER(0) RST. Returns
 /// (stdout, stderr, exit). LINUX-ONLY (the #339 SO_LINGER lesson, refined):
-/// on macOS/FreeBSD the RST surfaces through an EARLIER syscall (CI: a
-/// kind-only InvalidInput via the generic pre-test arm, deterministic on
-/// FreeBSD) and the send-write race is essentially never won — the mapping
-/// under test is platform-independent; only Linux timing exercises it.
+/// on macOS/FreeBSD the RST surfaces through an EARLIER syscall (CI:
+/// macOS = a kind-only InvalidInput via the generic pre-test arm;
+/// FreeBSD = ECONNABORTED at the accept/configure site, deterministic)
+/// and the send-write race is essentially never won — the mapping under
+/// test is platform-independent; only Linux timing exercises it (#362
+/// tracks the non-Linux surfaces).
 #[cfg(target_os = "linux")]
 fn drive_cookie_then_rst(json: bool) -> (String, String, std::process::ExitStatus) {
     drive_server_scenario(json, |port| {
@@ -3036,4 +3038,179 @@ fn sigterm_while_listening_text_line_and_exit_zero() {
         format!("riperf3: {SIGTERM_KEY}"),
         "the CLI's interrupt line: {serr:?}"
     );
+}
+
+// ---------------------------------------------------------------------------
+// #348: GT stamps CLIENT-side stderr error lines too — iperf_errexit routes
+// through the same strftime stamp as iperf_err (iperf_error.c:100-127).
+// Live-probed (GT 3.21, --timestamps="XTSX "): connect-refused = `XTSX
+// iperf3: error - ...`; the SERVER-ERROR relay = BOTH lines stamped (`XTSX
+// iperf3: SERVER ERROR - ...` then `XTSX iperf3: error - ...`); the
+// interrupt line = stamped on BOTH roles. GT prints NO second-signal line
+// at all (one interrupt line even on a double SIGINT), so riperf3's
+// second-signal emergency lines stay bare by design (#158's raw-handler
+// write can't render a stamp async-signal-safely).
+// ---------------------------------------------------------------------------
+
+/// #348: the client's connect-refused line carries the stamp.
+#[test]
+fn client_error_line_carries_the_timestamps_prefix() {
+    let free = std::net::TcpListener::bind("127.0.0.1:0").expect("bind");
+    let port = free.local_addr().unwrap().port();
+    drop(free); // nothing listens: connect refused
+    let out = std::process::Command::new(env!("CARGO_BIN_EXE_riperf3"))
+        .args([
+            "-c",
+            "127.0.0.1",
+            "-p",
+            &port.to_string(),
+            "--timestamps=XTSX ",
+        ])
+        .output()
+        .expect("run client");
+    assert_eq!(out.status.code(), Some(1), "iperf_errexit exits 1");
+    let serr = String::from_utf8_lossy(&out.stderr);
+    let line = serr.trim();
+    assert!(
+        line.contains("riperf3: error - ") && !line.starts_with("riperf3:"),
+        "a nonempty stamp precedes the client error line: {line:?}"
+    );
+    #[cfg(unix)]
+    assert!(
+        line.starts_with("XTSX riperf3: error - "),
+        "the literal format renders verbatim: {line:?}"
+    );
+}
+
+/// #348: the client's SERVER-ERROR relay surface — BOTH stderr lines carry
+/// the stamp, like GT's iperf_err + iperf_errexit pair.
+#[test]
+fn client_relay_lines_carry_the_timestamps_prefix() {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind");
+    let port = listener.local_addr().unwrap().port();
+    drop(listener);
+    let ps = port.to_string();
+    let mut server = common::ChildGuard(
+        std::process::Command::new(env!("CARGO_BIN_EXE_riperf3"))
+            .args(["-s", "-1", "-p", &ps, "--server-bitrate-limit", "1000"])
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .spawn()
+            .expect("spawn server"),
+    );
+    std::thread::sleep(std::time::Duration::from_millis(400));
+    let out = std::process::Command::new(env!("CARGO_BIN_EXE_riperf3"))
+        .args([
+            "-c",
+            "127.0.0.1",
+            "-p",
+            &ps,
+            "-b",
+            "1M",
+            "-t",
+            "2",
+            "--timestamps=XTSX ",
+        ])
+        .output()
+        .expect("run client");
+    let _ = riperf3_test_support::wait_bounded(&mut server.0, std::time::Duration::from_secs(8));
+    assert_eq!(out.status.code(), Some(1), "refused-run errexit");
+    let serr = String::from_utf8_lossy(&out.stderr);
+    let lines: Vec<&str> = serr.lines().filter(|l| !l.trim().is_empty()).collect();
+    let relay = lines
+        .iter()
+        .find(|l| l.contains("SERVER ERROR - "))
+        .unwrap_or_else(|| panic!("the relay line is present: {serr:?}"));
+    let exitl = lines
+        .iter()
+        .find(|l| l.contains("riperf3: error - "))
+        .unwrap_or_else(|| panic!("the errexit line is present: {serr:?}"));
+    for (name, l) in [("relay", relay), ("errexit", exitl)] {
+        assert!(
+            !l.starts_with("riperf3:"),
+            "{name} line carries a stamp: {l:?}"
+        );
+        #[cfg(unix)]
+        assert!(l.starts_with("XTSX riperf3: "), "{name} literal: {l:?}");
+    }
+}
+
+/// #348: the interrupt line is stamped on BOTH roles (the main.rs:660
+/// shared site — GT live: `XTSX iperf3: interrupt - ...` each role).
+#[cfg(unix)]
+#[test]
+fn interrupt_lines_carry_the_timestamps_prefix_both_roles() {
+    // Server role: SIGTERM while listening, text mode.
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind");
+    let port = listener.local_addr().unwrap().port();
+    drop(listener);
+    let ps = port.to_string();
+    let mut server = common::ChildGuard(
+        std::process::Command::new(env!("CARGO_BIN_EXE_riperf3"))
+            .args(["-s", "-p", &ps, "--timestamps=XTSX "])
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .spawn()
+            .expect("spawn server"),
+    );
+    let _so = riperf3_test_support::drain_reader(server.0.stdout.take().unwrap());
+    let se = riperf3_test_support::drain_reader(server.0.stderr.take().unwrap());
+    std::thread::sleep(std::time::Duration::from_millis(600));
+    unsafe { libc::kill(server.0.id() as i32, libc::SIGTERM) };
+    let status =
+        riperf3_test_support::wait_bounded(&mut server.0, std::time::Duration::from_secs(8))
+            .expect("signal-normal exit");
+    assert!(status.success());
+    let serr = se.join().expect("stderr");
+    assert!(
+        serr.trim()
+            .starts_with("XTSX riperf3: interrupt - the server has terminated by signal"),
+        "server interrupt line stamped: {serr:?}"
+    );
+
+    // Client role: SIGINT mid-test.
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind");
+    let port2 = listener.local_addr().unwrap().port();
+    drop(listener);
+    let ps2 = port2.to_string();
+    let mut srv2 = common::ChildGuard(
+        std::process::Command::new(env!("CARGO_BIN_EXE_riperf3"))
+            .args(["-s", "-1", "-p", &ps2])
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .spawn()
+            .expect("spawn server2"),
+    );
+    std::thread::sleep(std::time::Duration::from_millis(400));
+    let mut client = common::ChildGuard(
+        std::process::Command::new(env!("CARGO_BIN_EXE_riperf3"))
+            .args([
+                "-c",
+                "127.0.0.1",
+                "-p",
+                &ps2,
+                "-t",
+                "10",
+                "--timestamps=XTSX ",
+            ])
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .spawn()
+            .expect("spawn client"),
+    );
+    let _co = riperf3_test_support::drain_reader(client.0.stdout.take().unwrap());
+    let ce = riperf3_test_support::drain_reader(client.0.stderr.take().unwrap());
+    std::thread::sleep(std::time::Duration::from_secs(2));
+    unsafe { libc::kill(client.0.id() as i32, libc::SIGINT) };
+    let cstatus =
+        riperf3_test_support::wait_bounded(&mut client.0, std::time::Duration::from_secs(8))
+            .expect("client signal exit");
+    assert!(cstatus.success(), "signal-normal exit");
+    let cerr = ce.join().expect("client stderr");
+    assert!(
+        cerr.trim()
+            .starts_with("XTSX riperf3: interrupt - the client has terminated by signal"),
+        "client interrupt line stamped: {cerr:?}"
+    );
+    let _ = riperf3_test_support::wait_bounded(&mut srv2.0, std::time::Duration::from_secs(8));
 }

--- a/riperf3-cli/tests/wire_shape.rs
+++ b/riperf3-cli/tests/wire_shape.rs
@@ -3214,3 +3214,62 @@ fn interrupt_lines_carry_the_timestamps_prefix_both_roles() {
     );
     let _ = riperf3_test_support::wait_bounded(&mut srv2.0, std::time::Duration::from_secs(8));
 }
+
+/// #348 (r1 F1): the stamp renders AT PRINT TIME, per line, like GT's
+/// strftime — a prefix captured before the run would stamp the interrupt
+/// line with the START time. The literal-format pins can't see this;
+/// `%s` (epoch seconds) can: the interrupt line's epoch must be later
+/// than the banner's (SIGINT lands ≥2 s in; slow runners only widen it).
+#[cfg(unix)]
+#[test]
+fn interrupt_stamp_renders_at_print_time_not_capture_time() {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind");
+    let port = listener.local_addr().unwrap().port();
+    drop(listener);
+    let ps = port.to_string();
+    let mut srv = common::ChildGuard(
+        std::process::Command::new(env!("CARGO_BIN_EXE_riperf3"))
+            .args(["-s", "-1", "-p", &ps])
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .spawn()
+            .expect("spawn server"),
+    );
+    std::thread::sleep(std::time::Duration::from_millis(400));
+    let mut client = common::ChildGuard(
+        std::process::Command::new(env!("CARGO_BIN_EXE_riperf3"))
+            .args(["-c", "127.0.0.1", "-p", &ps, "-t", "10", "--timestamps=%s "])
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .spawn()
+            .expect("spawn client"),
+    );
+    let co = riperf3_test_support::drain_reader(client.0.stdout.take().unwrap());
+    let ce = riperf3_test_support::drain_reader(client.0.stderr.take().unwrap());
+    std::thread::sleep(std::time::Duration::from_secs(2));
+    unsafe { libc::kill(client.0.id() as i32, libc::SIGINT) };
+    let status =
+        riperf3_test_support::wait_bounded(&mut client.0, std::time::Duration::from_secs(8))
+            .expect("client signal exit");
+    assert!(status.success());
+    let cout = co.join().expect("stdout");
+    let cerr = ce.join().expect("stderr");
+    let _ = riperf3_test_support::wait_bounded(&mut srv.0, std::time::Duration::from_secs(8));
+
+    let epoch_of = |line: &str| -> Option<u64> { line.split(' ').next()?.parse().ok() };
+    let banner_epoch = cout
+        .lines()
+        .find_map(epoch_of)
+        .expect("a %s-stamped stdout line exists");
+    let interrupt_line = cerr
+        .lines()
+        .find(|l| l.contains("interrupt - the client has terminated"))
+        .unwrap_or_else(|| panic!("the interrupt line is present: {cerr:?}"));
+    let interrupt_epoch = epoch_of(interrupt_line)
+        .unwrap_or_else(|| panic!("the interrupt line is %s-stamped: {interrupt_line:?}"));
+    assert!(
+        interrupt_epoch > banner_epoch,
+        "print-time rendering: interrupt epoch {interrupt_epoch} must postdate \
+         the banner's {banner_epoch} (a pre-run capture freezes them equal)"
+    );
+}

--- a/riperf3/src/client.rs
+++ b/riperf3/src/client.rs
@@ -916,7 +916,11 @@ impl Client {
             // stderr. Revisit with the sink plumbing.
             // #290: quiet runs surface the error via Err alone.
             if !crate::macros::output_quiet() {
-                eprintln!("riperf3: SERVER ERROR - {msg}");
+                // #348: GT stamps this line too (iperf_err route).
+                eprintln!(
+                    "{}riperf3: SERVER ERROR - {msg}",
+                    crate::macros::output_timestamp_prefix()
+                );
             }
         }
         RiperfError::ServerErrorRelayed(msg)

--- a/riperf3/src/lib.rs
+++ b/riperf3/src/lib.rs
@@ -50,6 +50,12 @@ pub use json_report::Report;
 
 pub use net::set_cpu_affinity;
 
+/// Render a `--timestamps` strftime FORMAT into the line prefix
+/// (#202/#348) — the same renderer the lib's own iperf_err-class sites
+/// use, for CLI-layer stderr lines that print outside a run's scope
+/// (GT's stamp is process-global; the lib's is run-scoped).
+pub use macros::render_timestamp as render_timestamp_prefix;
+
 // --- Internal modules: implementation detail, NOT part of the public API. ---
 // Crate-private (`pub(crate)`), so nothing here is a semver commitment; the
 // few genuinely-public types are re-exported at the crate root above (#67).

--- a/riperf3/src/macros.rs
+++ b/riperf3/src/macros.rs
@@ -109,9 +109,10 @@ pub(crate) fn output_timestamp_prefix() -> String {
     render_timestamp(&fmt)
 }
 
-/// Unix: localtime + strftime with the stored FORMAT, exactly iperf3's
-/// iperf_printf (default "%c " — the trailing space lives in the format;
-/// user formats are used verbatim) (#202).
+/// Unix: localtime + strftime with the GIVEN format, exactly iperf3's
+/// iperf_printf (the CLI's bare `--timestamps` default is "%c " — the
+/// trailing space lives in the format; user formats are used verbatim)
+/// (#202; public via the crate-root re-export, #348).
 #[cfg(unix)]
 pub fn render_timestamp(fmt: &str) -> String {
     let Ok(cfmt) = std::ffi::CString::new(fmt) else {

--- a/riperf3/src/macros.rs
+++ b/riperf3/src/macros.rs
@@ -113,7 +113,7 @@ pub(crate) fn output_timestamp_prefix() -> String {
 /// iperf_printf (default "%c " — the trailing space lives in the format;
 /// user formats are used verbatim) (#202).
 #[cfg(unix)]
-fn render_timestamp(fmt: &str) -> String {
+pub fn render_timestamp(fmt: &str) -> String {
     let Ok(cfmt) = std::ffi::CString::new(fmt) else {
         return String::new();
     };
@@ -136,7 +136,7 @@ fn render_timestamp(fmt: &str) -> String {
 /// native Windows has no iperf3 ground truth to match — keep the simple
 /// HH:MM:SS UTC shape (#202).
 #[cfg(not(unix))]
-fn render_timestamp(_fmt: &str) -> String {
+pub fn render_timestamp(_fmt: &str) -> String {
     let secs = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap_or_default()

--- a/riperf3/src/protocol.rs
+++ b/riperf3/src/protocol.rs
@@ -211,7 +211,9 @@ pub async fn send_state(stream: &mut TcpStream, state: TestState) -> Result<()> 
 /// Send SERVER_ERROR with iperf3's (i_errno, errno) u32-pair payload (#224):
 /// the state byte, then both words big-endian — iperf_server_api.c's Nwrite
 /// pair (the bitrate, duration-timer, and cleanup_server relay sites). The os
-/// errno is always 0 from riperf3: our self-terminate causes carry none.
+/// errno word is always 0 from riperf3 — most relayed causes carry none, and
+/// where one exists (#345's send failure) the peer's RST makes the relay
+/// unobservable anyway; GT itself often leaks a stale word here (#336).
 pub async fn send_server_error(stream: &mut TcpStream, i_errno: u32) -> Result<()> {
     send_state(stream, TestState::ServerError).await?;
     stream.write_all(&i_errno.to_be_bytes()).await?;


### PR DESCRIPTION
Closes #348 — CLI-layer stderr lines carry the `--timestamps` prefix like GT's iperf_errexit (which routes through the same strftime stamp as iperf_err, iperf_error.c:100-127).

## The sites (all GT live-probed with `--timestamps="XTSX "`)

- **The CLI error sink** (`riperf3: error - ...`, main.rs): GT stamps it (connect-refused probed). The lib's prefix accessor is RUN-scoped and already empty when this prints, so the lib now exports `render_timestamp_prefix` (the same renderer its iperf_err-class sites use — strftime on unix, the documented HH:MM:SS fallback on Windows) and the CLI renders from its own format.
- **The SERVER-ERROR relay surface**: GT stamps BOTH lines (`XTSX iperf3: SERVER ERROR - ...` then `XTSX iperf3: error - ...`, live). The relay line prints inside the run, so it uses the internal run-scoped accessor; the errexit line rides the sink above.
- **The interrupt notice** (both roles — the #349-r2 scope note): GT stamps it on server and client alike (live, `Interrupt(2)` cells).
- **Second-signal lines: deliberately left bare.** GT prints NO second-signal line at all (a double SIGINT live-probed = one interrupt line), so these are riperf3-own emergency diagnostics — and the raw-handler one cannot render a stamp async-signal-safely (#158).
- Parse-time errors: **the boundary recorded here and on the issue was WRONG** (r2 F1, live-falsified). GT stamps POST-loop parameter errors (client-only/server-only class, raised after the full getopt loop) unconditionally in both flag orders; only MID-loop errors are order-dependent (the #301-F4 class). riperf3 leaves all of them bare — the post-loop stamp is a real divergence, **filed as #365**; the mid-loop ordering stays a recorded deviation.

## Rides along (#360 r2 nits)

- The RST-race gating comment's platform attribution corrected (macOS = kind-only InvalidInput, FreeBSD = ECONNABORTED; #362 tracks those surfaces).
- `send_server_error`'s errno-0 rationale updated for the #345 cause (a real errno exists there but the relay is unobservable; GT often leaks a stale word — #336).

## API note

New lib export: `riperf3::render_timestamp_prefix(&str) -> String` (semver-minor addition). The first cut re-exported the run-scoped `output_timestamp_prefix`, which renders "" outside a run — structurally useless to the CLI; the renderer is the honest surface.

### Mid-review delta (95116b1) + r1 round (932f22f)

While drafting r1's attack list I caught my own capture-once design: the prefix rendered before the run would stamp the exit line with the START time — GT strftimes per line. Fixed to print-time rendering (95116b1) and redirected the running r1. r1 = REQUEST-CHANGES with one actionable: **the print-time fix shipped test-free** (the `XTSX` literal renders identically either way — fair TDD violation on the hotfix). Fixed at 932f22f with r1's prescribed pin: `--timestamps="%s "`, SIGINT 2 s into a run, interrupt-line epoch must postdate the banner's — mutation-proven RED against the reintroduced capture shape (from the committed tree, dirty-target-guarded harness). r1's other findings: **#364 filed** (pre-existing: GT routes the relay + interrupt lines to `--logfile`, riperf3 sends them to stderr; the errexit sink line already matches byte-for-byte); the parse-time boundary verified drawn where GT draws it (GT stamps parameter errors only when `--timestamps` precedes the violating flag — the #301 F4 ordering class, recorded); warnings bare on both tools; zero stamp leakage into JSON; both relay cells (upfront + runtime breach, incl. cross-tool) stamped on both tools; the renderer overflow corner recorded precisely per r2 F3: GT prints a ~99-byte truncated (or, ≥128, partially-filled — its own strftime-returns-0 UB corner) buffer on ANY overflow; riperf3 renders fully up to 127 bytes else no prefix — matching GT would mean emulating UB, recorded-not-fixed (pre-existing #202).

### r2 (cold, independent, full PR at 932f22f) → record-blocker fixed → approve conditions met (7c86498)

r2 verified the code sound end-to-end (its own GT matrix re-derivation, its own capture-shape mutant proving the %s pin's discriminator with equal-epoch evidence, 45/45 pinned runs, SemVer/CI/suite clean) and found the blocker in the RECORD: the parse-time boundary claim certified a boundary GT doesn't have (post-loop parameter errors ARE stamped unconditionally — r1's mid-loop probe generalized incorrectly). **#365 filed** (the post-loop stamp is in scope and missing, pre-existing), this body corrected (see the sites section), the mutation-table precision and the #202 overflow record amended per F2/F3, and the capture-era rustdoc line fixed (F4, 7c86498 — doc-only).

## Verification

- 3 pins red-first (connect-refused sink; both relay-surface lines; the interrupt notice on BOTH roles), portable nonempty-prefix asserts + byte-exact `XTSX ` under `cfg(unix)` (the #339 Windows-strftime lesson).
- Mutations from the committed tree (harness now REFUSES dirty targets — the #360 lesson enforced in tooling): sink-stamp removal → pins 1 AND 2 red (pin 2 asserts the errexit line too — expected coupling, r2 F2); relay-stamp removal → exactly pin 2 red; interrupt-stamp removal → pins 3 and 4 red; the capture-shape reintroduction → the %s pin red with equal epochs in the panic (the literal pins are blind to it by design).
- Full workspace suite green (one pre-existing `tcp_listen_ipv6_only` port-race flake under parallel load, passed 2× isolated + clean full rerun — disclosed, untouched subsystem); clippy `-D warnings`/fmt clean; xcheck 7/7.
- CI + compat 52/52 on the final head before merge.
