### PR TITLE
fix: the setup doc's window actuals reflect the exchanged -w (#357)

### DIFF
--- a/riperf3-cli/tests/wire_shape.rs
+++ b/riperf3-cli/tests/wire_shape.rs
@@ -2261,6 +2261,41 @@ fn setup_doc_window_actuals_reflect_the_exchanged_window() {
     );
 }
 
+/// #391 r1 F1: an exchanged window:0 is NOT applied — GT's re-listen
+/// guard is C truthiness (iperf_tcp.c:257), so the doc reads the
+/// listener like the no-window state. Platform-independent: the w=0
+/// cell's actuals must EQUAL the no-window cell's (the pre-fix scratch
+/// arm applied 0 and emitted the kernel minimums instead).
+#[cfg(target_os = "linux")]
+#[test]
+fn setup_doc_window_zero_reads_the_listener_like_no_window() {
+    let drive = |params: &'static str| {
+        let (sout, _serr, status) = drive_server_scenario(true, move |port| {
+            let mut ctrl = std::net::TcpStream::connect(("127.0.0.1", port)).expect("ctrl");
+            ctrl.write_all(&[b'x'; 37]).unwrap();
+            assert_eq!(read_exact(&mut ctrl, 1)[0], 9, "ParamExchange");
+            write_json_blob(&mut ctrl, params);
+            assert_eq!(read_exact(&mut ctrl, 1)[0], 10, "CreateStreams");
+            drop(ctrl);
+            std::thread::sleep(std::time::Duration::from_millis(300));
+        });
+        assert!(status.success());
+        let doc: serde_json::Value = serde_json::from_str(sout.trim())
+            .unwrap_or_else(|e| panic!("one -J doc ({e}): {sout}"));
+        (
+            doc["start"]["sndbuf_actual"].as_u64(),
+            doc["start"]["rcvbuf_actual"].as_u64(),
+        )
+    };
+    let zero = drive(r#"{"tcp":true,"window":0}"#);
+    let none = drive(r#"{"tcp":true}"#);
+    assert_eq!(
+        zero, none,
+        "window:0 reads the listener like the no-window state (GT truthiness)"
+    );
+    assert!(zero.0.is_some() && zero.1.is_some(), "the trio is present");
+}
+
 const IDLE_TIMEOUT_MSG: &str = "idle timeout for receiving data";
 
 /// HOLD-variant driver: park in CREATE_STREAMS with the ctrl open, read the

--- a/riperf3-cli/tests/wire_shape.rs
+++ b/riperf3-cli/tests/wire_shape.rs
@@ -2220,6 +2220,47 @@ fn setup_phase_ctrl_eof_takes_gt_doc_shape_in_json() {
     );
 }
 
+/// #357: with `-w` exchanged, GT re-listens with the window applied and
+/// reads the setup doc's sndbuf/rcvbuf actuals off THAT socket (probed
+/// 131072/131072 for window 65536 — the Linux doubling); riperf3 read
+/// the un-windowed control listener (probed 16384/131072). The fix reads
+/// a scratch socket with the exchanged window applied — the identical
+/// kernel read-back without GT's re-listen step. Linux-exact values
+/// (the doubling is platform kernel behavior, like the GT probe).
+#[cfg(target_os = "linux")]
+#[test]
+fn setup_doc_window_actuals_reflect_the_exchanged_window() {
+    let (sout, serr, status) = drive_server_scenario(true, |port| {
+        let mut ctrl = std::net::TcpStream::connect(("127.0.0.1", port)).expect("ctrl");
+        ctrl.write_all(&[b'x'; 37]).unwrap();
+        assert_eq!(read_exact(&mut ctrl, 1)[0], 9, "ParamExchange");
+        write_json_blob(&mut ctrl, r#"{"tcp":true,"window":65536}"#);
+        assert_eq!(read_exact(&mut ctrl, 1)[0], 10, "CreateStreams");
+        drop(ctrl); // EOF with no data connections — the #338 doc cell
+        std::thread::sleep(std::time::Duration::from_millis(300));
+    });
+    assert!(status.success());
+    assert!(serr.trim().is_empty(), "-J keeps stderr silent: {serr:?}");
+    let doc: serde_json::Value =
+        serde_json::from_str(sout.trim()).unwrap_or_else(|e| panic!("one -J doc ({e}): {sout}"));
+    let start = &doc["start"];
+    assert_eq!(
+        start["sock_bufsize"].as_u64(),
+        Some(65536),
+        "the requested window: {start}"
+    );
+    assert_eq!(
+        start["sndbuf_actual"].as_u64(),
+        Some(131072),
+        "GT's windowed read-back (Linux doubling): {start}"
+    );
+    assert_eq!(
+        start["rcvbuf_actual"].as_u64(),
+        Some(131072),
+        "GT's windowed read-back (Linux doubling): {start}"
+    );
+}
+
 const IDLE_TIMEOUT_MSG: &str = "idle timeout for receiving data";
 
 /// HOLD-variant driver: park in CREATE_STREAMS with the ctrl open, read the

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -3668,10 +3668,12 @@ impl Server {
         // sockets, which never arrive in wedge cells — the doc carries the
         // clamped actuals instead (probed w=16M: GT errors, riperf3 emits
         // 8388608/8388608).
-        // #391 r1 F1: GT's re-listen guard is C truthiness (iperf_tcp.c:
-        // 257) — an exchanged window:0 is NOT applied; it reads the
+        // #391 r1 F1: GT's buffer-APPLY guard is C truthiness (the
+        // re-listen decision is iperf_tcp.c:195, the apply gate :257 — r2
+        // F2 cite) — an exchanged window:0 is NOT applied; it reads the
         // listener like the no-window state (probed: GT 16384/131072 for
-        // window:0). Negative windows ARE applied (truthiness; both tools
+        // window:0, and the nodelay-forced re-listen without buffer-apply
+        // reads the same defaults). Negative windows ARE applied (truthiness; both tools
         // clamp identically — probed w=-1).
         let (sndbuf_actual, rcvbuf_actual) = match (udp, ctx.cfg.window) {
             (false, Some(w)) if w != 0 => {

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -3661,8 +3661,20 @@ impl Server {
         // scratch socket with the same window applied yields the identical
         // kernel read-back. Without -w the un-windowed listener matches
         // GT's re-listened defaults.
+        // RECORDED DEVIATION (#391 r1 F3, pre-existing design consequence):
+        // at a window past 2x wmem_max GT fires IESETBUF2 at its re-listen
+        // (error doc, no trio, fe frame instead of CreateStreams); riperf3
+        // has no re-listen (deliberate) and its #97 check lives on data
+        // sockets, which never arrive in wedge cells — the doc carries the
+        // clamped actuals instead (probed w=16M: GT errors, riperf3 emits
+        // 8388608/8388608).
+        // #391 r1 F1: GT's re-listen guard is C truthiness (iperf_tcp.c:
+        // 257) — an exchanged window:0 is NOT applied; it reads the
+        // listener like the no-window state (probed: GT 16384/131072 for
+        // window:0). Negative windows ARE applied (truthiness; both tools
+        // clamp identically — probed w=-1).
         let (sndbuf_actual, rcvbuf_actual) = match (udp, ctx.cfg.window) {
-            (false, Some(w)) => {
+            (false, Some(w)) if w != 0 => {
                 let scratch =
                     socket2::Socket::new(socket2::Domain::IPV4, socket2::Type::STREAM, None).ok();
                 match scratch {
@@ -3676,7 +3688,7 @@ impl Server {
                     None => (None, None),
                 }
             }
-            (false, None) => (
+            (false, _) => (
                 sock.send_buffer_size().ok().map(|v| v as u64),
                 sock.recv_buffer_size().ok().map(|v| v as u64),
             ),

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -3655,14 +3655,37 @@ impl Server {
         // #383 r1 F1a: the four TCP-flavored keys are absent for UDP —
         // see the SetupPhaseDoc doc for the GT gates.
         let udp = matches!(ctx.cfg.protocol, TransportProtocol::Udp);
+        // #357: with -w exchanged, GT re-listens with the window applied
+        // and reads the actuals off THAT socket (probed 131072/131072 for
+        // window 65536); riperf3 has no re-listen step (deliberate), so a
+        // scratch socket with the same window applied yields the identical
+        // kernel read-back. Without -w the un-windowed listener matches
+        // GT's re-listened defaults.
+        let (sndbuf_actual, rcvbuf_actual) = match (udp, ctx.cfg.window) {
+            (false, Some(w)) => {
+                let scratch =
+                    socket2::Socket::new(socket2::Domain::IPV4, socket2::Type::STREAM, None).ok();
+                match scratch {
+                    Some(sc) => {
+                        net::apply_socket_window(&socket2::SockRef::from(&sc), Some(w));
+                        (
+                            sc.send_buffer_size().ok().map(|v| v as u64),
+                            sc.recv_buffer_size().ok().map(|v| v as u64),
+                        )
+                    }
+                    None => (None, None),
+                }
+            }
+            (false, None) => (
+                sock.send_buffer_size().ok().map(|v| v as u64),
+                sock.recv_buffer_size().ok().map(|v| v as u64),
+            ),
+            (true, _) => (None, None),
+        };
         crate::json_report::SetupPhaseDoc {
             sock_bufsize: (!udp).then(|| ctx.cfg.window.map(|w| w as u64).unwrap_or(0)),
-            sndbuf_actual: (!udp)
-                .then(|| sock.send_buffer_size().ok().map(|v| v as u64))
-                .flatten(),
-            rcvbuf_actual: (!udp)
-                .then(|| sock.recv_buffer_size().ok().map(|v| v as u64))
-                .flatten(),
+            sndbuf_actual,
+            rcvbuf_actual,
             // The server never reads the ctrl MSS — 0, the #50 convention.
             tcp_mss_default: (!udp).then_some(0),
             udp,


### PR DESCRIPTION
Closes #357.

## The defect

With `-w` exchanged, the setup-phase (CREATE_STREAMS) document's `sndbuf_actual`/`rcvbuf_actual` read the un-windowed control listener — GT re-listens at param exchange with SO_SNDBUF/SO_RCVBUF = the exchanged window and reads the actuals off THAT socket (the issue's probes: GT `131072/131072` for `window: 65536`, riperf3 `16384/131072`). `sock_bufsize` matched. Mock-reachable only (a real client that fails setup while having sent `-w`), but a value divergence in the #338 doc.

## The fix — no re-listen needed

The decision the issue deferred resolves to a FIX: what GT reports is the kernel read-back of a socket with the window applied — a scratch socket with the same `apply_socket_window` yields the identical values without GT's re-listen step (riperf3's no-re-listen design is deliberate and untouched). Without `-w`, the un-windowed listener already matches GT's re-listened defaults; the UDP arm keeps its #383 key absence.

## Verification

- Pin red-first on the issue's exact probed values (`sndbuf_actual` 16384 → 131072): `setup_doc_window_actuals_reflect_the_exchanged_window` — Linux-exact like the GT probe (the doubling is kernel behavior).
- Mutant: the scratch read reverted to the listener → red on the pinned value; exact restore verified.
- Gate: fmt / clippy `-D warnings` clean; workspace **880 passed / 0 failed** (879 + the pin).

**Rounds:** r1 REQUEST-CHANGES (the window:0 truthiness guard — GT does NOT apply an exchanged 0 — fixed with an equality pin; F2/F4 → #392; the wmem_max deviation recorded). r2 APPROVE (cold; 8 regimes re-probed byte-identical; joint pin discrimination mutation-proven; the cite nit applied comment-only; #392 amended — the negative render is real-client-reachable plus the normal-path `.max(0)` sites). Full round records in the PR comments. Merge-head evidence @ff69e9f: CI 17/17, compat 52/52, workspace 881/881.
