### PR TITLE
fix: the TEST_RUNNING data-idle watchdog — GT's IENOMSG(144) restart path (#351)

### DIFF
--- a/riperf3-cli/tests/wire_shape.rs
+++ b/riperf3-cli/tests/wire_shape.rs
@@ -3453,3 +3453,220 @@ fn runtime_rate_breach_relays_exactly_one_frame() {
          stale-global double-relay is the recorded deviation: {wire:?}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// #351: GT's TEST_RUNNING data-idle watchdog (IENOMSG=144). GT source
+// (iperf_server_api.c:720-739): fires only when the server RECEIVES
+// (mode != SENDER — reverse tests exempt) and `blocks_received` hasn't
+// advanced for rcv_timeout; ctrl traffic does NOT reset it. Live-probed
+// (--rcv-timeout 3000, silent client holding both sockets): wire
+// fe 00000090 00000000 at dt=3.0; text stderr `iperf3: error - idle
+// timeout for receiving data`, zero-byte interval rows keep ticking, NO
+// summary, rc=0; -J = ONE doc with the accumulated intervals + bare
+// end{} + the prefixed key, silent stderr.
+// ---------------------------------------------------------------------------
+
+/// #351 driver: reach TEST_RUNNING, send one chunk, go SILENT holding both
+/// sockets; read the relay until EOF.
+fn run_running_idle_scenario(json: bool) -> (Vec<u8>, String, String, std::process::ExitStatus) {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind");
+    let port = listener.local_addr().unwrap().port();
+    drop(listener);
+    let ps = port.to_string();
+    let mut args = vec!["-s", "-1", "-p", &ps, "--rcv-timeout", "3000"];
+    if json {
+        args.push("-J");
+    }
+    let mut server = common::ChildGuard(
+        std::process::Command::new(env!("CARGO_BIN_EXE_riperf3"))
+            .args(&args)
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .spawn()
+            .expect("spawn server"),
+    );
+    let sout = riperf3_test_support::drain_reader(server.0.stdout.take().unwrap());
+    let serr = riperf3_test_support::drain_reader(server.0.stderr.take().unwrap());
+    std::thread::sleep(std::time::Duration::from_millis(400));
+
+    let mock = std::thread::spawn(move || {
+        let cookie = [b'x'; 37];
+        let mut ctrl = std::net::TcpStream::connect(("127.0.0.1", port)).expect("ctrl");
+        ctrl.write_all(&cookie).unwrap();
+        assert_eq!(read_exact(&mut ctrl, 1)[0], 9);
+        // A LONG test so the duration watchdog can't be what bounds us.
+        write_json_blob(
+            &mut ctrl,
+            r#"{"tcp":true,"omit":0,"time":300,"num":0,"blockcount":0,"parallel":1,"len":131072,"pacing_timer":1000,"client_version":"x 0.0.0"}"#,
+        );
+        assert_eq!(read_exact(&mut ctrl, 1)[0], 10);
+        let mut data = std::net::TcpStream::connect(("127.0.0.1", port)).expect("data");
+        data.write_all(&cookie).unwrap();
+        assert_eq!(read_exact(&mut ctrl, 1)[0], 1);
+        assert_eq!(read_exact(&mut ctrl, 1)[0], 2);
+        data.write_all(&[0u8; 4096]).unwrap();
+        // SILENT from here, both sockets held open: only the idle watchdog
+        // can end this round (the test claims 300 s).
+        let frame = read_wireback(&mut ctrl);
+        drop((ctrl, data));
+        frame
+    });
+
+    let frame = mock.join().expect("mock");
+    let status =
+        riperf3_test_support::wait_bounded(&mut server.0, std::time::Duration::from_secs(10))
+            .expect("the idle watchdog bounds the round");
+    (
+        frame,
+        sout.join().expect("stdout"),
+        serr.join().expect("stderr"),
+        status,
+    )
+}
+
+/// #351 text: the 144 relay at the bound, GT's stderr line, ticking
+/// zero-byte rows, NO summary block, exit 0.
+#[test]
+fn running_idle_watchdog_takes_ienomsg_in_text() {
+    let (frame, sout, serr, status) = run_running_idle_scenario(false);
+    assert_eq!(
+        frame,
+        wireback_frame(144),
+        "SERVER_ERROR + htonl(IENOMSG) + htonl(0) on the running-idle bound"
+    );
+    assert!(status.success(), "keep-serving class exits 0");
+    assert!(
+        serr.contains(&format!("riperf3: error - {IDLE_TIMEOUT_MSG}")),
+        "GT's IENOMSG line: {serr:?}"
+    );
+    assert!(
+        sout.contains("0.00 Bytes"),
+        "zero-byte interval rows tick while idle: {sout:?}"
+    );
+    assert!(
+        !sout.contains("- - - - -"),
+        "NO summary block on the idle-killed round (GT): {sout:?}"
+    );
+}
+
+/// #351 -J: ONE doc — accumulated intervals present, bare end, the
+/// prefixed key, silent stderr.
+#[test]
+fn running_idle_watchdog_doc_shape_in_json() {
+    let (frame, sout, serr, status) = run_running_idle_scenario(true);
+    assert_eq!(frame, wireback_frame(144));
+    assert!(status.success());
+    assert!(serr.trim().is_empty(), "-J keeps stderr silent: {serr:?}");
+    let doc: serde_json::Value =
+        serde_json::from_str(sout.trim()).unwrap_or_else(|e| panic!("ONE -J doc ({e}): {sout:?}"));
+    assert_eq!(
+        doc["error"].as_str(),
+        Some(format!("error - {IDLE_TIMEOUT_MSG}").as_str()),
+        "the prefixed IENOMSG key: {doc}"
+    );
+    assert!(
+        !doc["intervals"].as_array().expect("intervals").is_empty(),
+        "the accumulated (zero-byte) intervals are PRESENT: {doc}"
+    );
+    assert!(
+        doc["end"].as_object().expect("end").is_empty(),
+        "bare end{{}}: {doc}"
+    );
+}
+
+/// #351 negative cells (GT's mode != SENDER gate + the progress reset):
+/// a reverse round longer than the bound completes (the server is the
+/// sender — exempt), and a slow-but-flowing forward round completes (each
+/// chunk resets the clock).
+#[test]
+fn running_idle_watchdog_negative_cells() {
+    // Reverse, real client: -R -t 5 under --rcv-timeout 3000.
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind");
+    let port = listener.local_addr().unwrap().port();
+    drop(listener);
+    let ps = port.to_string();
+    let mut server = common::ChildGuard(
+        std::process::Command::new(env!("CARGO_BIN_EXE_riperf3"))
+            .args(["-s", "-1", "-p", &ps, "--rcv-timeout", "3000"])
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .spawn()
+            .expect("spawn server"),
+    );
+    let _so = riperf3_test_support::drain_reader(server.0.stdout.take().unwrap());
+    let se = riperf3_test_support::drain_reader(server.0.stderr.take().unwrap());
+    std::thread::sleep(std::time::Duration::from_millis(400));
+    let cli = std::process::Command::new(env!("CARGO_BIN_EXE_riperf3"))
+        .args(["-c", "127.0.0.1", "-p", &ps, "-R", "-t", "5", "-b", "1M"])
+        .output()
+        .expect("reverse client");
+    assert!(
+        cli.status.success(),
+        "a reverse round outliving the bound completes (mode != SENDER gate): {}",
+        String::from_utf8_lossy(&cli.stderr)
+    );
+    let status =
+        riperf3_test_support::wait_bounded(&mut server.0, std::time::Duration::from_secs(10))
+            .expect("server exits");
+    assert!(status.success());
+    let serr = se.join().expect("stderr");
+    assert!(
+        !serr.contains(IDLE_TIMEOUT_MSG),
+        "no IENOMSG on the healthy reverse round: {serr:?}"
+    );
+
+    // Slow-but-flowing forward: one chunk per second for ~5 s under the
+    // 3 s bound — progress resets the clock, the round must NOT be killed.
+    let (frame, _sout, serr2, status2) = {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind");
+        let port = listener.local_addr().unwrap().port();
+        drop(listener);
+        let ps = port.to_string();
+        let mut server = common::ChildGuard(
+            std::process::Command::new(env!("CARGO_BIN_EXE_riperf3"))
+                .args(["-s", "-1", "-p", &ps, "--rcv-timeout", "3000"])
+                .stdout(std::process::Stdio::piped())
+                .stderr(std::process::Stdio::piped())
+                .spawn()
+                .expect("spawn server"),
+        );
+        let _so = riperf3_test_support::drain_reader(server.0.stdout.take().unwrap());
+        let se2 = riperf3_test_support::drain_reader(server.0.stderr.take().unwrap());
+        std::thread::sleep(std::time::Duration::from_millis(400));
+        let mock = std::thread::spawn(move || {
+            let cookie = [b'x'; 37];
+            let mut ctrl = std::net::TcpStream::connect(("127.0.0.1", port)).expect("ctrl");
+            ctrl.write_all(&cookie).unwrap();
+            assert_eq!(read_exact(&mut ctrl, 1)[0], 9);
+            write_json_blob(&mut ctrl, MOCK_PARAMS);
+            assert_eq!(read_exact(&mut ctrl, 1)[0], 10);
+            let mut data = std::net::TcpStream::connect(("127.0.0.1", port)).expect("data");
+            data.write_all(&cookie).unwrap();
+            assert_eq!(read_exact(&mut ctrl, 1)[0], 1);
+            assert_eq!(read_exact(&mut ctrl, 1)[0], 2);
+            for _ in 0..5 {
+                data.write_all(&[0u8; 1024]).unwrap();
+                std::thread::sleep(std::time::Duration::from_millis(1000));
+            }
+            ctrl.write_all(&[4u8]).unwrap(); // TestEnd: finish cleanly
+            assert_eq!(read_exact(&mut ctrl, 1)[0], 13);
+            let blob = MOCK_RESULTS.as_bytes().to_vec();
+            ctrl.write_all(&(blob.len() as u32).to_be_bytes()).unwrap();
+            ctrl.write_all(&blob).unwrap();
+            let len = u32::from_be_bytes(read_exact(&mut ctrl, 4).try_into().unwrap()) as usize;
+            let _ = read_exact(&mut ctrl, len);
+            Vec::<u8>::new()
+        });
+        let frame = mock.join().expect("mock");
+        let status =
+            riperf3_test_support::wait_bounded(&mut server.0, std::time::Duration::from_secs(12))
+                .expect("server exits");
+        (frame, String::new(), se2.join().expect("stderr"), status)
+    };
+    assert!(frame.is_empty());
+    assert!(status2.success());
+    assert!(
+        !serr2.contains(IDLE_TIMEOUT_MSG),
+        "slow-but-flowing progress resets the clock: {serr2:?}"
+    );
+}

--- a/riperf3-cli/tests/wire_shape.rs
+++ b/riperf3-cli/tests/wire_shape.rs
@@ -3458,7 +3458,9 @@ fn runtime_rate_breach_relays_exactly_one_frame() {
 // #351: GT's TEST_RUNNING data-idle watchdog (IENOMSG=144). GT source
 // (iperf_server_api.c:720-739): fires only when the server RECEIVES
 // (mode != SENDER — reverse tests exempt) and `blocks_received` hasn't
-// advanced for rcv_timeout; ctrl traffic does NOT reset it. Live-probed
+// advanced for rcv_timeout; ctrl traffic does NOT reset it. riperf3's
+// progress signal is received BYTES — a recorded deviation below the
+// Nread quanta (see the negative-cells test + the arm comment). Live-probed
 // (--rcv-timeout 3000, silent client holding both sockets): wire
 // fe 00000090 00000000 at dt=3.0; text stderr `iperf3: error - idle
 // timeout for receiving data`, zero-byte interval rows keep ticking, NO
@@ -3574,10 +3576,16 @@ fn running_idle_watchdog_doc_shape_in_json() {
     );
 }
 
-/// #351 negative cells (GT's mode != SENDER gate + the progress reset):
-/// a reverse round longer than the bound completes (the server is the
-/// sender — exempt), and a slow-but-flowing forward round completes (each
-/// chunk resets the clock).
+/// #351 negative cells: a reverse round longer than the bound completes
+/// (GT's mode != SENDER gate — the server is the sender, exempt), and a
+/// slow-but-flowing forward round completes. The second half is a
+/// RECORDED DEVIATION, not GT parity (PR #369 r1, live-probed): GT's
+/// blocks_received is quantized to COMPLETED `len` blocks by Nread, so GT
+/// kills this exact sub-block trickle at the bound ("idle timeout" while
+/// data flows); riperf3's byte-based progress deliberately survives it —
+/// the liveness-preserving reading of "idle" (emergent Nread noise, the
+/// #356 TEST_START precedent). The two signals converge at the 120 s
+/// default, where the 10 s/30 s Nread partial quanta are absorbed.
 #[test]
 fn running_idle_watchdog_negative_cells() {
     // Reverse, real client: -R -t 5 under --rcv-timeout 3000.
@@ -3667,6 +3675,7 @@ fn running_idle_watchdog_negative_cells() {
     assert!(status2.success());
     assert!(
         !serr2.contains(IDLE_TIMEOUT_MSG),
-        "slow-but-flowing progress resets the clock: {serr2:?}"
+        "byte-based progress keeps a flowing sub-block trickle alive (the \
+         RECORDED DEVIATION — GT's block-quantized signal kills this cell): {serr2:?}"
     );
 }

--- a/riperf3-cli/tests/wire_shape.rs
+++ b/riperf3-cli/tests/wire_shape.rs
@@ -3459,8 +3459,9 @@ fn runtime_rate_breach_relays_exactly_one_frame() {
 // (iperf_server_api.c:720-739): fires only when the server RECEIVES
 // (mode != SENDER — reverse tests exempt) and `blocks_received` hasn't
 // advanced for rcv_timeout; ctrl traffic does NOT reset it. riperf3's
-// progress signal is received BYTES — a recorded deviation below the
-// Nread quanta (see the negative-cells test + the arm comment). Live-probed
+// progress signal is received BYTES — a recorded RATE-scoped deviation
+// (GT's blocks_received is full-block-quantized at ANY bound; see the
+// negative-cells test + the arm comment). Live-probed
 // (--rcv-timeout 3000, silent client holding both sockets): wire
 // fe 00000090 00000000 at dt=3.0; text stderr `iperf3: error - idle
 // timeout for receiving data`, zero-byte interval rows keep ticking, NO
@@ -3579,13 +3580,14 @@ fn running_idle_watchdog_doc_shape_in_json() {
 /// #351 negative cells: a reverse round longer than the bound completes
 /// (GT's mode != SENDER gate — the server is the sender, exempt), and a
 /// slow-but-flowing forward round completes. The second half is a
-/// RECORDED DEVIATION, not GT parity (PR #369 r1, live-probed): GT's
-/// blocks_received is quantized to COMPLETED `len` blocks by Nread, so GT
+/// RECORDED DEVIATION, not GT parity (PR #369 r1+r2, live-probed): GT's
+/// blocks_received is quantized to COMPLETED `len` blocks (running-phase
+/// reads are Nrecv_no_select — timeout-free full-block accumulate), so GT
 /// kills this exact sub-block trickle at the bound ("idle timeout" while
-/// data flows); riperf3's byte-based progress deliberately survives it —
-/// the liveness-preserving reading of "idle" (emergent Nread noise, the
-/// #356 TEST_START precedent). The two signals converge at the 120 s
-/// default, where the 10 s/30 s Nread partial quanta are absorbed.
+/// data flows) — at ANY bound, for any flow slower than len*8/bound
+/// (~8.7 kbit/s at stock defaults). riperf3's byte-based progress
+/// deliberately survives it — the liveness-preserving reading of "idle"
+/// (the #356 TEST_START precedent).
 #[test]
 fn running_idle_watchdog_negative_cells() {
     // Reverse, real client: -R -t 5 under --rcv-timeout 3000.

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -1692,11 +1692,28 @@ impl Server {
 
         // #351: GT's TEST_RUNNING data-idle watchdog (iperf_server_api.c:
         // 720-739): armed only when the server RECEIVES (mode != SENDER —
-        // reverse rounds are exempt); progress = received bytes advancing
-        // (GT's blocks_received); ctrl traffic does NOT reset it. On expiry:
-        // IENOMSG(144) — the relay, then the self-terminate surface (the
-        // prefixed doc key over the accumulated intervals + bare end, the
-        // stderr line, no summary), exit-0 keep-serving like GT's restart.
+        // reverse rounds are exempt); ctrl traffic does NOT reset it. On
+        // expiry: IENOMSG(144) — the relay, then the self-terminate surface
+        // (the prefixed doc key over the accumulated intervals + bare end,
+        // the stderr line, no summary), exit-0 keep-serving like GT's
+        // restart. RECORDED DEVIATIONS (PR #369 r1, live-probed):
+        // (1) progress — riperf3 resets on received BYTES advancing; GT's
+        // blocks_received advances only when a full `len` block completes
+        // (or Nread's static 10s/30s partials land, net.c:75-76), so under
+        // a bound below those quanta GT kills a genuinely FLOWING sub-block
+        // trickle (1 KiB/s vs len 128K, bound 3s: GT fires "idle timeout"
+        // at 3.02s while data arrives). Emergent Nread noise, not designed
+        // semantics — bytes are the liveness-preserving reading (the #356
+        // TEST_START precedent). At the 120s default the quanta are
+        // absorbed and the signals converge (probed).
+        // (2) kill envelope — riperf3 fires within [bound, bound+250ms];
+        // GT's baseline lags its main-loop wakes and expiry needs a full
+        // select timeout, so its band is [bound, ~bound+2s] (a full-block
+        // 3.6s cadence under a 3s bound survives GT, dies here). Neither
+        // tool fires before a genuine bound-length gap.
+        // (3) the killed round's doc keeps riperf3's #210/#325 partial
+        // catch-up interval row; GT's fatal wake precedes its reporter
+        // tick, so GT's doc holds one fewer whole row + no partial.
         let idle_armed = !ctx.cfg.reverse || ctx.cfg.bidir;
         let idle_bound =
             std::time::Duration::from_millis(self.rcv_timeout.unwrap_or(DEFAULT_RCV_TIMEOUT_MS));

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -1696,17 +1696,22 @@ impl Server {
         // expiry: IENOMSG(144) — the relay, then the self-terminate surface
         // (the prefixed doc key over the accumulated intervals + bare end,
         // the stderr line, no summary), exit-0 keep-serving like GT's
-        // restart. RECORDED DEVIATIONS (PR #369 r1, live-probed):
+        // restart. RECORDED DEVIATIONS (PR #369 r1+r2, live-probed):
         // (1) progress — riperf3 resets on received BYTES advancing; GT's
-        // blocks_received advances only when a full `len` block completes
-        // (or Nread's static 10s/30s partials land, net.c:75-76), so under
-        // a bound below those quanta GT kills a genuinely FLOWING sub-block
-        // trickle (1 KiB/s vs len 128K, bound 3s: GT fires "idle timeout"
-        // at 3.02s while data arrives). Emergent Nread noise, not designed
-        // semantics — bytes are the liveness-preserving reading (the #356
-        // TEST_START precedent). At the 120s default the quanta are
-        // absorbed and the signals converge (probed).
-        // (2) kill envelope — riperf3 fires within [bound, bound+250ms];
+        // blocks_received advances ONLY on full-`len` block completions
+        // (the running-phase reads are Nrecv_no_select, net.c:511-553 — a
+        // timeout-free full-block accumulate; the 10s/30s statics are
+        // control-path only). The divergence is RATE-scoped, at ANY bound:
+        // GT false-kills every receiving flow slower than len*8/bound
+        // (~8.7 kbit/s at stock 128K/120s — a GT `-b 8k` TCP client dies
+        // against its own server; probed at bounds 3s/35s/120s). riperf3
+        // never kills a byte-flowing round — the liveness-preserving
+        // reading (the #356 precedent). Flip side, recorded honestly: a
+        // 1-byte-per-(bound-epsilon) trickle holds a riperf3 slot
+        // indefinitely where GT reaps at ~bound — but a full-block cadence
+        // >= bound holds GT forever too (probed), so neither watchdog is a
+        // security bound.
+        // (2) kill envelope — riperf3 fires within [bound, bound+~250ms];
         // GT's baseline lags its main-loop wakes and expiry needs a full
         // select timeout, so its band is [bound, ~bound+2s] (a full-block
         // 3.6s cadence under a 3s bound survives GT, dies here). Neither

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -1685,7 +1685,25 @@ impl Server {
         const SELF_TERM_RATE_MSG: &str = "total required bandwidth is larger than server limit";
         const SELF_TERM_DURATION_MSG: &str =
             "server test duration expired - test is terminated by the server";
+        // #351: iperf_strerror(IENOMSG) — must match RiperfError::DataIdleTimeout's
+        // Display (the #338 pre-test sibling renders through that variant).
+        const SELF_TERM_IDLE_MSG: &str = "idle timeout for receiving data";
         let mut interrupt_rx = self.interrupt.clone().map(|w| w.0);
+
+        // #351: GT's TEST_RUNNING data-idle watchdog (iperf_server_api.c:
+        // 720-739): armed only when the server RECEIVES (mode != SENDER —
+        // reverse rounds are exempt); progress = received bytes advancing
+        // (GT's blocks_received); ctrl traffic does NOT reset it. On expiry:
+        // IENOMSG(144) — the relay, then the self-terminate surface (the
+        // prefixed doc key over the accumulated intervals + bare end, the
+        // stderr line, no summary), exit-0 keep-serving like GT's restart.
+        let idle_armed = !ctx.cfg.reverse || ctx.cfg.bidir;
+        let idle_bound =
+            std::time::Duration::from_millis(self.rcv_timeout.unwrap_or(DEFAULT_RCV_TIMEOUT_MS));
+        let mut idle_check = tokio::time::interval(std::time::Duration::from_millis(250));
+        idle_check.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+        let mut idle_last_rx: u64 = 0;
+        let mut idle_last_at = tokio::time::Instant::now();
 
         loop {
             tokio::select! {
@@ -1809,6 +1827,29 @@ impl Server {
                                 break;
                             }
                         }
+                    }
+                }
+                _ = idle_check.tick(), if idle_armed => {
+                    let rx: u64 = ctx
+                        .streams
+                        .iter()
+                        .map(|s| s.meta.counters.bytes_received())
+                        .sum();
+                    if rx > idle_last_rx {
+                        idle_last_rx = rx;
+                        idle_last_at = tokio::time::Instant::now();
+                    } else if idle_last_at.elapsed() >= idle_bound {
+                        // Best-effort like the #338/#349 relay sites — the
+                        // idle peer may be gone entirely.
+                        let _ = protocol::send_server_error(&mut ctx.ctrl, 144).await;
+                        ctx.server_error = Some(SELF_TERM_IDLE_MSG);
+                        // GT's kill path never runs end processing — the
+                        // doc keeps the accumulated intervals over a bare
+                        // end{} (live-probed; the rate-breach sibling's
+                        // populated end is the pre-existing divergence
+                        // filed from this probe).
+                        ctx.bare_end = true;
+                        break;
                     }
                 }
                 _ = &mut watchdog_deadline, if watchdog_secs > 0 => {


### PR DESCRIPTION
Closes #351 — GT's TEST_RUNNING data-idle watchdog (the IENOMSG=144 restart path), the mid-test sibling of #338's CREATE_STREAMS bound.

## GT semantics (source + live)

iperf_server_api.c:720-739, all live-probed on 3.21:
- **Gate: `mode != SENDER`** — the watchdog only arms when the server RECEIVES; a reverse round outliving the bound completes normally.
- **Progress = `blocks_received` advancing.** Ctrl traffic does NOT reset the clock. (See the r1 round below: GT's signal is block-QUANTIZED — riperf3's byte-based reset is a recorded deviation under small bounds.)
- **Surface at expiry** (`--rcv-timeout 3000`, silent client holding both sockets): wire `fe 00000090 00000000` at dt=3.0; text stderr `iperf3: error - idle timeout for receiving data` with zero-byte interval rows ticking and NO summary block; `-J` = ONE doc, accumulated intervals present, **bare `end:{}`**, prefixed error key, silent stderr; rc=0 keep-serving.

## Implementation

A 250 ms idle check in the running loop, armed when the server receives (`!reverse || bidir`): received-byte totals advancing reset the clock (GT's blocks_received equivalent); expiry relays 144 best-effort (the #338/#349 relay convention) and takes the existing self-terminate surface (`ctx.server_error`) with `ctx.bare_end` for GT's end shape. `--rcv-timeout` now covers both server watchdog halves (#338's default, `DEFAULT_RCV_TIMEOUT_MS`).

**Found while probing: #368 filed.** BOTH GT self-terminate cells keep the bare `end{}` — riperf3's populated end on the rate-breach sibling (`--server-bitrate-limit`, #224-era) is a pre-existing `-J` divergence; the duration-expiry sibling likely shares the class. This PR fixes only its own arm; #368 carries the siblings (their #224-era pins need realigning with the GT probe).

### r1 (cold) → REQUEST-CHANGES → deviation recorded (89604e8)

r1's major find, live-proven: GT's `blocks_received` advances only when a full `len` block completes (Nread quantization + its static 10 s/30 s partials), so **GT kills a genuinely flowing 1 KiB/s trickle at a 3 s bound** — the PR's slow-flow negative cell had pinned the opposite as "GT's progress reset". DECISION: keep byte-based progress as a **recorded deviation** (r1's own lean): GT's behavior is emergent Nread noise that fires "idle timeout for receiving data" while data arrives — bytes are the liveness-preserving reading (the #356 TEST_START precedent) — and the signals converge at the 120 s default. The cell, arm comment, and section header now record the deviation (F1), the kill-envelope delta ([bound, +250 ms] vs GT's [bound, ~+2 s] — a 3.6 s full-block cadence survives GT, dies here; neither tool fires before a genuine bound-length gap) (F2), and the #210/#325 partial-row doc delta (F4); the probe facts are banked on issue #351. F3 (TEST_END racing expiry): probed — both tools kill first, single frame, no double surface; GT's structural ctrl preference left unmirrored (≤250 ms window, identical observables). r1's parity matrix otherwise verified everything: the hard bidir-half-silent cell (server pumping 40 GB TX while c→s is silent — killed on both, TX is not progress), UDP on both server paths incl. demux counters feeding the sum, omit-window gross counters, the exchange-wedge already bounded identically byte-for-byte, teardown bounded with a socket-holding peer, and #368's framing.

### r2 (cold, independent) → REQUEST-CHANGES on the record → corrected (820c1e4)

r2 verified the code fully (its own probe matrix incl. the interop-relay surface, a NEW RX→TX-flip mutation killed by the slow-flow cell, and the deviation-(3) row counts exact) and then falsified the r1-era record ONE LEVEL DOWN: the "converge at the 120 s default" claim was wrong — GT's running-phase reads are `Nrecv_no_select` (timeout-free full-block accumulate; the 10 s/30 s statics are control-path only), so the divergence is **rate-scoped at any bound**: GT false-kills every receiving flow slower than len×8/bound (~8.7 kbit/s at stock defaults — a GT `-b 8k` TCP client dies against its own 120 s-default server, probed at bounds 3/35/120 s). The record is corrected in all three code sites + the banked #351 comment, now including the honest flip side (a sub-byte trickle holds a riperf3 slot where GT reaps at ~bound — but a full-block cadence ≥ bound holds GT forever too; neither watchdog is a security bound) and the "+~250 ms" envelope precision. **The byte-based decision stands, strengthened**: mirroring block quantization would import false kills into legitimate slow-rate interop rounds at stock settings.

## Verification

- 3 pins red-first: the text surface (144 frame + stderr line + ticking zero rows + no summary), the `-J` doc shape (intervals present + bare end + prefixed key), and the negative cells (a reverse round outliving the bound completes — the mode gate; a slow-but-flowing forward round completes — the progress reset).
- Mutations from the committed tree (dirty-target-guarded): mode gate removed → the reverse cell red; progress reset removed → the slow-flow cell red; the whole arm removed → text pin red; bare_end removed → doc pin red; the relay removed → text pin red. 5/5.
- Full workspace suite exit 0 (one `udp_receiver_survives_connection_reset` parallel-load flake, passed 2× isolated — pre-existing class, untouched subsystem); clippy `-D warnings`/fmt clean; xcheck 7/7.
- CI + compat 52/52 on the final head before merge.
