### PR TITLE
fix: every post-setup exit runs the stream teardown, both roles (#372, #375)

### DIFF
--- a/riperf3-cli/tests/wire_shape.rs
+++ b/riperf3-cli/tests/wire_shape.rs
@@ -3915,3 +3915,154 @@ fn forward_client_exits_bounded_while_server_stops_reading() {
         client.stdout
     );
 }
+
+// ---------------------------------------------------------------------------
+// #372: a start_test / await_test_end Err must not skip the end-of-round
+// abort/join gate — the RUNNING-phase siblings of #353 (the same
+// detached-parked-task fd leak, one and two phases earlier). PERSISTENT
+// server on purpose: one-off process exit closes the sockets either way
+// (the #356 F7 vacuous-pin lesson).
+// ---------------------------------------------------------------------------
+
+/// Params for the #372 drives: parallel 2, so a PARTIAL teardown (abort
+/// stream 0 only) still reds (the #354 r2 F1 lesson).
+#[cfg(unix)]
+const MOCK_PARAMS_P2: &str = r#"{"tcp":true,"omit":0,"time":1,"num":0,"blockcount":0,"parallel":2,"len":131072,"pacing_timer":1000,"client_version":"riperf3 0.0.0"}"#;
+
+/// One #372 attempt. The mock completes setup — proven complete by
+/// TestStart(1) arriving on ctrl, so the RST below cannot land in a
+/// setup-phase arm (those run their own teardown and would false-green) —
+/// optionally rides TEST_RUNNING for ~0.3 s of traffic, then
+/// SO_LINGER(0)-RSTs the ctrl while HOLDING both data sockets. The RST
+/// surfaces as a send-Err inside start_test or a non-EOF recv Err inside
+/// await_test_end; both `?` past the gate on an unguarded build.
+/// Classification (the #370 r2 positive-classification lesson): a valid
+/// round printed an `error - ` line — the clean-EOF class (which runs the
+/// whole normal flow, gate included) prints its line WITHOUT the prefix,
+/// and a line-less round (the kill racing stderr) just retries. The
+/// exchange class ("unable to receive results") also runs the gate (#353)
+/// and is excluded. Returns (valid_class, data_reads, server_alive).
+#[cfg(unix)]
+fn drive_running_err_hold(
+    mid_running: bool,
+) -> (bool, Vec<Result<usize, std::io::ErrorKind>>, bool) {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind");
+    let port = listener.local_addr().unwrap().port();
+    drop(listener);
+    let ps = port.to_string();
+    let mut server = common::ChildGuard(
+        std::process::Command::new(env!("CARGO_BIN_EXE_riperf3"))
+            .args(["-s", "-p", &ps])
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .spawn()
+            .expect("spawn server"),
+    );
+    let _so = riperf3_test_support::drain_reader(server.0.stdout.take().unwrap());
+    let se = riperf3_test_support::drain_reader(server.0.stderr.take().unwrap());
+    std::thread::sleep(std::time::Duration::from_millis(400));
+
+    let mock = std::thread::spawn(move || {
+        use std::io::Read;
+        let cookie = [b'x'; 37];
+        let mut ctrl = std::net::TcpStream::connect(("127.0.0.1", port)).expect("ctrl");
+        ctrl.write_all(&cookie).unwrap();
+        assert_eq!(read_exact(&mut ctrl, 1)[0], 9);
+        write_json_blob(&mut ctrl, MOCK_PARAMS_P2);
+        assert_eq!(read_exact(&mut ctrl, 1)[0], 10);
+        let mut datas = Vec::new();
+        for _ in 0..2 {
+            let mut data = std::net::TcpStream::connect(("127.0.0.1", port)).expect("data");
+            data.write_all(&cookie).unwrap();
+            datas.push(data);
+        }
+        assert_eq!(read_exact(&mut ctrl, 1)[0], 1, "TestStart");
+        if mid_running {
+            assert_eq!(read_exact(&mut ctrl, 1)[0], 2, "TestRunning");
+            for data in &mut datas {
+                data.write_all(&[0u8; 65536]).unwrap();
+            }
+            // Let the receivers drain the burst and PARK in read().await —
+            // the hold below must hold parked tasks, not live ones.
+            std::thread::sleep(Duration::from_millis(300));
+        }
+        let linger = libc::linger {
+            l_onoff: 1,
+            l_linger: 0,
+        };
+        let rc = unsafe {
+            use std::os::fd::AsRawFd;
+            libc::setsockopt(
+                ctrl.as_raw_fd(),
+                libc::SOL_SOCKET,
+                libc::SO_LINGER,
+                std::ptr::from_ref(&linger).cast(),
+                std::mem::size_of::<libc::linger>() as libc::socklen_t,
+            )
+        };
+        assert_eq!(rc, 0, "SO_LINGER setsockopt failed");
+        drop(ctrl);
+        let mut reads = Vec::new();
+        for data in &mut datas {
+            data.set_read_timeout(Some(std::time::Duration::from_secs(4)))
+                .expect("set_read_timeout");
+            let mut buf = [0u8; 16];
+            reads.push(data.read(&mut buf).map_err(|e| e.kind()));
+        }
+        drop(datas);
+        reads
+    });
+
+    let reads = mock.join().expect("mock");
+    let alive = server.0.try_wait().expect("try_wait").is_none();
+    drop(server); // ChildGuard kills; the drained stderr classifies the round
+    let serr = se.join().expect("stderr");
+    let valid = serr.contains("error - ") && !serr.contains("unable to receive results");
+    (valid, reads, alive)
+}
+
+/// The shared #372 assert: on a valid ECONNRESET-class round, both held
+/// data sockets see a bounded close (EOF, or RST when the abort drops a
+/// receiver with bytes unread — the #370 r2 record) while the persistent
+/// server keeps serving. An unguarded build leaks the parked receivers,
+/// so the reads time out instead.
+#[cfg(unix)]
+fn running_phase_err_case(mid_running: bool) {
+    let mut seen = Vec::new();
+    for _ in 0..10 {
+        let (valid, reads, alive) = drive_running_err_hold(mid_running);
+        if valid {
+            for (i, r) in reads.iter().enumerate() {
+                assert!(
+                    matches!(r, Ok(0) | Err(std::io::ErrorKind::ConnectionReset)),
+                    "held data socket {i} sees a bounded close (the \
+                     running-phase Err ran the gate): {r:?}"
+                );
+            }
+            assert!(
+                alive,
+                "the persistent server kept serving after the failed round"
+            );
+            return;
+        }
+        seen.push(format!("off-class round: {reads:?}"));
+    }
+    panic!("no error-line round in 10 RST attempts; saw: {seen:#?}");
+}
+
+/// #372, window 1: the RST lands right after TestStart — the TestRunning
+/// send (start_test) or the first end-loop recv (await_test_end) errors.
+#[cfg(unix)]
+#[test]
+fn running_phase_err_at_test_start_still_tears_down_streams() {
+    running_phase_err_case(false);
+}
+
+/// #372, window 2: ~0.3 s of live TEST_RUNNING traffic first — the RST
+/// lands in await_test_end's non-EOF recv arm (ECONNRESET, not the mapped
+/// PeerDisconnected EOF class).
+#[cfg(unix)]
+#[test]
+fn running_phase_err_mid_running_still_tears_down_streams() {
+    running_phase_err_case(true);
+}

--- a/riperf3/src/client.rs
+++ b/riperf3/src/client.rs
@@ -386,7 +386,16 @@ impl Client {
         let _done_guard = stream::DoneOnDrop(ctx.done.clone());
 
         // ---- State machine: react to server-driven transitions ----
-        loop {
+        // #375: the whole dispatch loop runs inside this block so EVERY
+        // exit — the `?` propagations and the early returns alike — falls
+        // through to the ONE unconditional teardown below (the server's
+        // #372 shape; per-arm wrappers were whack-a-mole across the
+        // #331/#353/#354 family). `Ok(Some(report))` = an early-exit round
+        // that already rendered its output (the interrupt dumps); the
+        // clean IperfDone break is `Ok(None)`. A `return` inside the block
+        // exits the BLOCK, not run().
+        let outcome: Result<Option<crate::json_report::Report>> = async {
+            loop {
             // #231: iperf_catch_sigend is armed for the WHOLE run, so the
             // central state wait polls the interrupt watch like the
             // TEST_RUNNING selects — covering the setup phases AND the
@@ -412,7 +421,7 @@ impl Client {
                     Err(e) => return Err(e),
                 },
                 msg = wait_interrupt(ctx.interrupt.as_mut()) => {
-                    return Ok(self.on_interrupted_wait(&mut ctx, &msg).await);
+                    return Ok(Some(self.on_interrupted_wait(&mut ctx, &msg).await));
                 }
             };
 
@@ -436,7 +445,7 @@ impl Client {
 
                 TestState::ExchangeResults => match self.on_exchange_results(&mut ctx).await? {
                     // #268: a signal landed inside the bulk results read.
-                    Some(report) => return Ok(report),
+                    Some(report) => return Ok(Some(report)),
                     None => StepFlow::Continue,
                 },
 
@@ -474,36 +483,54 @@ impl Client {
             match flow {
                 StepFlow::Continue => {}
                 StepFlow::Break => break,
-                StepFlow::Return(report) => return Ok(*report),
+                StepFlow::Return(report) => return Ok(Some(*report)),
             }
             // #145: AUDITABILITY ONLY — advance the table cursor to the state
             // just handled, before the next recv. Reached only by the arms that
             // fall through (the break/return arms end the run anyway).
             ctx.prev_state = state;
         }
+        Ok(None)
+        }
+        .await;
 
-        // ---- Clean up ----
-        ctx.done.store(true, Ordering::Relaxed);
-        tokio::time::sleep(Duration::from_millis(100)).await;
+        // ---- Unconditional stream teardown (#354/#375) ----
+        // Every exit reaps the spawned stream tasks: a detached task parked
+        // in read()/write().await against a holding peer survives `done`
+        // (the flag cannot wake a parked await) and leaks with its fd into
+        // a library consumer's runtime — a CLI process exit masked the
+        // class. GT joins its stream threads on the error exits too
+        // (iperf_client_api.c's cleanup paths run iperf_client_end).
         // #354: abort before join, like the #352 server gate — GT's client
         // cancels its stream threads before joining
-        // (iperf_client_api.c:817-841). A receiver parked in read() on a
-        // socket-holding server cannot see `done`, so a bare join is
-        // peer-bound. Counts are frozen: senders stopped at the data-phase
-        // end and the final report was captured at DisplayResults. UDP
-        // receivers are spawn_blocking (abort is a no-op there) and exit
-        // via `done` + their 500 ms read-timeout poll.
+        // (iperf_client_api.c:817-841). Counts are frozen: senders stopped
+        // at the data-phase end and the final report was captured at
+        // DisplayResults. UDP receivers are spawn_blocking (abort is a
+        // no-op there) and exit via `done` + their 500 ms read-timeout
+        // poll. The 100 ms catch-up grace is skipped when no streams were
+        // ever spawned (the pre-CreateStreams error paths have nothing to
+        // let land).
         // RESIDUAL (the #352 join-site sibling record): GT closes its data
         // sockets at DISPLAY_RESULTS, BEFORE sending IPERF_DONE, and
         // sync-closes ctrl with a bounded drain-to-EOF
         // (iperf_client_api.c:562-566, net.c:877-886); riperf3's data FINs
         // land ~100 ms later, at this abort, and ctrl closes abruptly —
         // observable only by a peer that holds the round open.
+        ctx.done.store(true, Ordering::Relaxed);
+        if !ctx.streams.is_empty() {
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
         for s in &ctx.streams {
             s.task.abort();
         }
-        for s in ctx.streams {
+        for s in ctx.streams.drain(..) {
             let _ = s.task.await;
+        }
+
+        // The early-exit rounds (the interrupt dumps, #210/#268) already
+        // rendered their output — only the teardown above was owed.
+        if let Some(report) = outcome? {
+            return Ok(report);
         }
 
         // #222: every clean text-mode client run closes with a blank line +

--- a/riperf3/src/client.rs
+++ b/riperf3/src/client.rs
@@ -396,101 +396,101 @@ impl Client {
         // exits the BLOCK, not run().
         let outcome: Result<Option<crate::json_report::Report>> = async {
             loop {
-            // #231: iperf_catch_sigend is armed for the WHOLE run, so the
-            // central state wait polls the interrupt watch like the
-            // TEST_RUNNING selects — covering the setup phases AND the
-            // post-test ExchangeResults/DisplayResults waits, which
-            // previously ignored a signal until the control read returned
-            // (against a wedged server: forever, with only the CLI's #211
-            // second-signal hard exit as the way out). iperf_got_sigend's
-            // client arm has NO phase gate: it dumps the accumulated stats
-            // from any phase (empty rows pre-data), tells the peer via
-            // CLIENT_TERMINATE, and exits signal-normal — the same shape as
-            // the run_test arm. recv_state is a single 1-byte read, so the
-            // select is cancel-safe.
-            let state = tokio::select! {
-                s = protocol::recv_state(&mut ctx.ctrl) => match s {
-                    Ok(state) => state,
-                    // #267: a CLEAN close (EOF) is GT's IECTRLCLOSE — dump
-                    // the populated doc. Io-class failures (e.g. a pre-data
-                    // RST, the #195 retry surface) keep their own classes
-                    // and propagate bare, as before.
-                    Err(e @ (RiperfError::PeerDisconnected | RiperfError::ControlSocketClosed)) => {
-                        return Err(self.on_ctrl_lost(&ctx, e))
+                // #231: iperf_catch_sigend is armed for the WHOLE run, so the
+                // central state wait polls the interrupt watch like the
+                // TEST_RUNNING selects — covering the setup phases AND the
+                // post-test ExchangeResults/DisplayResults waits, which
+                // previously ignored a signal until the control read returned
+                // (against a wedged server: forever, with only the CLI's #211
+                // second-signal hard exit as the way out). iperf_got_sigend's
+                // client arm has NO phase gate: it dumps the accumulated stats
+                // from any phase (empty rows pre-data), tells the peer via
+                // CLIENT_TERMINATE, and exits signal-normal — the same shape as
+                // the run_test arm. recv_state is a single 1-byte read, so the
+                // select is cancel-safe.
+                let state = tokio::select! {
+                    s = protocol::recv_state(&mut ctx.ctrl) => match s {
+                        Ok(state) => state,
+                        // #267: a CLEAN close (EOF) is GT's IECTRLCLOSE — dump
+                        // the populated doc. Io-class failures (e.g. a pre-data
+                        // RST, the #195 retry surface) keep their own classes
+                        // and propagate bare, as before.
+                        Err(e @ (RiperfError::PeerDisconnected | RiperfError::ControlSocketClosed)) => {
+                            return Err(self.on_ctrl_lost(&ctx, e))
+                        }
+                        Err(e) => return Err(e),
+                    },
+                    msg = wait_interrupt(ctx.interrupt.as_mut()) => {
+                        return Ok(Some(self.on_interrupted_wait(&mut ctx, &msg).await));
                     }
-                    Err(e) => return Err(e),
-                },
-                msg = wait_interrupt(ctx.interrupt.as_mut()) => {
-                    return Ok(Some(self.on_interrupted_wait(&mut ctx, &msg).await));
+                };
+
+                let flow = match state {
+                    TestState::ParamExchange => {
+                        self.on_param_exchange(&mut ctx).await?;
+                        StepFlow::Continue
+                    }
+
+                    TestState::CreateStreams => {
+                        self.on_create_streams(&mut ctx).await?;
+                        StepFlow::Continue
+                    }
+
+                    TestState::TestStart => {
+                        self.on_test_start(&mut ctx);
+                        StepFlow::Continue
+                    }
+
+                    TestState::TestRunning => self.on_test_running(&mut ctx).await?,
+
+                    TestState::ExchangeResults => match self.on_exchange_results(&mut ctx).await? {
+                        // #268: a signal landed inside the bulk results read.
+                        Some(report) => return Ok(Some(report)),
+                        None => StepFlow::Continue,
+                    },
+
+                    TestState::DisplayResults => self.on_display_results(&mut ctx).await?,
+
+                    TestState::IperfDone => StepFlow::Break,
+
+                    TestState::AccessDenied => {
+                        return Err(RiperfError::AccessDenied);
+                    }
+                    TestState::ServerError => {
+                        // #261: a relay arriving before TestStart is the upfront
+                        // refusal (code 37 et al.) — its `end` is GT's bare {}.
+                        // After TestStart the dump keeps the full structure.
+                        let bare_end = !ctx.stage.started();
+                        return Err(self.on_server_error_relay(&mut ctx, bare_end).await);
+                    }
+
+                    // iperf_handle_message_client handles SERVER_TERMINATE in
+                    // ANY state, not just TEST_RUNNING (#210 review r1 n2): a
+                    // server interrupt racing the client's TestEnd lands here
+                    // (the ExchangeResults wait) — dump the partial summary and
+                    // surface IESERVERTERM instead of dying later on a bare
+                    // peer-disconnect with no dump.
+                    TestState::ServerTerminate => {
+                        return Err(self.on_server_terminate(&ctx));
+                    }
+
+                    other => {
+                        self.on_unexpected_state(&ctx, other);
+                        StepFlow::Continue
+                    }
+                };
+
+                match flow {
+                    StepFlow::Continue => {}
+                    StepFlow::Break => break,
+                    StepFlow::Return(report) => return Ok(Some(*report)),
                 }
-            };
-
-            let flow = match state {
-                TestState::ParamExchange => {
-                    self.on_param_exchange(&mut ctx).await?;
-                    StepFlow::Continue
-                }
-
-                TestState::CreateStreams => {
-                    self.on_create_streams(&mut ctx).await?;
-                    StepFlow::Continue
-                }
-
-                TestState::TestStart => {
-                    self.on_test_start(&mut ctx);
-                    StepFlow::Continue
-                }
-
-                TestState::TestRunning => self.on_test_running(&mut ctx).await?,
-
-                TestState::ExchangeResults => match self.on_exchange_results(&mut ctx).await? {
-                    // #268: a signal landed inside the bulk results read.
-                    Some(report) => return Ok(Some(report)),
-                    None => StepFlow::Continue,
-                },
-
-                TestState::DisplayResults => self.on_display_results(&mut ctx).await?,
-
-                TestState::IperfDone => StepFlow::Break,
-
-                TestState::AccessDenied => {
-                    return Err(RiperfError::AccessDenied);
-                }
-                TestState::ServerError => {
-                    // #261: a relay arriving before TestStart is the upfront
-                    // refusal (code 37 et al.) — its `end` is GT's bare {}.
-                    // After TestStart the dump keeps the full structure.
-                    let bare_end = !ctx.stage.started();
-                    return Err(self.on_server_error_relay(&mut ctx, bare_end).await);
-                }
-
-                // iperf_handle_message_client handles SERVER_TERMINATE in
-                // ANY state, not just TEST_RUNNING (#210 review r1 n2): a
-                // server interrupt racing the client's TestEnd lands here
-                // (the ExchangeResults wait) — dump the partial summary and
-                // surface IESERVERTERM instead of dying later on a bare
-                // peer-disconnect with no dump.
-                TestState::ServerTerminate => {
-                    return Err(self.on_server_terminate(&ctx));
-                }
-
-                other => {
-                    self.on_unexpected_state(&ctx, other);
-                    StepFlow::Continue
-                }
-            };
-
-            match flow {
-                StepFlow::Continue => {}
-                StepFlow::Break => break,
-                StepFlow::Return(report) => return Ok(Some(*report)),
+                // #145: AUDITABILITY ONLY — advance the table cursor to the state
+                // just handled, before the next recv. Reached only by the arms that
+                // fall through (the break/return arms end the run anyway).
+                ctx.prev_state = state;
             }
-            // #145: AUDITABILITY ONLY — advance the table cursor to the state
-            // just handled, before the next recv. Reached only by the arms that
-            // fall through (the break/return arms end the run anyway).
-            ctx.prev_state = state;
-        }
-        Ok(None)
+            Ok(None)
         }
         .await;
 
@@ -507,17 +507,23 @@ impl Client {
         // at the data-phase end and the final report was captured at
         // DisplayResults. UDP receivers are spawn_blocking (abort is a
         // no-op there) and exit via `done` + their 500 ms read-timeout
-        // poll. The 100 ms catch-up grace is skipped when no streams were
-        // ever spawned (the pre-CreateStreams error paths have nothing to
-        // let land).
+        // poll.
         // RESIDUAL (the #352 join-site sibling record): GT closes its data
         // sockets at DISPLAY_RESULTS, BEFORE sending IPERF_DONE, and
         // sync-closes ctrl with a bounded drain-to-EOF
         // (iperf_client_api.c:562-566, net.c:877-886); riperf3's data FINs
-        // land ~100 ms later, at this abort, and ctrl closes abruptly —
-        // observable only by a peer that holds the round open.
-        ctx.done.store(true, Ordering::Relaxed);
-        if !ctx.streams.is_empty() {
+        // land later, at this abort (one state past GT's close point), and
+        // ctrl closes abruptly — observable only by a peer that holds the
+        // round open.
+        // `swap` (#379 r1 F3): run_test's end-of-data cleanup already set
+        // `done` and slept this same grace on every path that passes
+        // through it (the clean break and the mid-running error/event
+        // arms), so a second sleep there buys nothing. The grace is owed
+        // only when this gate is the FIRST to stop the streams (errors
+        // between CreateStreams and the data phase) — and never when no
+        // streams were spawned at all.
+        let grace_owed = !ctx.done.swap(true, Ordering::Relaxed);
+        if grace_owed && !ctx.streams.is_empty() {
             tokio::time::sleep(Duration::from_millis(100)).await;
         }
         for s in &ctx.streams {

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -995,6 +995,13 @@ impl Server {
         // spawn_blocking UDP runner ignores abort() and exits via `done` +
         // its 500 ms read-timeout poll; joining it with `done` unset would
         // hang. Idempotent on the clean path (shutdown_and_flush set it).
+        // The interval reporter (ctx.interval_handle) is deliberately NOT
+        // reaped here (#379 r1 F2 record): on the Err paths it
+        // self-terminates detached via `done` (bounded: its ~1 s tick +
+        // 2 s wait), prints nothing post-done, and holds no peer-visible
+        // fd — while an abort could kill a text-mode emit mid-line. The
+        // done-store-BEFORE-abort order also keeps a post-close reporter
+        // tick from sampling a recycled raw_fd.
         ctx.done.store(true, Ordering::Relaxed);
         for s in &ctx.streams {
             s.task.abort();

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -864,108 +864,110 @@ impl Server {
             return Ok(None);
         }
 
-        // ---- TestStart / TestRunning ----
-        self.start_test(&mut ctx).await?;
+        // #372: every phase from TestStart to the final output runs inside
+        // this block, so every `?` — start_test's sends, await_test_end's
+        // non-EOF recv errors, the exchange phase (#353) — falls through to
+        // the ONE unconditional abort/join gate below instead of skipping
+        // it. Per-arm teardown wrappers were whack-a-mole: this is the 4th
+        // site in the family (#331 gate, #353 exchange, #372 running
+        // phase). A `return` inside the block exits the BLOCK, not
+        // handle_one_test.
+        let outcome: Result<crate::json_report::Report> = async {
+            // ---- TestStart / TestRunning ----
+            self.start_test(&mut ctx).await?;
 
-        // ---- Wait for TEST_END (watchdog + bitrate limit + interrupt) ----
-        self.await_test_end(&mut ctx).await?;
+            // ---- Wait for TEST_END (watchdog + bitrate limit + interrupt) ----
+            self.await_test_end(&mut ctx).await?;
 
-        // ---- Shut down streams + flush the reporter ----
-        let mut end = self.shutdown_and_flush(&mut ctx).await;
+            // ---- Shut down streams + flush the reporter ----
+            let mut end = self.shutdown_and_flush(&mut ctx).await;
 
-        // ORDER CONSTRAINT (#296): built BEFORE the --get-server-output
-        // finish. Both read live stream counters; the exchange figures must
-        // be captured before the capture-finish renders text summaries, or
-        // a still-draining receiver could send the peer fresher numbers
-        // than its own rendered rows. Post-flush the counters are usually
-        // settled, so no deterministic pin can catch an inversion — this
-        // comment (and TestRunCtx's docs) are the guard.
-        let result_streams = self.build_result_streams(&ctx, &end);
+            // ORDER CONSTRAINT (#296): built BEFORE the --get-server-output
+            // finish. Both read live stream counters; the exchange figures must
+            // be captured before the capture-finish renders text summaries, or
+            // a still-draining receiver could send the peer fresher numbers
+            // than its own rendered rows. Post-flush the counters are usually
+            // settled, so no deterministic pin can catch an inversion — this
+            // comment (and TestRunCtx's docs) are the guard.
+            let result_streams = self.build_result_streams(&ctx, &end);
 
-        // The ONE drain of the reporter's collections (#287): the reporter was
-        // joined in shutdown_and_flush, so the take is final. From here the
-        // collections move by value — into the pre-exchange build (JSON-mode
-        // --get-server-output) or through `ReportSource::Pending` to the
-        // single post-exchange build below.
-        let collected = crate::reporter::CollectedIntervals::drain(&ctx.interval_data);
+            // The ONE drain of the reporter's collections (#287): the reporter was
+            // joined in shutdown_and_flush, so the take is final. From here the
+            // collections move by value — into the pre-exchange build (JSON-mode
+            // --get-server-output) or through `ReportSource::Pending` to the
+            // single post-exchange build below.
+            let collected = crate::reporter::CollectedIntervals::drain(&ctx.interval_data);
 
-        // ---- --get-server-output finish + ExchangeResults / IperfDone ----
-        let (server_output_text, server_output_json, report_source) =
-            self.finish_server_output(&mut ctx, &end, collected);
-        let was_captured = server_output_text.is_some();
-        // #353: the exchange's own Err (e.g. the ExchangeResults state
-        // write failing against an RST'd ctrl) must not skip the
-        // unconditional end-of-round abort/join below — a hostile peer
-        // provoking it while HOLDING its data sockets would leak detached
-        // parked receiver tasks + fds in a persistent server (the
-        // #331/#352/#356-F7 family, one phase later). Counts are frozen at
-        // build_result_streams, so the teardown is safe here.
-        if let Err(e) = self
-            .exchange_results_phase(
+            // ---- --get-server-output finish + ExchangeResults / IperfDone ----
+            let (server_output_text, server_output_json, report_source) =
+                self.finish_server_output(&mut ctx, &end, collected);
+            let was_captured = server_output_text.is_some();
+            // #353: the exchange's own Err (e.g. the ExchangeResults state
+            // write failing against an RST'd ctrl) reaches the gate through
+            // this `?` — counts are frozen at build_result_streams, so the
+            // teardown is safe on this path.
+            self.exchange_results_phase(
                 &mut ctx,
                 &end,
                 result_streams,
                 server_output_text,
                 server_output_json,
             )
-            .await
-        {
-            abort_setup_streams(&mut ctx).await;
-            if let Some(h) = ctx.udp_demux_handle.take() {
-                h.abort();
-                let _ = h.await;
-            }
-            return Err(e);
-        }
+            .await?;
 
-        // #319: an interrupt landing INSIDE the exchange phase fires after
-        // EndState froze report_error — re-resolve so the sigend dump
-        // carries the interrupt key like the mid-test arms. (A pre-exchange
-        // --get-server-output capture keeps its frozen shape: it was built
-        // before the signal by definition.)
-        if end.report_error.is_none() {
-            if let Some(msg) = &ctx.interrupted {
-                end.report_error = Some(msg.clone());
-            } else if ctx.client_terminated {
-                // #325: an end-loop CLIENT_TERMINATE postdates EndState's
-                // resolution exactly like the #322 mid-exchange interrupt.
-                end.report_error = Some("the client has terminated".to_string());
-            } else if ctx.unknown_message {
-                // #325: GT's IEMESSAGE reaches the doc through main.c:174's
-                // `iperf_err(test, "error - %s", ...)` json sink — the
-                // in-doc value carries the prefix (live-captured), unlike
-                // IECLIENTTERM's bare sentence above.
-                end.report_error = Some(format!("error - {}", RiperfError::UnknownControlMessage));
-            } else if ctx.ctrl_closed {
-                // #330: IECTRLCLOSE's read-site line is a DIRECT iperf_err
-                // — bare, no prefix (live-probed both windows).
-                end.report_error = Some(CTRL_CLOSED_MSG.to_string());
-            } else if ctx.exchange_recv_failed {
-                // #330: the perr dangling `: ` at errno 0 (#248 form; see
-                // the field's deviation record).
-                end.report_error = Some(format!("error - {}: ", RiperfError::RecvResultsFailed));
-            }
-        }
-
-        // #137/#287: the report is built exactly ONCE per test, by
-        // construction — the collections moved either into the pre-exchange
-        // --get-server-output build (#33) or arrive here for the single
-        // post-exchange build. handle_one_test returns it (run discards it;
-        // run_once hands it back to the library caller).
-        let report = match report_source {
-            ReportSource::Built(mut report) => {
-                // #322 r1 F4: a mid-exchange interrupt postdates the
-                // pre-exchange --get-server-output build — carry the key
-                // like GT's exit-time json_finish.
-                if report.error.is_none() {
-                    report.error = end.report_error.clone();
+            // #319: an interrupt landing INSIDE the exchange phase fires after
+            // EndState froze report_error — re-resolve so the sigend dump
+            // carries the interrupt key like the mid-test arms. (A pre-exchange
+            // --get-server-output capture keeps its frozen shape: it was built
+            // before the signal by definition.)
+            if end.report_error.is_none() {
+                if let Some(msg) = &ctx.interrupted {
+                    end.report_error = Some(msg.clone());
+                } else if ctx.client_terminated {
+                    // #325: an end-loop CLIENT_TERMINATE postdates EndState's
+                    // resolution exactly like the #322 mid-exchange interrupt.
+                    end.report_error = Some("the client has terminated".to_string());
+                } else if ctx.unknown_message {
+                    // #325: GT's IEMESSAGE reaches the doc through main.c:174's
+                    // `iperf_err(test, "error - %s", ...)` json sink — the
+                    // in-doc value carries the prefix (live-captured), unlike
+                    // IECLIENTTERM's bare sentence above.
+                    end.report_error =
+                        Some(format!("error - {}", RiperfError::UnknownControlMessage));
+                } else if ctx.ctrl_closed {
+                    // #330: IECTRLCLOSE's read-site line is a DIRECT iperf_err
+                    // — bare, no prefix (live-probed both windows).
+                    end.report_error = Some(CTRL_CLOSED_MSG.to_string());
+                } else if ctx.exchange_recv_failed {
+                    // #330: the perr dangling `: ` at errno 0 (#248 form; see
+                    // the field's deviation record).
+                    end.report_error =
+                        Some(format!("error - {}: ", RiperfError::RecvResultsFailed));
                 }
-                *report
             }
-            ReportSource::Pending(collected) => self.build_ctx_report(&ctx, &end, collected),
-        };
 
-        self.emit_final_output(&ctx, &end, &report, was_captured);
+            // #137/#287: the report is built exactly ONCE per test, by
+            // construction — the collections moved either into the pre-exchange
+            // --get-server-output build (#33) or arrive here for the single
+            // post-exchange build. handle_one_test returns it (run discards it;
+            // run_once hands it back to the library caller).
+            let report = match report_source {
+                ReportSource::Built(mut report) => {
+                    // #322 r1 F4: a mid-exchange interrupt postdates the
+                    // pre-exchange --get-server-output build — carry the key
+                    // like GT's exit-time json_finish.
+                    if report.error.is_none() {
+                        report.error = end.report_error.clone();
+                    }
+                    *report
+                }
+                ReportSource::Pending(collected) => self.build_ctx_report(&ctx, &end, collected),
+            };
+
+            self.emit_final_output(&ctx, &end, &report, was_captured);
+            Ok(report)
+        }
+        .await;
 
         // Join stream tasks (best-effort, they should be done).
         // #322 r1 F1: a mid-EXCHANGE interrupt postdates shutdown_and_flush's
@@ -988,20 +990,28 @@ impl Server {
         // every sink has emitted. Abort drops each tokio task's socket at
         // its next await; the spawn_blocking UDP runners are bounded by the
         // 500 ms read-timeout + `done` polling either way.
+        // #372: `done` must be set HERE, not only by the drop guard — on
+        // the block's Err paths shutdown_and_flush never ran, and a
+        // spawn_blocking UDP runner ignores abort() and exits via `done` +
+        // its 500 ms read-timeout poll; joining it with `done` unset would
+        // hang. Idempotent on the clean path (shutdown_and_flush set it).
+        ctx.done.store(true, Ordering::Relaxed);
         for s in &ctx.streams {
             s.task.abort();
         }
         if let Some(h) = &ctx.udp_demux_handle {
             h.abort();
         }
-        for s in ctx.streams {
+        for s in ctx.streams.drain(..) {
             let _ = s.task.await;
         }
         // The single-socket UDP demux receiver (#80) serves all receiving streams
         // and lives outside `streams`; join it too. `None` on the recycling path.
-        if let Some(h) = ctx.udp_demux_handle {
+        if let Some(h) = ctx.udp_demux_handle.take() {
             let _ = h.await;
         }
+
+        let report = outcome?;
 
         if ctx.client_terminated {
             // The dump above already rendered; the caller prints iperf3's

--- a/riperf3/tests/teardown.rs
+++ b/riperf3/tests/teardown.rs
@@ -1,0 +1,109 @@
+//! #375: an abnormal-path early return from `Client::run` must still tear
+//! down the spawned stream tasks. A detached task parked in `read().await`
+//! against a holding peer survives `done` (the flag cannot wake a parked
+//! read) and leaks with its fd — visible only to LIBRARY consumers, so
+//! this is an in-process lib test: a CLI process exit closes the fds and
+//! masks the class (the #356 bound_server.rs in-process precedent).
+
+use std::io::{Read, Write};
+use std::time::Duration;
+
+use riperf3::ClientBuilder;
+
+fn read_exact(s: &mut std::net::TcpStream, n: usize) -> Vec<u8> {
+    let mut buf = vec![0u8; n];
+    s.read_exact(&mut buf).expect("read_exact");
+    buf
+}
+
+/// Mock server: full setup through TestRunning, ~0.3 s of reverse traffic,
+/// then SILENCE — the client's receivers drain the tail and PARK in
+/// `read().await` (the silence-before-the-kill timing is load-bearing, the
+/// #354 r1 F1 lesson: a still-flowing peer parks nothing) — then a plain
+/// FIN of the ctrl. The client's data-phase control watch folds the dead
+/// ctrl to its closed class and `run()` propagates the error out of the
+/// TestRunning arm. The mock then reads each still-held data socket with a
+/// bounded timeout: a teardown-less client HOLDS them (the parked tasks
+/// own the fds, and the test's runtime is still alive), so the reads time
+/// out; a run() that reaps its tasks before returning closes them
+/// immediately.
+fn mock_fin_mid_running(
+    listener: std::net::TcpListener,
+    parallel: usize,
+) -> Vec<Result<usize, std::io::ErrorKind>> {
+    let (mut ctrl, _) = listener.accept().expect("ctrl accept");
+    read_exact(&mut ctrl, 37); // cookie
+    ctrl.write_all(&[9u8]).unwrap(); // ParamExchange
+    let len = u32::from_be_bytes(read_exact(&mut ctrl, 4).try_into().unwrap()) as usize;
+    read_exact(&mut ctrl, len); // the client's params blob
+    ctrl.write_all(&[10u8]).unwrap(); // CreateStreams
+    let mut datas = Vec::new();
+    for _ in 0..parallel {
+        let (mut data, _) = listener.accept().expect("data accept");
+        read_exact(&mut data, 37); // data-stream cookie
+        datas.push(data);
+    }
+    ctrl.write_all(&[1u8]).unwrap(); // TestStart
+    ctrl.write_all(&[2u8]).unwrap(); // TestRunning
+    let t0 = std::time::Instant::now();
+    while t0.elapsed() < Duration::from_millis(300) {
+        for data in &mut datas {
+            data.write_all(&[0u8; 8192]).expect("reverse burst");
+        }
+        std::thread::sleep(Duration::from_millis(5));
+    }
+    // Silence: let the receivers drain and park before the ctrl dies.
+    std::thread::sleep(Duration::from_millis(200));
+    drop(ctrl); // FIN → the client's closed class → run() errors
+    let mut reads = Vec::new();
+    for data in &mut datas {
+        data.set_read_timeout(Some(Duration::from_secs(4)))
+            .expect("set_read_timeout");
+        let mut buf = [0u8; 16];
+        reads.push(data.read(&mut buf).map_err(|e| e.kind()));
+    }
+    reads
+}
+
+/// #375: reverse -P 2 (a partial teardown — stream 0 only — still reds),
+/// ctrl FIN mid-running.
+#[test]
+fn client_error_return_tears_down_stream_tasks() {
+    // Plain #[test] + explicit runtime: the runtime must stay ALIVE while
+    // the mock's bounded reads run — dropping it reaps leaked tasks and
+    // would mask exactly the leak under test.
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(2)
+        .enable_all()
+        .build()
+        .expect("runtime");
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind mock");
+    let port = listener.local_addr().unwrap().port();
+    let mock = std::thread::spawn(move || mock_fin_mid_running(listener, 2));
+
+    let client = ClientBuilder::new("127.0.0.1")
+        .port(Some(port))
+        .reverse(true)
+        .num_streams(2)
+        .duration(30) // the FIN at ~0.5 s ends the run, not the timer
+        .json_output(true)
+        .build()
+        .expect("build client");
+    let res = rt
+        .block_on(async { tokio::time::timeout(Duration::from_secs(8), client.run()).await })
+        .expect("run() exits bounded after the ctrl FIN");
+    assert!(
+        res.is_err(),
+        "the dead ctrl surfaces an error, not a report"
+    );
+
+    let reads = mock.join().expect("mock");
+    for (i, r) in reads.iter().enumerate() {
+        assert!(
+            matches!(r, Ok(0) | Err(std::io::ErrorKind::ConnectionReset)),
+            "stream {i}: the held data socket sees a bounded close \
+             (run() reaped its stream tasks before returning): {r:?}"
+        );
+    }
+    drop(rt);
+}


### PR DESCRIPTION
Closes #372. Closes #375.

## The defect (one family, both roles)

The teardown-skip fd leak, sites 4 and 5 (#331 gate → #353 exchange → these): a `?` between stream-spawn and the unconditional abort/join gate detaches tasks parked in `read()`/`write().await` — a parked await cannot see `done`, so each leaks with its fd until the peer lets go.

- **Server (#372):** `start_test`'s TestStart/TestRunning sends and `await_test_end`'s non-EOF recv arm (e.g. ECONNRESET, not mapped to the EOF class) propagated out of `handle_one_test` past the gate. Live repro on the issue: +1 fd/round on a persistent server, held peer never sees EOF.
- **Client (#375):** every abnormal-path early return from `run()` dropped the stream JoinHandles — only the clean path had the #354 abort-before-join. Blast radius = library consumers (`run()` in-process); a CLI process exit closes the fds and masked the class.

## The fix

No 4th/5th per-arm wrapper. Each role's fallible region now runs inside an inner async block whose outcome is checked only **after** the one unconditional teardown, so every `?` and early return falls through the gate (full JOIN semantics — the async-RAII alternative can't await joins in Drop):

- **Server:** the whole TestStart→final-output pipeline is the block; the gate follows; then `outcome?` and the existing post-gate arms. The #353 arm's duplicated teardown folds back to a plain `?`, and `abort_setup_streams` reverts to setup-phase-only call sites (resolves the #370 r1 F3 doc rider — its doc is accurate again). The gate now sets `done` itself: on the new Err paths `shutdown_and_flush` never ran, and a `spawn_blocking` UDP runner ignores `abort()` and exits via `done` + its 500 ms read-timeout poll — joining it with `done` unset would hang. Idempotent on the clean path.
- **Client:** the dispatch loop is the block (`Ok(Some(report))` = early-exit rounds that already rendered — the interrupt dumps; `Ok(None)` = the clean IperfDone break). The teardown is the #354 clean-path sequence, now unconditional; the 100 ms catch-up grace is skipped when no streams were spawned, so pre-stream error paths (connect, ParamExchange) add no latency. Error paths with live streams gain ~100 ms + the join before the error surfaces — GT-like (its cleanup paths run `iperf_client_end`, which cancels and joins the stream threads).

Diff note: the block re-indents both regions; review with whitespace-ignoring diff to see the real changes.

## Verification

**Pins, red-first on the unguarded build** (each red = the held-socket read timing out, i.e. the leak itself; the park is proven by silence/hold before the kill — the #354 r1 F1 hold-coupling lesson):

- `running_phase_err_at_test_start_still_tears_down_streams` / `..._mid_running_...` (wire_shape): persistent server, -P 2 holding mock, SO_LINGER(0) ctrl RST in each window; setup completion proven by TestStart(1) before the RST (a setup-window landing runs its own teardown and would false-green); positive stderr classification per the #370 r2 lesson (clean-EOF and exchange classes run the gate and retry).
- `client_error_return_tears_down_stream_tasks` (new lib test `riperf3/tests/teardown.rs`): **in-process** reverse -P 2 client on an explicit runtime that stays alive through the asserts (dropping it would reap the leaked tasks and mask the class); mock goes silent, FINs the ctrl mid-running, then reads the held data sockets.

**Mutation table** (harness refuses dirty targets, anchor-uniqueness checked, exact restore verified): M1 server gate-bypass (`outcome?` hoisted before the gate = main-equivalent) → both #372 pins red; M1b same mutant → the folded #353 exchange pin still reds; M2 server abort/join `take(1)` → red via the second held socket; M3 client gate-bypass → red; M4 client `take(1)` → red; M5 client abort-stripped (bare join) → red via the 8 s bound (the join parks peer-bound).

Not pin-covered (disclosed): dropping the gate's new `done.store` only bites the UDP `spawn_blocking` join-hang class — a TCP pin can't see it and a UDP window pin would need the full UDP mock stack; the store is comment-guarded at the site with the rationale.

**Gate:** fmt / clippy `-D warnings` clean; workspace **851 passed / 0 failed** (848 + the 3 pins).

## Coordination

#293 (0.9.0 milestone) reworks the client's abnormal-end **return shapes** (partial Report) but not teardown; it lands after this and adapts inside the block — recorded on #375.

**Rounds:** r1 APPROVE (5 non-blocking: #380 + #381 filed; the done-gated grace, the reporter-asymmetry record, and the block re-indent applied @73d1838). r2 APPROVE (cold, no blockers; #381 extended with the client `create_streams` twin). Full round records in the PR comments. Merge-head evidence on 73d1838: CI 17/17, mutation table 6/6 red re-run post-fixes, sandbox compat matrix 52/52 PASS.
