### PR TITLE
fix: the client aborts stream tasks before the clean-path join (#354)

### DIFF
--- a/riperf3-cli/tests/wire_shape.rs
+++ b/riperf3-cli/tests/wire_shape.rs
@@ -3802,65 +3802,94 @@ fn exchange_phase_err_still_tears_down_streams() {
 
 // ---------------------------------------------------------------------------
 // #354: the clean-path join must not be peer-bound — GT's client cancels
-// its stream threads before joining (iperf_client_api.c:817-841), so it
-// exits on its own clock against a server that HOLDS its sockets after
-// the round. A bare join parks reverse receivers in read() (`done` cannot
-// wake a parked read) until the peer lets go.
+// its stream threads before joining (iperf_client_api.c:817-841). A bare
+// join parks on a stream task stuck in a socket wait (`done` cannot wake
+// a parked read or write) until the peer lets go.
 // ---------------------------------------------------------------------------
 
-/// #354: reverse client vs a socket-holding server — the mock speaks the
-/// full protocol through reading IperfDone, then HOLDS ctrl + data open.
-/// The bounded `run_client` wait IS the pin: a bare join is peer-bound
-/// (~25 s here); the abort-before-join exits on the client's own clock.
+/// #354 mock: full protocol, but the data phase goes SILENT/deaf after
+/// ~0.3 s — BEFORE the client's `done` lands — so the stream task
+/// genuinely PARKS: reverse = the writer stops writing (a receiver parked
+/// in `read().await`); forward = the drain stops reading (a sender parked
+/// in `write().await` on full buffers). Then it reads IperfDone(16) and
+/// HOLDS every socket for 25 s. The silence timing is load-bearing (r1
+/// F1): a writer that runs to TestEnd hands the receiver to the #23
+/// 10 s drain cap instead, and the pin's red couples to that unrelated
+/// constant rather than to the park.
+fn holding_mock_round(listener: std::net::TcpListener, reverse: bool) {
+    let (mut ctrl, _) = listener.accept().expect("ctrl accept");
+    read_exact(&mut ctrl, 37); // cookie
+    ctrl.write_all(&[9u8]).unwrap(); // ParamExchange
+    read_json_blob(&mut ctrl); // params
+    ctrl.write_all(&[10u8]).unwrap(); // CreateStreams
+    let (mut data, _) = listener.accept().expect("data accept");
+    read_exact(&mut data, 37); // data-stream cookie
+    ctrl.write_all(&[1u8]).unwrap(); // TestStart
+    ctrl.write_all(&[2u8]).unwrap(); // TestRunning
+                                     // ~0.3 s of live traffic, then silence. The thread holds only a
+                                     // dup'd fd — its exit does NOT close the socket while `data` lives
+                                     // on below (the hold must be real).
+    let mut data_io = data.try_clone().expect("clone data");
+    let io = std::thread::spawn(move || {
+        let mut chunk = vec![0u8; 65536];
+        let t0 = Instant::now();
+        while t0.elapsed() < Duration::from_millis(300) {
+            if reverse {
+                if data_io.write_all(&chunk).is_err() {
+                    break;
+                }
+                std::thread::sleep(Duration::from_millis(5));
+            } else if data_io.read(&mut chunk).map(|n| n == 0).unwrap_or(true) {
+                break;
+            }
+        }
+    });
+    assert_eq!(read_exact(&mut ctrl, 1)[0], 4, "TestEnd");
+    ctrl.write_all(&[13u8]).unwrap(); // ExchangeResults
+    read_json_blob(&mut ctrl); // the client's results
+    write_json_blob(&mut ctrl, MOCK_RESULTS);
+    ctrl.write_all(&[14u8]).unwrap(); // DisplayResults
+    assert_eq!(read_exact(&mut ctrl, 1)[0], 16, "IperfDone");
+    io.join().expect("data io");
+    // THE HOLD: ctrl + data stay open well past the exit bound — the
+    // park pin must prove the park (the #352/#356-F7 dwell lesson).
+    std::thread::sleep(Duration::from_secs(25));
+    drop(ctrl);
+    drop(data);
+}
+
+/// #354: reverse — a receiver parked in `read().await` on a holding
+/// server. The bounded `run_client` wait IS the pin: a bare join is
+/// peer-bound (the 25 s hold), the abort exits on the client's clock.
 #[test]
 fn reverse_client_exits_bounded_while_server_holds() {
     let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind mock");
     let port = listener.local_addr().unwrap().port().to_string();
-
-    let _mock = std::thread::spawn(move || {
-        let (mut ctrl, _) = listener.accept().expect("ctrl accept");
-        read_exact(&mut ctrl, 37); // cookie
-        ctrl.write_all(&[9u8]).unwrap(); // ParamExchange
-        read_json_blob(&mut ctrl); // params (the client's -R lands here)
-        ctrl.write_all(&[10u8]).unwrap(); // CreateStreams
-        let (mut data, _) = listener.accept().expect("data accept");
-        read_exact(&mut data, 37); // data-stream cookie
-        ctrl.write_all(&[1u8]).unwrap(); // TestStart
-        ctrl.write_all(&[2u8]).unwrap(); // TestRunning
-                                         // Reverse: the mock is the sender until the client's TestEnd. The
-                                         // writer holds a dup'd fd — dropping it does NOT close the socket
-                                         // while `data` lives on below (the hold must be real).
-        let stop = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
-        let stop_w = stop.clone();
-        let mut data_w = data.try_clone().expect("clone data writer");
-        let writer = std::thread::spawn(move || {
-            let chunk = vec![0u8; 65536];
-            while !stop_w.load(std::sync::atomic::Ordering::Relaxed) {
-                if data_w.write_all(&chunk).is_err() {
-                    break;
-                }
-                std::thread::sleep(Duration::from_millis(5));
-            }
-        });
-        assert_eq!(read_exact(&mut ctrl, 1)[0], 4, "TestEnd");
-        stop.store(true, std::sync::atomic::Ordering::Relaxed);
-        writer.join().expect("writer");
-        ctrl.write_all(&[13u8]).unwrap(); // ExchangeResults
-        read_json_blob(&mut ctrl); // the client's results
-        write_json_blob(&mut ctrl, MOCK_RESULTS);
-        ctrl.write_all(&[14u8]).unwrap(); // DisplayResults
-        assert_eq!(read_exact(&mut ctrl, 1)[0], 16, "IperfDone");
-        // THE HOLD: ctrl + data stay open well past the exit bound — a
-        // park pin must prove the park (the #352/#356-F7 dwell lesson).
-        std::thread::sleep(Duration::from_secs(25));
-        drop(ctrl);
-        drop(data);
-    });
-
+    let _mock = std::thread::spawn(move || holding_mock_round(listener, true));
     let client = common::run_client(
         &["-c", "127.0.0.1", "-p", &port, "-R", "-t", "1"],
         Duration::from_secs(8),
         "reverse client vs holding server",
+    );
+    assert_eq!(client.status.code(), Some(0), "{}", client.stderr);
+    assert!(
+        client.stdout.contains("iperf Done."),
+        "the round completed clean before the bounded exit: {}",
+        client.stdout
+    );
+}
+
+/// #354 (r1 F4): forward — a sender parked in `write().await` on a peer
+/// that stopped reading is the same class; the abort unparks it too.
+#[test]
+fn forward_client_exits_bounded_while_server_stops_reading() {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind mock");
+    let port = listener.local_addr().unwrap().port().to_string();
+    let _mock = std::thread::spawn(move || holding_mock_round(listener, false));
+    let client = common::run_client(
+        &["-c", "127.0.0.1", "-p", &port, "-t", "1"],
+        Duration::from_secs(8),
+        "forward client vs deaf server",
     );
     assert_eq!(client.status.code(), Some(0), "{}", client.stderr);
     assert!(

--- a/riperf3-cli/tests/wire_shape.rs
+++ b/riperf3-cli/tests/wire_shape.rs
@@ -3799,3 +3799,73 @@ fn exchange_phase_err_still_tears_down_streams() {
     }
     panic!("the send-Err class never surfaced in 10 RST races; saw: {seen:#?}");
 }
+
+// ---------------------------------------------------------------------------
+// #354: the clean-path join must not be peer-bound — GT's client cancels
+// its stream threads before joining (iperf_client_api.c:817-841), so it
+// exits on its own clock against a server that HOLDS its sockets after
+// the round. A bare join parks reverse receivers in read() (`done` cannot
+// wake a parked read) until the peer lets go.
+// ---------------------------------------------------------------------------
+
+/// #354: reverse client vs a socket-holding server — the mock speaks the
+/// full protocol through reading IperfDone, then HOLDS ctrl + data open.
+/// The bounded `run_client` wait IS the pin: a bare join is peer-bound
+/// (~25 s here); the abort-before-join exits on the client's own clock.
+#[test]
+fn reverse_client_exits_bounded_while_server_holds() {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind mock");
+    let port = listener.local_addr().unwrap().port().to_string();
+
+    let _mock = std::thread::spawn(move || {
+        let (mut ctrl, _) = listener.accept().expect("ctrl accept");
+        read_exact(&mut ctrl, 37); // cookie
+        ctrl.write_all(&[9u8]).unwrap(); // ParamExchange
+        read_json_blob(&mut ctrl); // params (the client's -R lands here)
+        ctrl.write_all(&[10u8]).unwrap(); // CreateStreams
+        let (mut data, _) = listener.accept().expect("data accept");
+        read_exact(&mut data, 37); // data-stream cookie
+        ctrl.write_all(&[1u8]).unwrap(); // TestStart
+        ctrl.write_all(&[2u8]).unwrap(); // TestRunning
+                                         // Reverse: the mock is the sender until the client's TestEnd. The
+                                         // writer holds a dup'd fd — dropping it does NOT close the socket
+                                         // while `data` lives on below (the hold must be real).
+        let stop = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let stop_w = stop.clone();
+        let mut data_w = data.try_clone().expect("clone data writer");
+        let writer = std::thread::spawn(move || {
+            let chunk = vec![0u8; 65536];
+            while !stop_w.load(std::sync::atomic::Ordering::Relaxed) {
+                if data_w.write_all(&chunk).is_err() {
+                    break;
+                }
+                std::thread::sleep(Duration::from_millis(5));
+            }
+        });
+        assert_eq!(read_exact(&mut ctrl, 1)[0], 4, "TestEnd");
+        stop.store(true, std::sync::atomic::Ordering::Relaxed);
+        writer.join().expect("writer");
+        ctrl.write_all(&[13u8]).unwrap(); // ExchangeResults
+        read_json_blob(&mut ctrl); // the client's results
+        write_json_blob(&mut ctrl, MOCK_RESULTS);
+        ctrl.write_all(&[14u8]).unwrap(); // DisplayResults
+        assert_eq!(read_exact(&mut ctrl, 1)[0], 16, "IperfDone");
+        // THE HOLD: ctrl + data stay open well past the exit bound — a
+        // park pin must prove the park (the #352/#356-F7 dwell lesson).
+        std::thread::sleep(Duration::from_secs(25));
+        drop(ctrl);
+        drop(data);
+    });
+
+    let client = common::run_client(
+        &["-c", "127.0.0.1", "-p", &port, "-R", "-t", "1"],
+        Duration::from_secs(8),
+        "reverse client vs holding server",
+    );
+    assert_eq!(client.status.code(), Some(0), "{}", client.stderr);
+    assert!(
+        client.stdout.contains("iperf Done."),
+        "the round completed clean before the bounded exit: {}",
+        client.stdout
+    );
+}

--- a/riperf3-cli/tests/wire_shape.rs
+++ b/riperf3-cli/tests/wire_shape.rs
@@ -3808,66 +3808,83 @@ fn exchange_phase_err_still_tears_down_streams() {
 // ---------------------------------------------------------------------------
 
 /// #354 mock: full protocol, but the data phase goes SILENT/deaf after
-/// ~0.3 s — BEFORE the client's `done` lands — so the stream task
-/// genuinely PARKS: reverse = the writer stops writing (a receiver parked
-/// in `read().await`); forward = the drain stops reading (a sender parked
+/// ~0.3 s — BEFORE the client's `done` lands — so the stream tasks
+/// genuinely PARK: reverse = the writers stop writing (receivers parked
+/// in `read().await`); forward = the drains stop reading (senders parked
 /// in `write().await` on full buffers). Then it reads IperfDone(16) and
 /// HOLDS every socket for 25 s. The silence timing is load-bearing (r1
 /// F1): a writer that runs to TestEnd hands the receiver to the #23
 /// 10 s drain cap instead, and the pin's red couples to that unrelated
-/// constant rather than to the park.
-fn holding_mock_round(listener: std::net::TcpListener, reverse: bool) {
+/// constant rather than to the park. `parallel` accepts that many data
+/// connections — the reverse pin drives -P 2 so a PARTIAL teardown
+/// (abort stream 0 only) still reds (r2 F1); the peer blob keeps its
+/// one row (the client merges what the peer sent; the pin's asserts
+/// don't read rows).
+fn holding_mock_round(listener: std::net::TcpListener, reverse: bool, parallel: usize) {
     let (mut ctrl, _) = listener.accept().expect("ctrl accept");
     read_exact(&mut ctrl, 37); // cookie
     ctrl.write_all(&[9u8]).unwrap(); // ParamExchange
     read_json_blob(&mut ctrl); // params
     ctrl.write_all(&[10u8]).unwrap(); // CreateStreams
-    let (mut data, _) = listener.accept().expect("data accept");
-    read_exact(&mut data, 37); // data-stream cookie
+    let mut datas = Vec::new();
+    for _ in 0..parallel {
+        let (mut data, _) = listener.accept().expect("data accept");
+        read_exact(&mut data, 37); // data-stream cookie
+        datas.push(data);
+    }
     ctrl.write_all(&[1u8]).unwrap(); // TestStart
     ctrl.write_all(&[2u8]).unwrap(); // TestRunning
-                                     // ~0.3 s of live traffic, then silence. The thread holds only a
-                                     // dup'd fd — its exit does NOT close the socket while `data` lives
-                                     // on below (the hold must be real).
-    let mut data_io = data.try_clone().expect("clone data");
-    let io = std::thread::spawn(move || {
-        let mut chunk = vec![0u8; 65536];
-        let t0 = Instant::now();
-        while t0.elapsed() < Duration::from_millis(300) {
-            if reverse {
-                if data_io.write_all(&chunk).is_err() {
-                    break;
+                                     // ~0.3 s of live traffic per stream, then silence. Each thread holds
+                                     // only a dup'd fd — its exit does NOT close the socket while `datas`
+                                     // lives on below (the hold must be real).
+    let ios: Vec<_> = datas
+        .iter()
+        .map(|d| {
+            let mut data_io = d.try_clone().expect("clone data");
+            std::thread::spawn(move || {
+                let mut chunk = vec![0u8; 65536];
+                let t0 = Instant::now();
+                while t0.elapsed() < Duration::from_millis(300) {
+                    if reverse {
+                        if data_io.write_all(&chunk).is_err() {
+                            break;
+                        }
+                        std::thread::sleep(Duration::from_millis(5));
+                    } else if data_io.read(&mut chunk).map(|n| n == 0).unwrap_or(true) {
+                        break;
+                    }
                 }
-                std::thread::sleep(Duration::from_millis(5));
-            } else if data_io.read(&mut chunk).map(|n| n == 0).unwrap_or(true) {
-                break;
-            }
-        }
-    });
+            })
+        })
+        .collect();
     assert_eq!(read_exact(&mut ctrl, 1)[0], 4, "TestEnd");
     ctrl.write_all(&[13u8]).unwrap(); // ExchangeResults
     read_json_blob(&mut ctrl); // the client's results
     write_json_blob(&mut ctrl, MOCK_RESULTS);
     ctrl.write_all(&[14u8]).unwrap(); // DisplayResults
     assert_eq!(read_exact(&mut ctrl, 1)[0], 16, "IperfDone");
-    io.join().expect("data io");
-    // THE HOLD: ctrl + data stay open well past the exit bound — the
-    // park pin must prove the park (the #352/#356-F7 dwell lesson).
+    for io in ios {
+        io.join().expect("data io");
+    }
+    // THE HOLD: ctrl + every data socket stay open well past the exit
+    // bound — the park pin must prove the park (the #352/#356-F7 dwell
+    // lesson).
     std::thread::sleep(Duration::from_secs(25));
     drop(ctrl);
-    drop(data);
+    drop(datas);
 }
 
-/// #354: reverse — a receiver parked in `read().await` on a holding
+/// #354: reverse -P2 — receivers parked in `read().await` on a holding
 /// server. The bounded `run_client` wait IS the pin: a bare join is
 /// peer-bound (the 25 s hold), the abort exits on the client's clock.
+/// -P 2 so a partial teardown (stream 0 only) also reds (r2 F1).
 #[test]
 fn reverse_client_exits_bounded_while_server_holds() {
     let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind mock");
     let port = listener.local_addr().unwrap().port().to_string();
-    let _mock = std::thread::spawn(move || holding_mock_round(listener, true));
+    let _mock = std::thread::spawn(move || holding_mock_round(listener, true, 2));
     let client = common::run_client(
-        &["-c", "127.0.0.1", "-p", &port, "-R", "-t", "1"],
+        &["-c", "127.0.0.1", "-p", &port, "-R", "-P", "2", "-t", "1"],
         Duration::from_secs(8),
         "reverse client vs holding server",
     );
@@ -3885,7 +3902,7 @@ fn reverse_client_exits_bounded_while_server_holds() {
 fn forward_client_exits_bounded_while_server_stops_reading() {
     let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind mock");
     let port = listener.local_addr().unwrap().port().to_string();
-    let _mock = std::thread::spawn(move || holding_mock_round(listener, false));
+    let _mock = std::thread::spawn(move || holding_mock_round(listener, false, 1));
     let client = common::run_client(
         &["-c", "127.0.0.1", "-p", &port, "-t", "1"],
         Duration::from_secs(8),

--- a/riperf3/src/client.rs
+++ b/riperf3/src/client.rs
@@ -485,6 +485,17 @@ impl Client {
         // ---- Clean up ----
         ctx.done.store(true, Ordering::Relaxed);
         tokio::time::sleep(Duration::from_millis(100)).await;
+        // #354: abort before join, like the #352 server gate — GT's client
+        // cancels its stream threads before joining
+        // (iperf_client_api.c:817-841). A receiver parked in read() on a
+        // socket-holding server cannot see `done`, so a bare join is
+        // peer-bound. Counts are frozen: senders stopped at the data-phase
+        // end and the final report was captured at DisplayResults. UDP
+        // receivers are spawn_blocking (abort is a no-op there) and exit
+        // via `done` + their 500 ms read-timeout poll.
+        for s in &ctx.streams {
+            s.task.abort();
+        }
         for s in ctx.streams {
             let _ = s.task.await;
         }

--- a/riperf3/src/client.rs
+++ b/riperf3/src/client.rs
@@ -493,6 +493,12 @@ impl Client {
         // end and the final report was captured at DisplayResults. UDP
         // receivers are spawn_blocking (abort is a no-op there) and exit
         // via `done` + their 500 ms read-timeout poll.
+        // RESIDUAL (the #352 join-site sibling record): GT closes its data
+        // sockets at DISPLAY_RESULTS, BEFORE sending IPERF_DONE, and
+        // sync-closes ctrl with a bounded drain-to-EOF
+        // (iperf_client_api.c:562-566, net.c:877-886); riperf3's data FINs
+        // land ~100 ms later, at this abort, and ctrl closes abruptly —
+        // observable only by a peer that holds the round open.
         for s in &ctx.streams {
             s.task.abort();
         }


### PR DESCRIPTION
Closes #354.

## The defect

`Client::run`'s clean-path cleanup joined bare — `done.store(true)` + 100 ms grace + `let _ = s.task.await` with no abort. `done` cannot wake a stream task parked in a socket wait, so against a peer that goes quiet mid-window and then HOLDS its sockets after the round, the client's exit was **peer-bound** (r1's live A/B on the stripped fix: 12 s hold → 13.2 s exit, tracking the hold). GT's client exits on its own clock: it cancels its stream threads before joining (iperf_client_api.c:817-841).

## The fix

The #352 server-gate shape, mirrored: unconditionally `abort()` every stream task right before the join. Safety is the same order-of-phases argument:

- Senders stopped at the **data-phase** end (`done` + 100 ms teardown grace at the #159 site) — long before this join; counters are settled. (r1 mutation (c) — abort hoisted above the cleanup-site done/sleep — stays green across the CLI suite: nothing reads a counter after this site.)
- The final report was captured at DisplayResults and the results exchange is complete — the teardown can't touch any figure.
- UDP receivers are `spawn_blocking` (abort is a no-op there) and exit via `done` + their 500 ms read-timeout poll — r1 live-verified 0.595 s exits with the abort stripped, so the abort is not load-bearing for UDP, matching the #352 rationale.
- No client-side demux exists (#80's demux is server-only).

r1's live mode matrix on the head (exit measured after the mock read IperfDone): -R P1 0.170 s, -R -P4 0.283 s, --bidir 0.239 s, fwd -P2 0.299 s, UDP -R 0.552 s, parked-sender fwd 0.261 s — every cell own-clock; GT itself takes 10.1 s on the same holding mock (its bounded sync-close, see the residual below).

## The pins (reworked after r1 F1)

r1 proved the first-draft pin never parked the receiver: its mock wrote until TestEnd, so every `read` completed and the receiver landed in the **#23 `RECEIVER_DRAIN_TIMEOUT` (10 s)** — the red was `10 s > 8 s bound`, coupled to an unrelated constant (abort-stripped + bound raised to 14 s → that pin PASSED at 11.07 s). The reworked mock goes **silent/deaf at 0.3 s — before `done` lands** — so the stream task genuinely parks:

- `reverse_client_exits_bounded_while_server_holds` — receiver parked in `read().await`.
- `forward_client_exits_bounded_while_server_stops_reading` (r1 F4, the #352-r2-F2 analog) — sender parked in `write().await` on full buffers.

Both: full protocol through reading IperfDone(16), then a 25 s hold; the bounded `run_client` (8 s) is the assert, plus exit 0 + clean `iperf Done.`.

- **Red** (abort stripped from the committed tree, anchor-uniqueness-verified): both pins 8.01 s timeouts.
- **Hold-coupling discriminator** (the r1 F1 concern, re-proven on the rework): mutant vs a 12 s-hold mock exits at **13.203 s** (tracks the hold — the park, not the 10 s drain cap); restored head exits **1.305 s** on the same mock.
- **Green** on the fix; stability 5/5 free + 6/6 `taskset -c 0,1 --test-threads 2`. Cross-platform (no libc/SO_LINGER — plain socket hold), runs ungated on all native legs.
- r1 mutation (b) — join stripped, abort kept — is mutation-invisible (the #370 M3 precedent: defensive symmetry; the join is the only wait for UDP `spawn_blocking` runners, and a discriminating pin would need thread-liveness observation, flake-prone). Accepted, recorded here.

## Scope decisions + records from the r1 round

- **GT's 10 s data-read bound is NOT taken here.** The abort-at-join gives a tighter own-clock exit for this class; mid-test the client's duration timer bounds the run. The remaining unbounded client waits are the **ctrl reads** (wedged exchange → parks forever where GT self-bounds at 10 s) — now properly recorded as **#374** (r1 F2 caught that the prior "#330 residual" attribution was unbacked: #330 never carried it).
- **#375 filed** (r1 F3): abnormal-path early returns still drop JoinHandles — the client sibling of #372, same RAII prescription; coordinate with #293's arm rework.
- **Join-site residual comment added** (r1 F5): GT FINs its data sockets at DISPLAY_RESULTS before IPERF_DONE and sync-closes ctrl bounded; riperf3's FINs land ~100 ms later at the abort, ctrl closes abruptly — holding-peer-visible only.
- r1 F6 (the cleanup-site `done.store` + 100 ms is redundant — the data-phase end already did both): pre-existing, noted, untouched (100 ms of exit latency, not correctness).

## Gate

- fmt / clippy `-D warnings` / workspace suite: clean, **846 passed, 0 failed** (845 + the forward pin).
- Red/green/mutation as above; CI green on the r1 head, re-running on this one.
