### PR TITLE
fix: the accept/configure failure sites take GT's error classes (#362)

### DIFF
--- a/riperf3-cli/tests/wire_shape.rs
+++ b/riperf3-cli/tests/wire_shape.rs
@@ -4761,15 +4761,30 @@ fn tcp_reverse_setup_hold_is_idle_exempt() {
 // Linux-only (prlimit + errno 24 = EMFILE).
 // ---------------------------------------------------------------------------
 
-/// Clamp the target's RLIMIT_NOFILE to its current first-free slot.
+/// The EMFILE cells serialize on this lock: two concurrent clamped
+/// servers on 2 pinned cores interfered (~50% ConnectionRefused on the
+/// second cell's data connect — the paired hot-spin starves the other
+/// server's accept path); each cell is deterministic alone.
+#[cfg(target_os = "linux")]
+static EMFILE_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+/// Clamp the target's RLIMIT_NOFILE to its current FIRST-FREE slot — a
+/// new fd always takes the lowest free index, so the limit must sit AT
+/// that hole, not at max+1 (the CI runner's spawned processes carry
+/// holes below max; the dense-table assumption let the accept dodge the
+/// clamp — the 28c1184 Linux CI red).
 #[cfg(target_os = "linux")]
 fn clamp_fd_table(pid: u32) {
-    let max_fd = std::fs::read_dir(format!("/proc/{pid}/fd"))
+    let open: std::collections::BTreeSet<u32> = std::fs::read_dir(format!("/proc/{pid}/fd"))
         .expect("read fd table")
         .filter_map(|e| e.ok()?.file_name().to_str()?.parse::<u32>().ok())
-        .max()
-        .expect("nonempty fd table");
-    let limit = (max_fd + 1).to_string();
+        .collect();
+    assert!(!open.is_empty(), "nonempty fd table");
+    let mut first_free = 0u32;
+    while open.contains(&first_free) {
+        first_free += 1;
+    }
+    let limit = first_free.to_string();
     let st = std::process::Command::new("prlimit")
         .args([
             &format!("--pid={pid}"),
@@ -4788,6 +4803,7 @@ fn clamp_fd_table(pid: u32) {
 #[cfg(target_os = "linux")]
 #[test]
 fn accept_emfile_takes_gt_ieaccept_class() {
+    let _serial = EMFILE_LOCK.lock().unwrap_or_else(|p| p.into_inner());
     let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind");
     let port = listener.local_addr().unwrap().port();
     drop(listener);
@@ -4823,11 +4839,14 @@ fn accept_emfile_takes_gt_ieaccept_class() {
 }
 
 /// #362: the setup data-accept under EMFILE — the fe+203+LIVE-errno
-/// wire-back (r1 F2: a GT client prints its SERVER ERROR line only when
-/// the wire word is > 0), the strerror'd line, exit 0.
+/// wire-back (r1 F2/r2 F2: the wire word carries the strerror content of
+/// the GT client's SERVER ERROR line — live-proven interop on the
+/// PERSISTENT pairing; the one-off pairing's close-ordering divergence is
+/// the filed follow-up), the strerror'd line, exit 0.
 #[cfg(target_os = "linux")]
 #[test]
 fn setup_data_accept_emfile_wires_iestreamconnect_with_live_errno() {
+    let _serial = EMFILE_LOCK.lock().unwrap_or_else(|p| p.into_inner());
     let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind");
     let port = listener.local_addr().unwrap().port();
     drop(listener);

--- a/riperf3-cli/tests/wire_shape.rs
+++ b/riperf3-cli/tests/wire_shape.rs
@@ -4751,6 +4751,126 @@ fn tcp_reverse_setup_hold_is_idle_exempt() {
     reverse_hold_case(r#"{"tcp":true,"reverse":true}"#, false);
 }
 
+// ---------------------------------------------------------------------------
+// #362 (#387 r1 F3): the accept-failure classes, E2E via prlimit-after-
+// startup — clamp RLIMIT_NOFILE to the process's first free slot, then
+// connect; the accept fails EMFILE deterministically. GT byte-parity is
+// NOT pinnable (GT's own class drifts 203→200 with one fd of budget and
+// its printed errno is post-cleanup clobbered — r1's probes); these pin
+// riperf3's OWN surfaces, whose shapes r1 verified against GT source.
+// Linux-only (prlimit + errno 24 = EMFILE).
+// ---------------------------------------------------------------------------
+
+/// Clamp the target's RLIMIT_NOFILE to its current first-free slot.
+#[cfg(target_os = "linux")]
+fn clamp_fd_table(pid: u32) {
+    let max_fd = std::fs::read_dir(format!("/proc/{pid}/fd"))
+        .expect("read fd table")
+        .filter_map(|e| e.ok()?.file_name().to_str()?.parse::<u32>().ok())
+        .max()
+        .expect("nonempty fd table");
+    let limit = (max_fd + 1).to_string();
+    let st = std::process::Command::new("prlimit")
+        .args([
+            &format!("--pid={pid}"),
+            &format!("--nofile={limit}:{limit}"),
+        ])
+        .status()
+        .expect("prlimit runs");
+    assert!(st.success(), "prlimit failed");
+}
+
+/// #362: the control accept() under EMFILE — GT's IEACCEPT class line
+/// (strerror'd, no dangling suffix) and keep-serving. The persistent
+/// server currently line-spins on the sticky error (the filed hot-spin
+/// issue records the GT listener-recycle delta) — the pin asserts the
+/// class, at least once, and the process staying alive.
+#[cfg(target_os = "linux")]
+#[test]
+fn accept_emfile_takes_gt_ieaccept_class() {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind");
+    let port = listener.local_addr().unwrap().port();
+    drop(listener);
+    let ps = port.to_string();
+    let mut server = common::ChildGuard(
+        std::process::Command::new(env!("CARGO_BIN_EXE_riperf3"))
+            .args(["-s", "-p", &ps])
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::piped())
+            .spawn()
+            .expect("spawn server"),
+    );
+    let se = riperf3_test_support::drain_reader(server.0.stderr.take().unwrap());
+    std::thread::sleep(std::time::Duration::from_millis(500));
+    clamp_fd_table(server.0.id());
+    let _client = std::net::TcpStream::connect(("127.0.0.1", port)).expect("connect");
+    std::thread::sleep(std::time::Duration::from_millis(700));
+    let alive = server.0.try_wait().expect("try_wait").is_none();
+    drop(server);
+    let serr = se.join().expect("stderr");
+    assert!(alive, "keep-serving like GT's rc -1 class");
+    assert!(
+        serr.contains("error - unable to accept connection from client: ")
+            && serr.contains("(os error 24)"),
+        "GT's IEACCEPT sentence with the live strerror, no dangling: {}",
+        &serr[..serr.len().min(400)]
+    );
+    assert!(
+        !serr.contains("client: Too many open files (os error 24): "),
+        "no dangling suffix after the strerror (r1 F1): {}",
+        &serr[..serr.len().min(400)]
+    );
+}
+
+/// #362: the setup data-accept under EMFILE — the fe+203+LIVE-errno
+/// wire-back (r1 F2: a GT client prints its SERVER ERROR line only when
+/// the wire word is > 0), the strerror'd line, exit 0.
+#[cfg(target_os = "linux")]
+#[test]
+fn setup_data_accept_emfile_wires_iestreamconnect_with_live_errno() {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind");
+    let port = listener.local_addr().unwrap().port();
+    drop(listener);
+    let ps = port.to_string();
+    let mut server = common::ChildGuard(
+        std::process::Command::new(env!("CARGO_BIN_EXE_riperf3"))
+            .args(["-s", "-1", "-p", &ps])
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::piped())
+            .spawn()
+            .expect("spawn server"),
+    );
+    let se = riperf3_test_support::drain_reader(server.0.stderr.take().unwrap());
+    std::thread::sleep(std::time::Duration::from_millis(500));
+    let pid = server.0.id();
+
+    let mut ctrl = std::net::TcpStream::connect(("127.0.0.1", port)).expect("ctrl");
+    ctrl.write_all(&[b'x'; 37]).unwrap();
+    assert_eq!(read_exact(&mut ctrl, 1)[0], 9, "ParamExchange");
+    write_json_blob(&mut ctrl, INCOMPLETE_PARAMS);
+    assert_eq!(read_exact(&mut ctrl, 1)[0], 10, "CreateStreams");
+    // The server is parked in the setup select — clamp NOW, then connect
+    // the data socket; its accept fails EMFILE.
+    clamp_fd_table(pid);
+    let _data = std::net::TcpStream::connect(("127.0.0.1", port)).expect("data connect");
+    let frame = read_wireback(&mut ctrl);
+    assert_eq!(
+        frame,
+        vec![0xfe, 0, 0, 0, 203, 0, 0, 0, 24],
+        "fe + htonl(IESTREAMCONNECT=203) + htonl(EMFILE=24), GT's live-errno wire"
+    );
+    drop(ctrl);
+    let status =
+        riperf3_test_support::wait_bounded(&mut server.0, std::time::Duration::from_secs(5))
+            .expect("one-off exits");
+    let serr = se.join().expect("stderr");
+    assert!(status.success(), "exit 0 keep-serving class");
+    assert!(
+        serr.contains("error - unable to connect stream: ") && serr.contains("(os error 24)"),
+        "the strerror'd IESTREAMCONNECT line: {serr:?}"
+    );
+}
+
 /// #383 r2 F1: the demux design's idle exemption — the both-designs
 /// convention every other #358 cell follows.
 #[test]

--- a/riperf3/src/error.rs
+++ b/riperf3/src/error.rs
@@ -103,6 +103,27 @@ pub enum RiperfError {
     #[error("unable to send control message - port may not be available, the other side may have stopped running, etc.: {0}")]
     SendControlFailed(std::io::Error),
 
+    /// iperf3's IEACCEPT(104): the control accept() failed
+    /// (iperf_server_api.c:163; herr+perr — the live strerror rides, the
+    /// #345 SendControlFailed convention). BSD-class reachable
+    /// (ECONNABORTED surfaces from accept there); Linux EMFILE (#362 —
+    /// previously the raw io line on the generic arm).
+    #[error("unable to accept connection from client: {0}")]
+    AcceptFailed(std::io::Error),
+
+    /// iperf3's IESTREAMCONNECT(203): the SETUP data-stream accept()
+    /// failed (iperf_tcp.c:134-135) — GT's cleanup_server round-kill with
+    /// the fe+203 wire-back and the populated setup doc (#362, the
+    /// PR #384 r2 F4 cell). Live strerror rides (herr+perr).
+    #[error("unable to connect stream: {0}")]
+    StreamConnectFailed(std::io::Error),
+
+    /// iperf3's IESETNODELAY(112-class): TCP_NODELAY on the just-accepted
+    /// control socket failed (iperf_server_api.c:170-173; perr) — the
+    /// #362 macOS kind-only-InvalidInput cell's likeliest site.
+    #[error("unable to set TCP/SCTP NODELAY: {0}")]
+    SetNoDelayFailed(std::io::Error),
+
     /// iperf3's IENOMSG(144): the server's no-progress watchdog fired — no
     /// messages/data received within `--rcv-timeout` (default 120000 ms, GT's
     /// DEFAULT_NO_MSG_RCVD_TIMEOUT, iperf_api.h:70). First wired at the

--- a/riperf3/src/error.rs
+++ b/riperf3/src/error.rs
@@ -104,12 +104,14 @@ pub enum RiperfError {
     SendControlFailed(std::io::Error),
 
     /// iperf3's IEACCEPT(104): the control accept() failed
-    /// (iperf_server_api.c:163; herr+perr). RECORDED DEVIATION (#387 r1
-    /// F6): riperf3 carries the SITE-CAPTURED errno; GT's surface prints
-    /// the post-cleanup CLOBBERED errno (live: "Bad file descriptor"
-    /// where the accept errno was EMFILE) — the honest-errno call, the
-    /// #345 convention. BSD-class reachable (ECONNABORTED); Linux EMFILE
-    /// (#362 — previously the raw io line on the generic arm).
+    /// (iperf_server_api.c:163; herr+perr). The site-captured errno rides
+    /// — and MATCHES GT's text surface in this pre-test cell (#387 r2 F1
+    /// live probes, all four sinks: GT prints the LIVE strerror here;
+    /// nothing gets closed before the print, so no clobber — the clobber
+    /// is real only in the mid-setup double-close cells, see
+    /// [`Self::StreamConnectFailed`]). BSD-class reachable (ECONNABORTED);
+    /// Linux EMFILE (#362 — previously the raw io line on the generic
+    /// arm).
     #[error("unable to accept connection from client: {0}")]
     AcceptFailed(std::io::Error),
 

--- a/riperf3/src/error.rs
+++ b/riperf3/src/error.rs
@@ -104,23 +104,28 @@ pub enum RiperfError {
     SendControlFailed(std::io::Error),
 
     /// iperf3's IEACCEPT(104): the control accept() failed
-    /// (iperf_server_api.c:163; herr+perr — the live strerror rides, the
-    /// #345 SendControlFailed convention). BSD-class reachable
-    /// (ECONNABORTED surfaces from accept there); Linux EMFILE (#362 —
-    /// previously the raw io line on the generic arm).
+    /// (iperf_server_api.c:163; herr+perr). RECORDED DEVIATION (#387 r1
+    /// F6): riperf3 carries the SITE-CAPTURED errno; GT's surface prints
+    /// the post-cleanup CLOBBERED errno (live: "Bad file descriptor"
+    /// where the accept errno was EMFILE) — the honest-errno call, the
+    /// #345 convention. BSD-class reachable (ECONNABORTED); Linux EMFILE
+    /// (#362 — previously the raw io line on the generic arm).
     #[error("unable to accept connection from client: {0}")]
     AcceptFailed(std::io::Error),
 
     /// iperf3's IESTREAMCONNECT(203): the SETUP data-stream accept()
     /// failed (iperf_tcp.c:134-135) — GT's cleanup_server round-kill with
-    /// the fe+203 wire-back and the populated setup doc (#362, the
-    /// PR #384 r2 F4 cell). Live strerror rides (herr+perr).
+    /// the fe+203+LIVE-errno wire-back and the populated setup doc (#362,
+    /// the PR #384 r2 F4 cell). The site-captured errno rides text and
+    /// wire (GT's TEXT surface prints the clobbered post-cleanup errno
+    /// but WIRES the live one — #387 r1 F2/F6).
     #[error("unable to connect stream: {0}")]
     StreamConnectFailed(std::io::Error),
 
-    /// iperf3's IESETNODELAY(112-class): TCP_NODELAY on the just-accepted
-    /// control socket failed (iperf_server_api.c:170-173; perr) — the
-    /// #362 macOS kind-only-InvalidInput cell's likeliest site.
+    /// iperf3's IESETNODELAY(122, iperf_api.h:471): TCP_NODELAY on the
+    /// just-accepted control socket failed (iperf_server_api.c:170-173;
+    /// perr) — the #362 macOS kind-only-InvalidInput cell's likeliest
+    /// site. The fe+122+errno relay is best-effort on the failing ctrl.
     #[error("unable to set TCP/SCTP NODELAY: {0}")]
     SetNoDelayFailed(std::io::Error),
 

--- a/riperf3/src/protocol.rs
+++ b/riperf3/src/protocol.rs
@@ -217,11 +217,14 @@ pub async fn send_server_error(stream: &mut TcpStream, i_errno: u32) -> Result<(
     send_server_error_errno(stream, i_errno, 0).await
 }
 
-/// [`send_server_error`] with a live os errno word (#387 r1 F2): GT's
-/// cleanup_server wires htonl(errno) captured live
-/// (iperf_server_api.c:469-470), and a GT client prints its immediate
-/// `SERVER ERROR - …, errno: …` line only when the wire word is > 0 —
-/// so the accept-failure relays must carry the real errno.
+/// [`send_server_error`] with a live os errno word (#387 r1 F2, wording
+/// corrected r2 F2): GT's cleanup_server wires htonl(errno) captured
+/// live (iperf_server_api.c:470-471). A GT client prints its immediate
+/// `SERVER ERROR - …` line in BOTH branches — the wire word gates only
+/// the `, errno: <strerror>` suffix and the strerror content
+/// (iperf_client_api.c:403-407; live: fe+203+0 still prints the dangling
+/// line) — so the accept-failure relays carry the real errno for the
+/// CONTENT parity, not the line's existence.
 pub async fn send_server_error_errno(
     stream: &mut TcpStream,
     i_errno: u32,

--- a/riperf3/src/protocol.rs
+++ b/riperf3/src/protocol.rs
@@ -209,13 +209,27 @@ pub async fn send_state(stream: &mut TcpStream, state: TestState) -> Result<()> 
 /// Send SERVER_ERROR with iperf3's (i_errno, errno) u32-pair payload (#224):
 /// the state byte, then both words big-endian — iperf_server_api.c's Nwrite
 /// pair (the bitrate, duration-timer, and cleanup_server relay sites). The os
-/// errno word is always 0 from riperf3 — most relayed causes carry none, and
+/// errno word is 0 from this form — most relayed causes carry none, and
 /// where one exists (#345's send failure) the peer's RST makes the relay
 /// unobservable anyway; GT itself often leaks a stale word here (#336).
+/// A cause with a REAL live errno uses [`send_server_error_errno`].
 pub async fn send_server_error(stream: &mut TcpStream, i_errno: u32) -> Result<()> {
+    send_server_error_errno(stream, i_errno, 0).await
+}
+
+/// [`send_server_error`] with a live os errno word (#387 r1 F2): GT's
+/// cleanup_server wires htonl(errno) captured live
+/// (iperf_server_api.c:469-470), and a GT client prints its immediate
+/// `SERVER ERROR - …, errno: …` line only when the wire word is > 0 —
+/// so the accept-failure relays must carry the real errno.
+pub async fn send_server_error_errno(
+    stream: &mut TcpStream,
+    i_errno: u32,
+    os_errno: u32,
+) -> Result<()> {
     send_state(stream, TestState::ServerError).await?;
     stream.write_all(&i_errno.to_be_bytes()).await?;
-    stream.write_all(&0u32.to_be_bytes()).await?;
+    stream.write_all(&os_errno.to_be_bytes()).await?;
     Ok(())
 }
 

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -623,6 +623,17 @@ impl Server {
                         );
                     }
                 }
+                Err(e @ RiperfError::StreamConnectFailed(_)) => {
+                    // #362: the data-accept kill — the populated setup doc
+                    // emitted at the site; text prints the strerror'd line
+                    // (live errno, no dangling). Keep-serving, exit 0.
+                    if !json && !crate::macros::output_quiet() {
+                        eprintln!(
+                            "{}riperf3: error - {e}",
+                            crate::macros::output_timestamp_prefix()
+                        );
+                    }
+                }
                 Err(RiperfError::RecvDataCookieFailed) => {
                     // #359 r1 F2: GT's hard-read-error kill at the DATA
                     // cookie gate (IERECVCOOKIE via cleanup_server). The
@@ -646,7 +657,12 @@ impl Server {
                 // -J, one text line otherwise.
                 Err(e @ RiperfError::RecvCookieFailed)
                 | Err(e @ RiperfError::RecvParamsFailed)
-                | Err(e @ RiperfError::SendControlFailed(_)) => {
+                | Err(e @ RiperfError::SendControlFailed(_))
+                // #362: IEACCEPT / IESETNODELAY ride the same pre-test
+                // sink (their Displays carry the live strerror, so no
+                // dangling suffix — the SendControlFailed convention).
+                | Err(e @ RiperfError::AcceptFailed(_))
+                | Err(e @ RiperfError::SetNoDelayFailed(_)) => {
                     self.emit_pretest_error(&e);
                 }
                 Err(e) => {
@@ -797,7 +813,13 @@ impl Server {
         // (#222 r1 item 6: the Time/banner/Cookie/MSS block prints AFTER the
         // param exchange — GT's iperf_on_connect fires there — so a
         // --get-server-output capture relays it; see print_connect_block.)
-        net::configure_tcp_stream(&ctrl, true)?;
+        // #362: GT classes a failed TCP_NODELAY on the just-accepted ctrl
+        // as IESETNODELAY (iperf_server_api.c:170-173) — the macOS
+        // kind-only-InvalidInput cell's likeliest site.
+        net::configure_tcp_stream(&ctrl, true).map_err(|e| match e {
+            RiperfError::Io(io) => RiperfError::SetNoDelayFailed(io),
+            other => other,
+        })?;
 
         // The control-socket peer address feeds the server's `start.accepted_connection`
         // (iperf_api.c uses getpeername(ctrl_sck) — distinct from the data-stream
@@ -1105,6 +1127,9 @@ impl Server {
         let mut accept_interrupt = self.interrupt.clone().map(|w| w.0);
         let accepted = tokio::select! {
             r = async {
+                // #362: an accept() failure is GT's IEACCEPT
+                // (iperf_server_api.c:163) — previously the raw io line
+                // on the generic arm (BSD ECONNABORTED / Linux EMFILE).
                 if let Some(secs) = self.idle_timeout {
                     match tokio::time::timeout(
                         std::time::Duration::from_secs(secs as u64),
@@ -1112,11 +1137,11 @@ impl Server {
                     )
                     .await
                     {
-                        Ok(result) => result.map_err(RiperfError::from),
+                        Ok(result) => result.map_err(RiperfError::AcceptFailed),
                         Err(_) => Err(RiperfError::Aborted("idle timeout".into())),
                     }
                 } else {
-                    listener.accept().await.map_err(RiperfError::from)
+                    listener.accept().await.map_err(RiperfError::AcceptFailed)
                 }
             } => Some(r),
             _ = crate::client::wait_interrupt(accept_interrupt.as_mut()) => None,
@@ -1398,7 +1423,32 @@ impl Server {
                     let data_stream = loop {
                         tokio::select! {
                             accepted = listener.accept() => {
-                                let (mut candidate, _) = accepted?;
+                                // #362 (the PR #384 r2 F4 cell): a failed
+                                // data accept is GT's IESTREAMCONNECT
+                                // through cleanup_server (iperf_tcp.c:
+                                // 134-135) — the fe+203 wire-back, the
+                                // populated setup doc, round dead,
+                                // keep-serving. The raw io line rode the
+                                // generic arm before (BSD ECONNABORTED).
+                                let (mut candidate, _) = match accepted {
+                                    Ok(v) => v,
+                                    Err(e) => {
+                                        abort_setup_streams(ctx).await;
+                                        let _ = protocol::send_server_error(
+                                            &mut ctx.ctrl,
+                                            203,
+                                        )
+                                        .await;
+                                        let err =
+                                            RiperfError::StreamConnectFailed(e);
+                                        self.emit_setup_phase_error(
+                                            ctx,
+                                            listener,
+                                            &format!("error - {err}"),
+                                        );
+                                        return Err(err);
+                                    }
+                                };
                                 // #359: GT's deny-and-continue cookie gate —
                                 // a wrong-cookie or silent/FIN'd connect
                                 // gets ACCESS_DENIED on ITS socket

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -1446,9 +1446,11 @@ impl Server {
                                         // r1 F2: GT wires the LIVE accept
                                         // errno (cleanup_server sends
                                         // htonl(errno), iperf_server_api.c:
-                                        // 469-470) — a GT client prints its
-                                        // SERVER ERROR line only when the
-                                        // wire errno > 0.
+                                        // 470-471) — the wire word carries
+                                        // the strerror content of the GT
+                                        // client's SERVER ERROR line (r2
+                                        // F2: the line prints either way;
+                                        // the word gates its errno tail).
                                         let errno =
                                             e.raw_os_error().unwrap_or(0) as u32;
                                         let _ = protocol::send_server_error_errno(

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -814,12 +814,21 @@ impl Server {
         // param exchange — GT's iperf_on_connect fires there — so a
         // --get-server-output capture relays it; see print_connect_block.)
         // #362: GT classes a failed TCP_NODELAY on the just-accepted ctrl
-        // as IESETNODELAY (iperf_server_api.c:170-173) — the macOS
-        // kind-only-InvalidInput cell's likeliest site.
-        net::configure_tcp_stream(&ctrl, true).map_err(|e| match e {
-            RiperfError::Io(io) => RiperfError::SetNoDelayFailed(io),
-            other => other,
-        })?;
+        // as IESETNODELAY(122) (iperf_server_api.c:170-173) — the macOS
+        // kind-only-InvalidInput cell's likeliest site. GT's cleanup_server
+        // relays fe+122+errno on the live ctrl (ctrl_sck is set BEFORE the
+        // sockopt, :169) — best-effort here like the sibling relays (r1 F5).
+        if let Err(e) = net::configure_tcp_stream(&ctrl, true) {
+            let err = match e {
+                RiperfError::Io(io) => {
+                    let errno = io.raw_os_error().unwrap_or(0) as u32;
+                    let _ = protocol::send_server_error_errno(&mut ctrl, 122, errno).await;
+                    RiperfError::SetNoDelayFailed(io)
+                }
+                other => other,
+            };
+            return Err(err);
+        }
 
         // The control-socket peer address feeds the server's `start.accepted_connection`
         // (iperf_api.c uses getpeername(ctrl_sck) — distinct from the data-stream
@@ -1434,9 +1443,18 @@ impl Server {
                                     Ok(v) => v,
                                     Err(e) => {
                                         abort_setup_streams(ctx).await;
-                                        let _ = protocol::send_server_error(
+                                        // r1 F2: GT wires the LIVE accept
+                                        // errno (cleanup_server sends
+                                        // htonl(errno), iperf_server_api.c:
+                                        // 469-470) — a GT client prints its
+                                        // SERVER ERROR line only when the
+                                        // wire errno > 0.
+                                        let errno =
+                                            e.raw_os_error().unwrap_or(0) as u32;
+                                        let _ = protocol::send_server_error_errno(
                                             &mut ctx.ctrl,
                                             203,
+                                            errno,
                                         )
                                         .await;
                                         let err =
@@ -3754,7 +3772,11 @@ impl Server {
         // strerror (GT perr with a real errno); the errno-0 siblings keep
         // the #248 dangling ": ".
         let doc_error = match err {
-            RiperfError::SendControlFailed(_) => format!("error - {err}"),
+            // #362 r1 F1: the strerror-carrying classes take no dangling
+            // suffix — their Displays already end with the errno text.
+            RiperfError::SendControlFailed(_)
+            | RiperfError::AcceptFailed(_)
+            | RiperfError::SetNoDelayFailed(_) => format!("error - {err}"),
             _ => format!("error - {err}: "),
         };
         if self.json_output || self.json_stream {

--- a/riperf3/src/utils.rs
+++ b/riperf3/src/utils.rs
@@ -573,6 +573,31 @@ mod error_tests {
             format!("{}", RiperfError::CookieMismatch),
             "cookie mismatch"
         );
+        // #362: the GT accept/configure classes — the strerror rides via
+        // io::Error's "(os error N)" form, the recorded #151 convention
+        // (GT's perr prints strerror alone; the suffix is the house
+        // deviation every raw-os class already carries).
+        assert_eq!(
+            format!(
+                "{}",
+                RiperfError::AcceptFailed(std::io::Error::from_raw_os_error(24))
+            ),
+            "unable to accept connection from client: Too many open files (os error 24)"
+        );
+        assert_eq!(
+            format!(
+                "{}",
+                RiperfError::StreamConnectFailed(std::io::Error::from_raw_os_error(103))
+            ),
+            "unable to connect stream: Software caused connection abort (os error 103)"
+        );
+        assert_eq!(
+            format!(
+                "{}",
+                RiperfError::SetNoDelayFailed(std::io::Error::from_raw_os_error(22))
+            ),
+            "unable to set TCP/SCTP NODELAY: Invalid argument (os error 22)"
+        );
         assert_eq!(
             format!("{}", RiperfError::AccessDenied),
             "access denied by server"

--- a/riperf3/src/utils.rs
+++ b/riperf3/src/utils.rs
@@ -576,28 +576,41 @@ mod error_tests {
         // #362: the GT accept/configure classes — the strerror rides via
         // io::Error's "(os error N)" form, the recorded #151 convention
         // (GT's perr prints strerror alone; the suffix is the house
-        // deviation every raw-os class already carries).
-        assert_eq!(
-            format!(
-                "{}",
-                RiperfError::AcceptFailed(std::io::Error::from_raw_os_error(24))
+        // deviation every raw-os class already carries). The strerror
+        // TEXT is platform-specific (the macOS CI red on the first pin
+        // form), so the pins hold the GT sentence + the suffix only.
+        for (rendered, sentence) in [
+            (
+                format!(
+                    "{}",
+                    RiperfError::AcceptFailed(std::io::Error::from_raw_os_error(24))
+                ),
+                "unable to accept connection from client: ",
             ),
-            "unable to accept connection from client: Too many open files (os error 24)"
-        );
-        assert_eq!(
-            format!(
-                "{}",
-                RiperfError::StreamConnectFailed(std::io::Error::from_raw_os_error(103))
+            (
+                format!(
+                    "{}",
+                    RiperfError::StreamConnectFailed(std::io::Error::from_raw_os_error(24))
+                ),
+                "unable to connect stream: ",
             ),
-            "unable to connect stream: Software caused connection abort (os error 103)"
-        );
-        assert_eq!(
-            format!(
-                "{}",
-                RiperfError::SetNoDelayFailed(std::io::Error::from_raw_os_error(22))
+            (
+                format!(
+                    "{}",
+                    RiperfError::SetNoDelayFailed(std::io::Error::from_raw_os_error(24))
+                ),
+                "unable to set TCP/SCTP NODELAY: ",
             ),
-            "unable to set TCP/SCTP NODELAY: Invalid argument (os error 22)"
-        );
+        ] {
+            assert!(
+                rendered.starts_with(sentence),
+                "GT sentence prefix: {rendered}"
+            );
+            assert!(
+                rendered.ends_with("(os error 24)"),
+                "the #151 os-error suffix: {rendered}"
+            );
+        }
         assert_eq!(
             format!("{}", RiperfError::AccessDenied),
             "access denied by server"


### PR DESCRIPTION
Closes #362.

## The defect

On non-Linux unix platforms, pre-test accept/configure failures rode the serve loop's GENERIC arm with raw Rust io lines where GT has per-cell classes (the #360-era CI logs: FreeBSD `error - Software caused connection abort (os error 53)`; macOS the kind-only `error - invalid input parameter`). The #384 r2 F4 addendum added the setup data-accept to the same family.

## The fix (GT-source-reasoned mappings)

| Site | GT class (cite) | riperf3 surface |
|---|---|---|
| the control `accept()` | IEACCEPT(104), herr+perr (iperf_server_api.c:163) | `unable to accept connection from client: <strerror>` — the #330 pre-test sink (text line / skeleton doc), keep-serving |
| TCP_NODELAY on the just-accepted ctrl | IESETNODELAY, perr (iperf_server_api.c:170-173) | `unable to set TCP/SCTP NODELAY: <strerror>` — same pre-test sink; the macOS kind-only cell's likeliest site |
| the SETUP data-stream `accept()` | IESTREAMCONNECT(203), herr+perr (iperf_tcp.c:134-135) | the #359 kill-arm shape: fe+203 wire-back, the populated setup doc at the site, the strerror'd line, exit-0 keep-serving |

The strerror tails ride io::Error's `(os error N)` form — the recorded #151 convention every raw-os class already carries (GT prints strerror alone; the suffix is the established house deviation, e.g. the #224 relay rendering).

## Verification — the honest slice

**These cells are not deterministically constructible on Linux.** The EMFILE route was probed and abandoned: GT itself did not yield deterministic IEACCEPT/IESTREAMCONNECT surfaces under fd exhaustion (its fd budget tangles with /dev/urandom and shell plumbing; probe log in the session record), so no byte-parity E2E pin exists to write. What this PR carries instead:

- The three Display forms pinned (`error_display_variants` — exact strings incl. the `(os error N)` tails).
- Every mapping and serve-loop arm source-cited against GT 3.21 (reviewers: please verify the citations independently — the #384 lesson).
- No mutation table: no observing pin exists for the map sites (recorded here, not silently). The FreeBSD CI runner that surfaced the original raw lines exercises the mapped paths organically — a recurrence of that flake now shows the GT class.

**Gate:** fmt / clippy `-D warnings` clean; workspace **877 passed / 0 failed** (the Display asserts ride the existing test).

## Round 1 (commits 2-3, @28c1184)

An interim commit (@2817451) fixed the Display pins' platform-specific strerror text after a macOS CI red (io::Error renders platform wording — the pins now hold the GT sentence prefix + the #151 suffix only).

**r1 REQUEST-CHANGES, all three blockers live-proven and fixed:** **F1** — the pre-test sink appended the #248 dangling `: ` after the new classes' strerror; they join the SendControlFailed no-dangling arm. **F2** — the 203 wire-back sent errno=0 where GT wires the LIVE accept errno (interop-visible: a GT client prints its immediate SERVER ERROR line only when the wire word > 0); `send_server_error_errno` now carries `raw_os_error()`. **F3** — the "not constructible" claim was half wrong: GT *byte-parity* is confirmed unpinnable (r1 reproduced GT drifting 203→200 with one fd of budget, printing the clobbered post-cleanup errno), but riperf3's own surfaces pin deterministically via **prlimit-after-startup** — two Linux-only E2E pins added (the control-accept EMFILE cell; the setup data-accept cell asserting the `fe+203+24` live-errno wire bytes). **F5** — the ctrl-nodelay failure relays fe+122+errno best-effort (GT sets ctrl_sck before the sockopt). **F6** — the docs now record the errno deviation honestly (GT's TEXT prints the clobbered post-cleanup errno; its WIRE is live; riperf3 uses the site-captured word for both). **F7** — IESETNODELAY corrected to 122. **F4** → filed as #388 (the persistent-accept-error hot-spin vs the #291 bind-once contract, with the design analysis).

**Mutation table (now real, 4/4 red):** M1 dangling re-added → the accept pin red; M2 errno zeroed → the wire-bytes pin red; M3 the mapping reverted to the generic class → red; M4 wrong wire code → red.

**Gate @28c1184:** fmt / clippy clean; workspace **879/879** (877 + the 2 E2E pins).

## Round 2 (@e9669f3)

r2 REQUEST-CHANGES on three record-level blockers (the code/wire/pins verified correct — r2 live-proved the persistent-pairing interop: a real GT client prints the full strerror'd SERVER ERROR line against clamped riperf3): the AcceptFailed clobber record corrected (GT prints the LIVE strerror in the mapped pre-test cell); the "line only when wire word > 0" claim corrected (the word gates the errno tail, not the line); the one-off close-ordering divergence filed as #390 and the interop claim scoped to persistent. Interim CI fixes: platform-safe Display pins; the clamp moved to the FIRST-FREE fd slot (the dense-table assumption false-negatived on the runner); the two EMFILE cells serialize on a lock. Full round records in the PR comments. Merge-head evidence @e9669f3: CI 17/17, mutants 4/4, compat 52/52, workspace 879/879.
