### PR TITLE
fix: the TCP setup cookie gate denies-and-continues like GT (#359)

### DIFF
--- a/riperf3-cli/tests/wire_shape.rs
+++ b/riperf3-cli/tests/wire_shape.rs
@@ -4783,6 +4783,8 @@ fn setup_silent_conn_is_denied_then_the_round_ienomsgs() {
             *frame_in.lock().unwrap() = read_wireback(&mut ctrl);
             drop(ctrl);
         });
+    // Errno word 0: the recorded #336-class deviation — GT live leaks a
+    // stale EBADF (9) in this exact cell (#384 r1 F5).
     assert_eq!(
         *frame.lock().unwrap(),
         wireback_frame(144),

--- a/riperf3-cli/tests/wire_shape.rs
+++ b/riperf3-cli/tests/wire_shape.rs
@@ -4640,6 +4640,107 @@ fn udp_reverse_setup_hold_is_idle_exempt_demux() {
     reverse_hold_case(r#"{"udp":true,"reverse":true}"#, true);
 }
 
+// ---------------------------------------------------------------------------
+// #359: GT's deny-and-continue at the TCP setup cookie gate — a
+// wrong-cookie, silent, or died data connect gets ACCESS_DENIED (0xff) on
+// ITS socket (iperf_tcp.c:161-166; the closed-socket guard
+// iperf_server_api.c:786) and the CREATE_STREAMS wait continues; only the
+// #356 no-progress clock ends a round with no real streams (IENOMSG,
+// GT-probed at ~13 s = the 10 s cookie-read bound + rcv-timeout 3 s).
+// riperf3 killed the round in both cells (`error - cookie mismatch` /
+// `error - unexpected end of file`).
+// ---------------------------------------------------------------------------
+
+/// #359 cell 1: a wrong-cookie connect is denied on its own socket and
+/// the round then serves the REAL stream (TestStart/TestRunning arrive).
+#[test]
+fn setup_wrong_cookie_conn_is_denied_and_the_round_continues() {
+    let (_sout, serr, status) = drive_server_scenario(false, |port| {
+        use std::io::Read;
+        let mut ctrl = std::net::TcpStream::connect(("127.0.0.1", port)).expect("ctrl");
+        ctrl.write_all(&[b'x'; 37]).unwrap();
+        assert_eq!(read_exact(&mut ctrl, 1)[0], 9, "ParamExchange");
+        write_json_blob(&mut ctrl, INCOMPLETE_PARAMS);
+        assert_eq!(read_exact(&mut ctrl, 1)[0], 10, "CreateStreams");
+        // The imposter: right port, wrong cookie.
+        let mut imposter = std::net::TcpStream::connect(("127.0.0.1", port)).expect("imposter");
+        imposter.write_all(&[b'z'; 37]).unwrap();
+        imposter
+            .set_read_timeout(Some(Duration::from_secs(4)))
+            .expect("set_read_timeout");
+        let mut b = [0u8; 4];
+        let n = imposter.read(&mut b).expect("the deny byte");
+        assert_eq!(&b[..n], &[0xff], "ACCESS_DENIED on the offending socket");
+        assert_eq!(
+            imposter.read(&mut b).expect("the deny close"),
+            0,
+            "GT closes the denied socket"
+        );
+        // The REAL stream: the round must still be alive to accept it.
+        let mut data = std::net::TcpStream::connect(("127.0.0.1", port)).expect("data");
+        data.write_all(&[b'x'; 37]).unwrap();
+        assert_eq!(
+            read_exact(&mut ctrl, 1)[0],
+            1,
+            "TestStart after the deny — the round continued"
+        );
+        assert_eq!(read_exact(&mut ctrl, 1)[0], 2, "TestRunning");
+        drop((ctrl, data));
+        std::thread::sleep(std::time::Duration::from_millis(300));
+    });
+    assert!(status.success(), "one-off exits 0: {serr}");
+}
+
+/// #359 cell 2: a silent connect is denied at the 10 s cookie-read bound
+/// and the round then IENOMSGs at the re-armed rcv-timeout (~13 s), GT's
+/// exact cadence (probed). The pre-fix path killed the round at 10 s with
+/// `error - unexpected end of file` and no deny byte.
+#[test]
+fn setup_silent_conn_is_denied_then_the_round_ienomsgs() {
+    let frame = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+    let frame_in = frame.clone();
+    let (_sout, serr, status) =
+        drive_server_scenario_with(&["--rcv-timeout", "3000"], false, move |port| {
+            use std::io::Read;
+            let mut ctrl = std::net::TcpStream::connect(("127.0.0.1", port)).expect("ctrl");
+            ctrl.write_all(&[b'x'; 37]).unwrap();
+            assert_eq!(read_exact(&mut ctrl, 1)[0], 9, "ParamExchange");
+            write_json_blob(&mut ctrl, INCOMPLETE_PARAMS);
+            assert_eq!(read_exact(&mut ctrl, 1)[0], 10, "CreateStreams");
+            // The silent connect: no cookie, ever.
+            let mut silent = std::net::TcpStream::connect(("127.0.0.1", port)).expect("silent");
+            silent
+                .set_read_timeout(Some(Duration::from_secs(14)))
+                .expect("set_read_timeout");
+            let t0 = std::time::Instant::now();
+            let mut b = [0u8; 4];
+            let n = silent
+                .read(&mut b)
+                .expect("the deny byte at the read bound");
+            let dt = t0.elapsed();
+            assert_eq!(&b[..n], &[0xff], "ACCESS_DENIED at the cookie-read bound");
+            assert!(
+                dt >= Duration::from_secs(8) && dt <= Duration::from_secs(13),
+                "the deny lands at GT's ~10 s cookie-read bound: {dt:?}"
+            );
+            assert_eq!(silent.read(&mut b).expect("deny close"), 0);
+            // The round then IENOMSGs at the re-armed rcv-timeout.
+            *frame_in.lock().unwrap() = read_wireback(&mut ctrl);
+            drop(ctrl);
+        });
+    assert_eq!(
+        *frame.lock().unwrap(),
+        wireback_frame(144),
+        "the round IENOMSGs after the deny, GT's ~13 s cadence"
+    );
+    assert!(status.success(), "one-off exits 0 like GT");
+    assert_eq!(
+        serr.trim(),
+        format!("riperf3: error - {IDLE_TIMEOUT_MSG}"),
+        "GT's IENOMSG line, not the old kill surface: {serr:?}"
+    );
+}
+
 /// #383 r2 F3: reverse+bidir stays ARMED — GT's iperf_set_test_bidirectional
 /// forces mode BIDIRECTIONAL (iperf_api.c:827-834), which is != SENDER, so
 /// the bound fires (GT live: 3.01 s). A conforming client cannot send the

--- a/riperf3-cli/tests/wire_shape.rs
+++ b/riperf3-cli/tests/wire_shape.rs
@@ -4691,6 +4691,61 @@ fn setup_wrong_cookie_conn_is_denied_and_the_round_continues() {
     assert!(status.success(), "one-off exits 0: {serr}");
 }
 
+/// #359 (#384 r1 F2): a HARD read error mid-cookie (RST) is NOT a deny —
+/// GT kills the round via IERECVCOOKIE (iperf_tcp.c:155-159 ->
+/// cleanup_server): the fe+106 wire-back on ctrl, the prefixed dangling
+/// doc/text key (GT live appends the stale strerror "Bad file
+/// descriptor" — the #336-class recorded deviation, errno-0 form here),
+/// exit 0, NO deny byte on the imposter.
+#[cfg(unix)]
+#[test]
+fn setup_rst_mid_cookie_kills_the_round_ierecvcookie() {
+    let frame = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+    let frame_in = frame.clone();
+    let (_sout, serr, status) = drive_server_scenario(false, move |port| {
+        let mut ctrl = std::net::TcpStream::connect(("127.0.0.1", port)).expect("ctrl");
+        ctrl.write_all(&[b'x'; 37]).unwrap();
+        assert_eq!(read_exact(&mut ctrl, 1)[0], 9, "ParamExchange");
+        write_json_blob(&mut ctrl, INCOMPLETE_PARAMS);
+        assert_eq!(read_exact(&mut ctrl, 1)[0], 10, "CreateStreams");
+        // The imposter RSTs mid-cookie (SO_LINGER 0, nothing written).
+        let imposter = std::net::TcpStream::connect(("127.0.0.1", port)).expect("imposter");
+        std::thread::sleep(std::time::Duration::from_millis(300));
+        let linger = libc::linger {
+            l_onoff: 1,
+            l_linger: 0,
+        };
+        let rc = unsafe {
+            use std::os::fd::AsRawFd;
+            libc::setsockopt(
+                imposter.as_raw_fd(),
+                libc::SOL_SOCKET,
+                libc::SO_LINGER,
+                std::ptr::from_ref(&linger).cast(),
+                std::mem::size_of::<libc::linger>() as libc::socklen_t,
+            )
+        };
+        assert_eq!(rc, 0, "SO_LINGER setsockopt failed");
+        drop(imposter);
+        // GT's kill: the SERVER_ERROR relay lands on ctrl.
+        *frame_in.lock().unwrap() = read_wireback(&mut ctrl);
+        drop(ctrl);
+    });
+    assert_eq!(
+        *frame.lock().unwrap(),
+        wireback_frame(106),
+        "fe + htonl(IERECVCOOKIE=106), GT's cleanup_server wire-back"
+    );
+    assert!(status.success(), "one-off exits 0 like GT");
+    // No whole-string trim: the dangling `: ` IS the pin (#248 form).
+    let lines: Vec<&str> = serr.lines().collect();
+    assert_eq!(
+        lines,
+        vec![&format!("riperf3: error - {RECV_COOKIE_MSG}: ") as &str],
+        "the prefixed dangling IERECVCOOKIE line, once: {serr:?}"
+    );
+}
+
 /// #359 cell 2: a silent connect is denied at the 10 s cookie-read bound
 /// and the round then IENOMSGs at the re-armed rcv-timeout (~13 s), GT's
 /// exact cadence (probed). The pre-fix path killed the round at 10 s with

--- a/riperf3-cli/tests/wire_shape.rs
+++ b/riperf3-cli/tests/wire_shape.rs
@@ -4746,6 +4746,63 @@ fn setup_rst_mid_cookie_kills_the_round_ierecvcookie() {
     );
 }
 
+/// #384 r2 F2: the RST-kill's -J twin — the POPULATED setup doc (the
+/// RecvDataCookieFailed-vs-pretest-skeleton distinction is exactly this
+/// property), the prefixed dangling error key, bare end, silent stderr
+/// (GT live byte-parallel modulo the recorded strerror suffix).
+#[cfg(unix)]
+#[test]
+fn setup_rst_mid_cookie_takes_gt_doc_shape_in_json() {
+    let frame = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+    let frame_in = frame.clone();
+    let (sout, serr, status) = drive_server_scenario(true, move |port| {
+        let mut ctrl = std::net::TcpStream::connect(("127.0.0.1", port)).expect("ctrl");
+        ctrl.write_all(&[b'x'; 37]).unwrap();
+        assert_eq!(read_exact(&mut ctrl, 1)[0], 9, "ParamExchange");
+        write_json_blob(&mut ctrl, INCOMPLETE_PARAMS);
+        assert_eq!(read_exact(&mut ctrl, 1)[0], 10, "CreateStreams");
+        let imposter = std::net::TcpStream::connect(("127.0.0.1", port)).expect("imposter");
+        std::thread::sleep(std::time::Duration::from_millis(300));
+        let linger = libc::linger {
+            l_onoff: 1,
+            l_linger: 0,
+        };
+        let rc = unsafe {
+            use std::os::fd::AsRawFd;
+            libc::setsockopt(
+                imposter.as_raw_fd(),
+                libc::SOL_SOCKET,
+                libc::SO_LINGER,
+                std::ptr::from_ref(&linger).cast(),
+                std::mem::size_of::<libc::linger>() as libc::socklen_t,
+            )
+        };
+        assert_eq!(rc, 0, "SO_LINGER setsockopt failed");
+        drop(imposter);
+        *frame_in.lock().unwrap() = read_wireback(&mut ctrl);
+        drop(ctrl);
+    });
+    assert_eq!(*frame.lock().unwrap(), wireback_frame(106));
+    assert!(status.success());
+    assert!(serr.trim().is_empty(), "-J keeps stderr silent: {serr:?}");
+    let doc: serde_json::Value =
+        serde_json::from_str(sout.trim()).unwrap_or_else(|e| panic!("one -J doc ({e}): {sout}"));
+    assert_eq!(
+        doc["error"].as_str(),
+        Some(format!("error - {RECV_COOKIE_MSG}: ").as_str()),
+        "the prefixed dangling IERECVCOOKIE key: {doc}"
+    );
+    assert_eq!(
+        doc["start"]["accepted_connection"]["host"].as_str(),
+        Some("127.0.0.1"),
+        "the POPULATED setup doc, not the pretest skeleton: {doc}"
+    );
+    assert!(
+        doc["end"].as_object().expect("end").is_empty(),
+        "bare end{{}}: {doc}"
+    );
+}
+
 /// #359 cell 2: a silent connect is denied at the 10 s cookie-read bound
 /// and the round then IENOMSGs at the re-armed rcv-timeout (~13 s), GT's
 /// exact cadence (probed). The pre-fix path killed the round at 10 s with

--- a/riperf3/src/error.rs
+++ b/riperf3/src/error.rs
@@ -72,6 +72,15 @@ pub enum RiperfError {
     #[error("unable to receive cookie at server")]
     RecvCookieFailed,
 
+    /// iperf3's IERECVCOOKIE(106) from the SETUP phase's data-stream cookie
+    /// gate (#359): a HARD read error mid-cookie (e.g. ECONNRESET) takes
+    /// GT's cleanup_server round-kill (iperf_tcp.c:155-159) — unlike the
+    /// pre-test ctrl-cookie class above (skeleton doc), this one carries
+    /// the POPULATED setup doc, so the serve loop must tell them apart.
+    /// Same wire sentence and perr dangling as [`Self::RecvCookieFailed`].
+    #[error("unable to receive cookie at server")]
+    RecvDataCookieFailed,
+
     /// iperf3's IERECVPARAMS(114): the server could not read or parse the
     /// client's ParamExchange blob — malformed JSON, a short/absent
     /// length-prefixed body, or a timed-out read (bounded like every GT

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -623,6 +623,21 @@ impl Server {
                         );
                     }
                 }
+                Err(RiperfError::RecvDataCookieFailed) => {
+                    // #359 r1 F2: GT's hard-read-error kill at the DATA
+                    // cookie gate (IERECVCOOKIE via cleanup_server). The
+                    // populated setup doc emitted at the site; text prints
+                    // the prefixed dangling perr line (#248 errno-0 form —
+                    // GT appends the live/stale strerror, live "Bad file
+                    // descriptor"). Keep-serving, exit 0.
+                    if !json && !crate::macros::output_quiet() {
+                        eprintln!(
+                            "{}riperf3: error - {}: ",
+                            crate::macros::output_timestamp_prefix(),
+                            RiperfError::RecvDataCookieFailed
+                        );
+                    }
+                }
                 // #330: the pre-test control failures. Unlike the classes
                 // above — which build a partial report inside handle_one_test
                 // and carried the error in it — these error BEFORE any report
@@ -1370,7 +1385,7 @@ impl Server {
                             accepted = listener.accept() => {
                                 let (mut candidate, _) = accepted?;
                                 // #359: GT's deny-and-continue cookie gate —
-                                // a wrong-cookie, silent, or died connect
+                                // a wrong-cookie or silent/FIN'd connect
                                 // gets ACCESS_DENIED on ITS socket
                                 // (iperf_tcp.c:161-166; the closed-socket
                                 // guard iperf_server_api.c:786) and the wait
@@ -1378,19 +1393,36 @@ impl Server {
                                 // a round with no real streams. The old gate
                                 // killed the round (CookieMismatch /
                                 // unexpected-EOF).
-                                // RECORDED DEVIATION: this inline cookie
-                                // read blinds the ctrl-EOF / rcv_timeout
-                                // arms for its ≤10 s Nread bound — GT's
-                                // cookie read joins its select instead.
-                                // Adversarial-only: a real client writes
-                                // the cookie immediately on connect.
+                                // PARITY NOTE (#384 r1 F1): this inline
+                                // cookie read blinding the ctrl/timeout arms
+                                // is GT-FAITHFUL — GT's data-cookie read is
+                                // an inline blocking Nread inside
+                                // iperf_tcp_accept (iperf_tcp.c:155-160),
+                                // probed identical (silent conn + ctrl-EOF
+                                // at t=2 → both tools notice at ~10 s); the
+                                // bounds are Nread's (10 s idle / 30 s
+                                // overall on a dripper), same as GT's
+                                // net.c:75-76 modulo the recorded nread_step
+                                // per-step-idle nuance.
                                 match protocol::recv_cookie(&mut candidate).await {
                                     Ok(c) if c == ctx.cookie => break candidate,
-                                    // Wrong cookie, the 10 s silent bound,
-                                    // or died mid-cookie: best-effort deny
+                                    // Wrong cookie, the silent Nread bound,
+                                    // or a clean FIN (nread collapses both
+                                    // to UnexpectedEof): best-effort deny
                                     // like GT's Nwrite-then-close (the peer
-                                    // may already be gone).
-                                    _ => {
+                                    // may already be gone; GT prints a
+                                    // "failed to send access denied" line
+                                    // when ITS deny write fails — riperf3
+                                    // stays silent, recorded, racy cell).
+                                    // RECORDED DEVIATION (#384 r1 F3, GT
+                                    // bug not mirrored): with negotiated
+                                    // TOS != 0, GT runs sockopts on the
+                                    // just-denied CLOSED fd before its
+                                    // is_closed guard
+                                    // (iperf_server_api.c:780 vs :786) and
+                                    // IESETTOS-kills the round; riperf3
+                                    // continues (the #271 ethos).
+                                    Ok(_) => {
                                         let _ = protocol::send_state(
                                             &mut candidate,
                                             TestState::AccessDenied,
@@ -1398,6 +1430,42 @@ impl Server {
                                         .await;
                                         // Dropped here; the slot stays
                                         // unclaimed and the select re-arms.
+                                    }
+                                    Err(RiperfError::Io(ref io))
+                                        if io.kind()
+                                            == std::io::ErrorKind::UnexpectedEof =>
+                                    {
+                                        let _ = protocol::send_state(
+                                            &mut candidate,
+                                            TestState::AccessDenied,
+                                        )
+                                        .await;
+                                    }
+                                    // #384 r1 F2: a HARD read error (e.g.
+                                    // ECONNRESET) is NOT a deny — GT's
+                                    // Nread < 0 arm takes IERECVCOOKIE
+                                    // through cleanup_server
+                                    // (iperf_tcp.c:155-159): the fe+106
+                                    // wire-back, the populated setup doc,
+                                    // round dead, keep-serving.
+                                    Err(_) => {
+                                        abort_setup_streams(ctx).await;
+                                        let _ = protocol::send_server_error(
+                                            &mut ctx.ctrl,
+                                            106,
+                                        )
+                                        .await;
+                                        self.emit_setup_phase_error(
+                                            ctx,
+                                            listener,
+                                            &format!(
+                                                "error - {}: ",
+                                                RiperfError::RecvDataCookieFailed
+                                            ),
+                                        );
+                                        return Err(
+                                            RiperfError::RecvDataCookieFailed,
+                                        );
                                     }
                                 }
                             }

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -1365,9 +1365,42 @@ impl Server {
                 // patiently (GT live: >9 s at --rcv-timeout 3000).
                 let idle_armed = !ctx.cfg.reverse || ctx.cfg.bidir;
                 for i in 0..total {
-                    let (mut data_stream, _) = loop {
+                    let data_stream = loop {
                         tokio::select! {
-                            accepted = listener.accept() => break accepted?,
+                            accepted = listener.accept() => {
+                                let (mut candidate, _) = accepted?;
+                                // #359: GT's deny-and-continue cookie gate —
+                                // a wrong-cookie, silent, or died connect
+                                // gets ACCESS_DENIED on ITS socket
+                                // (iperf_tcp.c:161-166; the closed-socket
+                                // guard iperf_server_api.c:786) and the wait
+                                // continues; only the no-progress clock ends
+                                // a round with no real streams. The old gate
+                                // killed the round (CookieMismatch /
+                                // unexpected-EOF).
+                                // RECORDED DEVIATION: this inline cookie
+                                // read blinds the ctrl-EOF / rcv_timeout
+                                // arms for its ≤10 s Nread bound — GT's
+                                // cookie read joins its select instead.
+                                // Adversarial-only: a real client writes
+                                // the cookie immediately on connect.
+                                match protocol::recv_cookie(&mut candidate).await {
+                                    Ok(c) if c == ctx.cookie => break candidate,
+                                    // Wrong cookie, the 10 s silent bound,
+                                    // or died mid-cookie: best-effort deny
+                                    // like GT's Nwrite-then-close (the peer
+                                    // may already be gone).
+                                    _ => {
+                                        let _ = protocol::send_state(
+                                            &mut candidate,
+                                            TestState::AccessDenied,
+                                        )
+                                        .await;
+                                        // Dropped here; the slot stays
+                                        // unclaimed and the select re-arms.
+                                    }
+                                }
+                            }
                             activity = ctrl_activity(&ctx.ctrl) => match activity {
                                 // EOF: the peer closed without connecting its
                                 // data streams — GT's read-site surface. The
@@ -1407,11 +1440,6 @@ impl Server {
                             }
                         }
                     };
-                    let stream_cookie = protocol::recv_cookie(&mut data_stream).await?;
-                    if stream_cookie != ctx.cookie {
-                        abort_setup_streams(ctx).await;
-                        return Err(RiperfError::CookieMismatch);
-                    }
                     // Apply socket options (nodelay, MSS, window, congestion) to each stream
                     net::configure_tcp_stream_full(
                         &data_stream,

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -1414,6 +1414,22 @@ impl Server {
                                     // "failed to send access denied" line
                                     // when ITS deny write fails — riperf3
                                     // stays silent, recorded, racy cell).
+                                    // RECORDED DEVIATION (#384 r2 F1, GT
+                                    // bug not mirrored): a FIN/hold at
+                                    // EXACTLY 36 cookie bytes is ACCEPTED
+                                    // by GT as the real stream — its Nread
+                                    // returns the partial 36 and
+                                    // strncmp(cookie, buf, 37) passes via
+                                    // the zero-filled buffer byte matching
+                                    // the trailing NUL (iperf_util.c:
+                                    // 121-124); it then runs a zero-byte
+                                    // test on the dead socket. riperf3's
+                                    // exact-37 read denies the truncated
+                                    // cookie instead. Cookie-knowledge-
+                                    // gated cell (only the real client or
+                                    // an on-path observer holds the
+                                    // prefix); the #271 do-not-mirror
+                                    // ethos.
                                     // RECORDED DEVIATION (#384 r1 F3, GT
                                     // bug not mirrored): with negotiated
                                     // TOS != 0, GT runs sockopts on the


### PR DESCRIPTION
Closes #359.

## The defect

Two TCP CREATE_STREAMS sub-cells where GT takes a deny-and-continue path and riperf3 killed the round (found by #356's r2, GT 3.21 live-probed, pre-existing):

1. **Wrong-cookie data connect** — GT sends ACCESS_DENIED (0xff) on the offending data socket (iperf_tcp.c:161-166; the closed-socket guard iperf_server_api.c:786) and keeps waiting for the real streams. riperf3 killed the round instantly with the non-GT `error - cookie mismatch`.
2. **Silent data connect** — GT denies that socket at its 10 s cookie-read bound and IENOMSGs the round at ~13 s (the re-armed no-progress clock). riperf3 killed the round at 10 s with `error - unexpected end of file`, bypassing the #356 IENOMSG surface entirely.

## The fix

The cookie gate moves inside the accept arm of the #356 select: `recv_cookie` (already Nread-bounded) runs on the candidate; a match breaks out with the stream; anything else — wrong cookie, the 10 s silent bound, died mid-cookie — best-effort-writes `AccessDenied` and drops the candidate. The slot stays unclaimed, the select re-arms (the deny is receive progress, GT's semantics), and only the no-progress clock ends a streamless round with the pinned #356/#358 IENOMSG surface. The old `CookieMismatch` kill is gone (the error variant stays — no remaining server constructor; its Display test stands).

**Recorded deviation** (in-code): the inline cookie read blinds the ctrl-EOF/rcv_timeout arms for its ≤10 s bound — GT's cookie read joins its select instead. Adversarial-only: a real client writes its cookie immediately on connect.

Scope note: the UDP arms are untouched (the cookie rides the connect-magic handshake there — a different gate; GT's UDP slot-claiming validates nothing, the #383 record). The doc/sink emits on the post-deny IENOMSG round are the byte-identical #356 emit call sites already pinned by the #356/#358 -J/json-stream pins.

## Verification

**Pins, red-first** (both failed on the missing deny byte — EOF where 0xff was due):

- `setup_wrong_cookie_conn_is_denied_and_the_round_continues` — the imposter reads 0xff + EOF while the round proceeds to serve the REAL stream (TestStart/TestRunning arrive on ctrl); exit 0.
- `setup_silent_conn_is_denied_then_the_round_ienomsgs` — the deny lands at the ~10 s cookie-read bound (asserted 8–13 s window), then the 144 wire-back at GT's ~13 s cadence with the IENOMSG line; exit 0.

**Mutation table** (house harness): M1 deny byte dropped → red; M2 deny-and-continue reverted to the round kill → red; M3 wrong deny byte (0x01) → red; M4 denied candidate claims the slot → red.

**Gate:** fmt / clippy `-D warnings` clean; workspace **872 passed / 0 failed** (870 + the 2 pins).

## Round 1 (commit 2, @6a43ebb)

**r1 F2 (blocker):** the deny arm over-broadened into GT's kill cell — a HARD read error mid-cookie (abortive RST) takes GT's IERECVCOOKIE round-kill (iperf_tcp.c:155-159 Nread<0 → cleanup_server; r1 live probe: fe wire-back + the strerror'd line + round dead, no deny byte). The gate now splits: wrong-cookie / silent-bound / clean-FIN deny-and-continue; other read errors kill with the fe+106 wire-back, the populated setup doc, and the new `RecvDataCookieFailed` class (the pre-test `RecvCookieFailed` carries the SKELETON doc — the serve loop tells the phases apart). Pin red-first (`setup_rst_mid_cookie_kills_the_round_ierecvcookie`), M5 mutant added.

**r1 F1 (blocker, comment-only):** the deviation record was INVERTED — GT's data-cookie read is itself an inline blocking Nread (iperf_tcp.c:155-160; r1 probed both tools noticing a t=2 ctrl-EOF at ~10 s identically). Rewritten as a PARITY note with corrected bounds. **r1 F3:** GT's TOS-on-denied-closed-fd IESETTOS kill recorded as a do-not-mirror deviation (#271 ethos). **r1 F4:** GT's deny-write-failure stderr line recorded (racy cell, riperf3 silent). **r1 F5:** the pin-2 errno-word cross-reference to the #336 recorded deviation.

r1 also verified: the drip re-arm matches GT exactly (both IENOMSG 3 s after the LAST deny — 17.01 s in both probes); the DoS live-forever-under-drip property is GT's own; no fd growth; the imposter cannot claim slots. Mutation table re-run on this head: **5/5 red**. Gate @6a43ebb: fmt/clippy clean, workspace **873/873** (872 + the RST pin).

CI note: the first run's `Native test (macos-latest)` failed on `exchange_phase_err_still_tears_down_streams` — the #353 pin's RST-race retry-exhaustion class on a slow runner (untouched by this diff; green 3/3 locally, green on the CI rerun). Disclosed, no change.

## Round 2 (commit 3-4, @624da61)

**r2 F1 (blocker, record):** GT ACCEPTS a FIN/hold at exactly 36 cookie bytes as the real stream (strncmp passes via the zero-filled buffer's trailing-NUL match, iperf_util.c:121-124 — then runs a zero-byte test on the dead socket); riperf3's exact-37 read denies the truncated cookie. Recorded as a do-not-mirror deviation (GT bug, cookie-knowledge-gated; flagged for the release review). **r2 F2:** the -J twin of the RST-kill pin (the populated-doc-vs-skeleton distinction pinned; M6 doc-emit mutant added, red). **r2 F4** → noted on #362 (pre-existing accept-error class). Full round records in the PR comments.

**Merge-head evidence @624da61:** CI 17/17; mutation table 6/6 red; compat 52/52; workspace 874/874.
