### PR TITLE
fix: the cookie/params reads race the interrupt watch (#361)

### DIFF
--- a/riperf3-cli/tests/pidfile.rs
+++ b/riperf3-cli/tests/pidfile.rs
@@ -139,10 +139,13 @@ fn pidfile_unlinked_after_one_off_run() {
 /// #158/#210: a SECOND signal exits immediately, dying BY the signal. The
 /// first signal now takes the graceful sigend path (#210: dump + terminate
 /// the peer), so the old blasting-UDP wedge converges too fast to race.
-/// Instead a half-open control connection wedges the server in the param
-/// exchange — a phase with no interrupt-aware await — so the first signal's
-/// bounded dump window (5 s) holds deterministically while the second signal
-/// hits the pre-armed raw handler.
+/// The deterministic wedge is a phase with no interrupt-aware await: the
+/// cookie/param reads served until #361 made them interrupt-aware (GT
+/// exits immediately there), so the wedge now parks in the CREATE_STREAMS
+/// setup wait — params sent, no data connections; its select watches the
+/// ctrl and the rcv_timeout (120 s default) but NOT the interrupt — so the
+/// first signal's bounded dump window (5 s) holds deterministically while
+/// the second signal hits the pre-armed raw handler.
 #[cfg(unix)]
 #[test]
 fn second_signal_during_teardown_exits_immediately() {
@@ -168,10 +171,25 @@ fn second_signal_during_teardown_exits_immediately() {
         "server pidfile written",
     );
 
-    // The wedge: connect to the control port and send nothing — the server
-    // sits in the cookie/param read, which no interrupt arm covers.
-    let _wedge = std::net::TcpStream::connect(("127.0.0.1", port)).expect("wedge connect");
-    std::thread::sleep(Duration::from_millis(300)); // let the accept land
+    // The wedge (#361 moved it one phase later): complete the cookie/param
+    // exchange, then connect NO data streams — the server parks in the
+    // CREATE_STREAMS setup wait, which no interrupt arm covers.
+    let _wedge = {
+        use std::io::{Read as _, Write as _};
+        let mut w = std::net::TcpStream::connect(("127.0.0.1", port)).expect("wedge connect");
+        w.write_all(&[b'x'; 37]).expect("cookie");
+        let mut b = [0u8; 1];
+        w.read_exact(&mut b).expect("ParamExchange state");
+        assert_eq!(b[0], 9);
+        let params = br#"{"tcp":true}"#;
+        w.write_all(&(params.len() as u32).to_be_bytes())
+            .expect("len");
+        w.write_all(params).expect("params");
+        w.read_exact(&mut b).expect("CreateStreams state");
+        assert_eq!(b[0], 10);
+        w
+    };
+    std::thread::sleep(Duration::from_millis(300)); // let the setup wait park
 
     let pid = server.0.id() as i32;
     // SAFETY: plain kill(2) on our own child.

--- a/riperf3-cli/tests/signal_terminate.rs
+++ b/riperf3-cli/tests/signal_terminate.rs
@@ -971,15 +971,16 @@ fn server_sigterm_mid_test_emits_exactly_one_doc() {
     );
 }
 
-/// #346 (PR #360 r1 F1): a SIGTERM landing DURING a refused round must not
-/// append the idle-interrupt skeleton after the refusal doc — the refusal
-/// round returns Ok(None) after emitting its own document. Deterministic:
-/// the signal lands while the server is blocked in recv_params (which does
-/// not watch the interrupt), then the violating params complete the
-/// refusal round with the interrupt already pending.
+/// #346 (PR #360 r1 F1), reworked by #361: a SIGTERM landing while the
+/// server is parked in recv_params now ends the round IMMEDIATELY with the
+/// interrupt skeleton — GT's longjmp sigend never reaches the refusal (the
+/// old test baked the blind-window semantics: the violating params
+/// completed a refusal round with the interrupt pending). The #360
+/// no-double-doc property survives as the whole-stdout parse: EXACTLY one
+/// document, now the interrupt's.
 #[cfg(unix)]
 #[test]
-fn sigterm_during_refused_round_emits_exactly_one_doc() {
+fn sigterm_during_params_read_emits_exactly_one_doc() {
     use std::io::{Read, Write};
     let ps = free_port();
     let server = spawn(&[
@@ -998,27 +999,24 @@ fn sigterm_during_refused_round_emits_exactly_one_doc() {
     let mut b = [0u8; 1];
     ctrl.read_exact(&mut b).unwrap();
     assert_eq!(b[0], 9, "ParamExchange");
-    // Signal while the server is parked in recv_params.
+    // Signal while the server is parked in recv_params — #361 makes this
+    // window interrupt-aware, so the round ends here.
     let spid = server.0.id() as i32;
     unsafe {
         libc::kill(spid, libc::SIGTERM);
     }
-    std::thread::sleep(Duration::from_millis(100));
-    // Violating params (time 100 > max 5) complete the REFUSED round.
-    let params = br#"{"tcp":true,"time":100}"#;
-    ctrl.write_all(&(params.len() as u32).to_be_bytes())
-        .unwrap();
-    ctrl.write_all(params).unwrap();
 
     let (sout, serr, scode) = wait_with_output_bounded(server, Duration::from_secs(8), "server");
     drop(ctrl);
     assert_eq!(scode, 0, "signal-normal exit");
     assert!(serr.trim().is_empty(), "-J keeps stderr silent: {serr:?}");
-    // Whole-stdout parse: an appended skeleton doc fails it.
+    // Whole-stdout parse: an appended second doc fails it.
     let doc: serde_json::Value = serde_json::from_str(sout.trim())
-        .expect("server stdout is EXACTLY ONE JSON document (the refusal's)");
+        .expect("server stdout is EXACTLY ONE JSON document (the interrupt's)");
     assert!(
-        doc["error"].is_string(),
-        "the single doc is the refusal's: {doc}"
+        doc["error"]
+            .as_str()
+            .is_some_and(|e| e.starts_with("interrupt - ")),
+        "the single doc carries the interrupt key: {doc}"
     );
 }

--- a/riperf3-cli/tests/signal_terminate.rs
+++ b/riperf3-cli/tests/signal_terminate.rs
@@ -983,15 +983,7 @@ fn server_sigterm_mid_test_emits_exactly_one_doc() {
 fn sigterm_during_params_read_emits_exactly_one_doc() {
     use std::io::{Read, Write};
     let ps = free_port();
-    let server = spawn(&[
-        "-s",
-        "-1",
-        "-p",
-        &ps.to_string(),
-        "-J",
-        "--server-max-duration",
-        "5",
-    ]);
+    let server = spawn(&["-s", "-1", "-p", &ps.to_string(), "-J"]);
     std::thread::sleep(Duration::from_millis(400));
 
     let mut ctrl = std::net::TcpStream::connect(("127.0.0.1", ps)).expect("ctrl");

--- a/riperf3-cli/tests/wire_shape.rs
+++ b/riperf3-cli/tests/wire_shape.rs
@@ -3007,6 +3007,90 @@ fn sigterm_while_listening_emits_skeleton_doc_in_json() {
     );
 }
 
+/// #361: SIGTERM while a client sits WEDGED pre-cookie (connected,
+/// silent, never closing) — GT exits IMMEDIATELY with the same #346
+/// skeleton (live: exit 0, dt 0.00). riperf3 pre-fix rode the CLI's 5 s
+/// dump wall and exited with EMPTY -J stdout (the #158 interrupt-blind
+/// window; that test's wedge moved one phase later).
+#[cfg(unix)]
+fn drive_sigterm_wedged(args: &[&str]) -> (String, String, std::process::ExitStatus, Duration) {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind");
+    let port = listener.local_addr().unwrap().port();
+    drop(listener);
+    let port_s = port.to_string();
+    let mut all = vec!["-s", "-p", &port_s];
+    all.extend_from_slice(args);
+    let mut server = common::ChildGuard(
+        std::process::Command::new(env!("CARGO_BIN_EXE_riperf3"))
+            .args(&all)
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .spawn()
+            .expect("spawn server"),
+    );
+    let sout = riperf3_test_support::drain_reader(server.0.stdout.take().expect("piped stdout"));
+    let serr = riperf3_test_support::drain_reader(server.0.stderr.take().expect("piped stderr"));
+    std::thread::sleep(std::time::Duration::from_millis(600));
+    // The wedge: connected, silent, never closing — the server parks in
+    // the cookie read.
+    let _wedge = std::net::TcpStream::connect(("127.0.0.1", port)).expect("wedge");
+    std::thread::sleep(std::time::Duration::from_millis(400));
+    let t0 = std::time::Instant::now();
+    unsafe { libc::kill(server.0.id() as i32, libc::SIGTERM) };
+    let status =
+        riperf3_test_support::wait_bounded(&mut server.0, std::time::Duration::from_secs(8))
+            .expect("signal-normal exit");
+    let elapsed = t0.elapsed();
+    (
+        sout.join().expect("stdout"),
+        serr.join().expect("stderr"),
+        status,
+        elapsed,
+    )
+}
+
+/// #361 -J: the interrupt skeleton emits IMMEDIATELY (GT dt 0.00; the
+/// pre-fix red = empty stdout after the 5 s dump wall).
+#[cfg(unix)]
+#[test]
+fn sigterm_on_wedged_precookie_client_emits_skeleton_in_json() {
+    let (sout, serr, status, elapsed) = drive_sigterm_wedged(&["-J"]);
+    assert!(status.success(), "GT signormalexit exits 0");
+    assert!(
+        elapsed < Duration::from_secs(3),
+        "GT exits immediately, not at the 5 s dump wall: {elapsed:?}"
+    );
+    assert!(serr.trim().is_empty(), "-J keeps stderr silent: {serr:?}");
+    let doc: serde_json::Value =
+        serde_json::from_str(sout.trim()).unwrap_or_else(|e| panic!("one -J doc ({e}): {sout:?}"));
+    assert_eq!(
+        doc["error"].as_str(),
+        Some(SIGTERM_KEY),
+        "the interrupt-class key: {doc}"
+    );
+    assert!(
+        doc["end"].as_object().expect("end").is_empty(),
+        "bare end: {doc}"
+    );
+}
+
+/// #361 text: GT's stderr line + exit 0, immediately.
+#[cfg(unix)]
+#[test]
+fn sigterm_on_wedged_precookie_client_prints_line_in_text() {
+    let (_sout, serr, status, elapsed) = drive_sigterm_wedged(&[]);
+    assert!(status.success(), "exit 0: {serr:?}");
+    assert!(
+        elapsed < Duration::from_secs(3),
+        "GT exits immediately: {elapsed:?}"
+    );
+    assert_eq!(
+        serr.trim(),
+        format!("riperf3: {SIGTERM_KEY}"),
+        "GT's stderr interrupt line: {serr:?}"
+    );
+}
+
 /// #346 --json-stream: GT's error + bare-end event pair.
 #[cfg(unix)]
 #[test]

--- a/riperf3-cli/tests/wire_shape.rs
+++ b/riperf3-cli/tests/wire_shape.rs
@@ -3068,6 +3068,11 @@ fn sigterm_on_wedged_precookie_client_emits_skeleton_in_json() {
         Some(SIGTERM_KEY),
         "the interrupt-class key: {doc}"
     );
+    assert_eq!(
+        doc["start"]["connected"].as_array().map(Vec::len),
+        Some(0),
+        "skeleton start even with the client attached, like GT (#385 r2 F2): {doc}"
+    );
     assert!(
         doc["end"].as_object().expect("end").is_empty(),
         "bare end: {doc}"
@@ -3095,6 +3100,12 @@ fn sigterm_on_wedged_precookie_client_stream_events() {
     assert_eq!(events[0]["event"].as_str(), Some("error"));
     assert_eq!(events[0]["data"].as_str(), Some(SIGTERM_KEY));
     assert_eq!(events[1]["event"].as_str(), Some("end"));
+    assert_eq!(
+        events[1]["data"],
+        serde_json::json!({}),
+        "bare end event data like GT (#385 r2 F1): {}",
+        events[1]
+    );
 }
 
 /// #361 text: GT's stderr line + exit 0, immediately.

--- a/riperf3-cli/tests/wire_shape.rs
+++ b/riperf3-cli/tests/wire_shape.rs
@@ -3074,6 +3074,29 @@ fn sigterm_on_wedged_precookie_client_emits_skeleton_in_json() {
     );
 }
 
+/// #361 --json-stream (#385 r1 F3): GT's error + bare-end event pair,
+/// immediately — symmetric with the #346 idle-cell pin.
+#[cfg(unix)]
+#[test]
+fn sigterm_on_wedged_precookie_client_stream_events() {
+    let (sout, serr, status, elapsed) = drive_sigterm_wedged(&["--json-stream"]);
+    assert!(status.success());
+    assert!(
+        elapsed < Duration::from_secs(3),
+        "GT exits immediately: {elapsed:?}"
+    );
+    assert!(serr.trim().is_empty(), "silent stderr: {serr:?}");
+    let events: Vec<serde_json::Value> = sout
+        .lines()
+        .filter(|l| !l.trim().is_empty())
+        .map(|l| serde_json::from_str(l).unwrap_or_else(|e| panic!("event ({e}): {l}")))
+        .collect();
+    assert_eq!(events.len(), 2, "error + end pair: {sout:?}");
+    assert_eq!(events[0]["event"].as_str(), Some("error"));
+    assert_eq!(events[0]["data"].as_str(), Some(SIGTERM_KEY));
+    assert_eq!(events[1]["event"].as_str(), Some("end"));
+}
+
 /// #361 text: GT's stderr line + exit 0, immediately.
 #[cfg(unix)]
 #[test]

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -809,7 +809,21 @@ impl Server {
             (peer_addr.ip().to_canonical().to_string(), peer_addr.port());
 
         // ---- Cookie + ParamExchange (+ the #230 upfront max-duration refusal) ----
-        let (cookie, params, cfg) = match self.negotiate_test(&mut ctrl).await? {
+        // #361: the cookie/params reads race the interrupt watch — GT's
+        // sigend exits IMMEDIATELY from this window with the #346 skeleton
+        // (live: exit 0, dt 0.00); the old interrupt-blind window rode the
+        // CLI's 5 s dump wall with EMPTY -J stdout against a wedged
+        // client. (The #158 second-signal test's deterministic wedge moved
+        // one phase later, to the interrupt-blind setup wait.)
+        let mut neg_interrupt = self.interrupt.clone().map(|w| w.0);
+        let negotiated = tokio::select! {
+            r = self.negotiate_test(&mut ctrl) => r?,
+            msg = crate::client::wait_interrupt(neg_interrupt.as_mut()) => {
+                self.emit_pretest_error_doc(&msg);
+                return Ok(None);
+            }
+        };
+        let (cookie, params, cfg) = match negotiated {
             Some(negotiated) => negotiated,
             // Refused before any test ran → no report.
             None => return Ok(None),

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -1094,9 +1094,10 @@ impl Server {
     /// full 5 s dump window (the post-merge macOS CI red: systemd-style
     /// SIGTERM-while-listening took ~5 s). There is nothing to dump while
     /// idle; returning `None` lets the run loop's interrupt check exit the
-    /// serve loop. The post-accept phases (cookie/param reads) stay
-    /// interrupt-blind by design — the #158 second-signal wedge test depends
-    /// on that window.
+    /// serve loop. The cookie/param reads race the interrupt watch too
+    /// (#361 — GT's sigend exits immediately from any phase); the remaining
+    /// interrupt-blind window is the CREATE_STREAMS setup wait, where the
+    /// #158 second-signal wedge test now parks (recorded on #361).
     async fn accept_control(
         &self,
         listener: &tokio::net::TcpListener,


### PR DESCRIPTION
Closes #361.

## The defect

SIGTERM while a client sits wedged pre-cookie (connected, silent, never closing): riperf3 exited 0 with EMPTY `-J` stdout after the CLI's 5 s dump wall — the cookie/params reads were interrupt-blind, so the signal never surfaced inside the round, and the #346 accept-site emit never ran. GT exits IMMEDIATELY from any phase (its sigend longjmps out of the blocking read): live-probed, the #346 interrupt skeleton at dt 0.00, exit 0 (`-J`: skeleton doc with `"interrupt - the server has terminated by signal Terminated(15)"`; text: the stderr line).

## The fix

`negotiate_test` (the cookie + params reads) races `wait_interrupt` in a select — the interrupt arm emits the exact #346 skeleton (`emit_pretest_error_doc`) and ends the round `Ok(None)`; the serve loop's interrupt check exits 0. Cancel-safety: the round is over either way, the ctrl drops.

Two tests carried the old blind-window semantics and were reworked in the same commit:

- **The #158 second-signal wedge** moved one phase later: params sent, no data connections — the CREATE_STREAMS setup wait has no interrupt arm and a 120 s default rcv_timeout, so the first signal's 5 s dump window still holds deterministically for the second-signal hard-exit test. (If a future issue makes the setup waits interrupt-aware — the same GT-parity argument applies there — the test moves again or gets a synthetic wedge.)
- **The #360 refused-round single-doc test**: its scenario (signal parked in recv_params, then violating params) now ends at the signal — GT never reaches the refusal. The test asserts the GT shape (ONE doc, the interrupt key) and keeps its no-double-doc whole-stdout guard.

Scope note: the setup waits (TCP accept select, both UDP selects) remain interrupt-blind — bounded by rcv_timeout, but a signal there still rides the dump wall. Same family, one phase later; not in #361's probed scope — noted on the issue as a possible follow-up.

## Verification

**Pins, red-first** (both rode the 5 s wall — the `elapsed < 3 s` assert is the red):

- `sigterm_on_wedged_precookie_client_emits_skeleton_in_json` — the skeleton emits immediately, exit 0, silent stderr.
- `sigterm_on_wedged_precookie_client_prints_line_in_text` — GT's stderr line, exit 0, immediate.

**Mutation table:** M1 interrupt arm removed (the blind window back) → red; M2 skeleton emit dropped → red; M3 the arm errors instead of the signal-normal end → red (text pin's exit-0/line assert).

**Gate:** fmt / clippy `-D warnings` clean; workspace **876 passed / 0 failed**. One full-run flake (`end_loop_unknown_byte_takes_gt_iemessage_shape_in_json`, the #349-F4 load family — green 3/3 isolated, green on the full rerun); disclosed, no change.

**Rounds:** r1 APPROVE (F1 stale comment + F3 json-stream pin + F4 inert flag applied; F2 → #386, the pre-existing refusal-round-end divergence). r2 APPROVE (cold, 18/18 GT cells byte-parallel; the two one-line asserts applied). Full round records in the PR comments. Merge-head evidence: CI 17/17 on every head; compat 52/52; mutants 3/3.
