### PR TITLE
fix: mirror GT's first-value blob parsing + record the IETOTALRATE double-relay (#343, #350)

### DIFF
--- a/riperf3-cli/tests/wire_shape.rs
+++ b/riperf3-cli/tests/wire_shape.rs
@@ -3273,3 +3273,179 @@ fn interrupt_stamp_renders_at_print_time_not_capture_time() {
          the banner's {banner_epoch} (a pre-run capture freezes them equal)"
     );
 }
+
+// ---------------------------------------------------------------------------
+// #343 (DECISION: MIRROR): GT parses every length-prefixed blob with
+// cJSON_Parse(require_null_terminated=0) — the FIRST JSON value wins and
+// trailing bytes inside the declared length are ignored (live-probed both
+// blob sites: garbage-suffixed params → CREATE_STREAMS follows;
+// garbage-suffixed results → clean full round, rc 0). Deliberate wire
+// leniency GT depends on, not bug noise (the #328 atoi-fidelity
+// precedent) — a peer that over-declares its length interoperates with
+// iperf3 and must interoperate with riperf3. Garbage from byte 0 still
+// rejects in both tools.
+// ---------------------------------------------------------------------------
+
+/// #343: a params blob of valid JSON + trailing garbage is ACCEPTED — the
+/// round advances to CREATE_STREAMS like GT.
+#[test]
+fn params_blob_with_trailing_garbage_is_accepted() {
+    let (_sout, _serr, status) = drive_server_scenario(false, |port| {
+        let mut ctrl = std::net::TcpStream::connect(("127.0.0.1", port)).expect("ctrl");
+        ctrl.write_all(&[b'x'; 37]).unwrap();
+        assert_eq!(read_exact(&mut ctrl, 1)[0], 9, "ParamExchange");
+        let mut blob = MOCK_PARAMS.as_bytes().to_vec();
+        blob.extend_from_slice(b"\x00\xffGARBAGE");
+        ctrl.write_all(&(blob.len() as u32).to_be_bytes()).unwrap();
+        ctrl.write_all(&blob).unwrap();
+        assert_eq!(
+            read_exact(&mut ctrl, 1)[0],
+            10,
+            "CreateStreams follows a garbage-suffixed params blob (GT parity)"
+        );
+        drop(ctrl);
+        std::thread::sleep(std::time::Duration::from_millis(300));
+    });
+    // The mock EOF'd at CREATE_STREAMS — the round ends via the #338
+    // IECTRLCLOSE surface; the pin is the state byte above.
+    assert!(status.success());
+}
+
+/// #343 negative cell: garbage from byte 0 still rejects (IERECVPARAMS).
+#[test]
+fn params_blob_garbage_from_byte_zero_still_rejects() {
+    let (_sout, serr, status) = drive_server_scenario(false, |port| {
+        let mut ctrl = std::net::TcpStream::connect(("127.0.0.1", port)).expect("ctrl");
+        ctrl.write_all(&[b'x'; 37]).unwrap();
+        assert_eq!(read_exact(&mut ctrl, 1)[0], 9, "ParamExchange");
+        write_json_blob(&mut ctrl, "\x00\x7fGARBAGE from byte zero");
+        std::thread::sleep(std::time::Duration::from_millis(300));
+        drop(ctrl);
+    });
+    assert!(status.success());
+    assert!(
+        serr.contains("unable to receive parameters from client"),
+        "byte-0 garbage keeps the IERECVPARAMS surface: {serr:?}"
+    );
+}
+
+/// #343: a results blob of valid JSON + trailing garbage completes the
+/// exchange — the server sends its own results back and the round is
+/// clean, like GT.
+#[test]
+fn results_blob_with_trailing_garbage_completes_the_exchange() {
+    let (_sout, serr, status) = drive_server_scenario(false, |port| {
+        let cookie = [b'x'; 37];
+        let mut ctrl = std::net::TcpStream::connect(("127.0.0.1", port)).expect("ctrl");
+        ctrl.write_all(&cookie).unwrap();
+        assert_eq!(read_exact(&mut ctrl, 1)[0], 9);
+        write_json_blob(&mut ctrl, MOCK_PARAMS);
+        assert_eq!(read_exact(&mut ctrl, 1)[0], 10);
+        let mut data = std::net::TcpStream::connect(("127.0.0.1", port)).expect("data");
+        data.write_all(&cookie).unwrap();
+        assert_eq!(read_exact(&mut ctrl, 1)[0], 1);
+        assert_eq!(read_exact(&mut ctrl, 1)[0], 2);
+        data.write_all(&[0u8; 4096]).unwrap();
+        ctrl.write_all(&[4u8]).unwrap(); // TestEnd
+        assert_eq!(read_exact(&mut ctrl, 1)[0], 13); // ExchangeResults
+        let mut blob = MOCK_RESULTS.as_bytes().to_vec();
+        blob.extend_from_slice(b"\x00\xffGARBAGE");
+        ctrl.write_all(&(blob.len() as u32).to_be_bytes()).unwrap();
+        ctrl.write_all(&blob).unwrap();
+        // GT parity: the exchange COMPLETES — the server's own results
+        // come back as a length-prefixed blob.
+        let len = u32::from_be_bytes(read_exact(&mut ctrl, 4).try_into().unwrap()) as usize;
+        assert!(
+            (2..1_000_000).contains(&len),
+            "a plausible server-results blob follows: {len}"
+        );
+        let body = read_exact(&mut ctrl, len);
+        assert!(
+            serde_json::from_slice::<serde_json::Value>(&body).is_ok(),
+            "the server's results parse"
+        );
+        drop((ctrl, data));
+        std::thread::sleep(std::time::Duration::from_millis(300));
+    });
+    assert!(status.success());
+    assert!(
+        !serr.contains("unable to receive results"),
+        "no IERECVRESULTS on the garbage-suffixed exchange: {serr:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// #350 (DECISION: RECORD-DEVIATION): on the runtime IETOTALRATE breach GT
+// relays the SERVER_ERROR frame TWICE (the explicit rate-path write, then
+// cleanup_server re-reading the stale i_errno global at loop exit — live:
+// two back-to-back fe 0000001b 00000000 frames). Same stale-global class
+// as the #349 terminate-arm clobber; unobservable by conforming clients
+// (they stop reading after the first frame). riperf3 pins EXACTLY ONE
+// frame then EOF.
+// ---------------------------------------------------------------------------
+
+/// #350: the runtime-breach relay is exactly one 9-byte frame, then EOF.
+#[test]
+fn runtime_rate_breach_relays_exactly_one_frame() {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind");
+    let port = listener.local_addr().unwrap().port();
+    drop(listener);
+    let ps = port.to_string();
+    let mut server = common::ChildGuard(
+        std::process::Command::new(env!("CARGO_BIN_EXE_riperf3"))
+            .args(["-s", "-1", "-p", &ps, "--server-bitrate-limit", "8000"])
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .spawn()
+            .expect("spawn server"),
+    );
+    let _so = riperf3_test_support::drain_reader(server.0.stdout.take().unwrap());
+    let _se = riperf3_test_support::drain_reader(server.0.stderr.take().unwrap());
+    std::thread::sleep(std::time::Duration::from_millis(400));
+
+    let mock = std::thread::spawn(move || {
+        use std::io::Read;
+        let cookie = [b'x'; 37];
+        let mut ctrl = std::net::TcpStream::connect(("127.0.0.1", port)).expect("ctrl");
+        ctrl.write_all(&cookie).unwrap();
+        assert_eq!(read_exact(&mut ctrl, 1)[0], 9);
+        write_json_blob(&mut ctrl, MOCK_PARAMS);
+        assert_eq!(read_exact(&mut ctrl, 1)[0], 10);
+        let mut data = std::net::TcpStream::connect(("127.0.0.1", port)).expect("data");
+        data.write_all(&cookie).unwrap();
+        assert_eq!(read_exact(&mut ctrl, 1)[0], 1);
+        assert_eq!(read_exact(&mut ctrl, 1)[0], 2);
+        // Pump well past 8 kbit/s so the 1 Hz rate check fires, then read
+        // EVERYTHING off ctrl until EOF: exactly one fe-frame expected.
+        for _ in 0..40 {
+            if data.write_all(&[0u8; 8192]).is_err() {
+                break; // server tore the data socket down at the breach
+            }
+            std::thread::sleep(std::time::Duration::from_millis(50));
+        }
+        ctrl.set_read_timeout(Some(std::time::Duration::from_secs(8)))
+            .expect("set_read_timeout");
+        let mut wire = Vec::new();
+        let mut buf = [0u8; 64];
+        loop {
+            match ctrl.read(&mut buf) {
+                Ok(0) | Err(_) => break,
+                Ok(n) => wire.extend_from_slice(&buf[..n]),
+            }
+        }
+        drop((ctrl, data));
+        wire
+    });
+
+    let wire = mock.join().expect("mock");
+    let status =
+        riperf3_test_support::wait_bounded(&mut server.0, std::time::Duration::from_secs(12))
+            .expect("server exits after the breach");
+    assert!(status.success());
+    assert_eq!(
+        wire,
+        wireback_frame(27),
+        "EXACTLY one SERVER_ERROR+IETOTALRATE frame then EOF — GT's \
+         stale-global double-relay is the recorded deviation: {wire:?}"
+    );
+}

--- a/riperf3-cli/tests/wire_shape.rs
+++ b/riperf3-cli/tests/wire_shape.rs
@@ -3295,7 +3295,11 @@ fn params_blob_with_trailing_garbage_is_accepted() {
         ctrl.write_all(&[b'x'; 37]).unwrap();
         assert_eq!(read_exact(&mut ctrl, 1)[0], 9, "ParamExchange");
         let mut blob = MOCK_PARAMS.as_bytes().to_vec();
-        blob.extend_from_slice(b"\x00\xffGARBAGE");
+        // NUL-FREE suffix on purpose (r1 F3): a NUL-led one also passes GT
+        // via JSON_read's strlen truncation — this pin must prove the
+        // cJSON-side leniency (require_null_terminated=0), which GT grants
+        // NUL-free garbage too (live-probed).
+        blob.extend_from_slice(b" GARBAGE-NO-NUL");
         ctrl.write_all(&(blob.len() as u32).to_be_bytes()).unwrap();
         ctrl.write_all(&blob).unwrap();
         assert_eq!(

--- a/riperf3/src/protocol.rs
+++ b/riperf3/src/protocol.rs
@@ -281,13 +281,28 @@ pub async fn json_read(stream: &mut TcpStream, max_len: usize) -> Result<serde_j
 
     let mut buf = vec![0u8; len];
     stream.read_exact(&mut buf).await?;
-    let value: serde_json::Value = serde_json::from_slice(&buf)?;
+    let value: serde_json::Value = json_first_value(&buf)?;
     Ok(value)
 }
 
 // ---------------------------------------------------------------------------
 // Test parameters — exchanged as JSON during ParamExchange
 // ---------------------------------------------------------------------------
+
+/// #343: GT parses every length-prefixed blob with
+/// cJSON_Parse(require_null_terminated=0) — the FIRST JSON value wins and
+/// trailing bytes inside the declared length are ignored. Deliberate wire
+/// leniency GT depends on (a peer that over-declares its length
+/// interoperates), mirrored per the #328 fidelity precedent; garbage from
+/// byte 0 still errors like both tools.
+fn json_first_value(buf: &[u8]) -> serde_json::Result<serde_json::Value> {
+    let mut stream = serde_json::Deserializer::from_slice(buf).into_iter();
+    match stream.next() {
+        Some(v) => v,
+        // Empty/whitespace-only: surface the standard EOF error shape.
+        None => serde_json::from_slice(buf),
+    }
+}
 
 fn is_false_opt(v: &Option<bool>) -> bool {
     matches!(v, None | Some(false))
@@ -677,7 +692,7 @@ async fn json_read_bounded(stream: &mut TcpStream, max_len: usize) -> Result<ser
 
     let mut buf = vec![0u8; len];
     nread_exact(stream, &mut buf, deadline).await?;
-    let value: serde_json::Value = serde_json::from_slice(&buf)?;
+    let value: serde_json::Value = json_first_value(&buf)?;
     Ok(value)
 }
 
@@ -772,7 +787,7 @@ pub async fn recv_results_server(stream: &mut TcpStream) -> Result<TestResultsJs
         }
     }
     let value: serde_json::Value =
-        serde_json::from_slice(&buf).map_err(|_| crate::error::RiperfError::RecvResultsFailed)?;
+        json_first_value(&buf).map_err(|_| crate::error::RiperfError::RecvResultsFailed)?;
     validate_results(value)
 }
 

--- a/riperf3/src/protocol.rs
+++ b/riperf3/src/protocol.rs
@@ -290,11 +290,16 @@ pub async fn json_read(stream: &mut TcpStream, max_len: usize) -> Result<serde_j
 // ---------------------------------------------------------------------------
 
 /// #343: GT parses every length-prefixed blob with
-/// cJSON_Parse(require_null_terminated=0) — the FIRST JSON value wins and
+/// cJSON_Parse(require_null_terminated=0) — the first JSON value wins and
 /// trailing bytes inside the declared length are ignored. Deliberate wire
 /// leniency GT depends on (a peer that over-declares its length
 /// interoperates), mirrored per the #328 fidelity precedent; garbage from
-/// byte 0 still errors like both tools.
+/// byte 0 still errors like both tools. SCOPE (r1 F2): the mirror covers
+/// self-delimiting first values with whitespace-separated tails — the
+/// residual cJSON cells (UTF-8 BOM, bare-scalar roots, scalar-adjacent
+/// garbage, nesting past serde's 128, raw control chars in strings) stay
+/// divergent and are tracked in the follow-up issue; none are reachable
+/// from a real iperf3 encoder.
 fn json_first_value(buf: &[u8]) -> serde_json::Result<serde_json::Value> {
     let mut stream = serde_json::Deserializer::from_slice(buf).into_iter();
     match stream.next() {

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -1792,6 +1792,16 @@ impl Server {
                         let bits_per_sec = total_bytes as f64 * 8.0 / elapsed;
                         if let Some(limit) = bitrate_limit {
                             if bits_per_sec > limit as f64 {
+                                // #350 RECORDED DEVIATION: GT relays this
+                                // frame TWICE — the explicit rate-path write
+                                // (iperf_server_api.c:626-643), then
+                                // cleanup_server re-reads the stale i_errno
+                                // global at loop exit (:466) and relays
+                                // again (live: back-to-back fe 0000001b
+                                // frames). Same stale-global class as the
+                                // #349 terminate clobber; conforming clients
+                                // stop after the first frame, so riperf3
+                                // sends exactly one (pinned).
                                 // #224: SERVER_ERROR + IETOTALRATE(27), not
                                 // SERVER_TERMINATE (iperf 3.21 GT).
                                 protocol::send_server_error(&mut ctx.ctrl, 27).await?;


### PR DESCRIPTION
Closes #343, closes #350 — two banked wire-behavior decisions executed (both live-probed on GT 3.21; decision records on the issues).

## #343 — MIRROR: first-value blob parsing

GT parses every length-prefixed JSON blob with `cJSON_Parse(require_null_terminated=0)`: the first JSON value wins and trailing bytes inside the declared length are ignored. Live-probed at both blob sites — a garbage-suffixed params blob advances to CREATE_STREAMS; a garbage-suffixed results blob completes a clean exchange. This is deliberate wire leniency GT depends on (a peer that over-declares its length interoperates with iperf3), **not** bug noise — the don't-mirror ruling covers bugs; leniency mirrors (the #328 atoi-fidelity precedent).

`json_first_value` (serde `StreamDeserializer` first-value semantics; empty input surfaces the standard EOF error) now backs all three blob reads: `json_read`, `json_read_bounded` (server params), and `recv_results_server`. Garbage from byte 0 still rejects in both tools.

## #350 — RECORD-DEVIATION: the IETOTALRATE double-relay

GT relays the SERVER_ERROR frame **twice** on the runtime rate breach: the explicit rate-path write (iperf_server_api.c:626-643), then `cleanup_server` re-reads the stale `i_errno` global at loop exit and relays again (live: back-to-back `fe 0000001b 00000000`). Same stale-global class as the #349 terminate-arm clobber; conforming clients stop reading after the first frame. riperf3 keeps exactly one frame — deviation comment at the #224 relay site, plus a wire pin.

### r1 (cold) → APPROVE → hardening applied (805f409)

r1 reproduced everything live including a triangle A/B (GT / head / main) at all three sites — notably building the missing client-side cell itself (mock server, garbage-suffixed results → head rc 0 + IPERF_DONE = GT; main rc 1), and verifying serde's recursion limit survives the StreamDeserializer swap. Its two hardening items are applied at 805f409: the params MIRROR pin now uses a NUL-FREE suffix (r1 F3 — the NUL-led cell also passes GT via JSON_read's strlen truncation, so it couldn't prove the cJSON-side leniency; the results pin keeps the NUL-led form so both mechanisms stay covered), and the helper's scope comment records the mirror's boundary (self-delimiting firsts, whitespace tails). **#367 filed** (r1 F2: five residual cJSON-leniency cells — BOM, bare-scalar roots, adjacent-garbage scalars, nesting 128–999, raw control chars — all pre-existing, none reachable from a real iperf3 encoder; the client-side pin note rides it too). The #350 record's line refs source-verified; GT's 18-byte double frame reproduced live.

## Verification

- 4 pins: the two MIRROR cells red-first → green; the byte-0-garbage negative cell (green baseline, pins the reject); the #350 exactly-one-frame-then-EOF pin (green baseline — it exists to kill the double-relay regression direction, mutation-proven).
- Live A/B vs GT: both tools answer a garbage-suffixed params blob with CREATE_STREAMS (0x0a).
- Mutations from the committed tree (dirty-target-guarded harness): leniency reverted to strict `from_slice` → both MIRROR pins RED; a second relay added at the breach site → the one-frame pin RED.
- Full workspace suite green; clippy `-D warnings`/fmt clean; xcheck 7/7.
- CI + compat 52/52 on the final head before merge.
