### PR TITLE
fix: an exchange-phase Err runs the end-of-round teardown (#353)

### DIFF
--- a/riperf3-cli/tests/wire_shape.rs
+++ b/riperf3-cli/tests/wire_shape.rs
@@ -3681,3 +3681,111 @@ fn running_idle_watchdog_negative_cells() {
          RECORDED DEVIATION — GT's block-quantized signal kills this cell): {serr2:?}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// #353: an Err from the exchange phase itself (e.g. the ExchangeResults
+// state-byte write failing against an RST'd ctrl) must not skip the
+// end-of-round abort/join gate — a hostile peer provoking it while
+// HOLDING its data sockets would leak detached parked receiver tasks +
+// fds in a persistent server (the #331/#352/#356-F7 family, one phase
+// later). PERSISTENT server on purpose: one-off process exit closes the
+// sockets either way (the #356 F7 vacuous-pin lesson).
+// ---------------------------------------------------------------------------
+
+/// One #353 attempt. The ctrl-RST races the exchange's first write: RST
+/// first = the send-Err class (the `?` under test); write first = the
+/// graceful IERECVRESULTS class (which runs the gate — a retry). Returns
+/// (send_class, data_read, server_alive).
+#[cfg(unix)]
+fn drive_exchange_err_hold() -> (bool, Result<usize, std::io::ErrorKind>, bool) {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind");
+    let port = listener.local_addr().unwrap().port();
+    drop(listener);
+    let ps = port.to_string();
+    let mut server = common::ChildGuard(
+        std::process::Command::new(env!("CARGO_BIN_EXE_riperf3"))
+            .args(["-s", "-p", &ps])
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .spawn()
+            .expect("spawn server"),
+    );
+    let _so = riperf3_test_support::drain_reader(server.0.stdout.take().unwrap());
+    let se = riperf3_test_support::drain_reader(server.0.stderr.take().unwrap());
+    std::thread::sleep(std::time::Duration::from_millis(400));
+
+    let mock = std::thread::spawn(move || {
+        use std::io::Read;
+        let cookie = [b'x'; 37];
+        let mut ctrl = std::net::TcpStream::connect(("127.0.0.1", port)).expect("ctrl");
+        ctrl.write_all(&cookie).unwrap();
+        assert_eq!(read_exact(&mut ctrl, 1)[0], 9);
+        write_json_blob(&mut ctrl, MOCK_PARAMS);
+        assert_eq!(read_exact(&mut ctrl, 1)[0], 10);
+        let mut data = std::net::TcpStream::connect(("127.0.0.1", port)).expect("data");
+        data.write_all(&cookie).unwrap();
+        assert_eq!(read_exact(&mut ctrl, 1)[0], 1);
+        assert_eq!(read_exact(&mut ctrl, 1)[0], 2);
+        data.write_all(&[0u8; 4096]).unwrap();
+        ctrl.write_all(&[4u8]).unwrap(); // TestEnd
+                                         // RST quickly: the exchange's state write happens after the ~100 ms
+                                         // flush grace — landing the RST first yields the send-Err class.
+        std::thread::sleep(std::time::Duration::from_millis(50));
+        let linger = libc::linger {
+            l_onoff: 1,
+            l_linger: 0,
+        };
+        let rc = unsafe {
+            use std::os::fd::AsRawFd;
+            libc::setsockopt(
+                ctrl.as_raw_fd(),
+                libc::SOL_SOCKET,
+                libc::SO_LINGER,
+                std::ptr::from_ref(&linger).cast(),
+                std::mem::size_of::<libc::linger>() as libc::socklen_t,
+            )
+        };
+        assert_eq!(rc, 0, "SO_LINGER setsockopt failed");
+        drop(ctrl);
+        data.set_read_timeout(Some(std::time::Duration::from_secs(4)))
+            .expect("set_read_timeout");
+        let mut buf = [0u8; 16];
+        let r = data.read(&mut buf).map_err(|e| e.kind());
+        drop(data);
+        r
+    });
+
+    let data_read = mock.join().expect("mock");
+    let alive = server.0.try_wait().expect("try_wait").is_none();
+    drop(server); // ChildGuard kills; the drained stderr classifies the round
+    let serr = se.join().expect("stderr");
+    let send_class = !serr.contains("unable to receive results");
+    (send_class, data_read, alive)
+}
+
+/// #353: the exchange-phase Err runs the teardown — the held data socket
+/// sees EOF bounded while the server keeps serving. Retry-classified
+/// across the RST-vs-write race (the #345 pattern); the graceful
+/// recv-fail class already runs the gate and retries.
+#[cfg(unix)]
+#[test]
+fn exchange_phase_err_still_tears_down_streams() {
+    let mut seen = Vec::new();
+    for _ in 0..10 {
+        let (send_class, data_read, alive) = drive_exchange_err_hold();
+        if send_class {
+            assert_eq!(
+                data_read,
+                Ok(0),
+                "the held data socket sees EOF bounded (the exchange Err ran the teardown)"
+            );
+            assert!(
+                alive,
+                "the persistent server kept serving after the failed round"
+            );
+            return;
+        }
+        seen.push(format!("recv-class round: {data_read:?}"));
+    }
+    panic!("the send-Err class never surfaced in 10 RST races; saw: {seen:#?}");
+}

--- a/riperf3-cli/tests/wire_shape.rs
+++ b/riperf3-cli/tests/wire_shape.rs
@@ -3759,7 +3759,13 @@ fn drive_exchange_err_hold() -> (bool, Result<usize, std::io::ErrorKind>, bool) 
     let alive = server.0.try_wait().expect("try_wait").is_none();
     drop(server); // ChildGuard kills; the drained stderr classifies the round
     let serr = se.join().expect("stderr");
-    let send_class = !serr.contains("unable to receive results");
+    // Positive classification (#370 r2): the kill races the serve-loop's
+    // stderr line, so "no recv-results line" alone could misclassify a
+    // recv-class round as send-class — benign on the fix, but a false
+    // green for a teardown-less mutant (recv-class rounds tear down via
+    // the pre-existing gate). Require an error line to have landed; a
+    // line-less round just retries.
+    let send_class = serr.contains("error - ") && !serr.contains("unable to receive results");
     (send_class, data_read, alive)
 }
 
@@ -3774,10 +3780,14 @@ fn exchange_phase_err_still_tears_down_streams() {
     for _ in 0..10 {
         let (send_class, data_read, alive) = drive_exchange_err_hold();
         if send_class {
-            assert_eq!(
-                data_read,
-                Ok(0),
-                "the held data socket sees EOF bounded (the exchange Err ran the teardown)"
+            // EOF is the common close; RST lands when the abort drops the
+            // receiver with the mock's bytes unread (#370 r2 — GT's own
+            // close on this class RSTs too). Main's failure mode is
+            // TimedOut/WouldBlock, so the discrimination survives.
+            assert!(
+                matches!(data_read, Ok(0) | Err(std::io::ErrorKind::ConnectionReset)),
+                "the held data socket sees a bounded close (the exchange \
+                 Err ran the teardown): {data_read:?}"
             );
             assert!(
                 alive,

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -893,14 +893,30 @@ impl Server {
         let (server_output_text, server_output_json, report_source) =
             self.finish_server_output(&mut ctx, &end, collected);
         let was_captured = server_output_text.is_some();
-        self.exchange_results_phase(
-            &mut ctx,
-            &end,
-            result_streams,
-            server_output_text,
-            server_output_json,
-        )
-        .await?;
+        // #353: the exchange's own Err (e.g. the ExchangeResults state
+        // write failing against an RST'd ctrl) must not skip the
+        // unconditional end-of-round abort/join below — a hostile peer
+        // provoking it while HOLDING its data sockets would leak detached
+        // parked receiver tasks + fds in a persistent server (the
+        // #331/#352/#356-F7 family, one phase later). Counts are frozen at
+        // build_result_streams, so the teardown is safe here.
+        if let Err(e) = self
+            .exchange_results_phase(
+                &mut ctx,
+                &end,
+                result_streams,
+                server_output_text,
+                server_output_json,
+            )
+            .await
+        {
+            abort_setup_streams(&mut ctx).await;
+            if let Some(h) = ctx.udp_demux_handle.take() {
+                h.abort();
+                let _ = h.await;
+            }
+            return Err(e);
+        }
 
         // #319: an interrupt landing INSIDE the exchange phase fires after
         // EndState froze report_error — re-resolve so the sigend dump


### PR DESCRIPTION
Closes #353 — an `Err` from the exchange phase itself no longer skips the end-of-round teardown (the #331/#352/#356-F7 leak family, one phase later; found by PR #352's r1, pre-existing).

## The leak

`exchange_results_phase`'s `?` returned out of `handle_one_test` past the #331 **unconditional** abort/join gate. A hostile peer that provokes the exchange's own send failure — RST the ctrl inside the ~100 ms flush-grace window, before the ExchangeResults state write lands — while HOLDING its data sockets left detached receiver tasks parked in `read()` plus their fds, accumulating per round in a persistent server. (The graceful recv-fail class — IERECVRESULTS, #336 — was never affected: it routes through the report path and the gate.)

## The fix

The exchange result is captured; on `Err` the same abort+join (streams + demux) runs before propagating. Counts are frozen at `build_result_streams`, so the teardown is safe at this point — same argument as the #331 gate it mirrors.

## Verification

- Pin red-first (persistent server — the #356-F7 vacuous-pin lesson): retry-classified across the RST-vs-write race (the #345 pattern; recv-class rounds already run the gate and retry). The send-Err class asserts the held data socket sees EOF bounded while the server keeps serving. Red on main: the held socket outlived a 4 s read. Green on the fix in one round.
- Mutation from the committed tree (dirty-target-guarded): the teardown removed from the new Err arm → the pin RED.
- Full workspace suite exit 0; clippy `-D warnings`/fmt clean; xcheck 7/7.
- CI + compat 52/52 on the final head before merge.
