### PR TITLE
fix: the server -J start block emits the bufsize trio at GT's positions 4-6 (#355)

### DIFF
--- a/riperf3/src/json_report.rs
+++ b/riperf3/src/json_report.rs
@@ -447,6 +447,23 @@ impl Serialize for Start {
         m.serialize_entry("connected", &self.connected)?;
         m.serialize_entry("version", &self.version)?;
         m.serialize_entry("system_info", &self.system_info)?;
+        // #355: the SERVER inserts the bufsize trio at listen time
+        // (iperf_tcp.c:373-377) — positions 4-6, BEFORE timestamp; the
+        // client takes them at TestStart, after fq_rate (both live-probed
+        // 3.21). Same #261 stage gate either way; byte order is the only
+        // role difference.
+        let server_role = self.accepted_connection.is_some();
+        if server_role && self.stage == StartStage::Started {
+            if let Some(v) = &self.sock_bufsize {
+                m.serialize_entry("sock_bufsize", v)?;
+            }
+            if let Some(v) = &self.sndbuf_actual {
+                m.serialize_entry("sndbuf_actual", v)?;
+            }
+            if let Some(v) = &self.rcvbuf_actual {
+                m.serialize_entry("rcvbuf_actual", v)?;
+            }
+        }
         if self.stage != StartStage::Connecting {
             // GT stage 1 — stamped at on_connect (end of PARAM_EXCHANGE).
             m.serialize_entry("timestamp", &self.timestamp)?;
@@ -468,14 +485,18 @@ impl Serialize for Start {
         }
         if self.stage == StartStage::Started {
             // GT stage 2 — the #261 late fields, stamped at TestStart.
-            if let Some(v) = &self.sock_bufsize {
-                m.serialize_entry("sock_bufsize", v)?;
-            }
-            if let Some(v) = &self.sndbuf_actual {
-                m.serialize_entry("sndbuf_actual", v)?;
-            }
-            if let Some(v) = &self.rcvbuf_actual {
-                m.serialize_entry("rcvbuf_actual", v)?;
+            // The bufsize trio already went out at positions 4-6 on the
+            // server role (#355).
+            if !server_role {
+                if let Some(v) = &self.sock_bufsize {
+                    m.serialize_entry("sock_bufsize", v)?;
+                }
+                if let Some(v) = &self.sndbuf_actual {
+                    m.serialize_entry("sndbuf_actual", v)?;
+                }
+                if let Some(v) = &self.rcvbuf_actual {
+                    m.serialize_entry("rcvbuf_actual", v)?;
+                }
             }
             if let Some(v) = &self.test_start {
                 m.serialize_entry("test_start", v)?;
@@ -3796,6 +3817,72 @@ mod tests {
                 "receiver_tcp_congestion"
             ],
             "end key order drifted from the frozen 0.8.0 wire shape: {raw}"
+        );
+    }
+
+    /// #355: the SERVER role's start keys are GT's server insertion order —
+    /// the bufsize trio lands at listen time (iperf_tcp.c:373-377), at
+    /// positions 4-6, BEFORE timestamp; the client takes them at TestStart,
+    /// after fq_rate (both live-probed 3.21, byte order only — the value
+    /// set is identical). Parsed-Value asserts are order-blind; read the
+    /// raw string.
+    #[test]
+    fn server_role_start_key_order_is_gt_server_order() {
+        let mut input = base_input();
+        input.is_server = true;
+        input.connecting_host = String::new();
+        input.connecting_port = 0;
+        input.accepted_host = "127.0.0.1".into();
+        input.accepted_port = 5201;
+        input.streams = vec![tcp_stream(1, true, 10, 10)];
+        let raw = serde_json::to_string(&input.build()).unwrap();
+
+        let keys = |obj: &str| -> Vec<String> {
+            let from = raw.find(&format!("\"{obj}\":")).unwrap() + obj.len() + 3;
+            let bytes = raw.as_bytes();
+            let mut depth = 0i32;
+            let mut i = from;
+            let mut out = Vec::new();
+            while i < bytes.len() {
+                match bytes[i] {
+                    b'{' | b'[' => depth += 1,
+                    b'}' | b']' => {
+                        depth -= 1;
+                        if depth == 0 {
+                            break;
+                        }
+                    }
+                    b'"' => {
+                        let close = raw[i + 1..].find('"').unwrap() + i + 1;
+                        if depth == 1 && bytes.get(close + 1) == Some(&b':') {
+                            out.push(raw[i + 1..close].to_string());
+                        }
+                        i = close;
+                    }
+                    _ => {}
+                }
+                i += 1;
+            }
+            out
+        };
+        assert_eq!(
+            keys("start"),
+            [
+                "connected",
+                "version",
+                "system_info",
+                "sock_bufsize",
+                "sndbuf_actual",
+                "rcvbuf_actual",
+                "timestamp",
+                "accepted_connection",
+                "cookie",
+                "tcp_mss_default",
+                "target_bitrate",
+                "fq_rate",
+                "test_start"
+            ],
+            "server start key order drifted from GT's server order (#355): {raw}"
         );
     }
 

--- a/riperf3/src/json_report.rs
+++ b/riperf3/src/json_report.rs
@@ -221,7 +221,7 @@ pub(crate) struct SetupPhaseDoc {
 /// 0 (the server never reads the ctrl MSS, the #50 convention),
 /// target_bitrate, fq_rate — over `intervals:[]`, a bare `end:{}`, and the
 /// error key. KEY ORDER is GT's SERVER insertion order: the bufsize trio
-/// lands at listen time (iperf_tcp.c:373-377), BEFORE timestamp — the
+/// lands at listen time (iperf_tcp.c:372-375), BEFORE timestamp — the
 /// shared Start serializer's client-derived order is #355.
 pub(crate) fn setup_error_document(d: &SetupPhaseDoc, error: &str) -> String {
     setup_phase_document(d, &BareEnd {}, Some(error))
@@ -408,6 +408,11 @@ pub(crate) enum StartStage {
 pub struct Start {
     /// #281: the GT staging point this document was built at.
     pub(crate) stage: StartStage,
+    /// #355: the early bufsize trio is a TCP-SERVER artifact — only GT's
+    /// TCP listener inserts it at listen time (iperf_tcp.c:372-375);
+    /// UDP's trio lands at CREATE_STREAMS (iperf_udp_buffercheck,
+    /// iperf_udp.c:440-452, after on_connect), i.e. the late/client slot.
+    pub(crate) tcp: bool,
     pub connected: Vec<Connection>,
     pub version: String,
     pub system_info: String,
@@ -447,13 +452,14 @@ impl Serialize for Start {
         m.serialize_entry("connected", &self.connected)?;
         m.serialize_entry("version", &self.version)?;
         m.serialize_entry("system_info", &self.system_info)?;
-        // #355: the SERVER inserts the bufsize trio at listen time
-        // (iperf_tcp.c:373-377) — positions 4-6, BEFORE timestamp; the
-        // client takes them at TestStart, after fq_rate (both live-probed
-        // 3.21). Same #261 stage gate either way; byte order is the only
-        // role difference.
-        let server_role = self.accepted_connection.is_some();
-        if server_role && self.stage == StartStage::Started {
+        // #355: the TCP SERVER inserts the bufsize trio at listen time
+        // (iperf_tcp.c:372-375) — positions 4-6, BEFORE timestamp; the
+        // client takes them at TestStart, after fq_rate, and the UDP
+        // server does too (its trio lands at CREATE_STREAMS, not listen —
+        // r1 F1; all cells live-probed 3.21). Same #261 stage gate every
+        // way; byte order is the only difference.
+        let early_trio = self.tcp && self.accepted_connection.is_some();
+        if early_trio && self.stage == StartStage::Started {
             if let Some(v) = &self.sock_bufsize {
                 m.serialize_entry("sock_bufsize", v)?;
             }
@@ -486,8 +492,8 @@ impl Serialize for Start {
         if self.stage == StartStage::Started {
             // GT stage 2 — the #261 late fields, stamped at TestStart.
             // The bufsize trio already went out at positions 4-6 on the
-            // server role (#355).
-            if !server_role {
+            // TCP server role (#355).
+            if !early_trio {
                 if let Some(v) = &self.sock_bufsize {
                     m.serialize_entry("sock_bufsize", v)?;
                 }
@@ -1655,6 +1661,7 @@ impl ReportInput {
         Report {
             start: Start {
                 stage: self.start_stage,
+                tcp: !is_udp,
                 connected,
                 version: self.version.clone(),
                 system_info: self.system_info.clone(),
@@ -3743,6 +3750,39 @@ mod tests {
         }
     }
 
+    /// Top-level keys of the serialized sub-object `obj`, in on-wire order:
+    /// a quoted token is a KEY iff it sits at depth 1 and the next non-quote
+    /// char is ':'. String VALUES are skipped by the lookahead. (No escapes
+    /// occur in these fixture keys/values.)
+    fn raw_keys(raw: &str, obj: &str) -> Vec<String> {
+        let from = raw.find(&format!("\"{obj}\":")).unwrap() + obj.len() + 3;
+        let bytes = raw.as_bytes();
+        let mut depth = 0i32;
+        let mut i = from;
+        let mut out = Vec::new();
+        while i < bytes.len() {
+            match bytes[i] {
+                b'{' | b'[' => depth += 1,
+                b'}' | b']' => {
+                    depth -= 1;
+                    if depth == 0 {
+                        break;
+                    }
+                }
+                b'"' => {
+                    let close = raw[i + 1..].find('"').unwrap() + i + 1;
+                    if depth == 1 && bytes.get(close + 1) == Some(&b':') {
+                        out.push(raw[i + 1..close].to_string());
+                    }
+                    i = close;
+                }
+                _ => {}
+            }
+            i += 1;
+        }
+        out
+    }
+
     /// #281 r1 F2: the hand-written Start/End serializers own the key ORDER
     /// the derive used to guarantee — pin the raw on-wire sequences (the
     /// Interval struct has the same style of pin). Parsed-Value asserts can't
@@ -3753,38 +3793,7 @@ mod tests {
         input.streams = vec![tcp_stream(1, true, 10, 10)];
         let raw = serde_json::to_string(&input.build()).unwrap();
 
-        let keys = |obj: &str| -> Vec<String> {
-            // Top-level keys of the serialized sub-object `obj`, in on-wire
-            // order: a quoted token is a KEY iff it sits at depth 1 and the
-            // next non-quote char is ':'. String VALUES are skipped by the
-            // lookahead. (No escapes occur in these fixture keys/values.)
-            let from = raw.find(&format!("\"{obj}\":")).unwrap() + obj.len() + 3;
-            let bytes = raw.as_bytes();
-            let mut depth = 0i32;
-            let mut i = from;
-            let mut out = Vec::new();
-            while i < bytes.len() {
-                match bytes[i] {
-                    b'{' | b'[' => depth += 1,
-                    b'}' | b']' => {
-                        depth -= 1;
-                        if depth == 0 {
-                            break;
-                        }
-                    }
-                    b'"' => {
-                        let close = raw[i + 1..].find('"').unwrap() + i + 1;
-                        if depth == 1 && bytes.get(close + 1) == Some(&b':') {
-                            out.push(raw[i + 1..close].to_string());
-                        }
-                        i = close;
-                    }
-                    _ => {}
-                }
-                i += 1;
-            }
-            out
-        };
+        let keys = |obj: &str| raw_keys(&raw, obj);
         let start_keys = keys("start");
         assert_eq!(
             start_keys,
@@ -3821,7 +3830,7 @@ mod tests {
     }
 
     /// #355: the SERVER role's start keys are GT's server insertion order —
-    /// the bufsize trio lands at listen time (iperf_tcp.c:373-377), at
+    /// the bufsize trio lands at listen time (iperf_tcp.c:372-375), at
     /// positions 4-6, BEFORE timestamp; the client takes them at TestStart,
     /// after fq_rate (both live-probed 3.21, byte order only — the value
     /// set is identical). Parsed-Value asserts are order-blind; read the
@@ -3837,34 +3846,7 @@ mod tests {
         input.streams = vec![tcp_stream(1, true, 10, 10)];
         let raw = serde_json::to_string(&input.build()).unwrap();
 
-        let keys = |obj: &str| -> Vec<String> {
-            let from = raw.find(&format!("\"{obj}\":")).unwrap() + obj.len() + 3;
-            let bytes = raw.as_bytes();
-            let mut depth = 0i32;
-            let mut i = from;
-            let mut out = Vec::new();
-            while i < bytes.len() {
-                match bytes[i] {
-                    b'{' | b'[' => depth += 1,
-                    b'}' | b']' => {
-                        depth -= 1;
-                        if depth == 0 {
-                            break;
-                        }
-                    }
-                    b'"' => {
-                        let close = raw[i + 1..].find('"').unwrap() + i + 1;
-                        if depth == 1 && bytes.get(close + 1) == Some(&b':') {
-                            out.push(raw[i + 1..close].to_string());
-                        }
-                        i = close;
-                    }
-                    _ => {}
-                }
-                i += 1;
-            }
-            out
-        };
+        let keys = |obj: &str| raw_keys(&raw, obj);
         assert_eq!(
             keys("start"),
             [
@@ -3886,9 +3868,48 @@ mod tests {
         );
     }
 
+    /// #355 r1 F1: GT's UDP server keeps the trio LATE — only the TCP
+    /// listener inserts it early (iperf_tcp.c:372-375); UDP's lands at
+    /// CREATE_STREAMS via iperf_udp_buffercheck (iperf_udp.c:440-452,
+    /// after on_connect), i.e. the client slot. A protocol-blind server
+    /// gate would regress this previously-GT-matching cell. (GT also
+    /// duplicates target_bitrate at position 4 on rate-set runs — the
+    /// recorded #377 divergence; riperf3 emits it once.)
+    #[test]
+    fn udp_server_role_start_key_order_keeps_the_late_trio() {
+        let mut input = base_input();
+        input.protocol = TransportProtocol::Udp;
+        input.is_server = true;
+        input.connecting_host = String::new();
+        input.connecting_port = 0;
+        input.accepted_host = "127.0.0.1".into();
+        input.accepted_port = 5201;
+        input.streams = vec![udp_stream(1, true, 131072 * 96, None, 0.001, 0, 96)];
+        let raw = serde_json::to_string(&input.build()).unwrap();
+        let keys = |obj: &str| raw_keys(&raw, obj);
+        assert_eq!(
+            keys("start"),
+            [
+                "connected",
+                "version",
+                "system_info",
+                "timestamp",
+                "accepted_connection",
+                "cookie",
+                "target_bitrate",
+                "fq_rate",
+                "sock_bufsize",
+                "sndbuf_actual",
+                "rcvbuf_actual",
+                "test_start"
+            ],
+            "UDP server start keys must keep GT's late trio (#355 r1 F1): {raw}"
+        );
+    }
+
     /// #356 r1 F8 (+#355): the setup-phase doc's start keys are GT's SERVER
     /// insertion order — the bufsize trio at listen time, BEFORE timestamp
-    /// (iperf_tcp.c:373-377), unlike the client-derived order the shared
+    /// (iperf_tcp.c:372-375), unlike the client-derived order the shared
     /// Start serializer pins above. Parsed-Value asserts are order-blind;
     /// read the raw string. The terminate variant's zeros end rides along.
     #[test]
@@ -3917,34 +3938,7 @@ mod tests {
             },
         );
 
-        let keys = |obj: &str| -> Vec<String> {
-            let from = raw.find(&format!("\"{obj}\":")).unwrap() + obj.len() + 3;
-            let bytes = raw.as_bytes();
-            let mut depth = 0i32;
-            let mut i = from;
-            let mut out = Vec::new();
-            while i < bytes.len() {
-                match bytes[i] {
-                    b'{' | b'[' => depth += 1,
-                    b'}' | b']' => {
-                        depth -= 1;
-                        if depth == 0 {
-                            break;
-                        }
-                    }
-                    b'"' => {
-                        let close = raw[i + 1..].find('"').unwrap() + i + 1;
-                        if depth == 1 && bytes.get(close + 1) == Some(&b':') {
-                            out.push(raw[i + 1..close].to_string());
-                        }
-                        i = close;
-                    }
-                    _ => {}
-                }
-                i += 1;
-            }
-            out
-        };
+        let keys = |obj: &str| raw_keys(&raw, obj);
         assert_eq!(
             keys("start"),
             [


### PR DESCRIPTION
Closes #355.

## The defect

GT's TCP server inserts the bufsize trio (`sock_bufsize`, `sndbuf_actual`, `rcvbuf_actual`) into `json_start` at listen time (iperf_tcp.c:372-375), so its SERVER-role `start` block carries them at positions 4-6, before `timestamp`. The client takes them at TestStart, after `fq_rate`. riperf3's shared Start serializer emitted the client-derived order on both roles. Byte-order divergence only (the #300 raw-key-order class) — the key/value SET is identical, so this is a JSON-semantic no-op.

Live-probed orders (3.21 loopback, raw depth-1 extraction):

- GT server: `connected, version, system_info, sock_bufsize, sndbuf_actual, rcvbuf_actual, timestamp, accepted_connection, cookie, tcp_mss_default, target_bitrate, fq_rate, test_start`
- GT client: `connected, version, system_info, timestamp, connecting_to, cookie, tcp_mss_default, target_bitrate, fq_rate, sock_bufsize, sndbuf_actual, rcvbuf_actual, test_start` — **already byte-identical to riperf3's client**, so the client is untouched.

## The fix

The hand-written Start serializer (the #281 stage-gated impl) now emits the trio right after `system_info` on the server role (`accepted_connection.is_some()`), under the same `stage == Started` gate (#261 semantics unchanged — the trio still never appears in pre-TestStart docs; the #338/#356 setup-phase docs have their own builder that already carried GT's server order and explicitly deferred this shared-serializer gap to #355). The late slot skips the trio on the server role only.

## Verification

- **Pin**: `server_role_start_key_order_is_gt_server_order` (raw-string key extractor, the #300/#281-r1-F2 precedent) — **red** on the shared order (trio after `fq_rate`), green on the fix. The pre-fix red is the mutation proof: the diff IS the reorder, so reverting it is exactly the proven-red state. The existing client-order pin (`manual_serializer_key_order_is_pinned`) passes untouched — the client wire shape is frozen.
- **Live loopback** post-fix: riperf3 server and client `start` key orders both byte-order-match GT 3.21 (extractor compare, both roles).
- **Gate**: fmt / clippy `-D warnings` clean; workspace **847 passed / 0 failed**. One unrelated flake in the first full run (`exchange_eof_prints_warning_line_and_summary_in_text`, mock UnexpectedEof under parallel suite load — the #349-F4 port-race/load family; 5/5 green isolated, full wire_shape binary green on rerun, untouched surface): disclosed, no change.

**Round 2 (commit 2, r1 F1):** the gate above is TCP-only — GT's UDP server keeps the trio in the late slot (iperf_udp_buffercheck at CREATE_STREAMS, iperf_udp.c:440-452); `Start` carries an explicit `tcp` field from the single build site. UDP-server pin red-first; #377/#378 filed for the pre-existing rate-set-dup and --get-server-output-embed divergences. Full round records in the PR comments. r2: APPROVE (24-cell live GT matrix, 4 mutations red, 848/848).
