### PR TITLE
fix: the UDP setup phase runs the #356 select machinery, both designs (#358)

### DIFF
--- a/riperf3-cli/tests/wire_shape.rs
+++ b/riperf3-cli/tests/wire_shape.rs
@@ -4433,6 +4433,194 @@ fn udp_setup_ctrl_eof_takes_gt_doc_shape_in_json() {
         doc["end"].as_object().expect("end").is_empty(),
         "bare end{{}}: {doc}"
     );
+    // #383 r1 F1a: GT emits NONE of the four TCP-flavored start keys for a
+    // UDP round's setup doc — tcp_mss_default is SOCK_STREAM-gated
+    // (iperf_api.c:1021-1027) and the UDP bufsize trio only lands via
+    // iperf_udp_buffercheck at stream accept (iperf_udp.c:439-452), which
+    // never ran in this wedge (live key-diff probed).
+    for key in [
+        "sock_bufsize",
+        "sndbuf_actual",
+        "rcvbuf_actual",
+        "tcp_mss_default",
+    ] {
+        assert!(
+            doc["start"][key].is_null(),
+            "{key} must be ABSENT from the UDP setup doc: {doc}"
+        );
+    }
+}
+
+/// The #358 terminate driver: CLIENT_TERMINATE right after CreateStreams
+/// under UDP params; reads the fe 00000077 00000000 relay.
+fn run_udp_setup_terminate_scenario(
+    demux: bool,
+    json: bool,
+) -> (Vec<u8>, String, String, std::process::ExitStatus) {
+    let frame = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+    let frame_in = frame.clone();
+    let (sout, serr, status) = drive_udp_server_scenario(
+        demux,
+        &[],
+        json,
+        move |port| {
+            let mut ctrl = std::net::TcpStream::connect(("127.0.0.1", port)).expect("ctrl");
+            ctrl.write_all(&[b'x'; 37]).unwrap();
+            assert_eq!(read_exact(&mut ctrl, 1)[0], 9, "ParamExchange");
+            write_json_blob(&mut ctrl, UDP_INCOMPLETE_PARAMS);
+            assert_eq!(read_exact(&mut ctrl, 1)[0], 10, "CreateStreams");
+            ctrl.write_all(&[12u8]).unwrap(); // CLIENT_TERMINATE
+            *frame_in.lock().unwrap() = read_wireback(&mut ctrl);
+            drop(ctrl);
+        },
+        Duration::from_secs(5),
+    );
+    let frame = frame.lock().unwrap().clone();
+    (frame, sout, serr, status)
+}
+
+/// #358 (#383 r1 F3/F1c): CLIENT_TERMINATE mid-UDP-setup dispatches
+/// through the select's Data arm — the IECLIENTTERM relay, GT's stderr
+/// sentence, exit 0, and the terminate skeleton with GT's UDP header
+/// (live-probed: `…Bitrate         Jitter    Lost/Total Datagrams` — the
+/// TCP header was the r1 F1c divergence). Recycling design.
+#[test]
+fn udp_setup_terminate_dispatches_with_udp_skeleton() {
+    let (frame, sout, serr, status) = run_udp_setup_terminate_scenario(false, false);
+    assert_eq!(frame, wireback_frame(119), "fe + htonl(IECLIENTTERM=119)");
+    assert!(status.success(), "one-off exits 0 like GT");
+    assert_eq!(
+        serr.trim(),
+        format!("riperf3: {CLIENT_TERMINATED_MSG}"),
+        "GT's bare terminate sentence: {serr:?}"
+    );
+    assert!(
+        sout.contains("Jitter    Lost/Total Datagrams"),
+        "the UDP skeleton header (r1 F1c): {sout}"
+    );
+}
+
+/// #358 (#383 r1 F3), demux design: the same dispatch surfaces.
+#[test]
+fn udp_setup_terminate_dispatches_with_udp_skeleton_demux() {
+    let (frame, sout, serr, status) = run_udp_setup_terminate_scenario(true, false);
+    assert_eq!(frame, wireback_frame(119));
+    assert!(status.success(), "one-off exits 0 like GT");
+    assert_eq!(
+        serr.trim(),
+        format!("riperf3: {CLIENT_TERMINATED_MSG}"),
+        "GT's bare terminate sentence: {serr:?}"
+    );
+    assert!(
+        sout.contains("Jitter    Lost/Total Datagrams"),
+        "the UDP skeleton header (r1 F1c): {sout}"
+    );
+}
+
+/// #358 (#383 r1 F1a/F1b), -J: GT's UDP terminate-at-setup doc — the four
+/// TCP start keys ABSENT, and the zeros end UDP-FLAVORED: an `end.sum`
+/// block plus jitter_ms/lost_packets/packets/lost_percent in all three
+/// sums, sum_sent.sender true (live-probed 3.21).
+#[test]
+fn udp_setup_terminate_doc_takes_udp_zeros_end() {
+    let (frame, sout, serr, status) = run_udp_setup_terminate_scenario(false, true);
+    assert_eq!(frame, wireback_frame(119));
+    assert!(status.success());
+    assert!(serr.trim().is_empty(), "-J keeps stderr silent: {serr:?}");
+    let doc: serde_json::Value =
+        serde_json::from_str(sout.trim()).unwrap_or_else(|e| panic!("one -J doc ({e}): {sout}"));
+    assert_eq!(
+        doc["error"].as_str(),
+        Some(CLIENT_TERMINATED_MSG),
+        "the bare IECLIENTTERM key: {doc}"
+    );
+    for key in [
+        "sock_bufsize",
+        "sndbuf_actual",
+        "rcvbuf_actual",
+        "tcp_mss_default",
+    ] {
+        assert!(
+            doc["start"][key].is_null(),
+            "{key} must be ABSENT from the UDP setup doc: {doc}"
+        );
+    }
+    let end = &doc["end"];
+    assert!(
+        end["sum"].is_object(),
+        "GT's UDP zeros end carries end.sum: {end}"
+    );
+    for sum in ["sum", "sum_sent", "sum_received"] {
+        for key in ["jitter_ms", "lost_packets", "packets", "lost_percent"] {
+            assert_eq!(
+                end[sum][key].as_u64(),
+                Some(0),
+                "{sum}.{key} present as 0 in the UDP zeros end: {end}"
+            );
+        }
+    }
+    assert_eq!(
+        end["sum_sent"]["sender"].as_bool(),
+        Some(true),
+        "sum_sent.sender true like GT's UDP shape: {end}"
+    );
+}
+
+/// #383 r1 F2: GT arms the CREATE_STREAMS no-progress bound only when the
+/// server RECEIVES (test->mode != SENDER, iperf_server_api.c:662-678,
+/// 720-733; the #351 idle_armed precedent one phase later) — a
+/// pure-reverse round holds patiently (GT live: >9 s at --rcv-timeout
+/// 3000). The mock holds 5 s expecting NO wire-back, then EOFs into the
+/// clean IECTRLCLOSE class.
+fn reverse_hold_case(params: &'static str, demux: bool) {
+    let (_sout, serr, status) = drive_udp_server_scenario(
+        demux,
+        &["--rcv-timeout", "3000"],
+        false,
+        move |port| {
+            use std::io::Read;
+            let mut ctrl = std::net::TcpStream::connect(("127.0.0.1", port)).expect("ctrl");
+            ctrl.write_all(&[b'x'; 37]).unwrap();
+            assert_eq!(read_exact(&mut ctrl, 1)[0], 9, "ParamExchange");
+            write_json_blob(&mut ctrl, params);
+            assert_eq!(read_exact(&mut ctrl, 1)[0], 10, "CreateStreams");
+            // HOLD past the 3 s bound: a sender-mode server must NOT fire
+            // the IENOMSG wire-back (the pre-fix red: fe 00000090 at ~3 s).
+            ctrl.set_read_timeout(Some(Duration::from_secs(5)))
+                .expect("set_read_timeout");
+            let mut buf = [0u8; 16];
+            let r = ctrl.read(&mut buf).map_err(|e| e.kind());
+            assert!(
+                matches!(
+                    r,
+                    Err(std::io::ErrorKind::WouldBlock | std::io::ErrorKind::TimedOut)
+                ),
+                "no wire-back while the sender-mode server waits: {r:?}"
+            );
+            drop(ctrl); // EOF -> the clean ctrl-closed class
+            std::thread::sleep(std::time::Duration::from_millis(300));
+        },
+        Duration::from_secs(5),
+    );
+    assert!(status.success(), "one-off exits 0 like GT");
+    assert_eq!(
+        serr.trim(),
+        format!("riperf3: {CTRL_CLOSED}"),
+        "the clean EOF class after the patient wait: {serr:?}"
+    );
+}
+
+/// #383 r1 F2, UDP recycling: reverse params exempt the idle bound.
+#[test]
+fn udp_reverse_setup_hold_is_idle_exempt() {
+    reverse_hold_case(r#"{"udp":true,"reverse":true}"#, false);
+}
+
+/// #383 r1 F2, TCP: the #356 arm gets the same exemption (same family,
+/// fixed together — GT's gate is protocol-blind).
+#[test]
+fn tcp_reverse_setup_hold_is_idle_exempt() {
+    reverse_hold_case(r#"{"tcp":true,"reverse":true}"#, false);
 }
 
 /// #358 HOLD, recycling, text: bounded at --rcv-timeout with GT's IENOMSG

--- a/riperf3-cli/tests/wire_shape.rs
+++ b/riperf3-cli/tests/wire_shape.rs
@@ -4264,6 +4264,224 @@ fn client_server_error_payload_wedge_self_bounds() {
     );
 }
 
+// ---------------------------------------------------------------------------
+// #358: the UDP setup phase gets the #356 select machinery — the TCP-only
+// fix left three GT-fidelity gaps (all live-probed on GT 3.21 in #356's
+// r1, {"udp":true} params): ctrl-EOF sat out the riperf3-only 30 s UDP
+// connect budget where GT IECTRLCLOSEs at once; --rcv-timeout was ignored
+// (GT bounds the wait at rcv_timeout, probed dt 3.01 at 3000 ms); and the
+// timeout surface was riperf3-only ("test aborted: timed out waiting for
+// UDP stream connect", no IENOMSG wire-back, no setup doc — GT sends
+// fe 00000090 00000000 and emits the #356 setup-phase document). Both
+// server designs (recycling + demux) are pinned via
+// RIPERF3_UDP_SERVER_DEMUX.
+// ---------------------------------------------------------------------------
+
+/// Valid UDP params via serde defaults; the peer never sends the connect
+/// magic (the #356 INCOMPLETE_PARAMS shape, UDP protocol).
+const UDP_INCOMPLETE_PARAMS: &str = r#"{"udp":true}"#;
+
+/// [`drive_server_scenario_with`] + the UDP-design env knob and a caller
+/// exit bound (the EOF reds sit out the old 30 s budget — the bound IS
+/// the pin).
+fn drive_udp_server_scenario(
+    demux: bool,
+    extra_args: &[&str],
+    json: bool,
+    mock: impl FnOnce(u16) + Send + 'static,
+    exit_bound: Duration,
+) -> (String, String, std::process::ExitStatus) {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind");
+    let port = listener.local_addr().unwrap().port();
+    drop(listener);
+    let port_s = port.to_string();
+
+    let mut args = vec!["-s", "-1", "-p", &port_s];
+    args.extend_from_slice(extra_args);
+    if json {
+        args.push("-J");
+    }
+    let mut server = common::ChildGuard(
+        std::process::Command::new(env!("CARGO_BIN_EXE_riperf3"))
+            .args(&args)
+            .env("RIPERF3_UDP_SERVER_DEMUX", if demux { "1" } else { "0" })
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .spawn()
+            .expect("spawn server"),
+    );
+    let sout_reader =
+        riperf3_test_support::drain_reader(server.0.stdout.take().expect("piped stdout"));
+    let serr_reader =
+        riperf3_test_support::drain_reader(server.0.stderr.take().expect("piped stderr"));
+    std::thread::sleep(std::time::Duration::from_millis(400));
+
+    let mock = std::thread::spawn(move || mock(port));
+    mock.join().expect("mock");
+    let status = riperf3_test_support::wait_bounded(&mut server.0, exit_bound)
+        .expect("server exits bounded");
+    (
+        sout_reader.join().expect("stdout"),
+        serr_reader.join().expect("stderr"),
+        status,
+    )
+}
+
+/// The #358 EOF driver: full setup to CreateStreams under UDP params,
+/// then ctrl-EOF with the connect magic never sent.
+fn drive_udp_setup_eof(port: u16) {
+    let mut ctrl = std::net::TcpStream::connect(("127.0.0.1", port)).expect("ctrl");
+    ctrl.write_all(&[b'x'; 37]).unwrap();
+    assert_eq!(read_exact(&mut ctrl, 1)[0], 9, "ParamExchange");
+    write_json_blob(&mut ctrl, UDP_INCOMPLETE_PARAMS);
+    assert_eq!(read_exact(&mut ctrl, 1)[0], 10, "CreateStreams");
+    drop(ctrl); // EOF with the UDP connect never attempted
+    std::thread::sleep(std::time::Duration::from_millis(300));
+}
+
+/// The #358 HOLD runner: park in the UDP CREATE_STREAMS wait with the
+/// ctrl open, read the wire-back frame at the --rcv-timeout 3000 bound.
+fn run_udp_setup_hold_scenario(
+    demux: bool,
+    json: bool,
+) -> (Vec<u8>, String, String, std::process::ExitStatus) {
+    let frame = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+    let frame_in = frame.clone();
+    let (sout, serr, status) = drive_udp_server_scenario(
+        demux,
+        &["--rcv-timeout", "3000"],
+        json,
+        move |port| {
+            let mut ctrl = std::net::TcpStream::connect(("127.0.0.1", port)).expect("ctrl");
+            ctrl.write_all(&[b'x'; 37]).unwrap();
+            assert_eq!(read_exact(&mut ctrl, 1)[0], 9, "ParamExchange");
+            write_json_blob(&mut ctrl, UDP_INCOMPLETE_PARAMS);
+            assert_eq!(read_exact(&mut ctrl, 1)[0], 10, "CreateStreams");
+            // HOLD: the connect magic never comes, ctrl stays open. The
+            // wire-back should arrive at the ~3 s bound; the pre-fix path
+            // errors at its own 30 s budget with no wire-back at all.
+            *frame_in.lock().unwrap() = read_wireback(&mut ctrl);
+            drop(ctrl);
+        },
+        Duration::from_secs(8),
+    );
+    let frame = frame.lock().unwrap().clone();
+    (frame, sout, serr, status)
+}
+
+/// #358 EOF, recycling design, text: GT's instant IECTRLCLOSE — the
+/// pre-fix server sat out the full 30 s UDP connect budget (the 5 s exit
+/// bound is the red).
+#[test]
+fn udp_setup_ctrl_eof_exits_bounded_in_text() {
+    let (_sout, serr, status) = drive_udp_server_scenario(
+        false,
+        &[],
+        false,
+        drive_udp_setup_eof,
+        Duration::from_secs(5),
+    );
+    assert!(status.success(), "one-off exits 0 like GT");
+    assert_eq!(
+        serr.trim(),
+        format!("riperf3: {CTRL_CLOSED}"),
+        "GT's bare read-site sentence: {serr:?}"
+    );
+}
+
+/// #358 EOF, demux design, text: the same instant IECTRLCLOSE.
+#[test]
+fn udp_setup_ctrl_eof_exits_bounded_in_text_demux() {
+    let (_sout, serr, status) = drive_udp_server_scenario(
+        true,
+        &[],
+        false,
+        drive_udp_setup_eof,
+        Duration::from_secs(5),
+    );
+    assert!(status.success(), "one-off exits 0 like GT");
+    assert_eq!(
+        serr.trim(),
+        format!("riperf3: {CTRL_CLOSED}"),
+        "GT's bare read-site sentence: {serr:?}"
+    );
+}
+
+/// #358 EOF, -J (recycling): the #356 setup-phase doc with the bare
+/// IECTRLCLOSE key and silent stderr — the field walk is the TCP pins'
+/// (setup_phase_ctrl_eof_takes_gt_doc_shape_in_json); this asserts the
+/// UDP arm routes through the same emit.
+#[test]
+fn udp_setup_ctrl_eof_takes_gt_doc_shape_in_json() {
+    let (sout, serr, status) = drive_udp_server_scenario(
+        false,
+        &[],
+        true,
+        drive_udp_setup_eof,
+        Duration::from_secs(5),
+    );
+    assert!(status.success());
+    assert!(serr.trim().is_empty(), "-J keeps stderr silent: {serr:?}");
+    let doc: serde_json::Value =
+        serde_json::from_str(sout.trim()).unwrap_or_else(|e| panic!("one -J doc ({e}): {sout}"));
+    assert_eq!(
+        doc["error"].as_str(),
+        Some(CTRL_CLOSED),
+        "bare IECTRLCLOSE key: {doc}"
+    );
+    assert!(
+        doc["end"].as_object().expect("end").is_empty(),
+        "bare end{{}}: {doc}"
+    );
+}
+
+/// #358 HOLD, recycling, text: bounded at --rcv-timeout with GT's IENOMSG
+/// surface — the fe 00000090 00000000 wire-back, the stderr line, exit 0.
+#[test]
+fn udp_setup_ctrl_hold_bounds_at_rcv_timeout_in_text() {
+    let (frame, _sout, serr, status) = run_udp_setup_hold_scenario(false, false);
+    assert_eq!(
+        frame,
+        wireback_frame(144),
+        "SERVER_ERROR + htonl(IENOMSG) + htonl(0), like GT's cleanup_server"
+    );
+    assert!(status.success(), "one-off exits 0 like GT");
+    assert_eq!(
+        serr.trim(),
+        format!("riperf3: error - {IDLE_TIMEOUT_MSG}"),
+        "GT's IENOMSG line: {serr:?}"
+    );
+}
+
+/// #358 HOLD, demux, text: the same rcv_timeout bound and surface.
+#[test]
+fn udp_setup_ctrl_hold_bounds_at_rcv_timeout_in_text_demux() {
+    let (frame, _sout, serr, status) = run_udp_setup_hold_scenario(true, false);
+    assert_eq!(frame, wireback_frame(144));
+    assert!(status.success(), "one-off exits 0 like GT");
+    assert_eq!(
+        serr.trim(),
+        format!("riperf3: error - {IDLE_TIMEOUT_MSG}"),
+        "GT's IENOMSG line: {serr:?}"
+    );
+}
+
+/// #358 HOLD, -J (recycling): the prefixed IENOMSG key over the setup doc.
+#[test]
+fn udp_setup_ctrl_hold_takes_gt_doc_shape_in_json() {
+    let (frame, sout, serr, status) = run_udp_setup_hold_scenario(false, true);
+    assert_eq!(frame, wireback_frame(144));
+    assert!(status.success());
+    assert!(serr.trim().is_empty(), "-J keeps stderr silent: {serr:?}");
+    let doc: serde_json::Value =
+        serde_json::from_str(sout.trim()).unwrap_or_else(|e| panic!("one -J doc ({e}): {sout}"));
+    assert_eq!(
+        doc["error"].as_str(),
+        Some(format!("error - {IDLE_TIMEOUT_MSG}").as_str()),
+        "the prefixed IENOMSG key: {doc}"
+    );
+}
+
 /// #374: EOF where the results were due, -J — the doc carries the
 /// dangling error value and GT's bare `end: {}` (live-probed 3.21; GT's
 /// in-doc value appends a STALE errno's strerror — recorded deviation,

--- a/riperf3-cli/tests/wire_shape.rs
+++ b/riperf3-cli/tests/wire_shape.rs
@@ -4345,6 +4345,16 @@ fn run_udp_setup_hold_scenario(
     demux: bool,
     json: bool,
 ) -> (Vec<u8>, String, String, std::process::ExitStatus) {
+    run_udp_setup_hold_scenario_params(demux, json, UDP_INCOMPLETE_PARAMS)
+}
+
+/// The hold runner with explicit params — the #383 r2 F3 reverse+bidir
+/// hostile-peer cell needs a non-default param set.
+fn run_udp_setup_hold_scenario_params(
+    demux: bool,
+    json: bool,
+    params: &'static str,
+) -> (Vec<u8>, String, String, std::process::ExitStatus) {
     let frame = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
     let frame_in = frame.clone();
     let (sout, serr, status) = drive_udp_server_scenario(
@@ -4355,7 +4365,7 @@ fn run_udp_setup_hold_scenario(
             let mut ctrl = std::net::TcpStream::connect(("127.0.0.1", port)).expect("ctrl");
             ctrl.write_all(&[b'x'; 37]).unwrap();
             assert_eq!(read_exact(&mut ctrl, 1)[0], 9, "ParamExchange");
-            write_json_blob(&mut ctrl, UDP_INCOMPLETE_PARAMS);
+            write_json_blob(&mut ctrl, params);
             assert_eq!(read_exact(&mut ctrl, 1)[0], 10, "CreateStreams");
             // HOLD: the connect magic never comes, ctrl stays open. The
             // wire-back should arrive at the ~3 s bound; the pre-fix path
@@ -4621,6 +4631,88 @@ fn udp_reverse_setup_hold_is_idle_exempt() {
 #[test]
 fn tcp_reverse_setup_hold_is_idle_exempt() {
     reverse_hold_case(r#"{"tcp":true,"reverse":true}"#, false);
+}
+
+/// #383 r2 F1: the demux design's idle exemption — the both-designs
+/// convention every other #358 cell follows.
+#[test]
+fn udp_reverse_setup_hold_is_idle_exempt_demux() {
+    reverse_hold_case(r#"{"udp":true,"reverse":true}"#, true);
+}
+
+/// #383 r2 F3: reverse+bidir stays ARMED — GT's iperf_set_test_bidirectional
+/// forces mode BIDIRECTIONAL (iperf_api.c:827-834), which is != SENDER, so
+/// the bound fires (GT live: 3.01 s). A conforming client cannot send the
+/// combination (GT rejects -R --bidir locally); a hand-rolled peer can.
+#[test]
+fn udp_reverse_bidir_setup_hold_stays_armed() {
+    let (frame, _sout, serr, status) = run_udp_setup_hold_scenario_params(
+        false,
+        false,
+        r#"{"udp":true,"reverse":true,"bidirectional":true}"#,
+    );
+    assert_eq!(
+        frame,
+        wireback_frame(144),
+        "bidir arms the bound like GT (mode BIDIRECTIONAL != SENDER)"
+    );
+    assert!(status.success(), "one-off exits 0 like GT");
+    assert_eq!(
+        serr.trim(),
+        format!("riperf3: error - {IDLE_TIMEOUT_MSG}"),
+        "GT's IENOMSG line: {serr:?}"
+    );
+}
+
+/// #383 r2 F4: the --json-stream UDP terminate pair — the TCP flavor has
+/// its own pin (setup_phase_client_terminate_stream_events); the UDP end
+/// event carries the UDP-flavored zeros (end.sum + the datagram counters).
+#[test]
+fn udp_setup_terminate_takes_udp_zeros_in_json_stream() {
+    let frame = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+    let frame_in = frame.clone();
+    let (sout, serr, status) = drive_udp_server_scenario(
+        false,
+        &["--json-stream"],
+        false,
+        move |port| {
+            let mut ctrl = std::net::TcpStream::connect(("127.0.0.1", port)).expect("ctrl");
+            ctrl.write_all(&[b'x'; 37]).unwrap();
+            assert_eq!(read_exact(&mut ctrl, 1)[0], 9, "ParamExchange");
+            write_json_blob(&mut ctrl, UDP_INCOMPLETE_PARAMS);
+            assert_eq!(read_exact(&mut ctrl, 1)[0], 10, "CreateStreams");
+            ctrl.write_all(&[12u8]).unwrap(); // CLIENT_TERMINATE
+            *frame_in.lock().unwrap() = read_wireback(&mut ctrl);
+            drop(ctrl);
+        },
+        Duration::from_secs(5),
+    );
+    assert_eq!(*frame.lock().unwrap(), wireback_frame(119));
+    assert!(status.success());
+    assert!(
+        serr.trim().is_empty(),
+        "--json-stream keeps stderr silent: {serr:?}"
+    );
+    let events: Vec<serde_json::Value> = sout
+        .lines()
+        .filter(|l| !l.trim().is_empty())
+        .map(|l| serde_json::from_str(l).unwrap_or_else(|e| panic!("event line ({e}): {l}")))
+        .collect();
+    assert_eq!(events.len(), 2, "error + end pair: {sout:?}");
+    assert_eq!(events[0]["event"].as_str(), Some("error"));
+    assert_eq!(events[0]["data"].as_str(), Some(CLIENT_TERMINATED_MSG));
+    assert_eq!(events[1]["event"].as_str(), Some("end"));
+    let end = &events[1]["data"];
+    assert!(
+        end["sum"].is_object(),
+        "the UDP zeros end carries end.sum: {end}"
+    );
+    assert_eq!(
+        end["sum"]["jitter_ms"].as_u64(),
+        Some(0),
+        "the UDP datagram counters ride the stream event too: {end}"
+    );
+    assert_eq!(end["sum_sent"]["sender"].as_bool(), Some(true), "{end}");
 }
 
 /// #358 HOLD, recycling, text: bounded at --rcv-timeout with GT's IENOMSG

--- a/riperf3/src/json_report.rs
+++ b/riperf3/src/json_report.rs
@@ -4013,6 +4013,98 @@ mod tests {
         );
     }
 
+    /// #383 r2 F2: the UDP flavor's raw byte order — the four TCP keys
+    /// absent from start, `sum` FIRST in the zeros end, and the datagram
+    /// counters between bits_per_second and sender in every sum
+    /// (live-probed GT 3.21; the -J pin's parsed asserts are order-blind,
+    /// so this raw walk is the order guard).
+    #[test]
+    fn udp_setup_document_key_order_is_gt_server_order() {
+        let d = SetupPhaseDoc {
+            sock_bufsize: None,
+            sndbuf_actual: None,
+            rcvbuf_actual: None,
+            tcp_mss_default: None,
+            udp: true,
+            timemillisecs: 1_700_000_000_000,
+            accepted_host: "127.0.0.1".into(),
+            accepted_port: 5201,
+            cookie: "c".repeat(36),
+            target_bitrate: 0,
+            fq_rate: 0,
+        };
+        let raw = setup_terminate_document(
+            &d,
+            "the client has terminated",
+            &CpuUtilization {
+                host_total: 1.0,
+                host_user: 0.5,
+                host_system: 0.5,
+                remote_total: 0.0,
+                remote_user: 0.0,
+                remote_system: 0.0,
+            },
+        );
+        let keys = |obj: &str| raw_keys(&raw, obj);
+        assert_eq!(
+            keys("start"),
+            [
+                "connected",
+                "version",
+                "system_info",
+                "timestamp",
+                "accepted_connection",
+                "cookie",
+                "target_bitrate",
+                "fq_rate"
+            ],
+            "UDP setup start must drop the four TCP keys: {raw}"
+        );
+        assert_eq!(
+            keys("end"),
+            [
+                "streams",
+                "sum",
+                "sum_sent",
+                "sum_received",
+                "cpu_utilization_percent"
+            ],
+            "UDP zeros-end carries sum first: {raw}"
+        );
+        assert_eq!(
+            keys("sum"),
+            [
+                "start",
+                "end",
+                "seconds",
+                "bytes",
+                "bits_per_second",
+                "jitter_ms",
+                "lost_packets",
+                "packets",
+                "lost_percent",
+                "sender"
+            ],
+            "UDP zero-sum key order drifted from GT: {raw}"
+        );
+        assert_eq!(
+            keys("sum_sent"),
+            [
+                "start",
+                "end",
+                "seconds",
+                "bytes",
+                "bits_per_second",
+                "jitter_ms",
+                "lost_packets",
+                "packets",
+                "lost_percent",
+                "sender"
+            ],
+            "UDP sum_sent key order drifted from GT: {raw}"
+        );
+    }
+
     /// #281: the pre-ParamExchange shape (GT stage 0, second capture on the
     /// issue) — `start` carries ONLY connected/version/system_info; even the
     /// timestamp and cookie are absent, because GT stamps them at on_connect.

--- a/riperf3/src/json_report.rs
+++ b/riperf3/src/json_report.rs
@@ -202,10 +202,17 @@ pub(crate) fn refusal_document(error: &str, target_bitrate: Option<u64>) -> Stri
 
 /// Inputs for the #338 setup-phase document, gathered at the CREATE_STREAMS
 /// wait (the control connection and the listener are live; no data streams).
+/// #383 r1 F1a: for a UDP round the four TCP-flavored keys are ABSENT —
+/// GT's tcp_mss_default is SOCK_STREAM-gated (iperf_api.c:1021-1027) and
+/// its UDP bufsize trio only lands via iperf_udp_buffercheck at stream
+/// accept (iperf_udp.c:439-452), which never runs in a setup-phase wedge
+/// (live key-diff probed) — so the builder passes None for all four.
 pub(crate) struct SetupPhaseDoc {
-    pub sock_bufsize: u64,
+    pub sock_bufsize: Option<u64>,
     pub sndbuf_actual: Option<u64>,
     pub rcvbuf_actual: Option<u64>,
+    pub tcp_mss_default: Option<u32>,
+    pub udp: bool,
     pub timemillisecs: u64,
     pub accepted_host: String,
     pub accepted_port: u16,
@@ -238,7 +245,7 @@ pub(crate) fn setup_terminate_document(
     error: &str,
     cpu: &CpuUtilization,
 ) -> String {
-    setup_phase_document(d, &zeros_end(cpu), Some(error))
+    setup_phase_document(d, &zeros_end(d.udp, cpu), Some(error))
 }
 
 /// #356 r1 F1: GT's IPERF_DONE-at-setup document — the clean arm exits the
@@ -251,11 +258,11 @@ pub(crate) fn setup_done_document(d: &SetupPhaseDoc) -> String {
 /// #356 r1 F1: the `--json-stream` terminate-at-setup pair — GT emits the
 /// bare-sentence error event, then an `end` event whose data is the same
 /// FULL-zeros end block the -J doc carries (live-probed 3.21).
-pub(crate) fn terminate_stream_events(error: &str, cpu: &CpuUtilization) -> String {
+pub(crate) fn terminate_stream_events(udp: bool, error: &str, cpu: &CpuUtilization) -> String {
     format!(
         "{}\n{}",
         json_stream_event("error", &error),
-        json_stream_event("end", &zeros_end(cpu))
+        json_stream_event("end", &zeros_end(udp, cpu))
     )
 }
 
@@ -269,7 +276,10 @@ pub(crate) fn done_stream_events() -> String {
 struct BareEnd {}
 
 /// GT's zero sum block: exactly the six keys its reporter renders for a
-/// stream-less summary (no retransmits — the sender extras never arm).
+/// stream-less TCP summary (no retransmits — the sender extras never
+/// arm). #383 r1 F1b: the UDP flavor inserts jitter_ms / lost_packets /
+/// packets / lost_percent between bits_per_second and sender, GT's UDP
+/// sum order (live-probed 3.21).
 #[derive(Serialize)]
 struct ZeroSum {
     start: u64,
@@ -277,30 +287,48 @@ struct ZeroSum {
     seconds: u64,
     bytes: u64,
     bits_per_second: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    jitter_ms: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    lost_packets: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    packets: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    lost_percent: Option<u64>,
     sender: bool,
 }
 
+/// #383 r1 F1b: GT's UDP zeros end ALSO carries a bare `sum` block
+/// (streams, sum, sum_sent, sum_received, cpu — live-probed), and its
+/// sum_sent.sender is true; the TCP shape (#356-probed) has neither.
 #[derive(Serialize)]
 struct ZerosEnd {
     streams: [(); 0],
+    #[serde(skip_serializing_if = "Option::is_none")]
+    sum: Option<ZeroSum>,
     sum_sent: ZeroSum,
     sum_received: ZeroSum,
     cpu_utilization_percent: CpuUtilization,
 }
 
-fn zeros_end(cpu: &CpuUtilization) -> ZerosEnd {
-    let zero = || ZeroSum {
+fn zeros_end(udp: bool, cpu: &CpuUtilization) -> ZerosEnd {
+    let zero = |sender: bool| ZeroSum {
         start: 0,
         end: 0,
         seconds: 0,
         bytes: 0,
         bits_per_second: 0,
-        sender: false,
+        jitter_ms: udp.then_some(0),
+        lost_packets: udp.then_some(0),
+        packets: udp.then_some(0),
+        lost_percent: udp.then_some(0),
+        sender,
     };
     ZerosEnd {
         streams: [],
-        sum_sent: zero(),
-        sum_received: zero(),
+        sum: udp.then(|| zero(false)),
+        sum_sent: zero(udp),
+        sum_received: zero(false),
         cpu_utilization_percent: cpu.clone(),
     }
 }
@@ -311,7 +339,8 @@ fn setup_phase_document<E: Serialize>(d: &SetupPhaseDoc, end: &E, error: Option<
         connected: [(); 0],
         version: String,
         system_info: String,
-        sock_bufsize: u64,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        sock_bufsize: Option<u64>,
         #[serde(skip_serializing_if = "Option::is_none")]
         sndbuf_actual: Option<u64>,
         #[serde(skip_serializing_if = "Option::is_none")]
@@ -319,7 +348,8 @@ fn setup_phase_document<E: Serialize>(d: &SetupPhaseDoc, end: &E, error: Option<
         timestamp: Timestamp,
         accepted_connection: ConnectingTo,
         cookie: &'a str,
-        tcp_mss_default: u32,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        tcp_mss_default: Option<u32>,
         target_bitrate: u64,
         fq_rate: u64,
     }
@@ -350,7 +380,7 @@ fn setup_phase_document<E: Serialize>(d: &SetupPhaseDoc, end: &E, error: Option<
                 port: d.accepted_port,
             },
             cookie: &d.cookie,
-            tcp_mss_default: 0,
+            tcp_mss_default: d.tcp_mss_default,
             target_bitrate: d.target_bitrate,
             fq_rate: d.fq_rate,
         },
@@ -3915,9 +3945,11 @@ mod tests {
     #[test]
     fn setup_document_key_order_is_gt_server_order() {
         let d = SetupPhaseDoc {
-            sock_bufsize: 0,
+            sock_bufsize: Some(0),
             sndbuf_actual: Some(16384),
             rcvbuf_actual: Some(131072),
+            tcp_mss_default: Some(0),
+            udp: false,
             timemillisecs: 1_700_000_000_000,
             accepted_host: "127.0.0.1".into(),
             accepted_port: 5201,

--- a/riperf3/src/protocol.rs
+++ b/riperf3/src/protocol.rs
@@ -1,5 +1,3 @@
-use std::net::SocketAddr;
-
 use rand::Rng;
 use serde::{Deserialize, Serialize};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
@@ -927,16 +925,19 @@ pub async fn udp_connect_client(socket: &UdpSocket) -> Result<()> {
     ))
 }
 
-/// Server-side UDP connect handshake.
-/// Waits (up to `timeout`) for the client's magic word, "connects" the socket
-/// to the client, sends the reply, and returns the client address. The bounded
-/// wait means a client that never connects — or whose magic is lost on a real
-/// network — fails the test instead of hanging setup forever (issue #11).
+/// Server-side UDP connect handshake — retained as the REFERENCE
+/// implementation for the handshake round-trip tests below. #358 retired
+/// its production call: the recycling setup now receives the magic inside
+/// the #356 select machinery (server.rs) so ctrl-EOF/rcv-timeout are
+/// honored, and runs the connect+reply after the arm wins (this fn's
+/// select-cancellation would risk a lost reply). Validation semantics are
+/// duplicated verbatim at that site.
 /// Note: iperf3 uses native byte order (not network byte order) for the magic values.
+#[cfg(test)]
 pub async fn udp_connect_server(
     socket: &UdpSocket,
     timeout: std::time::Duration,
-) -> Result<SocketAddr> {
+) -> Result<std::net::SocketAddr> {
     let mut buf = [0u8; 65536];
     let (n, addr) = match tokio::time::timeout(timeout, socket.recv_from(&mut buf)).await {
         Ok(r) => r?,

--- a/riperf3/src/reporter.rs
+++ b/riperf3/src/reporter.rs
@@ -264,13 +264,20 @@ pub fn print_separator() {
 
 /// #356 r1 F1: GT's terminate-at-setup text skeleton — its
 /// reporter_callback runs under DISPLAY_RESULTS with zero streams
-/// (iperf_server_api.c:292-297), printing just the separator and the plain
-/// TCP header (live-probed 3.21).
-pub fn print_terminate_skeleton() {
+/// (iperf_server_api.c:292-297), printing just the separator and the
+/// plain protocol header (live-probed 3.21; #383 r1 F1c: the UDP header
+/// carries GT's Jitter / Lost/Total Datagrams columns).
+pub fn print_terminate_skeleton(udp: bool) {
     print_separator();
-    titled(format_args!(
-        "[ ID] Interval           Transfer     Bitrate"
-    ));
+    if udp {
+        titled(format_args!(
+            "[ ID] Interval           Transfer     Bitrate         Jitter    Lost/Total Datagrams"
+        ));
+    } else {
+        titled(format_args!(
+            "[ ID] Interval           Transfer     Bitrate"
+        ));
+    }
 }
 
 /// GT's final-partial-interval keep rule (iperf_print_intermediate,

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -426,6 +426,12 @@ enum CtrlActivity {
 /// Abort drops each task's socket at its next await; no counts exist yet,
 /// so there is nothing to freeze (the #352 join-site concern doesn't apply).
 async fn abort_setup_streams(ctx: &mut TestRunCtx) {
+    // #358: `done` first — the UDP paths hold spawn_blocking threads parked
+    // on the start barrier / 500 ms-poll reads, where abort() is a no-op
+    // and an unset `done` would hang the joins (the #372-gate lesson).
+    // Every caller ends the round, so the store is round-terminal by
+    // construction; the TCP tasks never needed it (abort suffices).
+    ctx.done.store(true, Ordering::Relaxed);
     for s in &ctx.streams {
         s.task.abort();
     }
@@ -1515,31 +1521,18 @@ impl Server {
                     Err(_) => cfg!(windows),
                 };
 
-                if udp_use_demux {
-                    self.setup_udp_demux_streams(
-                        &mut ctx.ctrl,
-                        &ctx.cfg,
-                        recv_count,
-                        total,
-                        max_duration,
-                        &ctx.done,
-                        &ctx.start,
-                        &mut ctx.streams,
-                        &mut ctx.udp_demux_handle,
-                    )
-                    .await?;
+                // #358: both UDP designs run the same #356 select machinery
+                // as the TCP arm, so they can dispatch ctrl bytes — a
+                // ClientDone (IPERF_DONE) surfaces here like TCP's.
+                let flow = if udp_use_demux {
+                    self.setup_udp_demux_streams(ctx, listener, recv_count, total, max_duration)
+                        .await?
                 } else {
-                    self.setup_udp_recycling_streams(
-                        &mut ctx.ctrl,
-                        &ctx.cfg,
-                        recv_count,
-                        total,
-                        max_duration,
-                        &ctx.done,
-                        &ctx.start,
-                        &mut ctx.streams,
-                    )
-                    .await?;
+                    self.setup_udp_recycling_streams(ctx, listener, recv_count, total, max_duration)
+                        .await?
+                };
+                if let SetupFlow::ClientDone = flow {
+                    return Ok(SetupFlow::ClientDone);
                 }
             }
         }
@@ -2466,15 +2459,24 @@ impl Server {
     #[allow(clippy::too_many_arguments)]
     async fn setup_udp_recycling_streams(
         &self,
-        ctrl: &mut tokio::net::TcpStream,
-        cfg: &TestConfig,
+        ctx: &mut TestRunCtx,
+        listener: &tokio::net::TcpListener,
         recv_count: u32,
         total: u32,
         max_duration: Option<std::time::Duration>,
-        done: &Arc<AtomicBool>,
-        start: &Arc<AtomicBool>,
-        streams: &mut Vec<DataStream>,
-    ) -> Result<()> {
+    ) -> Result<SetupFlow> {
+        // The scalar knobs, copied out so the select arms below can borrow
+        // ctx whole (dispatch_setup_ctrl_byte / emit_setup_phase_error).
+        let blksize = ctx.cfg.blksize;
+        let tos = ctx.cfg.tos;
+        let window = ctx.cfg.window;
+        let bandwidth = ctx.cfg.bandwidth;
+        let pacing_timer = ctx.cfg.pacing_timer;
+        let burst = ctx.cfg.burst;
+        let udp_counters_64bit = ctx.cfg.udp_counters_64bit;
+        let fq_rate = ctx.cfg.fq_rate;
+        let gso_dg_size = ctx.cfg.gso_dg_size;
+
         let mut udp_listener = net::udp_bind_reusable(
             self.bind_address.as_deref(),
             self.port,
@@ -2482,26 +2484,91 @@ impl Server {
             self.bind_dev.as_deref(),
         )
         .await?;
-        protocol::send_state(ctrl, TestState::CreateStreams).await?;
+        protocol::send_state(&mut ctx.ctrl, TestState::CreateStreams).await?;
+
+        // #358: GT's UDP CREATE_STREAMS wait runs inside its select loop
+        // like the TCP arm's — a ctrl-EOF is IECTRLCLOSE at once, a
+        // no-progress round bounds at rcv_timeout (IENOMSG), and a waiting
+        // ctrl byte dispatches. The old fixed per-stream
+        // UDP_CONNECT_TOTAL_TIMEOUT budget was riperf3-only: GT has no
+        // per-stream connect budget (the client keeps its own 30 s
+        // handshake budget in udp_connect_client).
+        let rcv_timeout =
+            std::time::Duration::from_millis(self.rcv_timeout.unwrap_or(DEFAULT_RCV_TIMEOUT_MS));
 
         // #316: the client's GSO/GRO request, probed per accepted socket
         // below. Once a probe fails, GT zeroes the setting and later
         // sockets don't retry (iperf_udp.c:459-515).
-        let (mut gso_on, mut gro_on) = (cfg.gso, cfg.gro);
+        let (mut gso_on, mut gro_on) = (ctx.cfg.gso, ctx.cfg.gro);
 
         // #178: each stream's spawn_blocking data thread is spawned through
         // the gate; the barrier below holds TestStart until the data plane
         // actually exists.
         let mut thread_gate = stream::StreamThreadGate::new();
         for i in 0..total {
-            // Accept: recv magic, connect() to client, send reply.
-            // Bounded so a client that never connects fails the test
-            // instead of hanging setup forever (#11); uses the same
-            // budget as the client's handshake so neither side aborts
-            // while the other is still retrying.
-            let _client_addr =
-                protocol::udp_connect_server(&udp_listener, protocol::UDP_CONNECT_TOTAL_TIMEOUT)
-                    .await?;
+            // Accept: recv magic (via the select), then connect() to the
+            // client and send the reply AFTER the arm wins — a ctrl byte
+            // cannot cancel a half-done handshake into a lost reply (the
+            // select-cancellation window the retired udp_connect_server
+            // call would have had).
+            let mut magic_buf = [0u8; 65536];
+            loop {
+                tokio::select! {
+                    r = udp_listener.recv_from(&mut magic_buf) => {
+                        let (n, addr) = r?;
+                        // Validation identical to the retired
+                        // udp_connect_server: short/foreign datagrams stay
+                        // fatal on this connected-per-stream design.
+                        if n < 4 {
+                            return Err(RiperfError::Protocol(
+                                "UDP connect message too short".into(),
+                            ));
+                        }
+                        let msg = u32::from_ne_bytes(magic_buf[..4].try_into().unwrap());
+                        if msg != protocol::UDP_CONNECT_MSG {
+                            return Err(RiperfError::Protocol(format!(
+                                "unexpected UDP connect message: {msg:#x}"
+                            )));
+                        }
+                        udp_listener.connect(addr).await?;
+                        udp_listener
+                            .send(&protocol::UDP_CONNECT_REPLY.to_ne_bytes())
+                            .await?;
+                        break;
+                    }
+                    activity = ctrl_activity(&ctx.ctrl) => match activity {
+                        // EOF: GT's read-site surface, noticed at once —
+                        // the TCP arm's exact shape (#338/#342).
+                        Ok(CtrlActivity::Eof) => {
+                            abort_setup_streams(ctx).await;
+                            let _ = protocol::send_server_error(&mut ctx.ctrl, 109).await;
+                            self.emit_setup_phase_error(ctx, listener, CTRL_CLOSED_MSG);
+                            return Err(RiperfError::ControlSocketClosed);
+                        }
+                        Ok(CtrlActivity::Data) => {
+                            if let SetupFlow::ClientDone =
+                                self.dispatch_setup_ctrl_byte(ctx, listener).await?
+                            {
+                                return Ok(SetupFlow::ClientDone);
+                            }
+                        }
+                        Err(e) => return Err(e.into()),
+                    },
+                    _ = tokio::time::sleep(rcv_timeout) => {
+                        // GT's no-progress bound: wire-back SERVER_ERROR +
+                        // IENOMSG(144) + errno 0, the doc with the prefixed
+                        // key, exit-0 keep-serving — the TCP arm's shape.
+                        abort_setup_streams(ctx).await;
+                        let _ = protocol::send_server_error(&mut ctx.ctrl, 144).await;
+                        self.emit_setup_phase_error(
+                            ctx,
+                            listener,
+                            &format!("error - {}", RiperfError::DataIdleTimeout),
+                        );
+                        return Err(RiperfError::DataIdleTimeout);
+                    }
+                }
+            }
             // The listener is now locked to this client — use it as the data socket
             let data_sock = udp_listener;
             // #316: per-accept like GT's iperf_udp_accept (iperf_udp.c:
@@ -2514,7 +2581,7 @@ impl Server {
             // reply, riperf3 after — no observable delta, the reply is
             // never segmented; r2 F4.)
             if gso_on {
-                gso_on = net::set_udp_gso(&data_sock, saturate_i32(cfg.gso_dg_size)).is_ok();
+                gso_on = net::set_udp_gso(&data_sock, saturate_i32(gso_dg_size)).is_ok();
             }
             if gro_on {
                 gro_on = net::set_udp_gro(&data_sock).is_ok();
@@ -2522,7 +2589,7 @@ impl Server {
             // #302 r2: pace EVERY accepted stream — GT's block lives in
             // iperf_udp_accept (iperf_udp.c:581-595), once per stream; the
             // pre-loop listener call covered stream 0 only.
-            net::apply_fq_rate(&data_sock, cfg.fq_rate);
+            net::apply_fq_rate(&data_sock, fq_rate);
 
             // Create a fresh listener for the next stream (if any)
             if i + 1 < total {
@@ -2548,37 +2615,36 @@ impl Server {
             // site (#45). The TCP accept loop has had this since #45; the
             // UDP paths never did (#154). IP_TOS is independent of SO_SND/RCVBUF,
             // so setting it before the window-apply/capture below is equivalent.
-            if cfg.tos != 0 {
-                net::set_tos(&data_sock, cfg.tos as u32)?;
+            if tos != 0 {
+                net::set_tos(&data_sock, tos as u32)?;
             }
             // Socket addresses + buffer sizes + the #97 window-clamp check for
             // the `-J` blob (#50), captured before the socket is converted to
             // std + moved. apply_window=true: honor -w/--window on the server's
             // UDP data socket too (#59) so reverse/bidir UDP matches iperf3,
             // before the read-back (#144).
-            let sock =
-                net::capture_stream_meta(socket2::SockRef::from(&data_sock), cfg.window, true)?;
+            let sock = net::capture_stream_meta(socket2::SockRef::from(&data_sock), window, true)?;
 
             let std_sock = data_sock.into_std().map_err(RiperfError::Io)?;
 
             if is_sender {
                 let c = counters.clone();
-                let d = done.clone();
-                let bs = cfg.blksize;
+                let d = ctx.done.clone();
+                let bs = blksize;
                 // Already resolved in TestConfig (#17); 0 = unlimited.
-                let rate = cfg.bandwidth;
-                let pt = cfg.pacing_timer; // #185: pace the UDP batch too
-                let u64bit = cfg.udp_counters_64bit;
-                let bu = cfg.burst;
-                let uw = cfg.window.is_some();
-                let st = start.clone();
+                let rate = bandwidth;
+                let pt = pacing_timer; // #185: pace the UDP batch too
+                let u64bit = udp_counters_64bit;
+                let bu = burst;
+                let uw = window.is_some();
+                let st = ctx.start.clone();
                 let md = max_duration;
                 let task = thread_gate.spawn(move || {
                     stream::run_udp_sender_blocking(
                         std_sock, c, bs, d, rate, pt, bu, uw, u64bit, st, md,
                     )
                 });
-                streams.push(DataStream {
+                ctx.streams.push(DataStream {
                     meta: StreamMeta {
                         id: stream_id,
                         is_sender,
@@ -2593,15 +2659,15 @@ impl Server {
                 });
             } else {
                 let c = counters.clone();
-                let d = done.clone();
-                let bs = cfg.blksize;
+                let d = ctx.done.clone();
+                let bs = blksize;
                 let stats = Arc::new(Mutex::new(UdpRecvStats::new()));
                 let stats_clone = stats.clone();
-                let u64bit = cfg.udp_counters_64bit;
+                let u64bit = udp_counters_64bit;
                 let task = thread_gate.spawn(move || {
                     stream::run_udp_receiver_blocking(std_sock, c, stats_clone, bs, d, u64bit)
                 });
-                streams.push(DataStream {
+                ctx.streams.push(DataStream {
                     meta: StreamMeta {
                         id: stream_id,
                         is_sender,
@@ -2621,7 +2687,7 @@ impl Server {
         // OS-thread creation, which stalls for seconds on loaded hosts. On
         // timeout proceed anyway (degraded = pre-fix behavior).
         thread_gate.wait(stream::STREAM_THREAD_START_TIMEOUT).await;
-        Ok(())
+        Ok(SetupFlow::Proceed)
     }
 
     /// Single-socket UDP server demux (#80; default on Windows). Bind ONE
@@ -2637,21 +2703,28 @@ impl Server {
     /// positional client/server stream pairing (the client creates streams
     /// sequentially by index). One demux thread serves every receiving stream;
     /// each sending stream `send_to`s its own client over the shared socket.
-    #[allow(clippy::too_many_arguments)]
     async fn setup_udp_demux_streams(
         &self,
-        ctrl: &mut tokio::net::TcpStream,
-        cfg: &TestConfig,
+        ctx: &mut TestRunCtx,
+        listener: &tokio::net::TcpListener,
         recv_count: u32,
         total: u32,
         max_duration: Option<std::time::Duration>,
-        done: &Arc<AtomicBool>,
-        start: &Arc<AtomicBool>,
-        streams: &mut Vec<DataStream>,
-        demux_handle: &mut Option<tokio::task::JoinHandle<Result<()>>>,
-    ) -> Result<()> {
+    ) -> Result<SetupFlow> {
         use std::collections::{HashMap, HashSet};
         use std::net::SocketAddr;
+
+        // The scalar knobs, copied out so the select arms below can borrow
+        // ctx whole (dispatch_setup_ctrl_byte / emit_setup_phase_error).
+        let blksize = ctx.cfg.blksize;
+        let tos = ctx.cfg.tos;
+        let window = ctx.cfg.window;
+        let bandwidth = ctx.cfg.bandwidth;
+        let pacing_timer = ctx.cfg.pacing_timer;
+        let burst = ctx.cfg.burst;
+        let udp_counters_64bit = ctx.cfg.udp_counters_64bit;
+        let fq_rate = ctx.cfg.fq_rate;
+        let gso_dg_size = ctx.cfg.gso_dg_size;
 
         // One unconnected dual-stack socket for the whole test. Never connect()'d
         // and never sharing its port with a second socket, so there is no
@@ -2668,73 +2741,96 @@ impl Server {
         // (per-stream sockets pace N×R); inherent to the demux design,
         // which is Windows-default (where the sockopt no-ops) and Linux
         // opt-in via RIPERF3_UDP_SERVER_DEMUX.
-        net::apply_fq_rate(&udp_sock, cfg.fq_rate);
+        net::apply_fq_rate(&udp_sock, fq_rate);
         // #316: the demux shared socket IS the data socket — same GSO/GRO
         // honor, best-effort, probed once for every stream's meta.
-        let (mut gso_on, mut gro_on) = (cfg.gso, cfg.gro);
+        let (mut gso_on, mut gro_on) = (ctx.cfg.gso, ctx.cfg.gro);
         if gso_on {
-            gso_on = net::set_udp_gso(&udp_sock, saturate_i32(cfg.gso_dg_size)).is_ok();
+            gso_on = net::set_udp_gso(&udp_sock, saturate_i32(gso_dg_size)).is_ok();
         }
         if gro_on {
             gro_on = net::set_udp_gro(&udp_sock).is_ok();
         }
 
-        protocol::send_state(ctrl, TestState::CreateStreams).await?;
+        protocol::send_state(&mut ctx.ctrl, TestState::CreateStreams).await?;
 
         // Accept the connect handshake from every client stream on the one
         // socket. Record the source address of each NEW client in arrival order
         // (slot i == stream i). Reply to every valid magic — including a
         // retransmit from an already-seen client whose reply was lost — but only
-        // a new source claims a slot. Bounded by the same budget as the client
-        // handshake so a client that never connects fails setup instead of
-        // hanging (#11).
+        // a new source claims a slot.
+        // #358: the wait runs the #356 select machinery like the TCP arm —
+        // ctrl-EOF is IECTRLCLOSE at once, a no-progress round bounds at
+        // rcv_timeout (IENOMSG; the per-iteration sleep re-arm makes any
+        // datagram or ctrl byte progress, GT's last_receive_time
+        // semantics), and a waiting ctrl byte dispatches. The old fixed
+        // per-stream UDP_CONNECT_TOTAL_TIMEOUT budget was riperf3-only
+        // (the client keeps its own 30 s handshake budget).
+        let rcv_timeout =
+            std::time::Duration::from_millis(self.rcv_timeout.unwrap_or(DEFAULT_RCV_TIMEOUT_MS));
         let mut client_addrs: Vec<SocketAddr> = Vec::with_capacity(total as usize);
         let mut seen: HashSet<SocketAddr> = HashSet::new();
         let mut magic_buf = [0u8; 65536];
-        // Each *new* stream gets a fresh budget — matching the recycling path,
-        // which calls udp_connect_server(UDP_CONNECT_TOTAL_TIMEOUT) once per
-        // stream, and the client, which retries each stream's connect for that
-        // long independently. A single aggregate deadline would abort setup while
-        // the client is still legitimately handshaking a later stream.
-        let mut deadline = tokio::time::Instant::now() + protocol::UDP_CONNECT_TOTAL_TIMEOUT;
         while client_addrs.len() < total as usize {
-            let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
-            if remaining.is_zero() {
-                return Err(RiperfError::Aborted(
-                    "timed out waiting for UDP stream connect".into(),
-                ));
-            }
-            let (n, src) =
-                match tokio::time::timeout(remaining, udp_sock.recv_from(&mut magic_buf)).await {
-                    Ok(Ok(r)) => r,
-                    // Reset-class noise: our own UDP_CONNECT_REPLY to a client
-                    // port that just closed (e.g. a retry on a fresh socket)
-                    // queues WSAECONNRESET on Windows — it must not abort setup
-                    // for EVERY stream; skip like the data-phase receivers (#180).
-                    Ok(Err(e)) if crate::stream::is_reset_class(&e) => continue,
-                    Ok(Err(e)) => return Err(e.into()),
-                    Err(_) => {
-                        return Err(RiperfError::Aborted(
-                            "timed out waiting for UDP stream connect".into(),
-                        ))
+            tokio::select! {
+                r = udp_sock.recv_from(&mut magic_buf) => {
+                    let (n, src) = match r {
+                        Ok(v) => v,
+                        // Reset-class noise: our own UDP_CONNECT_REPLY to a
+                        // client port that just closed (e.g. a retry on a
+                        // fresh socket) queues WSAECONNRESET on Windows — it
+                        // must not abort setup for EVERY stream; skip like
+                        // the data-phase receivers (#180).
+                        Err(e) if crate::stream::is_reset_class(&e) => continue,
+                        Err(e) => return Err(e.into()),
+                    };
+                    // Drop anything that isn't the connect magic (too short,
+                    // or a stray datagram) and keep waiting.
+                    if n < 4 {
+                        continue;
                     }
-                };
-            // Drop anything that isn't the connect magic (too short, or a stray
-            // datagram) and keep waiting — matches udp_connect_server's check.
-            if n < 4 {
-                continue;
-            }
-            let msg = u32::from_ne_bytes(magic_buf[..4].try_into().unwrap());
-            if msg != protocol::UDP_CONNECT_MSG {
-                continue;
-            }
-            udp_sock
-                .send_to(&protocol::UDP_CONNECT_REPLY.to_ne_bytes(), src)
-                .await?;
-            if seen.insert(src) {
-                client_addrs.push(src);
-                // Fresh per-stream budget for the next stream's handshake.
-                deadline = tokio::time::Instant::now() + protocol::UDP_CONNECT_TOTAL_TIMEOUT;
+                    let msg = u32::from_ne_bytes(magic_buf[..4].try_into().unwrap());
+                    if msg != protocol::UDP_CONNECT_MSG {
+                        continue;
+                    }
+                    udp_sock
+                        .send_to(&protocol::UDP_CONNECT_REPLY.to_ne_bytes(), src)
+                        .await?;
+                    if seen.insert(src) {
+                        client_addrs.push(src);
+                    }
+                }
+                activity = ctrl_activity(&ctx.ctrl) => match activity {
+                    // EOF: GT's read-site surface, noticed at once — the
+                    // TCP arm's exact shape (#338/#342).
+                    Ok(CtrlActivity::Eof) => {
+                        abort_setup_streams(ctx).await;
+                        let _ = protocol::send_server_error(&mut ctx.ctrl, 109).await;
+                        self.emit_setup_phase_error(ctx, listener, CTRL_CLOSED_MSG);
+                        return Err(RiperfError::ControlSocketClosed);
+                    }
+                    Ok(CtrlActivity::Data) => {
+                        if let SetupFlow::ClientDone =
+                            self.dispatch_setup_ctrl_byte(ctx, listener).await?
+                        {
+                            return Ok(SetupFlow::ClientDone);
+                        }
+                    }
+                    Err(e) => return Err(e.into()),
+                },
+                _ = tokio::time::sleep(rcv_timeout) => {
+                    // GT's no-progress bound: wire-back SERVER_ERROR +
+                    // IENOMSG(144) + errno 0, the doc with the prefixed
+                    // key, exit-0 keep-serving — the TCP arm's shape.
+                    abort_setup_streams(ctx).await;
+                    let _ = protocol::send_server_error(&mut ctx.ctrl, 144).await;
+                    self.emit_setup_phase_error(
+                        ctx,
+                        listener,
+                        &format!("error - {}", RiperfError::DataIdleTimeout),
+                    );
+                    return Err(RiperfError::DataIdleTimeout);
+                }
             }
         }
 
@@ -2750,7 +2846,7 @@ impl Server {
         // buffer sizes are read once; honor -w/--window on it once too.
         let (sndbuf_actual, rcvbuf_actual) = {
             let sock = socket2::SockRef::from(&udp_std);
-            net::apply_socket_window(&sock, cfg.window);
+            net::apply_socket_window(&sock, window);
             // The recycling path gives each receiving stream its OWN socket (and
             // its own SO_RCVBUF), drained by its own thread. This path funnels
             // every receiving stream through ONE socket drained by a single
@@ -2772,12 +2868,12 @@ impl Server {
         // #97: abort if -w was clamped below the request (iperf3 IESETBUF2). On the
         // single-socket demux path the recv buffer is sized to the aggregate, but a
         // genuine wmem/rmem_max clamp still drives the readback below the request.
-        net::check_socket_window(cfg.window, sndbuf_actual, rcvbuf_actual)?;
+        net::check_socket_window(window, sndbuf_actual, rcvbuf_actual)?;
         // iperf3 applies IP_TOS/IPV6_TCLASS per UDP stream socket on both
         // roles; every stream here shares this one socket and one cfg.tos,
         // so once-per-socket is semantically identical (#154). Fatal per #45.
-        if cfg.tos != 0 {
-            net::set_tos(&udp_std, cfg.tos as u32)?;
+        if tos != 0 {
+            net::set_tos(&udp_std, tos as u32)?;
         }
         // The connected recycling path reports each stream's local_host as the
         // kernel-selected source IP for that client. The demux socket is never
@@ -2793,10 +2889,10 @@ impl Server {
         // Build the per-stream entries: senders get their own send_to task;
         // receivers register a route and share the single demux thread.
         let mut routes: HashMap<SocketAddr, stream::UdpDemuxRoute> = HashMap::new();
-        let bs = cfg.blksize;
-        let rate = cfg.bandwidth;
-        let pt = cfg.pacing_timer; // #185: pace the UDP batch too
-        let u64bit = cfg.udp_counters_64bit;
+        let bs = blksize;
+        let rate = bandwidth;
+        let pt = pacing_timer; // #185: pace the UDP batch too
+        let u64bit = udp_counters_64bit;
         // #178: every spawn_blocking data thread (each sender + the one demux
         // receiver) is spawned through the gate; the barrier below holds
         // TestStart until the data plane actually exists.
@@ -2815,10 +2911,10 @@ impl Server {
             if is_sender {
                 let s = shared.clone();
                 let c = counters.clone();
-                let d = done.clone();
-                let bu = cfg.burst;
-                let uw = cfg.window.is_some();
-                let st = start.clone();
+                let d = ctx.done.clone();
+                let bu = burst;
+                let uw = window.is_some();
+                let st = ctx.start.clone();
                 let md = max_duration;
                 let task = thread_gate.spawn(move || {
                     stream::run_udp_server_demux_sender(
@@ -2836,7 +2932,7 @@ impl Server {
                         md,
                     )
                 });
-                streams.push(DataStream {
+                ctx.streams.push(DataStream {
                     meta: StreamMeta {
                         id: stream_id,
                         is_sender,
@@ -2867,7 +2963,7 @@ impl Server {
                 // below; give each a resolved placeholder task so the per-stream
                 // join at teardown stays uniform. The real handle is `demux_handle`.
                 let task = tokio::spawn(async { Ok::<(), RiperfError>(()) });
-                streams.push(DataStream {
+                ctx.streams.push(DataStream {
                     meta: StreamMeta {
                         id: stream_id,
                         is_sender,
@@ -2892,9 +2988,9 @@ impl Server {
         // is anything to receive — a pure-reverse test has senders only).
         if !routes.is_empty() {
             let s = shared.clone();
-            let d = done.clone();
-            let bs = cfg.blksize;
-            *demux_handle =
+            let d = ctx.done.clone();
+            let bs = blksize;
+            ctx.udp_demux_handle =
                 Some(thread_gate.spawn(move || {
                     stream::run_udp_server_demux_receiver(s, routes, bs, d, u64bit)
                 }));
@@ -2904,7 +3000,7 @@ impl Server {
         // OS-thread creation, which stalls for seconds on loaded hosts. On
         // timeout proceed anyway (degraded = pre-fix behavior).
         thread_gate.wait(stream::STREAM_THREAD_START_TIMEOUT).await;
-        Ok(())
+        Ok(SetupFlow::Proceed)
     }
 
     /// Per-stream final summaries for the text report (shared by the normal
@@ -4052,6 +4148,47 @@ mod tests {
         })
     }
 
+    /// A minimal TestRunCtx for driving the setup fns directly (#358: they
+    /// take the ctx whole so the select arms can dispatch ctrl bytes).
+    #[cfg(target_os = "linux")]
+    fn test_run_ctx(
+        ctrl: tokio::net::TcpStream,
+        params: TestParams,
+        cfg: TestConfig,
+    ) -> TestRunCtx {
+        TestRunCtx {
+            ctrl,
+            accepted_host: "127.0.0.1".into(),
+            accepted_port: 0,
+            accepted_millis: 0,
+            cookie: [b'x'; 37],
+            params,
+            cfg,
+            want_server_output: false,
+            capture: None,
+            done: Arc::new(AtomicBool::new(false)),
+            start: Arc::new(AtomicBool::new(false)),
+            streams: Vec::new(),
+            byte_budget: None,
+            budget_target: None,
+            udp_demux_handle: None,
+            interval_data: Arc::new(Mutex::new(crate::reporter::CollectedIntervals::default())),
+            cpu_start: CpuSnapshot::now(),
+            test_start_millis: 0,
+            report_start: std::time::Instant::now(),
+            reporter_end: Arc::new(crate::reporter::ReporterEnd::new()),
+            interval_handle: None,
+            server_error: None,
+            client_terminated: false,
+            unknown_message: false,
+            ctrl_closed: false,
+            early_done: false,
+            exchange_recv_failed: false,
+            bare_end: false,
+            interrupted: None,
+        }
+    }
+
     /// #154: the server's UDP data sockets must carry IP_TOS — iperf3 runs
     /// iperf_common_sockopts on UDP stream sockets on both roles (matters
     /// for reverse/bidir egress marking). Reverse, one stream: the server is
@@ -4065,7 +4202,7 @@ mod tests {
         let _ctrl_client = tokio::net::TcpStream::connect(l.local_addr().unwrap())
             .await
             .unwrap();
-        let (mut ctrl_srv, _) = l.accept().await.unwrap();
+        let (ctrl_srv, _) = l.accept().await.unwrap();
 
         let srv = ServerBuilder::new()
             .port(Some(port))
@@ -4080,29 +4217,18 @@ mod tests {
             ..Default::default()
         };
         let cfg = TestConfig::from_params(&params).unwrap();
-        let done = Arc::new(AtomicBool::new(false));
-        let start = Arc::new(AtomicBool::new(false));
-        let mut streams = Vec::new();
+        let mut ctx = test_run_ctx(ctrl_srv, params, cfg);
 
         let client = udp_tos_probe_client(format!("127.0.0.1:{port}").parse().unwrap());
 
-        srv.setup_udp_recycling_streams(
-            &mut ctrl_srv,
-            &cfg,
-            0,
-            1,
-            None,
-            &done,
-            &start,
-            &mut streams,
-        )
-        .await
-        .unwrap();
-        start.store(true, Ordering::Relaxed);
+        srv.setup_udp_recycling_streams(&mut ctx, &l, 0, 1, None)
+            .await
+            .unwrap();
+        ctx.start.store(true, Ordering::Relaxed);
 
         let tos = client.join().unwrap();
-        done.store(true, Ordering::Relaxed);
-        for s in streams {
+        ctx.done.store(true, Ordering::Relaxed);
+        for s in ctx.streams.drain(..) {
             let _ = s.task.await;
         }
         assert_eq!(tos, Some(0x48), "server UDP egress must carry cfg.tos");
@@ -4120,7 +4246,7 @@ mod tests {
         let _ctrl_client = tokio::net::TcpStream::connect(l.local_addr().unwrap())
             .await
             .unwrap();
-        let (mut ctrl_srv, _) = l.accept().await.unwrap();
+        let (ctrl_srv, _) = l.accept().await.unwrap();
 
         let srv = ServerBuilder::new()
             .port(Some(port))
@@ -4135,34 +4261,21 @@ mod tests {
             ..Default::default()
         };
         let cfg = TestConfig::from_params(&params).unwrap();
-        let done = Arc::new(AtomicBool::new(false));
-        let start = Arc::new(AtomicBool::new(false));
-        let mut streams = Vec::new();
-        let mut demux_handle = None;
+        let mut ctx = test_run_ctx(ctrl_srv, params, cfg);
 
         let client = udp_tos_probe_client(format!("127.0.0.1:{port}").parse().unwrap());
 
-        srv.setup_udp_demux_streams(
-            &mut ctrl_srv,
-            &cfg,
-            0,
-            1,
-            None,
-            &done,
-            &start,
-            &mut streams,
-            &mut demux_handle,
-        )
-        .await
-        .unwrap();
-        start.store(true, Ordering::Relaxed);
+        srv.setup_udp_demux_streams(&mut ctx, &l, 0, 1, None)
+            .await
+            .unwrap();
+        ctx.start.store(true, Ordering::Relaxed);
 
         let tos = client.join().unwrap();
-        done.store(true, Ordering::Relaxed);
-        for s in streams {
+        ctx.done.store(true, Ordering::Relaxed);
+        for s in ctx.streams.drain(..) {
             let _ = s.task.await;
         }
-        if let Some(h) = demux_handle {
+        if let Some(h) = ctx.udp_demux_handle.take() {
             h.abort();
         }
         assert_eq!(tos, Some(0x48), "demux UDP egress must carry cfg.tos");

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -2769,8 +2769,10 @@ impl Server {
         // #358: the wait runs the #356 select machinery like the TCP arm —
         // ctrl-EOF is IECTRLCLOSE at once, a no-progress round bounds at
         // rcv_timeout (IENOMSG; the per-iteration sleep re-arm makes any
-        // datagram or ctrl byte progress, GT's last_receive_time
-        // semantics), and a waiting ctrl byte dispatches. The old fixed
+        // datagram or ctrl byte progress — mirroring GT's select window
+        // restarting per fd wake; its last_receive_time anchor never
+        // resets pre-streams, observably equivalent in every reachable
+        // cell — #383 r2 F5), and a waiting ctrl byte dispatches. The old fixed
         // per-stream UDP_CONNECT_TOTAL_TIMEOUT budget was riperf3-only
         // (the client keeps its own 30 s handshake budget).
         let rcv_timeout =

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -1358,6 +1358,12 @@ impl Server {
                 let rcv_timeout = std::time::Duration::from_millis(
                     self.rcv_timeout.unwrap_or(DEFAULT_RCV_TIMEOUT_MS),
                 );
+                // #383 r1 F2: GT arms the CREATE_STREAMS no-progress bound
+                // only when the server RECEIVES (test->mode != SENDER,
+                // iperf_server_api.c:662-678, 720-733; the #351 idle_armed
+                // precedent one phase later) — a pure-reverse round waits
+                // patiently (GT live: >9 s at --rcv-timeout 3000).
+                let idle_armed = !ctx.cfg.reverse || ctx.cfg.bidir;
                 for i in 0..total {
                     let (mut data_stream, _) = loop {
                         tokio::select! {
@@ -1385,7 +1391,7 @@ impl Server {
                                 }
                                 Err(e) => return Err(e.into()),
                             },
-                            _ = tokio::time::sleep(rcv_timeout) => {
+                            _ = tokio::time::sleep(rcv_timeout), if idle_armed => {
                                 // GT's no-progress bound: wire-back
                                 // SERVER_ERROR + IENOMSG(144) + errno 0
                                 // (live: fe 00000090 00000000), the doc with
@@ -2456,7 +2462,6 @@ impl Server {
     /// stream. This is faithful to iperf3 and gives kernel-parallel receive, but
     /// relies on kernel demux that native winsock doesn't provide (see
     /// [`Self::setup_udp_demux_streams`] / #80).
-    #[allow(clippy::too_many_arguments)]
     async fn setup_udp_recycling_streams(
         &self,
         ctx: &mut TestRunCtx,
@@ -2495,6 +2500,8 @@ impl Server {
         // handshake budget in udp_connect_client).
         let rcv_timeout =
             std::time::Duration::from_millis(self.rcv_timeout.unwrap_or(DEFAULT_RCV_TIMEOUT_MS));
+        // #383 r1 F2: the sender-mode exemption — see the TCP arm's note.
+        let idle_armed = !ctx.cfg.reverse || ctx.cfg.bidir;
 
         // #316: the client's GSO/GRO request, probed per accepted socket
         // below. Once a probe fails, GT zeroes the setting and later
@@ -2554,7 +2561,7 @@ impl Server {
                         }
                         Err(e) => return Err(e.into()),
                     },
-                    _ = tokio::time::sleep(rcv_timeout) => {
+                    _ = tokio::time::sleep(rcv_timeout), if idle_armed => {
                         // GT's no-progress bound: wire-back SERVER_ERROR +
                         // IENOMSG(144) + errno 0, the doc with the prefixed
                         // key, exit-0 keep-serving — the TCP arm's shape.
@@ -2768,6 +2775,8 @@ impl Server {
         // (the client keeps its own 30 s handshake budget).
         let rcv_timeout =
             std::time::Duration::from_millis(self.rcv_timeout.unwrap_or(DEFAULT_RCV_TIMEOUT_MS));
+        // #383 r1 F2: the sender-mode exemption — see the TCP arm's note.
+        let idle_armed = !ctx.cfg.reverse || ctx.cfg.bidir;
         let mut client_addrs: Vec<SocketAddr> = Vec::with_capacity(total as usize);
         let mut seen: HashSet<SocketAddr> = HashSet::new();
         let mut magic_buf = [0u8; 65536];
@@ -2780,7 +2789,13 @@ impl Server {
                         // client port that just closed (e.g. a retry on a
                         // fresh socket) queues WSAECONNRESET on Windows — it
                         // must not abort setup for EVERY stream; skip like
-                        // the data-phase receivers (#180).
+                        // the data-phase receivers (#180). The continue
+                        // re-arms the no-progress clock (#383 r1 F5):
+                        // sustained ICMP feedback keeps the wait alive past
+                        // any bound, but GT can't reach the cell at all
+                        // (recvfrom error -> IESTREAMACCEPT fatal) and the
+                        // client's own 30 s handshake budget ends the round
+                        // via ctrl-EOF in practice.
                         Err(e) if crate::stream::is_reset_class(&e) => continue,
                         Err(e) => return Err(e.into()),
                     };
@@ -2818,7 +2833,7 @@ impl Server {
                     }
                     Err(e) => return Err(e.into()),
                 },
-                _ = tokio::time::sleep(rcv_timeout) => {
+                _ = tokio::time::sleep(rcv_timeout), if idle_armed => {
                     // GT's no-progress bound: wire-back SERVER_ERROR +
                     // IENOMSG(144) + errno 0, the doc with the prefixed
                     // key, exit-0 keep-serving — the TCP arm's shape.
@@ -3438,10 +3453,20 @@ impl Server {
         listener: &tokio::net::TcpListener,
     ) -> crate::json_report::SetupPhaseDoc {
         let sock = socket2::SockRef::from(listener);
+        // #383 r1 F1a: the four TCP-flavored keys are absent for UDP —
+        // see the SetupPhaseDoc doc for the GT gates.
+        let udp = matches!(ctx.cfg.protocol, TransportProtocol::Udp);
         crate::json_report::SetupPhaseDoc {
-            sock_bufsize: ctx.cfg.window.map(|w| w as u64).unwrap_or(0),
-            sndbuf_actual: sock.send_buffer_size().ok().map(|v| v as u64),
-            rcvbuf_actual: sock.recv_buffer_size().ok().map(|v| v as u64),
+            sock_bufsize: (!udp).then(|| ctx.cfg.window.map(|w| w as u64).unwrap_or(0)),
+            sndbuf_actual: (!udp)
+                .then(|| sock.send_buffer_size().ok().map(|v| v as u64))
+                .flatten(),
+            rcvbuf_actual: (!udp)
+                .then(|| sock.recv_buffer_size().ok().map(|v| v as u64))
+                .flatten(),
+            // The server never reads the ctrl MSS — 0, the #50 convention.
+            tcp_mss_default: (!udp).then_some(0),
+            udp,
             timemillisecs: ctx.accepted_millis,
             accepted_host: ctx.accepted_host.clone(),
             accepted_port: ctx.accepted_port,
@@ -3506,9 +3531,10 @@ impl Server {
             remote_user: 0.0,
             remote_system: 0.0,
         };
+        let udp = matches!(ctx.cfg.protocol, TransportProtocol::Udp);
         if self.json_stream {
             crate::reporter::emit_json_stream_line(&crate::json_report::terminate_stream_events(
-                &error, &cpu,
+                udp, &error, &cpu,
             ));
         } else if self.json_output {
             let doc = crate::json_report::setup_terminate_document(
@@ -3518,7 +3544,7 @@ impl Server {
             );
             println!("{doc}");
         } else {
-            crate::reporter::print_terminate_skeleton();
+            crate::reporter::print_terminate_skeleton(udp);
         }
     }
 


### PR DESCRIPTION
Closes #358.

## The defect

PR #356 (#338) gave the TCP CREATE_STREAMS wait GT's select semantics; the UDP wait — both server designs — stayed on a riperf3-only fixed 30 s connect budget (`UDP_CONNECT_TOTAL_TIMEOUT`). Three GT-fidelity gaps, all live-probed on GT 3.21 in #356's r1 (`{"udp":true}` params, values on the issue):

1. **ctrl-EOF unnoticed for the full 30 s** — GT IECTRLCLOSEs at once (dt ~0.0).
2. **--rcv-timeout ignored** — GT bounds the wait at rcv_timeout (probed dt 3.01 at 3000 ms); riperf3 was fixed at 30 s.
3. **riperf3-only timeout surface** — `error - test aborted: timed out waiting for UDP stream connect`, no IENOMSG wire-back, no setup doc; GT sends `fe 00000090 00000000` and emits the #356 setup-phase document.

## The fix

Both UDP setup fns take the ctx whole and run the TCP arm's select verbatim: UDP handshake progress | `ctrl_activity` (EOF → the IECTRLCLOSE surface; a waiting byte dispatches through `dispatch_setup_ctrl_byte`, so IPERF_DONE yields ClientDone from the UDP paths too) | `sleep(rcv_timeout)` → the IENOMSG shape (wire-back + doc + exit-0 keep-serving). The per-iteration sleep re-arm makes any datagram or ctrl byte progress — GT's last_receive_time semantics.

- **Recycling**: the magic is received inside the select; validation is the retired `udp_connect_server`'s verbatim (short/foreign datagrams stay fatal on the connected-per-stream design); `connect()`+reply run AFTER the arm wins, so a ctrl byte cannot cancel a half-done handshake into a lost reply. `udp_connect_server` is retired to a `#[cfg(test)]` reference implementation (its round-trip tests are unchanged).
- **Demux**: the inline handshake loop keeps its skip-strays/reset-class semantics (#180); the per-stream deadline machinery is gone.
- The server-side `UDP_CONNECT_TOTAL_TIMEOUT` budget is deleted — GT has no per-stream connect budget; the **client** keeps its own 30 s handshake budget (`udp_connect_client`, unchanged).
- `abort_setup_streams` now stores `done` first: the UDP paths park `spawn_blocking` threads on the start barrier / 500 ms-poll reads where `abort()` is a no-op — an unset `done` would hang the joins (the #372-gate lesson). Every caller ends the round, so the store is round-terminal by construction; the TCP tasks never needed it.
- Both fns return `SetupFlow` (the dispatch can yield ClientDone); the in-crate #154 TOS tests drive them through a minimal test ctx.

## Verification

**Pins, red-first** (all six sat out the old 30 s budget past the caller's exit bound — the bound IS the pin):

- `udp_setup_ctrl_eof_exits_bounded_in_text` / `..._demux` — ctrl-EOF at CREATE_STREAMS: GT's bare IECTRLCLOSE sentence, exit 0, bounded.
- `udp_setup_ctrl_eof_takes_gt_doc_shape_in_json` — the #356 setup doc with the bare key (field walk owned by the TCP pins; this asserts the UDP arm routes through the same emit).
- `udp_setup_ctrl_hold_bounds_at_rcv_timeout_in_text` / `..._demux` — `--rcv-timeout 3000` + a client that never sends the magic: the `fe 00000090 00000000` frame read off the held ctrl, GT's IENOMSG stderr line, exit 0.
- `udp_setup_ctrl_hold_takes_gt_doc_shape_in_json` — the prefixed IENOMSG doc key.

Both designs pinned via `RIPERF3_UDP_SERVER_DEMUX` (the #80 env knob).

**Mutation table** (harness refuses dirty targets, anchor-count checked, exact restore verified): M1/M3 EOF arm blinded (recycling/demux) → EOF pins red; M2/M4 rcv_timeout arm disabled → hold pins red; M5 wire-back dropped → red on the frame; M6 wrong errno class (144→109) → red on the frame bytes.

**Gate:** fmt / clippy `-D warnings` clean; workspace **861 passed / 0 failed** (855 + the 6 pins).

## Round 1 (commit 2, @41a66fb)

**r1 F1 (blocker):** the newly reachable UDP setup emits were TCP-flavored — all three sub-shapes fixed and pinned red-first: (a) the setup doc drops GT's four absent-for-UDP start keys (`sock_bufsize`/`sndbuf_actual`/`rcvbuf_actual`/`tcp_mss_default` — tcp_mss is SOCK_STREAM-gated at iperf_api.c:1021-1027, the UDP trio only lands via udp_buffercheck at accept); (b) the terminate zeros-end is UDP-flavored (an `end.sum` block + jitter_ms/lost_packets/packets/lost_percent in all three sums, `sum_sent.sender` true — live-probed); (c) the terminate skeleton prints GT's UDP header. **r1 F2:** all three setup sleep arms (the #356 TCP arm included — same family) carry GT's sender-mode exemption (`test->mode != SENDER`, the #351 idle_armed precedent); pure-reverse rounds wait patiently, pinned on both protocols. **r1 F3:** the Data dispatch arm pinned on both designs (CLIENT_TERMINATE mid-setup: relay + sentence + UDP skeleton + exit 0) plus the -J terminate doc pin. **r1 F4:** stale allow dropped. **r1 F5:** the demux reset-class re-arm recorded in-code.

Mutants added and re-run on this head — **10/10 red**: M7 Data arm blinded → terminate pin red; M8 doc protocol gate dropped → EOF -J pin red on the four keys; M9 skeleton flavor dropped → terminate text pin red; M10 idle_armed exemption dropped → reverse-hold pin red (plus M1-M6 re-anchored and re-run).

**Gate on @41a66fb:** fmt / clippy `-D warnings` clean; workspace **866 passed / 0 failed** (861 + the 5 new pins).

**Rounds:** r1 REQUEST-CHANGES (the UDP-flavored emits + sender-mode exemption, fixed @41a66fb) → r2 APPROVE (cold; 5 discretionary items applied @d8d2f2a as test-only + comment). Full round records in the PR comments. Merge-head evidence on d8d2f2a: CI 17/17, compat 52/52 re-run, workspace 870/870; mutation table 10/10 red @41a66fb.
