### PR TITLE
fix: route the SERVER-ERROR relay and interrupt lines to --logfile (#364)

### DIFF
--- a/riperf3-cli/src/main.rs
+++ b/riperf3-cli/src/main.rs
@@ -409,6 +409,9 @@ fn main() -> std::process::ExitCode {
             } else {
                 // #348: GT's iperf_errexit stamps this line like iperf_err
                 // (iperf_error.c:100-127).
+                // iperf3's iperf_errexit shape ("iperf3: error - <text>",
+                // exit 1) instead of Rust's Debug rendering; the Display
+                // strings mirror iperf3's IE* wording (#151).
                 let line = format!(
                     "{}riperf3: error - {e}{perr_tail}",
                     ts_format
@@ -416,26 +419,30 @@ fn main() -> std::process::ExitCode {
                         .map(riperf3::render_timestamp_prefix)
                         .unwrap_or_default()
                 );
-                let logged = logfile.as_deref().and_then(|path| {
-                    use std::io::Write;
-                    std::fs::OpenOptions::new()
-                        .create(true)
-                        .append(true)
-                        .open(path)
-                        .and_then(|mut f| writeln!(f, "{line}"))
-                        .ok()
-                });
-                if logged.is_none() {
-                    // iperf3's iperf_errexit shape ("iperf3: error - <text>",
-                    // exit 1) instead of Rust's Debug rendering; the Display
-                    // strings mirror iperf3's IE* wording (#151). Also the
-                    // fallback when the logfile cannot be opened.
-                    eprintln!("{line}");
-                }
+                err_line_to_logfile_or_stderr(logfile.as_deref(), &line);
             }
             std::process::ExitCode::FAILURE
         }
     }
+}
+
+/// The text-mode error-line sink (#198/#364): append to the logfile when
+/// one is set — GT's iperf_err and iperf_exit both write to test->outfile
+/// when a logfile is open (iperf_error.c:67-79, :107-115) — else stderr,
+/// which is also the fallback when the file cannot be opened.
+fn err_line_to_logfile_or_stderr(logfile: Option<&str>, line: &str) {
+    if let Some(path) = logfile {
+        use std::io::Write;
+        let logged = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(path)
+            .and_then(|mut f| writeln!(f, "{line}"));
+        if logged.is_ok() {
+            return;
+        }
+    }
+    eprintln!("{line}");
 }
 
 /// #365: the --timestamps format straight off raw argv — for the clap-arm
@@ -610,6 +617,12 @@ fn run(cli: Cli) -> std::result::Result<(), Box<dyn std::error::Error>> {
         }
     }
 
+    // #364: the LIB's iperf_err-shaped lines (the SERVER-ERROR relay
+    // receipt) follow the same file — GT's iperf_err honors the logfile.
+    // Armed unconditionally like the errexit sink in main() (#198), which
+    // appends on every platform regardless of the unix-only stdout redirect.
+    let _err_sink_guard = cli.logfile.as_deref().map(riperf3::ErrorSinkGuard::set);
+
     // Set CPU affinity BEFORE building the tokio runtime so worker threads
     // inherit the affinity mask from the main thread.
     if let Some(ref spec) = cli.affinity {
@@ -652,8 +665,10 @@ fn run(cli: Cli) -> std::result::Result<(), Box<dyn std::error::Error>> {
     let is_server = cli.server;
     let (json, json_stream) = (cli.json, cli.json_stream);
     // #348: the interrupt notice prints after the run — keep the CLI's
-    // format and render at print time (GT strftimes per line).
+    // format and render at print time (GT strftimes per line). #364: it
+    // also follows iperf_exit's logfile-or-stderr chooser.
     let ts_format = cli.timestamps.clone();
+    let logfile = cli.logfile.clone();
     // #210: the first signal no longer cancels the run outright — it fires
     // this watch with iperf3's formatted message, and the lib dumps the
     // accumulated stats + tells the peer (CLIENT_TERMINATE /
@@ -738,12 +753,16 @@ fn run(cli: Cli) -> std::result::Result<(), Box<dyn std::error::Error>> {
             if !json && !json_stream {
                 let role = if is_server { "server" } else { "client" };
                 // #348: stamped on both roles (GT live), rendered now.
-                eprintln!(
-                    "{}riperf3: interrupt - the {role} has terminated by signal {sig}",
-                    ts_format
-                        .as_deref()
-                        .map(riperf3::render_timestamp_prefix)
-                        .unwrap_or_default()
+                // #364: to the logfile when set, like iperf_signormalexit.
+                err_line_to_logfile_or_stderr(
+                    logfile.as_deref(),
+                    &format!(
+                        "{}riperf3: interrupt - the {role} has terminated by signal {sig}",
+                        ts_format
+                            .as_deref()
+                            .map(riperf3::render_timestamp_prefix)
+                            .unwrap_or_default()
+                    ),
                 );
             }
             Ok(())

--- a/riperf3-cli/src/main.rs
+++ b/riperf3-cli/src/main.rs
@@ -428,8 +428,9 @@ fn main() -> std::process::ExitCode {
 
 /// The text-mode error-line sink (#198/#364): append to the logfile when
 /// one is set — GT's iperf_err and iperf_exit both write to test->outfile
-/// when a logfile is open (iperf_error.c:67-79, :107-115) — else stderr,
-/// which is also the fallback when the file cannot be opened.
+/// when a logfile is open (iperf_err at iperf_error.c:67-71, iperf_exit's
+/// text branch at :136-141) — else stderr, which is also the fallback when
+/// the file cannot be opened.
 fn err_line_to_logfile_or_stderr(logfile: Option<&str>, line: &str) {
     if let Some(path) = logfile {
         use std::io::Write;

--- a/riperf3-cli/tests/error_format.rs
+++ b/riperf3-cli/tests/error_format.rs
@@ -199,8 +199,9 @@ fn logfile_receives_the_relay_line() {
     );
     let logged = std::fs::read_to_string(&log).expect("logfile written");
     assert!(
-        logged
-            .contains("riperf3: SERVER ERROR - total required bandwidth is larger than server limit"),
+        logged.contains(
+            "riperf3: SERVER ERROR - total required bandwidth is larger than server limit"
+        ),
         "the relay line lands in the logfile: {logged:?}"
     );
     assert!(

--- a/riperf3-cli/tests/error_format.rs
+++ b/riperf3-cli/tests/error_format.rs
@@ -125,6 +125,92 @@ fn logfile_receives_the_error_line() {
     let _ = std::fs::remove_file(&log);
 }
 
+/// #364: with --logfile, the SERVER-ERROR relay line lands in the LOGFILE
+/// alongside the errexit line — GT's iperf_err writes to test->outfile when
+/// a logfile is open (iperf_error.c:67-71), the same chooser iperf_exit
+/// uses. Live-probed (GT 3.21, a --server-bitrate-limit refusal): the
+/// client's logfile carries BOTH `iperf3: SERVER ERROR - total required
+/// bandwidth is larger than server limit` and the `iperf3: error - <same>`
+/// exit line; stderr is EMPTY; exit 1. riperf3 kept the relay half on
+/// stderr — the client.rs KNOWN-CORNER record this pin retires.
+#[cfg(unix)]
+#[test]
+fn logfile_receives_the_relay_line() {
+    let dir = std::env::temp_dir();
+    let pid = std::process::id();
+    let log = dir.join(format!("riperf3-relaylog-{pid}.log"));
+    let srv_log = dir.join(format!("riperf3-relaylog-srv-{pid}.log"));
+    let _ = std::fs::remove_file(&log);
+    let _ = std::fs::remove_file(&srv_log);
+    let bin = env!("CARGO_BIN_EXE_riperf3");
+    let ps = common::free_port().to_string();
+    let mut server = common::ChildGuard(
+        std::process::Command::new(bin)
+            .args([
+                "-s",
+                "-1",
+                "-p",
+                &ps,
+                "--server-bitrate-limit",
+                "1000",
+                "--logfile",
+                srv_log.to_str().unwrap(),
+            ])
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .spawn()
+            .expect("spawn server"),
+    );
+    // Readiness via the server's OWN logfile: the listen banner lands there
+    // once the redirect + bind are both up. The refused-retry runner can't
+    // gate a --logfile client (it keys off stderr, which --logfile empties).
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+    while !std::fs::read_to_string(&srv_log)
+        .map(|s| s.contains("Server listening"))
+        .unwrap_or(false)
+    {
+        assert!(
+            std::time::Instant::now() < deadline,
+            "server banner in its logfile"
+        );
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+    let out = std::process::Command::new(bin)
+        .args([
+            "-c",
+            "127.0.0.1",
+            "-p",
+            &ps,
+            "-b",
+            "1M",
+            "-t",
+            "2",
+            "--logfile",
+            log.to_str().unwrap(),
+        ])
+        .output()
+        .expect("run client");
+    let _ = common::wait_bounded(&mut server.0, std::time::Duration::from_secs(8));
+    assert_eq!(out.status.code(), Some(1), "refused-run errexit");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.trim().is_empty(),
+        "the relay line must not leak to stderr: {stderr:?}"
+    );
+    let logged = std::fs::read_to_string(&log).expect("logfile written");
+    assert!(
+        logged
+            .contains("riperf3: SERVER ERROR - total required bandwidth is larger than server limit"),
+        "the relay line lands in the logfile: {logged:?}"
+    );
+    assert!(
+        logged.contains("riperf3: error - total required bandwidth is larger than server limit"),
+        "the errexit line stays in the logfile too: {logged:?}"
+    );
+    let _ = std::fs::remove_file(&log);
+    let _ = std::fs::remove_file(&srv_log);
+}
+
 /// #198 items 3+4: usage errors exit 1 like iperf3's getopt path (clap's
 /// default is 2), and the bare invocation prints iperf3's exact parameter
 /// error.

--- a/riperf3-cli/tests/signal_terminate.rs
+++ b/riperf3-cli/tests/signal_terminate.rs
@@ -1012,3 +1012,45 @@ fn sigterm_during_params_read_emits_exactly_one_doc() {
         "the single doc carries the interrupt key: {doc}"
     );
 }
+
+/// #364: with --logfile, the interrupt notice lands in the LOGFILE —
+/// iperf_got_sigend exits through iperf_signormalexit → iperf_exit, whose
+/// sink is test->outfile when a logfile is open (iperf_error.c:107-115),
+/// stderr otherwise. Live-probed (GT 3.21, server signalled while
+/// listening): the logfile ends with `iperf3: interrupt - the server has
+/// terminated by signal Interrupt(2)`, stderr is EMPTY, exit 0. riperf3
+/// kept the notice on stderr. The client role rides the same shared
+/// notice site (main.rs's Exit::Signal arm), also GT-probed.
+#[test]
+fn logfile_receives_the_interrupt_notice() {
+    let ps = free_port().to_string();
+    let log = std::env::temp_dir().join(format!("riperf3-intlog-{}.log", std::process::id()));
+    let _ = std::fs::remove_file(&log);
+    let server = spawn(&["-s", "-p", &ps, "--logfile", log.to_str().unwrap()]);
+    // Readiness gate: the listen banner arriving IN THE FILE proves both the
+    // redirect and the bind are up before the signal goes out.
+    let deadline = Instant::now() + Duration::from_secs(10);
+    while !std::fs::read_to_string(&log)
+        .map(|s| s.contains("Server listening"))
+        .unwrap_or(false)
+    {
+        assert!(Instant::now() < deadline, "server banner in the logfile");
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    let spid = server.0.id() as i32;
+    unsafe {
+        libc::kill(spid, libc::SIGTERM);
+    }
+    let (_sout, serr, scode) = wait_with_output_bounded(server, Duration::from_secs(8), "server");
+    assert_eq!(scode, 0, "signal-normal exit");
+    assert!(
+        serr.trim().is_empty(),
+        "the notice must not leak to stderr: {serr:?}"
+    );
+    let logged = std::fs::read_to_string(&log).expect("logfile read");
+    assert!(
+        logged.contains("riperf3: interrupt - the server has terminated by signal"),
+        "the interrupt notice lands in the logfile: {logged:?}"
+    );
+    let _ = std::fs::remove_file(&log);
+}

--- a/riperf3-cli/tests/signal_terminate.rs
+++ b/riperf3-cli/tests/signal_terminate.rs
@@ -1015,8 +1015,9 @@ fn sigterm_during_params_read_emits_exactly_one_doc() {
 
 /// #364: with --logfile, the interrupt notice lands in the LOGFILE —
 /// iperf_got_sigend exits through iperf_signormalexit → iperf_exit, whose
-/// sink is test->outfile when a logfile is open (iperf_error.c:107-115),
-/// stderr otherwise. Live-probed (GT 3.21, server signalled while
+/// sink is test->outfile when a logfile is open (iperf_error.c:136-141;
+/// :126-131 for the json branch), stderr otherwise. Live-probed (GT 3.21,
+/// server signalled while
 /// listening): the logfile ends with `iperf3: interrupt - the server has
 /// terminated by signal Interrupt(2)`, stderr is EMPTY, exit 0. riperf3
 /// kept the notice on stderr. The client role rides the same shared

--- a/riperf3/src/client.rs
+++ b/riperf3/src/client.rs
@@ -990,18 +990,16 @@ impl Client {
         if self.json_output || self.json_stream {
             self.emit_results(ctx, None, bare_end, ctx.measured_secs, Some(&msg));
         } else {
-            // KNOWN CORNER (r1 n5): with --logfile set,
-            // iperf_err writes this line to the logfile;
-            // riperf3's logfile plumbing lives in the
-            // CLI (#198), so this lib line stays on
-            // stderr. Revisit with the sink plumbing.
             // #290: quiet runs surface the error via Err alone.
             if !crate::macros::output_quiet() {
-                // #348: GT stamps this line too (iperf_err route).
-                eprintln!(
+                // #348: GT stamps this line too (iperf_err route). #364:
+                // and iperf_err honors the logfile — err_println follows
+                // its logfile-or-stderr chooser (the binary arms the sink
+                // alongside its --logfile redirect).
+                crate::macros::err_println(&format!(
                     "{}riperf3: SERVER ERROR - {msg}",
                     crate::macros::output_timestamp_prefix()
-                );
+                ));
             }
         }
         RiperfError::ServerErrorRelayed(msg)

--- a/riperf3/src/lib.rs
+++ b/riperf3/src/lib.rs
@@ -56,6 +56,11 @@ pub use net::set_cpu_affinity;
 /// (GT's stamp is process-global; the lib's is run-scoped).
 pub use macros::render_timestamp as render_timestamp_prefix;
 
+/// `--logfile` routing for the lib's error lines (#364) — armed by the
+/// binary next to its stdout redirect, so the SERVER-ERROR relay receipt
+/// follows iperf_err's logfile-or-stderr chooser.
+pub use macros::ErrorSinkGuard;
+
 // --- Internal modules: implementation detail, NOT part of the public API. ---
 // Crate-private (`pub(crate)`), so nothing here is a semver commitment; the
 // few genuinely-public types are re-exported at the crate root above (#67).

--- a/riperf3/src/macros.rs
+++ b/riperf3/src/macros.rs
@@ -195,16 +195,20 @@ impl Drop for OutputQuietGuard {
 /// Process-global like OUTPUT_TITLE (one run at a time).
 static ERR_SINK: RwLock<Option<String>> = RwLock::new(None);
 
-/// RAII guard routing this crate's error lines — diagnostics that otherwise
-/// print to stderr, like the client's `SERVER ERROR - …` relay receipt — to
-/// a logfile instead, matching iperf3's `--logfile` behavior (its iperf_err
-/// writes to the logfile whenever one is open). Lines are appended; stderr
-/// remains the fallback when the file cannot be opened. Construct ONLY when
-/// a logfile is active (callers gate then `.map(ErrorSinkGuard::set)`);
-/// Drop restores stderr routing. Process-global: one run at a time.
+/// RAII guard routing this crate's error lines to a logfile instead of
+/// stderr, matching iperf3's `--logfile` behavior (its iperf_err writes to
+/// the logfile whenever one is open). Currently routed: the client's
+/// `SERVER ERROR - …` relay receipt; the crate's remaining stderr
+/// diagnostics are tracked in #398 and still print to stderr. A quiet run
+/// (#290) suppresses these lines entirely — quiet wins over the sink.
+/// Lines are appended; stderr remains the fallback when the file cannot be
+/// opened. Construct ONLY when a logfile is active (callers gate then
+/// `.map(ErrorSinkGuard::set)`); Drop restores stderr routing.
+/// Process-global: one run at a time.
 // The private unit field makes `set()` the only constructor, like
 // OutputQuietGuard — a literal construction elsewhere would pair a no-op
 // arm with a sink-clearing Drop.
+#[must_use = "the sink disarms when the guard drops — bind it for the run's duration"]
 pub struct ErrorSinkGuard(());
 
 impl ErrorSinkGuard {

--- a/riperf3/src/macros.rs
+++ b/riperf3/src/macros.rs
@@ -186,6 +186,65 @@ impl Drop for OutputQuietGuard {
     }
 }
 
+/// The `--logfile` error-line sink (#364): when armed, the crate's
+/// iperf_err-shaped stderr lines (e.g. the client's SERVER-ERROR relay
+/// receipt) append to this file instead — iperf3's iperf_err writes to
+/// test->outfile whenever a logfile is open (iperf_error.c:67-71), the same
+/// chooser its exit paths use. The binary arms this alongside its --logfile
+/// stdout redirect; the lib itself has no logfile flag (#198).
+/// Process-global like OUTPUT_TITLE (one run at a time).
+static ERR_SINK: RwLock<Option<String>> = RwLock::new(None);
+
+/// RAII guard routing this crate's error lines — diagnostics that otherwise
+/// print to stderr, like the client's `SERVER ERROR - …` relay receipt — to
+/// a logfile instead, matching iperf3's `--logfile` behavior (its iperf_err
+/// writes to the logfile whenever one is open). Lines are appended; stderr
+/// remains the fallback when the file cannot be opened. Construct ONLY when
+/// a logfile is active (callers gate then `.map(ErrorSinkGuard::set)`);
+/// Drop restores stderr routing. Process-global: one run at a time.
+// The private unit field makes `set()` the only constructor, like
+// OutputQuietGuard — a literal construction elsewhere would pair a no-op
+// arm with a sink-clearing Drop.
+pub struct ErrorSinkGuard(());
+
+impl ErrorSinkGuard {
+    /// Arm the sink: error lines append to the file at `path` until drop.
+    pub fn set(path: &str) -> Self {
+        if let Ok(mut g) = ERR_SINK.write() {
+            *g = Some(path.to_string());
+        }
+        ErrorSinkGuard(())
+    }
+}
+
+impl Drop for ErrorSinkGuard {
+    fn drop(&mut self) {
+        if let Ok(mut g) = ERR_SINK.write() {
+            *g = None;
+        }
+    }
+}
+
+/// Print one fully-formatted error line to the active sink (#364): append
+/// to the armed logfile, else stderr — stderr is also the fallback when the
+/// file cannot be opened, like the CLI's errexit sink (#198).
+pub(crate) fn err_println(line: &str) {
+    if let Ok(g) = ERR_SINK.read() {
+        if let Some(path) = g.as_deref() {
+            use std::io::Write;
+            let logged = std::fs::OpenOptions::new()
+                .create(true)
+                .append(true)
+                .open(path)
+                .and_then(|mut f| writeln!(f, "{line}"));
+            if logged.is_ok() {
+                return;
+            }
+        }
+    }
+    eprintln!("{line}");
+}
+
 pub(crate) fn set_output_title(title: Option<String>) {
     if let Ok(mut g) = OUTPUT_TITLE.write() {
         *g = title;


### PR DESCRIPTION
Closes #364.

With `--logfile`, riperf3 kept two GT-`iperf_err`-routed lines on stderr: the client's `SERVER ERROR - …` relay receipt (the lib's `client.rs` KNOWN-CORNER r1 n5 record, retired by this PR) and the interrupt notice. GT routes both to the logfile.

## GT probes (3.21, live — all cells probed on both tools)

| cell | GT | riperf3 pre-fix |
|---|---|---|
| relay (a `--server-bitrate-limit` refusal), `--logfile` | BOTH `iperf3: SERVER ERROR - …` and `iperf3: error - …` in the file; stderr empty; exit 1 | relay half on stderr; only the errexit line in the file |
| client SIGINT mid-test, `--logfile` | `iperf3: interrupt - the client has terminated by signal Interrupt(2)` in the file; stderr empty; exit 0 | notice on stderr |
| server SIGTERM/SIGINT while listening, `--logfile` | same shape, server role | notice on stderr |

GT source: `iperf_err` writes to `test->outfile` whenever a logfile is open (iperf_error.c:67-71), and `iperf_exit` (signormalexit/errexit) uses the same chooser (:107-115).

## Fix shape

- **lib**: `macros::ERR_SINK` run-scoped global + public `ErrorSinkGuard` RAII (construct-only-when-armed, private unit field — the `OutputQuietGuard` shape), crate-root re-export. `err_println()` chooses append-to-logfile vs stderr, with stderr as the open-failure fallback — the #198 CLI sink's exact semantics. The relay site routes through it.
- **CLI**: arms the guard next to its `--logfile` stdout dup2; the interrupt notice and the existing #198 errexit sink now share one `err_line_to_logfile_or_stderr()` (pure refactor of the errexit half).
- The guard is armed unconditionally (all platforms), matching the #198 errexit sink, which already appends on every platform — the unix-only part of `--logfile` is just the stdout redirect.

## Tests (red-first)

- `error_format.rs::logfile_receives_the_relay_line` — the bitrate-limit refusal cell; asserts both lines in the file, stderr empty, exit 1. Readiness is gated by polling the server's own logfile for the listen banner — the refused-retry runner can't gate a `--logfile` client (it keys off stderr, which `--logfile` empties).
- `signal_terminate.rs::logfile_receives_the_interrupt_notice` — server role, SIGTERM while listening; asserts the notice in the file, stderr empty, exit 0. The client role rides the same shared notice site.

## Mutation table — 6/6 killed

| mutant | pin that reds |
|---|---|
| M1 lib chooser falls through (armed sink still eprintlns) | relay pin |
| M2 CLI never arms the lib guard | relay pin |
| M3 CLI chooser falls through | interrupt pin |
| M3b same mutant | #198 errexit pin |
| M4 interrupt notice passes `None` | interrupt pin |
| M5 relay site reverts to bare `eprintln!` | relay pin |

## Full-suite disclosure

One known #349-F4 wire_shape mock-EOF flake under parallel load (`udp_setup_ctrl_eof_takes_gt_doc_shape_in_json`) in one of two full-workspace runs; green isolated and in the other full run.

Follow-up (filed separately, not in the 0.9.0 batch): the lib has more GT-`iperf_err`-shaped stderr sites (server ctrl-closed / client-terminated / accept classes, pacing warnings) that would take the same chooser — each needs its own GT `--logfile` probe first.
