### PR TITLE
fix: post-loop parameter errors carry the timestamp stamp (#365)

### DIFF
--- a/riperf3-cli/src/main.rs
+++ b/riperf3-cli/src/main.rs
@@ -51,6 +51,9 @@ fn main() -> std::process::ExitCode {
                     if e.to_string().contains("--server") && e.to_string().contains("--client") =>
                 {
                     // iperf3's IESERVCLIENT (live: exit 1 + usage trailer).
+                    // Deliberately UNSTAMPED (#365 r1 F5): GT raises this
+                    // MID-loop (iperf_api.c:1293/:1300 — probed bare with
+                    // --timestamps last), the #301-F4 ordering class.
                     eprintln!("riperf3: parameter error - cannot be both server and client");
                     print_usage_trailer();
                     return std::process::ExitCode::FAILURE;
@@ -437,15 +440,22 @@ fn main() -> std::process::ExitCode {
 
 /// #365: the --timestamps format straight off raw argv — for the clap-arm
 /// post-loop errors (IENOROLE), where clap errored before a parse existed.
-/// Mirrors the arg's clap definition: `=`-attached value or the bare-flag
-/// "%c " default.
+/// Mirrors GT's getopt optional_argument (r1 F2 — NOT clap's parse, which
+/// also accepts a space-separated value; that clap-vs-getopt divergence is
+/// the filed require_equals follow-up): `=`-attached value or the
+/// bare-flag "%c " default, last occurrence wins. args_os: a non-UTF8
+/// argv elsewhere must not panic the error path (r1 F1 — std::env::args
+/// panics mid-iteration; GT prints its parameter error regardless).
+/// KNOWN LIMIT (r1 F3): a `--timestamps=X` token consumed as ANOTHER
+/// option's value still stamps here (position-blind scan); GT's getopt is
+/// bare in that cell — contrived argv, not worth position tracking.
 fn timestamps_from_argv() -> Option<String> {
     let mut fmt = None;
-    for a in std::env::args() {
-        if a == "--timestamps" {
+    for a in std::env::args_os() {
+        if a == std::ffi::OsStr::new("--timestamps") {
             fmt = Some("%c ".to_string());
-        } else if let Some(v) = a.strip_prefix("--timestamps=") {
-            fmt = Some(v.to_string());
+        } else if let Some(v) = a.as_encoded_bytes().strip_prefix(b"--timestamps=") {
+            fmt = Some(String::from_utf8_lossy(v).into_owned());
         }
     }
     fmt

--- a/riperf3-cli/src/main.rs
+++ b/riperf3-cli/src/main.rs
@@ -32,8 +32,17 @@ fn main() -> std::process::ExitCode {
                     // "block size too large", riperf3 this sentence). clap's
                     // required mode group fires first by construction (#198);
                     // same reject class + exit either way.
+                    // #365: GT's IENOROLE is post-loop — stamped
+                    // unconditionally (the format parsed by then). clap died
+                    // before the parse here, so the format comes off raw
+                    // argv (=-attached or the bare-flag default, matching
+                    // the arg's clap definition).
                     eprintln!(
-                        "riperf3: parameter error - must either be a client (-c) or server (-s)"
+                        "{}riperf3: parameter error - must either be a client (-c) or server (-s)",
+                        timestamps_from_argv()
+                            .as_deref()
+                            .map(riperf3::render_timestamp_prefix)
+                            .unwrap_or_default()
                     );
                     print_usage_trailer();
                     return std::process::ExitCode::FAILURE;
@@ -291,7 +300,19 @@ fn main() -> std::process::ExitCode {
         // with the usage trailer (live-probed for all three classes here:
         // end-conditions, client-only, server-only). #328: the -l range
         // checks live INSIDE parse_class_rejection at GT's post-loop slot.
-        eprintln!("riperf3: parameter error - {msg}");
+        // #365: post-loop parameter errors are stamped UNCONDITIONALLY in
+        // GT (the format is always parsed by the post-loop checks,
+        // iperf_api.c ~:1825+; live: stamped with --timestamps LAST) — the
+        // #348 mid-loop ordering note applies only to in-loop errors (the
+        // range checks above, which stay bare — the #301-F4 recorded
+        // deviation). GT stamps the error line only; the trailer is bare.
+        eprintln!(
+            "{}riperf3: parameter error - {msg}",
+            cli.timestamps
+                .as_deref()
+                .map(riperf3::render_timestamp_prefix)
+                .unwrap_or_default()
+        );
         print_usage_trailer();
         return std::process::ExitCode::FAILURE;
     }
@@ -412,6 +433,22 @@ fn main() -> std::process::ExitCode {
             std::process::ExitCode::FAILURE
         }
     }
+}
+
+/// #365: the --timestamps format straight off raw argv — for the clap-arm
+/// post-loop errors (IENOROLE), where clap errored before a parse existed.
+/// Mirrors the arg's clap definition: `=`-attached value or the bare-flag
+/// "%c " default.
+fn timestamps_from_argv() -> Option<String> {
+    let mut fmt = None;
+    for a in std::env::args() {
+        if a == "--timestamps" {
+            fmt = Some("%c ".to_string());
+        } else if let Some(v) = a.strip_prefix("--timestamps=") {
+            fmt = Some(v.to_string());
+        }
+    }
+    fmt
 }
 
 /// iperf3's parameter-error usage trailer (usage_shortstr + the --help hint).

--- a/riperf3-cli/tests/error_format.rs
+++ b/riperf3-cli/tests/error_format.rs
@@ -1223,3 +1223,58 @@ fn udp_file_transfer_rejects_before_blocksize() {
         );
     }
 }
+
+/// #365: POST-LOOP parameter errors are stamped unconditionally in GT
+/// (the --timestamps format is always parsed by the post-loop checks,
+/// iperf_api.c ~:1825+; live: stamped with --timestamps LAST). The stamp
+/// rides the error line only — the usage trailer stays bare (GT probed
+/// with cat -A). Mid-loop-equivalent errors (the range checks) keep the
+/// #301-F4 recorded ordering deviation and stay bare.
+#[test]
+fn post_loop_parameter_errors_are_stamped() {
+    // The parse-class rejection (client-only flag on a server) — stamped.
+    let out = std::process::Command::new(env!("CARGO_BIN_EXE_riperf3"))
+        .args(["-s", "--bidir", "--timestamps=XTSX "])
+        .output()
+        .expect("spawn riperf3");
+    assert_eq!(out.status.code(), Some(1));
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.starts_with("XTSX riperf3: parameter error - "),
+        "the post-loop class is stamped with --timestamps LAST: {stderr}"
+    );
+    assert!(
+        stderr.contains("\nUsage:"),
+        "the trailer stays bare (its line has no stamp): {stderr}"
+    );
+    assert!(
+        !stderr.contains("XTSX Usage:"),
+        "GT stamps the error line only: {stderr}"
+    );
+
+    // IENOROLE (no -s/-c at all) — post-loop in GT, stamped; clap dies
+    // pre-parse here so the format rides raw argv.
+    let out = std::process::Command::new(env!("CARGO_BIN_EXE_riperf3"))
+        .args(["--timestamps=XTSX "])
+        .output()
+        .expect("spawn riperf3");
+    assert_eq!(out.status.code(), Some(1));
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.starts_with("XTSX riperf3: parameter error - must either be a client"),
+        "IENOROLE is stamped off raw argv: {stderr}"
+    );
+
+    // The boundary guard: a range check (GT mid-loop) stays BARE — the
+    // #301-F4 ordering class is a recorded deviation, not stamped.
+    let out = std::process::Command::new(env!("CARGO_BIN_EXE_riperf3"))
+        .args(["-c", "127.0.0.1", "-t", "90000", "--timestamps=XTSX "])
+        .output()
+        .expect("spawn riperf3");
+    assert_eq!(out.status.code(), Some(1));
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.starts_with("riperf3: parameter error - ") && !stderr.starts_with("XTSX"),
+        "mid-loop-equivalent range errors stay bare: {stderr}"
+    );
+}

--- a/riperf3-cli/tests/error_format.rs
+++ b/riperf3-cli/tests/error_format.rs
@@ -1280,6 +1280,32 @@ fn post_loop_parameter_errors_are_stamped() {
         "a stamp rides IENOROLE on every platform: {stderr}"
     );
 
+    // r1 F4: the bare-flag branch — GT's optional_argument renders the
+    // "%c " default; the stamp must be PRESENT (its rendered text is
+    // locale/platform-dependent, so presence-only). Last occurrence wins.
+    let out = std::process::Command::new(env!("CARGO_BIN_EXE_riperf3"))
+        .args(["--timestamps"])
+        .output()
+        .expect("spawn riperf3");
+    assert_eq!(out.status.code(), Some(1));
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        !stderr.starts_with("riperf3:")
+            && stderr.contains("riperf3: parameter error - must either be a client"),
+        "the bare --timestamps stamps IENOROLE with the %c default: {stderr}"
+    );
+    let out = std::process::Command::new(env!("CARGO_BIN_EXE_riperf3"))
+        .args(["--timestamps=XTSX ", "--timestamps=YTSY "])
+        .output()
+        .expect("spawn riperf3");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    #[cfg(unix)]
+    assert!(
+        stderr.starts_with("YTSY riperf3: parameter error - "),
+        "the LAST occurrence wins, like getopt: {stderr}"
+    );
+    let _ = &stderr;
+
     // The boundary guard: a range check (GT mid-loop) stays BARE — the
     // #301-F4 ordering class is a recorded deviation, not stamped.
     let out = std::process::Command::new(env!("CARGO_BIN_EXE_riperf3"))

--- a/riperf3-cli/tests/error_format.rs
+++ b/riperf3-cli/tests/error_format.rs
@@ -1239,9 +1239,18 @@ fn post_loop_parameter_errors_are_stamped() {
         .expect("spawn riperf3");
     assert_eq!(out.status.code(), Some(1));
     let stderr = String::from_utf8_lossy(&out.stderr);
+    // Unix renders the literal format verbatim; Windows uses the #202
+    // HH:MM:SS fallback and ignores the format, so the byte-exact half is
+    // unix-only (the house stamp-pin convention) — the stamp's PRESENCE
+    // asserts everywhere.
+    #[cfg(unix)]
     assert!(
         stderr.starts_with("XTSX riperf3: parameter error - "),
         "the post-loop class is stamped with --timestamps LAST: {stderr}"
+    );
+    assert!(
+        !stderr.starts_with("riperf3:") && stderr.contains("riperf3: parameter error - "),
+        "a stamp rides the post-loop line on every platform: {stderr}"
     );
     assert!(
         stderr.contains("\nUsage:"),
@@ -1260,9 +1269,15 @@ fn post_loop_parameter_errors_are_stamped() {
         .expect("spawn riperf3");
     assert_eq!(out.status.code(), Some(1));
     let stderr = String::from_utf8_lossy(&out.stderr);
+    #[cfg(unix)]
     assert!(
         stderr.starts_with("XTSX riperf3: parameter error - must either be a client"),
         "IENOROLE is stamped off raw argv: {stderr}"
+    );
+    assert!(
+        !stderr.starts_with("riperf3:")
+            && stderr.contains("riperf3: parameter error - must either be a client"),
+        "a stamp rides IENOROLE on every platform: {stderr}"
     );
 
     // The boundary guard: a range check (GT mid-loop) stays BARE — the


### PR DESCRIPTION
Closes #365.

## The defect

riperf3 left ALL parameter errors unstamped. GT stamps POST-loop parameter errors **unconditionally** — the `--timestamps` format is always parsed by the time the post-loop checks run (iperf_api.c ~:1825+; the issue's live probe: `XTSX iperf3: parameter error - some option you are trying to set is client only` with `--timestamps` LAST). The #348 scope note's "only when --timestamps precedes the flag" claim was true only for MID-getopt-loop errors (the #301-F4 ordering class).

## The fix

- **The `parse_class_rejection` family** (client-only / server-only / reverse-rcv-timeout / UDP-file + the `-l` range slot that lives at GT's post-loop position) stamps via the parsed `cli.timestamps` — the #348 error-sink pattern.
- **The IENOROLE clap arm** stamps via a raw-argv extractor (clap errored before a parse existed there; `=`-attached value or the bare-flag `%c ` default, matching the arg's clap definition — exactly what GT's completed getopt loop would hold).
- GT stamps the **error line only** — the usage trailer stays bare (probed with `cat -A`).
- The mid-loop-equivalent range checks **stay bare** — the #301-F4 ordering deviation stands recorded, unchanged.

## Verification

- Pins (`post_loop_parameter_errors_are_stamped`): the stamped parse-class cell (`-s --bidir --timestamps=XTSX ` → stamped line, bare trailer), the stamped IENOROLE cell (role-less argv), and the stays-bare range-check boundary guard (`-t 90000` → no stamp).
- Mutants: both stamp sites stripped independently → the pin red each time; exact restores verified.
- Gate: fmt / clippy `-D warnings` clean; workspace **882 passed / 0 failed** (881 + the pin).

**Rounds:** r1 REQUEST-CHANGES (the non-UTF8 argv panic — a crash regression — plus the getopt-mirror comment, the bare-flag pin gap, the IESERVCLIENT why-bare note; #394/#395 filed) → fixed @f141e5e. r2 APPROVE (cold; the full stamp matrix re-probed cell-for-cell; five mutants hand-red; five polish notes → the #394 ledger + #396). Full round records in the PR comments. Merge-head evidence @f141e5e: CI 17/17, compat 52/52, workspace 882/882.
