### PR TITLE
fix: the client's results read gets GT's Nread bounds + IERECVRESULTS surface (#374)

### DIFF
--- a/riperf3-cli/src/main.rs
+++ b/riperf3-cli/src/main.rs
@@ -349,8 +349,25 @@ fn main() -> std::process::ExitCode {
                         // #267: the lib emits the populated ctrl-closed doc
                         // (bare end{}) before returning this class.
                         | riperf3::RiperfError::ControlSocketClosed
+                        // #374: the client's failed results read — the lib
+                        // emitted the doc with the dangling IERECVRESULTS
+                        // value before returning.
+                        | riperf3::RiperfError::RecvResultsFailed
                 )
             });
+            // #374: GT marks IERECVRESULTS perr, so its errexit line carries
+            // the strerror tail — at the wedge/EOF windows that is the #248
+            // dangling `: ` (GT appends a STALE errno's strerror, live
+            // "Transport endpoint is not connected"; recorded deviation —
+            // the errno-0 form, the #330 server-line precedent).
+            let perr_tail = if e
+                .downcast_ref::<riperf3::RiperfError>()
+                .is_some_and(|le| matches!(le, riperf3::RiperfError::RecvResultsFailed))
+            {
+                ": "
+            } else {
+                ""
+            };
             // --json-stream wins over -J when combined: iperf3's
             // --json-stream gates iperf_json_finish into stream events
             // (review r1 f2, live-verified).
@@ -369,7 +386,7 @@ fn main() -> std::process::ExitCode {
                 // #348: GT's iperf_errexit stamps this line like iperf_err
                 // (iperf_error.c:100-127).
                 let line = format!(
-                    "{}riperf3: error - {e}",
+                    "{}riperf3: error - {e}{perr_tail}",
                     ts_format
                         .as_deref()
                         .map(riperf3::render_timestamp_prefix)

--- a/riperf3-cli/tests/wire_shape.rs
+++ b/riperf3-cli/tests/wire_shape.rs
@@ -4066,3 +4066,196 @@ fn running_phase_err_at_test_start_still_tears_down_streams() {
 fn running_phase_err_mid_running_still_tears_down_streams() {
     running_phase_err_case(true);
 }
+
+// ---------------------------------------------------------------------------
+// #374: the CLIENT's results read gets GT's Nread bounds + the shared
+// Nread_json warning surface (get_results is role-agnostic in GT,
+// iperf_api.c:3036-3080) and the IERECVRESULTS errexit. GT live-probes
+// (3.21, all windows): the state-byte WAITS are UNBOUNDED in GT (silent
+// post-accept, post-TestEnd, and pre-DisplayResults wedges all exceed
+// 45 s) — so riperf3's unbounded recv_state waits are already faithful
+// and stay; only the in-message exchange reads bound. Wedge-hold → exit 1
+// at ~11 s (1 s test + the 10 s idle bound; GT adds its ~10 s close-drain,
+// the #354-recorded residual riperf3 deliberately lacks), the size-read
+// warning, and `error - unable to receive results: ` — the #248 dangling
+// errno-0 form (GT appends a STALE errno's strerror on the EOF path,
+// "Transport endpoint is not connected" live — the #330-recorded
+// deviation, not mirrored). Text prints NO summary. -J: the doc carries
+// the dangling error value and GT's bare `end: {}`.
+// ---------------------------------------------------------------------------
+
+/// How the mock server wedges the results slot after reading the
+/// client's blob.
+#[derive(Clone, Copy)]
+enum ExchangeWedge {
+    /// Send nothing and HOLD the sockets — the size read must self-bound.
+    Hold,
+    /// Send a 500-byte promise + 5 bytes, then HOLD — the blob read must
+    /// self-bound and warn with both counts.
+    PartialBlob,
+    /// Close where the results were due — the fast EOF form.
+    Eof,
+}
+
+/// Mock SERVER for the #374 client pins: full protocol through the
+/// client's TestEnd, sends ExchangeResults, reads the client's results
+/// blob, then wedges per the variant.
+fn exchange_wedge_mock(listener: std::net::TcpListener, wedge: ExchangeWedge) {
+    use std::io::Read;
+    let (mut ctrl, _) = listener.accept().expect("ctrl accept");
+    read_exact(&mut ctrl, 37); // cookie
+    ctrl.write_all(&[9u8]).unwrap(); // ParamExchange
+    read_json_blob(&mut ctrl); // the client's params
+    ctrl.write_all(&[10u8]).unwrap(); // CreateStreams
+    let (mut data, _) = listener.accept().expect("data accept");
+    read_exact(&mut data, 37); // data-stream cookie
+    ctrl.write_all(&[1u8]).unwrap(); // TestStart
+    ctrl.write_all(&[2u8]).unwrap(); // TestRunning
+                                     // Drain the forward data until TestEnd lands on ctrl.
+    let stop = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let drain = {
+        let stop = stop.clone();
+        let mut d = data.try_clone().expect("clone data");
+        d.set_read_timeout(Some(Duration::from_millis(500)))
+            .expect("drain timeout");
+        std::thread::spawn(move || {
+            let mut buf = vec![0u8; 65536];
+            while !stop.load(std::sync::atomic::Ordering::Relaxed) {
+                match d.read(&mut buf) {
+                    Ok(0) => break,
+                    Ok(_) => {}
+                    Err(e)
+                        if e.kind() == std::io::ErrorKind::WouldBlock
+                            || e.kind() == std::io::ErrorKind::TimedOut =>
+                    {
+                        continue
+                    }
+                    Err(_) => break,
+                }
+            }
+        })
+    };
+    assert_eq!(read_exact(&mut ctrl, 1)[0], 4, "TestEnd");
+    stop.store(true, std::sync::atomic::Ordering::Relaxed);
+    drain.join().expect("drain");
+    ctrl.write_all(&[13u8]).unwrap(); // ExchangeResults
+    read_json_blob(&mut ctrl); // the client's results
+    match wedge {
+        ExchangeWedge::Hold => std::thread::sleep(Duration::from_secs(30)),
+        ExchangeWedge::PartialBlob => {
+            ctrl.write_all(&500u32.to_be_bytes()).unwrap();
+            ctrl.write_all(b"12345").unwrap();
+            std::thread::sleep(Duration::from_secs(30));
+        }
+        ExchangeWedge::Eof => {}
+    }
+    drop((ctrl, data));
+}
+
+const CLIENT_RECV_RESULTS_LINE: &str = "riperf3: error - unable to receive results: ";
+
+/// One #374 client run against the wedging mock; returns the finished
+/// client output (the bounded wait inside run_client IS the self-bound
+/// pin — an unbounded read parks past it).
+fn run_exchange_wedge_client(wedge: ExchangeWedge, json: bool) -> common::ClientRun {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind mock");
+    let port = listener.local_addr().unwrap().port().to_string();
+    let _mock = std::thread::spawn(move || exchange_wedge_mock(listener, wedge));
+    let mut args = vec!["-c", "127.0.0.1", "-p", port.as_str(), "-t", "1"];
+    if json {
+        args.push("-J");
+    }
+    common::run_client(
+        &args,
+        Duration::from_secs(25),
+        "client vs results-wedging server",
+    )
+}
+
+/// #374: the wedge-hold — the size read self-bounds at GT's 10 s idle
+/// Nread bound with the read-returned-0 warning, the dangling errexit
+/// line, exit 1, and NO summary (GT prints none on IERECVRESULTS).
+#[test]
+fn client_exchange_wedge_self_bounds_with_gt_warning() {
+    let client = run_exchange_wedge_client(ExchangeWedge::Hold, false);
+    assert_eq!(
+        client.status.code(),
+        Some(1),
+        "GT errexits 1: {}",
+        client.stderr
+    );
+    assert!(
+        client
+            .stderr
+            .contains("warning: Failed to read JSON data size - read returned 0; errno=0"),
+        "the sink-bypassing size-read warning: {}",
+        client.stderr
+    );
+    assert!(
+        client
+            .stderr
+            .contains(&format!("{CLIENT_RECV_RESULTS_LINE}\n")),
+        "the dangling errno-0 errexit line: {:?}",
+        client.stderr
+    );
+    assert_eq!(
+        client.stdout.matches(SUMMARY_SEPARATOR).count(),
+        0,
+        "no summary on the failed exchange: {}",
+        client.stdout
+    );
+}
+
+/// #374: the mid-blob wedge — the blob read self-bounds and warns with
+/// GT's expected/received counts.
+#[test]
+fn client_exchange_mid_blob_wedge_warns_partial_count() {
+    let client = run_exchange_wedge_client(ExchangeWedge::PartialBlob, false);
+    assert_eq!(client.status.code(), Some(1), "{}", client.stderr);
+    assert!(
+        client.stderr.contains(
+            "warning: JSON size of data read does not correspond to offered length - \
+             expected 500 bytes but received 5; errno=0"
+        ),
+        "the expected/received warning arm: {}",
+        client.stderr
+    );
+    assert!(
+        client
+            .stderr
+            .contains(&format!("{CLIENT_RECV_RESULTS_LINE}\n")),
+        "the dangling errexit line: {:?}",
+        client.stderr
+    );
+}
+
+/// #374: EOF where the results were due, -J — the doc carries the
+/// dangling error value and GT's bare `end: {}` (live-probed 3.21; GT's
+/// in-doc value appends a STALE errno's strerror — recorded deviation,
+/// the errno-0 form is emitted instead, the #330 server precedent).
+/// riperf3's collected closing interval may appear where GT's is still
+/// pending display — the intervals count is deliberately un-pinned (the
+/// #55 flush-order drift, recorded in the PR).
+#[test]
+fn client_exchange_eof_takes_gt_recv_results_shape_in_json() {
+    let client = run_exchange_wedge_client(ExchangeWedge::Eof, true);
+    assert_eq!(client.status.code(), Some(1), "{}", client.stderr);
+    let doc: serde_json::Value = serde_json::from_str(client.stdout.trim())
+        .unwrap_or_else(|e| panic!("one -J doc ({e}): {}", client.stdout));
+    assert_eq!(
+        doc["error"].as_str(),
+        Some("unable to receive results: "),
+        "the IERECVRESULTS key in the errno-0 form: {doc}"
+    );
+    assert_eq!(
+        doc["end"],
+        serde_json::json!({}),
+        "GT's bare end on the failed exchange: {doc}"
+    );
+    assert_eq!(
+        client.stderr.trim(),
+        "warning: Failed to read JSON data size - read returned 0; errno=0",
+        "the warning bypasses the -J sink, and nothing else: {}",
+        client.stderr
+    );
+}

--- a/riperf3-cli/tests/wire_shape.rs
+++ b/riperf3-cli/tests/wire_shape.rs
@@ -4229,6 +4229,41 @@ fn client_exchange_mid_blob_wedge_warns_partial_count() {
     );
 }
 
+/// #374 (r1 F1): the SERVER_ERROR relay payload read is bounded too — GT
+/// bounds these Nreads (iperf_client_api.c:393-401; live: a
+/// state-byte-then-hold wedge exits 1 at ~30.0 s with a garbage-errno
+/// SERVER ERROR line — GT prints UNINITIALIZED bytes on the short read).
+/// riperf3 self-bounds on the house Nread budgets and degrades to the
+/// deterministic payloadless fallback instead of mirroring the
+/// uninitialized-memory line (recorded deviation). Unlike the results
+/// read, this window races NO interrupt arm, so an unbounded read was
+/// SIGNAL-IMMUNE (r1's live probe: SIGTERM did not free it).
+#[test]
+fn client_server_error_payload_wedge_self_bounds() {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind mock");
+    let port = listener.local_addr().unwrap().port().to_string();
+    let _mock = std::thread::spawn(move || {
+        let (mut ctrl, _) = listener.accept().expect("ctrl accept");
+        read_exact(&mut ctrl, 37); // cookie
+        ctrl.write_all(&[9u8]).unwrap(); // ParamExchange
+        read_json_blob(&mut ctrl); // the client's params
+        ctrl.write_all(&[0xfeu8]).unwrap(); // SERVER_ERROR (-2), then HOLD
+        std::thread::sleep(Duration::from_secs(30));
+        drop(ctrl);
+    });
+    let client = common::run_client(
+        &["-c", "127.0.0.1", "-p", &port, "-t", "1"],
+        Duration::from_secs(25),
+        "client vs payloadless SERVER_ERROR wedge",
+    );
+    assert_eq!(client.status.code(), Some(1), "{}", client.stderr);
+    assert!(
+        client.stderr.contains("SERVER ERROR - server error"),
+        "the payloadless fallback line: {}",
+        client.stderr
+    );
+}
+
 /// #374: EOF where the results were due, -J — the doc carries the
 /// dangling error value and GT's bare `end: {}` (live-probed 3.21; GT's
 /// in-doc value appends a STALE errno's strerror — recorded deviation,

--- a/riperf3/src/client.rs
+++ b/riperf3/src/client.rs
@@ -919,14 +919,45 @@ impl Client {
         let results = self.build_results(&ctx.streams, ctx.cpu_start.as_ref(), ctx.measured_secs);
         protocol::send_results(&mut ctx.ctrl, &results).await?;
         tokio::select! {
-            r = protocol::recv_results(&mut ctx.ctrl) => {
-                ctx.server_results = Some(r?);
-                Ok(None)
-            }
+            r = protocol::recv_results(&mut ctx.ctrl) => match r {
+                Ok(results) => {
+                    ctx.server_results = Some(results);
+                    Ok(None)
+                }
+                // #374: GT's IERECVRESULTS surface. The bounded read (GT's
+                // Nread 10 s idle / 30 s overall — a wedging server can't
+                // park the client) already printed the sink-bypassing
+                // Nread_json warning at the read site; here the JSON sinks
+                // get the doc and the class errexits (the CLI renders the
+                // text line).
+                Err(_) => Err(self.on_recv_results_failed(ctx)),
+            },
             msg = wait_interrupt(ctx.interrupt.as_mut()) => {
                 Ok(Some(self.on_interrupted_wait(ctx, &msg).await))
             }
         }
+    }
+
+    /// The client's failed results read (#374), the on_ctrl_lost shape:
+    /// JSON sinks get the populated doc with GT's bare `end: {}` and the
+    /// error value in the #248 dangling errno-0 perr form ("unable to
+    /// receive results: " — GT appends a STALE errno's strerror, live
+    /// "Transport endpoint is not connected"; recorded deviation, the
+    /// #330 server precedent). Text gets NO dump (GT prints no summary on
+    /// this class — probed; the errexit line is the CLI's). The collected
+    /// closing interval may appear where GT's is still pending display —
+    /// the #55 flush-order drift, recorded on #374.
+    fn on_recv_results_failed(&self, ctx: &RunCtx) -> RiperfError {
+        if self.json_output || self.json_stream {
+            self.emit_results(
+                ctx,
+                None,
+                true,
+                ctx.measured_secs,
+                Some(&format!("{}: ", RiperfError::RecvResultsFailed)),
+            );
+        }
+        RiperfError::RecvResultsFailed
     }
 
     async fn on_display_results(&self, ctx: &mut RunCtx) -> Result<StepFlow> {

--- a/riperf3/src/protocol.rs
+++ b/riperf3/src/protocol.rs
@@ -222,13 +222,20 @@ pub async fn send_server_error(stream: &mut TcpStream, i_errno: u32) -> Result<(
 }
 
 /// Read SERVER_ERROR's (i_errno, errno) payload. `None` when it never
-/// arrives (a peer that died mid-relay, or a bare -2 sender): the caller
-/// degrades to its generic message — a payloadless SERVER_ERROR must error
-/// cleanly, never hang or panic (tested in-crate).
+/// arrives (a peer that died mid-relay, held the socket, or sent a bare
+/// -2): the caller degrades to its generic message — a payloadless
+/// SERVER_ERROR must error cleanly, never hang or panic (tested
+/// in-crate). Bounded like every GT Nread (#382 r1 F1 — GT bounds these
+/// two reads, iperf_client_api.c:393-401, exiting a hold at ~30 s with a
+/// garbage-errno line from the UNINITIALIZED short-read buffer; the
+/// deterministic None-fallback is the recorded deviation, and the house
+/// 10 s idle bound fires first on a fully-silent hold). This read races
+/// NO interrupt arm, so an unbounded read was signal-immune.
 pub async fn read_server_error_payload(stream: &mut TcpStream) -> Option<(u32, u32)> {
+    let deadline = tokio::time::Instant::now() + NREAD_OVERALL_TIMEOUT;
     let mut buf = [0u8; 8];
-    match stream.read_exact(&mut buf).await {
-        Ok(_) => Some((
+    match nread_exact(stream, &mut buf, deadline).await {
+        Ok(()) => Some((
             u32::from_be_bytes(buf[0..4].try_into().unwrap()),
             u32::from_be_bytes(buf[4..8].try_into().unwrap()),
         )),
@@ -655,10 +662,11 @@ async fn nread_exact(
     Ok(())
 }
 
-/// GT-bounded [`json_read`] (#339 r2b F1): the server's params read gets
-/// Nread's idle/overall bounds so a holding peer can't park the serial
-/// serve loop. Client-side reads keep the plain [`json_read`] — their
-/// bound/warning parity is a separate surface (noted on #330).
+/// The bounded length-prefixed JSON read (#339 r2b F1): Nread's
+/// idle/overall bounds so a holding peer can't park the reader. The
+/// params slot's reader; the results slot has its own warning-parity
+/// reader below (#330/#374 — which retired the plain unbounded reader
+/// this fn was once the bounded variant of).
 async fn json_read_bounded(stream: &mut TcpStream, max_len: usize) -> Result<serde_json::Value> {
     let deadline = tokio::time::Instant::now() + NREAD_OVERALL_TIMEOUT;
     let mut len_buf = [0u8; 4];
@@ -678,9 +686,10 @@ async fn json_read_bounded(stream: &mut TcpStream, max_len: usize) -> Result<ser
 }
 
 /// The results read, BOTH roles (#330 server, #374 client — GT's
-/// get_results is role-agnostic, iperf_api.c:3033): a malformed read gets
-/// GT's Nread_json warning surface (iperf_api.c:3036-3080 — all five
-/// arms, deterministic text and counts, live-probed under -J and text)
+/// get_results, iperf_api.c:2801, is called by both roles at
+/// iperf_api.c:2400/2404): a malformed read gets GT's Nread_json warning
+/// surface (JSON_read, iperf_api.c:3036-3080 — all five arms,
+/// deterministic text and counts, live-probed under -J and text)
 /// and maps to the IERECVRESULTS class each role renders at its own site.
 /// Reads are bounded like GT's Nrecv (#374 live probes: the client's
 /// state-byte WAITS are unbounded in GT — silent post-accept,

--- a/riperf3/src/protocol.rs
+++ b/riperf3/src/protocol.rs
@@ -267,24 +267,6 @@ pub async fn json_write(stream: &mut TcpStream, value: &serde_json::Value) -> Re
     Ok(())
 }
 
-/// Read a length-prefixed JSON value. If `max_len` is 0, no size limit is enforced.
-pub async fn json_read(stream: &mut TcpStream, max_len: usize) -> Result<serde_json::Value> {
-    let mut len_buf = [0u8; 4];
-    stream.read_exact(&mut len_buf).await?;
-    let len = u32::from_be_bytes(len_buf) as usize;
-
-    if max_len > 0 && len > max_len {
-        return Err(RiperfError::Protocol(format!(
-            "JSON payload too large: {len} bytes (max {max_len})"
-        )));
-    }
-
-    let mut buf = vec![0u8; len];
-    stream.read_exact(&mut buf).await?;
-    let value: serde_json::Value = json_first_value(&buf)?;
-    Ok(value)
-}
-
 // ---------------------------------------------------------------------------
 // Test parameters — exchanged as JSON during ParamExchange
 // ---------------------------------------------------------------------------
@@ -581,12 +563,6 @@ pub async fn send_results(stream: &mut TcpStream, results: &TestResultsJson) -> 
     json_write(stream, &value).await
 }
 
-/// Receive test results from length-prefixed JSON (no size limit).
-pub async fn recv_results(stream: &mut TcpStream) -> Result<TestResultsJson> {
-    let value = json_read(stream, 0).await?;
-    validate_results(value)
-}
-
 /// The #271 shape validation shared by both results readers.
 fn validate_results(value: serde_json::Value) -> Result<TestResultsJson> {
     let results: TestResultsJson = serde_json::from_value(value)?;
@@ -701,13 +677,16 @@ async fn json_read_bounded(stream: &mut TcpStream, max_len: usize) -> Result<ser
     Ok(value)
 }
 
-/// The SERVER's results read (#330): a malformed read gets GT's Nread_json
-/// warning surface (iperf_api.c:3036-3080 — all five arms, deterministic
-/// text and counts, live-probed under -J and text) and maps to the
-/// IERECVRESULTS class the caller renders into the doc. Reads are bounded
-/// like GT's Nrecv. The client keeps the plain [`recv_results`]: its
-/// warning parity needs its own GT probes (noted on #330).
-pub async fn recv_results_server(stream: &mut TcpStream) -> Result<TestResultsJson> {
+/// The results read, BOTH roles (#330 server, #374 client — GT's
+/// get_results is role-agnostic, iperf_api.c:3033): a malformed read gets
+/// GT's Nread_json warning surface (iperf_api.c:3036-3080 — all five
+/// arms, deterministic text and counts, live-probed under -J and text)
+/// and maps to the IERECVRESULTS class each role renders at its own site.
+/// Reads are bounded like GT's Nrecv (#374 live probes: the client's
+/// state-byte WAITS are unbounded in GT — silent post-accept,
+/// post-TestEnd, and pre-DisplayResults wedges all exceeded 45 s — so
+/// recv_state stays unbounded by design; only in-message reads bound).
+pub async fn recv_results(stream: &mut TcpStream) -> Result<TestResultsJson> {
     let deadline = tokio::time::Instant::now() + NREAD_OVERALL_TIMEOUT;
     let mut len_buf = [0u8; 4];
     let mut got = 0usize;
@@ -1270,7 +1249,9 @@ mod tests {
         });
 
         let (mut stream, _) = listener.accept().await.unwrap();
-        let value = json_read(&mut stream, MAX_PARAMS_JSON_LEN).await.unwrap();
+        let value = json_read_bounded(&mut stream, MAX_PARAMS_JSON_LEN)
+            .await
+            .unwrap();
         writer.await.unwrap();
 
         assert_eq!(value["tcp"], true);
@@ -1646,7 +1627,7 @@ mod protocol_tests {
         });
 
         let (mut stream, _) = listener.accept().await.unwrap();
-        let result = protocol::json_read(&mut stream, protocol::MAX_PARAMS_JSON_LEN).await;
+        let result = protocol::json_read_bounded(&mut stream, protocol::MAX_PARAMS_JSON_LEN).await;
         writer.await.unwrap();
 
         assert!(result.is_err());

--- a/riperf3/src/protocol.rs
+++ b/riperf3/src/protocol.rs
@@ -228,9 +228,14 @@ pub async fn send_server_error(stream: &mut TcpStream, i_errno: u32) -> Result<(
 /// in-crate). Bounded like every GT Nread (#382 r1 F1 — GT bounds these
 /// two reads, iperf_client_api.c:393-401, exiting a hold at ~30 s with a
 /// garbage-errno line from the UNINITIALIZED short-read buffer; the
-/// deterministic None-fallback is the recorded deviation, and the house
-/// 10 s idle bound fires first on a fully-silent hold). This read races
-/// NO interrupt arm, so an unbounded read was signal-immune.
+/// deterministic None-fallback is the recorded deviation — GT's rc<0
+/// arm maps to IECTRLREAD (iperf_client_api.c:394-400) and folds into
+/// the same fallback here, pre-existing — and the house 10 s idle bound
+/// fires first on a fully-silent hold). This read races NO interrupt
+/// arm, so an unbounded read was signal-immune; post-fix a signal in
+/// this window is honored when the bound fires (≤10 s silent, ≤30 s
+/// dripping — GT's select EINTRs immediately; adversarial-only, the
+/// recv_cookie/json_read_bounded house pattern) (#382 r2 F2/F3).
 pub async fn read_server_error_payload(stream: &mut TcpStream) -> Option<(u32, u32)> {
     let deadline = tokio::time::Instant::now() + NREAD_OVERALL_TIMEOUT;
     let mut buf = [0u8; 8];

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -2270,7 +2270,7 @@ impl Server {
             // iperf3's server reports only its own measured bytes and a 0 remote
             // CPU (#50).
             let _client_results = tokio::select! {
-                r = protocol::recv_results_server(&mut ctx.ctrl) => match r {
+                r = protocol::recv_results(&mut ctx.ctrl) => match r {
                     Ok(v) => v,
                     // #330: a malformed results read routes to the
                     // exchange_recv_failed surface — the Nread_json warning


### PR DESCRIPTION
Closes #374.

## The defect

The client's exchange reads were unbounded: a server that sends ExchangeResults, reads the client's blob, and then wedges parked the client until the peer released (the issue's live repro: 16+ s on a 15 s wedge, forever on a hold). GT self-bounds via its Nread 10 s idle / 30 s overall budgets (net.c:75-76) and errexits IERECVRESULTS.

## GT live probes (3.21) — they narrowed the issue's scope

- **State-byte WAITS are UNBOUNDED in GT.** Silent-after-accept, silent-after-TestEnd (no ExchangeResults state), and silent-before-DisplayResults wedges all exceeded a 45 s cap. riperf3's unbounded `recv_state` waits are already faithful and stay — the issue's "recv_state waits" item is probe-corrected (comment added on #374).
- **The exchange read IS bounded**: wedge-hold → `warning: Failed to read JSON data size - read returned 0; errno=0` at the 10 s idle bound, then `iperf3: error - unable to receive results:` (the #248 dangling errno-0 perr form), exit 1 at ~21.6 s (the extra ~10 s is GT's sync-close drain-to-EOF — the #354-recorded residual riperf3 deliberately lacks, so riperf3 exits ~10 s sooner on the same wedge).
- Mid-blob wedge → the `expected 500 bytes but received 5; errno=0` warning arm, same errexit.
- EOF at the results slot → same warning; the error tail appends a **stale errno's strerror** (`: Transport endpoint is not connected`) — the #330-recorded GT deviation, not mirrored; the errno-0 dangling form is emitted instead (the server-line precedent).
- **-J doc shape**: populated start, bare `end: {}`, error value `"unable to receive results: "` (no `error - ` prefix in-doc), warning still on stderr, exit 1. Intervals: GT shows collected-so-far, whose closing interval is still pending display (-t 1 → `[]`, -t 3 → 2 rows); riperf3's reporter flushes the closing interval before the exchange, so its count runs one ahead — the #55 flush-order drift, RECORDED here and deliberately un-pinned.

## The fix

- `recv_results_server` (bounded, warning-parity) is now `recv_results` for **both roles** — GT's `get_results` (iperf_api.c:2801) is called by both roles (:2400/:2404), so the five Nread_json warning arms and the bounds are shared. The plain client `recv_results`/`json_read` are deleted (their tests retarget `json_read_bounded`).
- The client's fail arm (`on_recv_results_failed`, the on_ctrl_lost shape): JSON sinks get the doc (bare end, dangling error value), text gets no dump (GT prints no summary on this class — probed), and the class errexits `RecvResultsFailed`.
- CLI: the class joins the #225 single-doc suppress list; the text line renders GT's perr tail (`riperf3: error - unable to receive results: `).
- **r1 F1 (blocker, commit 2):** `read_server_error_payload` — the SERVER_ERROR relay payload — was a bare unbounded `read_exact`, and unlike the results read it races NO interrupt arm, so the park was **signal-immune** (r1's live probe: SIGTERM did not free it). GT bounds these two Nreads (iperf_client_api.c:393-401), exiting a hold at ~30 s with a garbage-errno line read from the UNINITIALIZED short-read buffer. The read now runs on the house Nread budgets; the deterministic `"server error"` None-fallback is the recorded deviation (GT's uninitialized-memory line is not mirrored; its rc<0 IECTRLREAD arm folds into the same fallback — recorded in-code), and the 10 s idle bound fires first on a fully-silent hold (~10 s vs GT's ~30 s — the nread_step per-step-idle recorded-deviation class).

## Verification

**Pins, red-first on the unbounded build** (the wedge pins parked past the 25 s harness bound — the leak is the red; the -J pin rendered the CLI's skeleton `"early eof"` doc with no warning):

- `client_exchange_wedge_self_bounds_with_gt_warning` — wedge-hold: exit 1, the size-read warning, the dangling line, NO summary separator.
- `client_exchange_mid_blob_wedge_warns_partial_count` — 500-byte promise + 5 bytes + hold: the expected/received arm.
- `client_exchange_eof_takes_gt_recv_results_shape_in_json` — EOF, -J: doc error value + bare end + warning-only stderr + exit 1.
- `client_server_error_payload_wedge_self_bounds` — SERVER_ERROR byte then hold: parked past the 25 s harness bound red; self-bounds at ~10 s with the fallback line + exit 1 on the fix.

**Mutation table** (harness refuses dirty targets, anchor-uniqueness, exact restore): M1 nread_step unbounded (idle+overall arms stripped) → wedge pin red via the park; M2 size-read warning suppressed → red; M3 expected/received counts zeroed → red; M4 client doc emission stripped → -J pin red; M5 CLI suppress-list entry dropped (second doc concatenates) → red; M6 perr tail dropped → red; M7 payload-read bound reverted to the bare read_exact → red via the park (7/7 re-run on the r1-fixed head).

**Gate:** fmt / clippy `-D warnings` clean; workspace **855 passed / 0 failed** (851 + the 4 pins). One full-suite run flaked two pre-existing wire_shape tests (`cookie_failure_wire_back_is_server_error_ierecvcookie`, `clean_finish_reverse_exits_bounded_while_peer_holds` — mock EOF under parallel load, the #349-F4 family): green isolated, green ×3 in-binary, green on two full reruns; disclosed, no change.

Claim-coverage note (r1 F4): the --json-stream shape for this class rides the shared render_results stream machinery (the #170/#198-verified path) — probed surfaces are -J and text.
