### PR TITLE
fix: rate-breach and duration-watchdog -J docs render bare end{} like GT (#368)

### DIFF
--- a/riperf3-cli/tests/get_server_output.rs
+++ b/riperf3-cli/tests/get_server_output.rs
@@ -178,6 +178,13 @@ fn json_client_gets_server_output_json() {
         own_n > 0,
         "the -J server's own doc lost its intervals (double-build class): {server_own}"
     );
+    // #368 inverse guard: a NORMAL (non-self-terminated) server run keeps the
+    // POPULATED finalize end — the bare-end flag must not fire on the happy
+    // path (only the rate/duration/idle kill arms set it).
+    assert!(
+        sv["end"].as_object().is_some_and(|m| !m.is_empty()),
+        "a normal server run's end must stay populated: {server_own}"
+    );
     assert_eq!(
         Some(own_n),
         sj["intervals"].as_array().map(Vec::len),

--- a/riperf3-cli/tests/self_terminate.rs
+++ b/riperf3-cli/tests/self_terminate.rs
@@ -145,11 +145,15 @@ fn bitrate_limit_json_client_single_doc_with_relayed_error() {
     );
 }
 
-/// -J server: the full document still emits (intervals and all) with the
-/// error key carrying iperf_err's `error - ` prefix wart, stderr empty,
-/// exit 0 — live-verified against iperf 3.21.
+/// -J server: the accumulated intervals emit over a BARE `end: {}` (#368) —
+/// GT's rate-breach kill path (cleanup_server + return -1,
+/// iperf_server_api.c:624-646) never runs end processing, so the reader's
+/// document finishes with `end` as an empty object; the error key carries
+/// iperf_err's `error - ` prefix wart, stderr empty, exit 0. Live-verified
+/// against iperf 3.21 (`--server-bitrate-limit 1K` + `-t 5`: GT `end` keys
+/// `[]`, riperf3 pre-#368 rendered the full finalize end).
 #[test]
-fn bitrate_limit_json_server_doc_carries_prefixed_error() {
+fn bitrate_limit_json_server_doc_bare_end_and_prefixed_error() {
     let ps = common::free_port().to_string();
     let server = spawn_server(&["--server-bitrate-limit", "1K", "-J"], &ps);
     std::thread::sleep(Duration::from_millis(300));
@@ -172,6 +176,19 @@ fn bitrate_limit_json_server_doc_carries_prefixed_error() {
         doc["error"].as_str(),
         Some(format!("error - {BITRATE_MSG}").as_str()),
         "iperf_err's in-doc prefix wart, mirrored exactly: {doc}"
+    );
+    // #368: the kill path skips end processing — bare `end: {}`, NOT the
+    // populated finalize end (streams/sums/cpu/congestion).
+    assert_eq!(
+        doc["end"].as_object().map(serde_json::Map::len),
+        Some(0),
+        "GT's rate-breach end is bare {{}}: {doc}"
+    );
+    // The accumulated interval rows still ride the doc (the start block too);
+    // only the end block is suppressed.
+    assert!(
+        doc["intervals"].is_array() && doc["start"].as_object().is_some_and(|m| !m.is_empty()),
+        "intervals + start survive the bare-end path: {doc}"
     );
 }
 

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -2075,6 +2075,14 @@ impl Server {
                                 // SERVER_TERMINATE (iperf 3.21 GT).
                                 protocol::send_server_error(&mut ctx.ctrl, 27).await?;
                                 ctx.server_error = Some(SELF_TERM_RATE_MSG);
+                                // #368: GT's rate-breach kill path
+                                // (cleanup_server + return -1,
+                                // iperf_server_api.c:624-646) never runs end
+                                // processing — the -J doc keeps the
+                                // accumulated intervals over a BARE end{}
+                                // (live-probed: GT end keys []). Same shape
+                                // as the idle-arm sibling below.
+                                ctx.bare_end = true;
                                 break;
                             }
                         }
@@ -2108,6 +2116,17 @@ impl Server {
                     // IESERVERTESTDURATIONEXPIRED(160) on the wire.
                     protocol::send_server_error(&mut ctx.ctrl, 160).await?;
                     ctx.server_error = Some(SELF_TERM_DURATION_MSG);
+                    // #368: the duration-watchdog kill path is the rate
+                    // breach's sibling — server_timer_proc frees the streams
+                    // and the run loop exits without end processing, so GT's
+                    // -J doc is BARE end{} here too. Probe-confirmed: a
+                    // wedged client past the (duration+omit+40 s) watchdog
+                    // yields GT end keys [] (the error key then clobbers to a
+                    // stale select-fail global — the recorded #349/#350
+                    // nondeterminism class — but the end SHAPE is bare). Not
+                    // CI-pinnable: the 40 s grace can't be shortened, same as
+                    // the #230 watchdog-timing behavior.
+                    ctx.bare_end = true;
                     break;
                 }
             }


### PR DESCRIPTION
Closes #368.

On a runtime **`--server-bitrate-limit` breach** (and its **duration-watchdog** sibling), GT's `-J` document renders the accumulated intervals over a **bare `end: {}`** — the kill path frees the streams and returns without running end processing. riperf3's #224-era code rendered the fully populated finalize end (streams/sums/cpu/congestion) on these arms. The idle-watchdog arm (#351) already sets `ctx.bare_end`; this extends the same one-line flag to the two siblings.

## GT probes (3.21, live)

| cell | GT `-J` end | riperf3 pre-fix |
|---|---|---|
| rate breach (`--server-bitrate-limit 1K`, `-t 5`) | `end` keys `[]`, error key, exit 0 | populated: `streams/sum_sent/sum_received/cpu_utilization_percent/receiver_tcp_congestion` |
| duration watchdog (wedged client past `dur+omit+40s`) | `end` keys `[]` | populated |

GT source: rate path `cleanup_server` + `return -1` (iperf_server_api.c:624-646); duration path `server_timer_proc` frees streams + sends SERVER_ERROR (iperf_server_api.c:318-337) — neither reaches the TEST_END → DISPLAY_RESULTS end processing that populates the doc.

Note on the duration probe: with a wedged client, GT's error key clobbers to a stale `select failed: Bad file descriptor` (the same `i_errno`-global nondeterminism recorded for #349/#350) — but the end **shape** is bare, which is all #368 concerns. The error-key content stays riperf3's intended `SELF_TERM_DURATION_MSG` (pinned since #224).

## Fix

`ctx.bare_end = true` at the rate-breach arm and the duration-watchdog arm in `await_test_end` — identical to the idle arm. The flag flows to `input.bare_end` in the server's report builder; intervals and the start block are untouched (only the end block is suppressed).

## Tests + mutation table

- `bitrate_limit_json_server_doc_bare_end_and_prefixed_error` (renamed from `..._carries_prefixed_error`, whose "intervals and all" comment was the stale claim) — red-first: asserts bare `end: {}` + the prefixed error key + intervals/start survive. Red pre-fix (populated end), green after.
- `get_server_output`'s server-own-doc read gains an inverse guard: a NORMAL run keeps a populated end (the flag must not fire on the happy path) — this was an untested property (mutation M3 initially survived without it).
- Mutation table 3/3: M1 rate-arm flag dropped, M2 consumer wiring forced false (both red the rate pin), M3 consumer forced true (reds the inverse guard). Tree restored clean.

**Duration arm — not CI-pinnable**: the watchdog fires at `duration + omit + 40s` and the 40s grace can't be shortened (same as the #230 watchdog-timing behavior), so a ~41s wedged-client test doesn't belong in CI. It's a one-line flag identical to the rate/idle siblings, GT-probe-confirmed bare, verified by inspection.

Full workspace green.
