### PR TITLE
fix: exchange-phase send failures map to IESENDMESSAGE/IESENDRESULTS over the populated doc (#371)

### DIFF
--- a/riperf3-cli/tests/wire_shape.rs
+++ b/riperf3-cli/tests/wire_shape.rs
@@ -3018,14 +3018,18 @@ fn pretest_send_state_failure_takes_iesendmessage_json() {
 
 // ---------------------------------------------------------------------------
 // #371: the POST-TEST_END exchange-phase send failure. A peer that RSTs the
-// ctrl after TEST_END fails the server's send_state(EXCHANGE_RESULTS) — GT's
-// IESENDMESSAGE(111). Unlike the pre-test #345 sibling, the reporter already
-// ran at TEST_END, so GT emits the POPULATED doc (start/intervals/end) + the
-// prefixed key, not the skeleton (PR #370 r2 addendum, live-probed; probe371
-// re-confirmed all three sub-classes → populated + IESENDMESSAGE). riperf3's
-// 100 ms flush sleep in shutdown_and_flush runs BEFORE this send, so the RST
-// has arrived and the send deterministically fails (no #345 race). LINUX-ONLY
-// like #345 (SO_LINGER(0) RST; the mapping is platform-independent).
+// ctrl right after TEST_END fails the server's FIRST exchange send —
+// send_state(EXCHANGE_RESULTS) — GT's IESENDMESSAGE(111). Unlike the pre-test
+// #345 sibling, the reporter already ran at TEST_END, so GT emits the
+// POPULATED doc (start/intervals/end) + the prefixed key, not the skeleton
+// (PR #370 r2 addendum, live-probed). riperf3's 100 ms flush sleep in
+// shutdown_and_flush runs BEFORE this send, so the RST has arrived and the
+// send deterministically fails (no #345 race). This pin covers the WHICH-
+// SENDS-FIRST cell (EXCHANGE_RESULTS); the later sends buffer on loopback and
+// diverge by class/phase (recorded: send_results → IESENDRESULTS deviation on
+// ExchangeSendResultsFailed; the DISPLAY_RESULTS-buffers-then-IperfDone-read
+// skeleton is filed as #406). LINUX-ONLY like #345 (SO_LINGER(0) RST; the
+// mapping is platform-independent).
 // ---------------------------------------------------------------------------
 
 /// Drive a FULL round through TEST_END, then SO_LINGER(0) RST the ctrl so the

--- a/riperf3-cli/tests/wire_shape.rs
+++ b/riperf3-cli/tests/wire_shape.rs
@@ -3024,12 +3024,16 @@ fn pretest_send_state_failure_takes_iesendmessage_json() {
 // POPULATED doc (start/intervals/end) + the prefixed key, not the skeleton
 // (PR #370 r2 addendum, live-probed). riperf3's 100 ms flush sleep in
 // shutdown_and_flush runs BEFORE this send, so the RST has arrived and the
-// send deterministically fails (no #345 race). This pin covers the WHICH-
-// SENDS-FIRST cell (EXCHANGE_RESULTS); the later sends buffer on loopback and
-// diverge by class/phase (recorded: send_results → IESENDRESULTS deviation on
-// ExchangeSendResultsFailed; the DISPLAY_RESULTS-buffers-then-IperfDone-read
-// skeleton is filed as #406). LINUX-ONLY like #345 (SO_LINGER(0) RST; the
-// mapping is platform-independent).
+// send deterministically fails (no #345 race). The three exchange sends
+// diverge cell-by-cell: (A) send_state(EXCHANGE_RESULTS) fails → IESENDMESSAGE
+// (this cell); (B) send_results ALSO fails deterministically on riperf3
+// (ECONNRESET) → IESENDRESULTS, where GT's buffers-and-succeeds so its failure
+// shifts to the next send → IESENDMESSAGE (recorded deviation on
+// ExchangeSendResultsFailed; pinned by the sub-class-B test below); (C)
+// send_state(DISPLAY_RESULTS) buffers on riperf3 and the RST is caught on the
+// following IperfDone read → skeleton (the pre-#371 recv-path shape, filed as
+// #406). LINUX-ONLY like #345 (SO_LINGER(0) RST; the mapping is
+// platform-independent).
 // ---------------------------------------------------------------------------
 
 /// Drive a FULL round through TEST_END, then SO_LINGER(0) RST the ctrl so the
@@ -3074,6 +3078,87 @@ fn drive_full_round_then_rst(json: bool) -> (String, String, std::process::ExitS
         drop((ctrl, data));
         std::thread::sleep(std::time::Duration::from_millis(500));
     })
+}
+
+/// Drive through the client's results send, THEN SO_LINGER(0) RST — so the
+/// server's `send_results` write is the one that fails. On riperf3 this write
+/// fails deterministically (ECONNRESET) → IESENDRESULTS; GT's buffers and the
+/// failure shifts to the next state send → IESENDMESSAGE (recorded deviation).
+#[cfg(target_os = "linux")]
+fn drive_round_rst_after_client_results(json: bool) -> (String, String, std::process::ExitStatus) {
+    drive_server_scenario(json, |port| {
+        let set_rst = |s: &std::net::TcpStream| {
+            let linger = libc::linger {
+                l_onoff: 1,
+                l_linger: 0,
+            };
+            let rc = unsafe {
+                use std::os::fd::AsRawFd;
+                libc::setsockopt(
+                    s.as_raw_fd(),
+                    libc::SOL_SOCKET,
+                    libc::SO_LINGER,
+                    std::ptr::from_ref(&linger).cast(),
+                    std::mem::size_of::<libc::linger>() as libc::socklen_t,
+                )
+            };
+            assert_eq!(rc, 0, "SO_LINGER setsockopt failed");
+        };
+        let cookie = [b'x'; 37];
+        let mut ctrl = std::net::TcpStream::connect(("127.0.0.1", port)).expect("ctrl");
+        set_rst(&ctrl);
+        ctrl.write_all(&cookie).unwrap();
+        assert_eq!(read_exact(&mut ctrl, 1)[0], 9); // ParamExchange
+        write_json_blob(&mut ctrl, MOCK_PARAMS);
+        assert_eq!(read_exact(&mut ctrl, 1)[0], 10); // CreateStreams
+        let mut data = std::net::TcpStream::connect(("127.0.0.1", port)).expect("data");
+        set_rst(&data);
+        data.write_all(&cookie).unwrap();
+        assert_eq!(read_exact(&mut ctrl, 1)[0], 1); // TestStart
+        assert_eq!(read_exact(&mut ctrl, 1)[0], 2); // TestRunning
+        data.write_all(&[0u8; 4096]).unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(100));
+        ctrl.write_all(&[4u8]).unwrap(); // TestEnd
+        assert_eq!(read_exact(&mut ctrl, 1)[0], 13); // ExchangeResults
+        write_json_blob(&mut ctrl, MOCK_RESULTS); // the client's results
+                                                  // RST NOW — the server's send_results write is next and fails.
+        drop((ctrl, data));
+        std::thread::sleep(std::time::Duration::from_millis(500));
+    })
+}
+
+/// #371 sub-class B (-J): the `send_results` write fails → GT's
+/// IESENDRESULTS(116) over the POPULATED doc. Deterministic on riperf3
+/// (the write fails, ECONNRESET); GT diverges to IESENDMESSAGE (recorded
+/// on `ExchangeSendResultsFailed`). Red pre-fix (raw-io skeleton).
+#[cfg(target_os = "linux")]
+#[test]
+fn exchange_send_results_failure_takes_iesendresults_json_over_populated_doc() {
+    const SENDRESULTS_SENTENCE: &str = "unable to send results";
+    let mut seen = Vec::new();
+    for _ in 0..8 {
+        let (sout, serr, status) = drive_round_rst_after_client_results(true);
+        assert!(status.success());
+        assert!(serr.trim().is_empty(), "-J keeps stderr silent: {serr:?}");
+        let doc: serde_json::Value = serde_json::from_str(sout.trim())
+            .unwrap_or_else(|e| panic!("one -J doc ({e}): {sout}"));
+        let key = doc["error"].as_str().unwrap_or_default().to_string();
+        if key.contains(SENDRESULTS_SENTENCE) {
+            assert!(
+                key.starts_with(&format!("error - {SENDRESULTS_SENTENCE}: "))
+                    && !key.ends_with(": "),
+                "prefixed IESENDRESULTS key + live strerror: {key:?}"
+            );
+            assert!(
+                doc["end"].as_object().is_some_and(|m| !m.is_empty())
+                    && doc["intervals"].as_array().is_some_and(|a| !a.is_empty()),
+                "populated end + intervals: {doc}"
+            );
+            return;
+        }
+        seen.push(key);
+    }
+    panic!("exchange IESENDRESULTS never surfaced in 8 RST rounds; saw: {seen:#?}");
 }
 
 /// #371 text: the exchange-send failure prints GT's IESENDMESSAGE line, and

--- a/riperf3-cli/tests/wire_shape.rs
+++ b/riperf3-cli/tests/wire_shape.rs
@@ -3065,8 +3065,8 @@ fn drive_full_round_then_rst(json: bool) -> (String, String, std::process::ExitS
         data.write_all(&[0u8; 4096]).unwrap();
         std::thread::sleep(std::time::Duration::from_millis(100));
         ctrl.write_all(&[4u8]).unwrap(); // TestEnd
-        // RST both sockets NOW — the server's 100 ms flush sleep guarantees
-        // the RST lands before its send_state(ExchangeResults) write.
+                                         // RST both sockets NOW — the server's 100 ms flush sleep guarantees
+                                         // the RST lands before its send_state(ExchangeResults) write.
         drop((ctrl, data));
         std::thread::sleep(std::time::Duration::from_millis(500));
     })

--- a/riperf3-cli/tests/wire_shape.rs
+++ b/riperf3-cli/tests/wire_shape.rs
@@ -3017,6 +3017,127 @@ fn pretest_send_state_failure_takes_iesendmessage_json() {
 }
 
 // ---------------------------------------------------------------------------
+// #371: the POST-TEST_END exchange-phase send failure. A peer that RSTs the
+// ctrl after TEST_END fails the server's send_state(EXCHANGE_RESULTS) — GT's
+// IESENDMESSAGE(111). Unlike the pre-test #345 sibling, the reporter already
+// ran at TEST_END, so GT emits the POPULATED doc (start/intervals/end) + the
+// prefixed key, not the skeleton (PR #370 r2 addendum, live-probed; probe371
+// re-confirmed all three sub-classes → populated + IESENDMESSAGE). riperf3's
+// 100 ms flush sleep in shutdown_and_flush runs BEFORE this send, so the RST
+// has arrived and the send deterministically fails (no #345 race). LINUX-ONLY
+// like #345 (SO_LINGER(0) RST; the mapping is platform-independent).
+// ---------------------------------------------------------------------------
+
+/// Drive a FULL round through TEST_END, then SO_LINGER(0) RST the ctrl so the
+/// server's first exchange-phase send fails. Returns (stdout, stderr, exit).
+#[cfg(target_os = "linux")]
+fn drive_full_round_then_rst(json: bool) -> (String, String, std::process::ExitStatus) {
+    drive_server_scenario(json, |port| {
+        let set_rst = |s: &std::net::TcpStream| {
+            let linger = libc::linger {
+                l_onoff: 1,
+                l_linger: 0,
+            };
+            let rc = unsafe {
+                use std::os::fd::AsRawFd;
+                libc::setsockopt(
+                    s.as_raw_fd(),
+                    libc::SOL_SOCKET,
+                    libc::SO_LINGER,
+                    std::ptr::from_ref(&linger).cast(),
+                    std::mem::size_of::<libc::linger>() as libc::socklen_t,
+                )
+            };
+            assert_eq!(rc, 0, "SO_LINGER setsockopt failed");
+        };
+        let cookie = [b'x'; 37];
+        let mut ctrl = std::net::TcpStream::connect(("127.0.0.1", port)).expect("ctrl");
+        set_rst(&ctrl);
+        ctrl.write_all(&cookie).unwrap();
+        assert_eq!(read_exact(&mut ctrl, 1)[0], 9); // ParamExchange
+        write_json_blob(&mut ctrl, MOCK_PARAMS);
+        assert_eq!(read_exact(&mut ctrl, 1)[0], 10); // CreateStreams
+        let mut data = std::net::TcpStream::connect(("127.0.0.1", port)).expect("data");
+        set_rst(&data);
+        data.write_all(&cookie).unwrap();
+        assert_eq!(read_exact(&mut ctrl, 1)[0], 1); // TestStart
+        assert_eq!(read_exact(&mut ctrl, 1)[0], 2); // TestRunning
+        data.write_all(&[0u8; 4096]).unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(100));
+        ctrl.write_all(&[4u8]).unwrap(); // TestEnd
+        // RST both sockets NOW — the server's 100 ms flush sleep guarantees
+        // the RST lands before its send_state(ExchangeResults) write.
+        drop((ctrl, data));
+        std::thread::sleep(std::time::Duration::from_millis(500));
+    })
+}
+
+/// #371 text: the exchange-send failure prints GT's IESENDMESSAGE line, and
+/// (the #371 point) stdout still carries the POPULATED report the reporter
+/// built at TEST_END — not the pre-test skeleton. Keep-serving, exit 0.
+#[cfg(target_os = "linux")]
+#[test]
+fn exchange_send_failure_takes_iesendmessage_text_over_populated_report() {
+    let mut seen = Vec::new();
+    for _ in 0..8 {
+        let (sout, serr, status) = drive_full_round_then_rst(false);
+        assert!(status.success(), "keep-serving one-off exits 0: {serr:?}");
+        let line = serr.trim().to_string();
+        if line.contains(SENDMSG_SENTENCE) {
+            assert!(
+                line.starts_with(&format!("riperf3: error - {SENDMSG_SENTENCE}: ")),
+                "GT's sentence + live strerror suffix: {line:?}"
+            );
+            // #371: the report ran (reporter_callback at TEST_END) — the
+            // stdout summary is present, not the empty pre-test skeleton.
+            assert!(
+                sout.contains("receiver") || sout.contains("sender"),
+                "the populated summary rode the doc (not the skeleton): {sout:?}"
+            );
+            return;
+        }
+        seen.push(line);
+    }
+    panic!("exchange IESENDMESSAGE never surfaced in 8 RST rounds; saw: {seen:#?}");
+}
+
+/// #371 -J: the doc is POPULATED (end non-empty: streams/sums) with the
+/// prefixed IESENDMESSAGE key + live strerror — GT's json_finish over the
+/// TEST_END reporter output. Pre-fix this took the generic catch-all's
+/// skeleton doc with a raw io key.
+#[cfg(target_os = "linux")]
+#[test]
+fn exchange_send_failure_takes_iesendmessage_json_over_populated_doc() {
+    let mut seen = Vec::new();
+    for _ in 0..8 {
+        let (sout, serr, status) = drive_full_round_then_rst(true);
+        assert!(status.success());
+        assert!(serr.trim().is_empty(), "-J keeps stderr silent: {serr:?}");
+        let doc: serde_json::Value = serde_json::from_str(sout.trim())
+            .unwrap_or_else(|e| panic!("one -J doc ({e}): {sout}"));
+        let key = doc["error"].as_str().unwrap_or_default().to_string();
+        if key.contains(SENDMSG_SENTENCE) {
+            assert!(
+                key.starts_with(&format!("error - {SENDMSG_SENTENCE}: ")) && !key.ends_with(": "),
+                "prefixed key + live strerror (no errno-0 dangling): {key:?}"
+            );
+            // #371 core: POPULATED end, not the pre-test skeleton `{}`.
+            assert!(
+                doc["end"].as_object().is_some_and(|m| !m.is_empty()),
+                "the exchange-send doc keeps the populated end: {doc}"
+            );
+            assert!(
+                doc["intervals"].as_array().is_some_and(|a| !a.is_empty()),
+                "and the accumulated intervals: {doc}"
+            );
+            return;
+        }
+        seen.push(key);
+    }
+    panic!("exchange IESENDMESSAGE never surfaced in 8 RST rounds; saw: {seen:#?}");
+}
+
+// ---------------------------------------------------------------------------
 // #346: SIGTERM while LISTENING (no client ever). GT live-probed: -J =
 // skeleton doc with the interrupt-class key (NO "error - " prefix), silent
 // stderr, exit 0; --json-stream = the error+bare-end event pair; text =

--- a/riperf3/src/error.rs
+++ b/riperf3/src/error.rs
@@ -103,6 +103,27 @@ pub enum RiperfError {
     #[error("unable to send control message - port may not be available, the other side may have stopped running, etc.: {0}")]
     SendControlFailed(std::io::Error),
 
+    /// iperf3's IESENDMESSAGE(111) on the POST-TEST_END exchange phase — the
+    /// `send_state(EXCHANGE_RESULTS)` / `send_state(DISPLAY_RESULTS)` writes
+    /// failing against a peer that RST the control socket after TEST_END
+    /// (#371). Distinct from the pre-test [`Self::SendControlFailed`] only in
+    /// PHASE: the reporter already ran at TEST_END, so GT's json_finish emits
+    /// the POPULATED doc (start/intervals/end) + this error key, where the
+    /// pre-test sibling emits the skeleton. Same GT sentence (IESENDMESSAGE,
+    /// perr). Live errno rides per the #345 honest-errno convention (GT's
+    /// stale-global "Transport endpoint is not connected" is not mirrored).
+    #[error("unable to send control message - port may not be available, the other side may have stopped running, etc.: {0}")]
+    ExchangeSendMessageFailed(std::io::Error),
+
+    /// iperf3's IESENDRESULTS(116, iperf_api.h:465): the `send_results` write
+    /// in the post-TEST_END exchange failed (#371). GT's sentence, perr; the
+    /// populated-doc surface of [`Self::ExchangeSendMessageFailed`]. (In
+    /// practice the buffered results write often succeeds and the failure
+    /// lands on the following state send → IESENDMESSAGE; this class is the
+    /// faithful mapping for the write that does fail.)
+    #[error("unable to send results: {0}")]
+    ExchangeSendResultsFailed(std::io::Error),
+
     /// iperf3's IEACCEPT(104): the control accept() failed
     /// (iperf_server_api.c:163; herr+perr). The site-captured errno rides
     /// — and MATCHES GT's text surface in this pre-test cell (#387 r2 F1

--- a/riperf3/src/error.rs
+++ b/riperf3/src/error.rs
@@ -116,11 +116,16 @@ pub enum RiperfError {
     ExchangeSendMessageFailed(std::io::Error),
 
     /// iperf3's IESENDRESULTS(116, iperf_api.h:465): the `send_results` write
-    /// in the post-TEST_END exchange failed (#371). GT's sentence, perr; the
-    /// populated-doc surface of [`Self::ExchangeSendMessageFailed`]. (In
-    /// practice the buffered results write often succeeds and the failure
-    /// lands on the following state send → IESENDMESSAGE; this class is the
-    /// faithful mapping for the write that does fail.)
+    /// in the post-TEST_END exchange failed (#371, iperf_api.c:2789). GT's
+    /// sentence, perr; the populated-doc surface of
+    /// [`Self::ExchangeSendMessageFailed`]. The mapping is GT-RULE-faithful
+    /// (send_results fail → IESENDRESULTS on both tools). RECORDED DEVIATION
+    /// (r1, probe-confirmed both tools): in the peer-RSTs-after-its-results
+    /// cell riperf3's `send_results` write FAILS deterministically (ECONNRESET)
+    /// → this class, whereas GT's write BUFFERS and succeeds and the failure
+    /// lands on the following `send_state(DISPLAY_RESULTS)` → IESENDMESSAGE.
+    /// So the class riperf3 surfaces here diverges from GT's for the same
+    /// scenario — an honest socket-buffering difference, not a mis-mapping.
     #[error("unable to send results: {0}")]
     ExchangeSendResultsFailed(std::io::Error),
 

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -57,7 +57,11 @@ fn exchange_send_message_error(e: RiperfError) -> RiperfError {
     }
 }
 
-/// #371: the `send_results` sibling → IESENDRESULTS.
+/// #371: the `send_results` sibling → IESENDRESULTS. `send_results`
+/// serializes before the socket write, so a (theoretical) serialize error
+/// would be non-Io; the fallthrough leaves it unchanged rather than
+/// mislabel it. In practice `TestResultsJson` never fails to serialize
+/// (non-finite f64 → JSON null, not Err), so the input is always Io.
 fn exchange_send_results_error(e: RiperfError) -> RiperfError {
     match e {
         RiperfError::Io(io) => RiperfError::ExchangeSendResultsFailed(io),

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -46,6 +46,25 @@ pub(crate) struct TestConfig {
 /// round ends CLEAN (exit 0, persistent keeps serving).
 const CTRL_CLOSED_MSG: &str = "the client has unexpectedly closed the connection";
 
+/// #371: map a POST-TEST_END exchange control-write failure to the
+/// IESENDMESSAGE class, preserving the live errno. `send_state`'s only
+/// fallible op is `write_all` (→ `RiperfError::Io`); the fallthrough keeps
+/// any already-typed error unchanged.
+fn exchange_send_message_error(e: RiperfError) -> RiperfError {
+    match e {
+        RiperfError::Io(io) => RiperfError::ExchangeSendMessageFailed(io),
+        other => other,
+    }
+}
+
+/// #371: the `send_results` sibling → IESENDRESULTS.
+fn exchange_send_results_error(e: RiperfError) -> RiperfError {
+    match e {
+        RiperfError::Io(io) => RiperfError::ExchangeSendResultsFailed(io),
+        other => other,
+    }
+}
+
 /// i64→i32 for the adopted dg (#316 r2 F3 / r3 nit): GT's bundled cjson
 /// carries `int64_t valueint` (cjson.h:119) and the narrowing happens at
 /// the C `int` field assignment (iperf_api.c:2602) — an
@@ -297,6 +316,12 @@ struct TestRunCtx {
     /// IERECVRESULTS surface for every close-type and file upstream rather
     /// than reproduce the misleading flip.
     exchange_recv_failed: bool,
+    /// #371: a POST-TEST_END exchange-phase SEND failed (the state writes →
+    /// IESENDMESSAGE, `send_results` → IESENDRESULTS). Set instead of
+    /// propagating the raw io Err so the finalize renders the POPULATED doc
+    /// (the reporter ran at TEST_END) + this typed key; the post-emit gate
+    /// then returns it so the serve loop prints GT's line and keeps serving.
+    exchange_send_error: Option<RiperfError>,
     /// #330 r1 F1: a mid-test IPERF_DONE — GT's switch has an EXPLICIT
     /// no-error arm for it (iperf_server_api.c:287-288) and Nread wrote
     /// the byte into test->state, so its run loop exits CLEAN: no error
@@ -592,6 +617,22 @@ impl Server {
                             "{}riperf3: error - {}: ",
                             crate::macros::output_timestamp_prefix(),
                             RiperfError::RecvResultsFailed
+                        );
+                    }
+                }
+                Err(e @ RiperfError::ExchangeSendMessageFailed(_))
+                | Err(e @ RiperfError::ExchangeSendResultsFailed(_)) => {
+                    // #371: the POST-TEST_END exchange-send failure — the
+                    // POPULATED doc rendered at the site (GT's json_finish
+                    // over the TEST_END reporter output). Text prints GT's
+                    // IESENDMESSAGE/IESENDRESULTS line with the live strerror
+                    // (no dangling ": ", the Display carries the errno);
+                    // -J/json-stream carried it in the doc. Keep-serving,
+                    // exit 0 (GT's rc -1 class).
+                    if !json && !crate::macros::output_quiet() {
+                        eprintln!(
+                            "{}riperf3: error - {e}",
+                            crate::macros::output_timestamp_prefix()
                         );
                     }
                 }
@@ -913,6 +954,7 @@ impl Server {
             ctrl_closed: false,
             early_done: false,
             exchange_recv_failed: false,
+            exchange_send_error: None,
             bare_end: false,
             interrupted: None,
         };
@@ -1009,6 +1051,11 @@ impl Server {
                     // the field's deviation record).
                     end.report_error =
                         Some(format!("error - {}: ", RiperfError::RecvResultsFailed));
+                } else if let Some(err) = &ctx.exchange_send_error {
+                    // #371: GT's IESENDMESSAGE/IESENDRESULTS key over the
+                    // populated doc — prefixed like the self-terminate keys,
+                    // with the live strerror the variant's Display carries.
+                    end.report_error = Some(format!("error - {err}"));
                 }
             }
 
@@ -1110,6 +1157,12 @@ impl Server {
             // line (json keeps stderr to the warning alone) and keeps
             // serving — a failed test is rc -1, one-off exit 0.
             return Err(RiperfError::RecvResultsFailed);
+        }
+        if let Some(err) = ctx.exchange_send_error.take() {
+            // #371: the populated doc rendered above (its key came from
+            // report_error); the caller prints GT's IESENDMESSAGE/
+            // IESENDRESULTS line (text only) and keeps serving, exit 0.
+            return Err(err);
         }
         Ok(Some(report))
     }
@@ -2472,7 +2525,16 @@ impl Server {
                 streams: result_streams,
             };
 
-            protocol::send_state(&mut ctx.ctrl, TestState::ExchangeResults).await?;
+            // #371: an exchange-phase send failing against a peer that RST
+            // the ctrl after TEST_END is GT's IESENDMESSAGE — the reporter
+            // already ran, so render the POPULATED doc + the typed key
+            // (return Ok(()) into the finalize path), not the raw-io skeleton
+            // the generic serve-loop arm would emit. `send_state` maps to
+            // IESENDMESSAGE; `send_results` to IESENDRESULTS.
+            if let Err(e) = protocol::send_state(&mut ctx.ctrl, TestState::ExchangeResults).await {
+                ctx.exchange_send_error = Some(exchange_send_message_error(e));
+                return Ok(());
+            }
             // #319 (sibling of #268): both post-test reads race the
             // interrupt watch — a client wedging mid-results (or never
             // sending IperfDone) must not hold the server past a signal.
@@ -2509,10 +2571,16 @@ impl Server {
                     return Ok(());
                 }
             };
-            protocol::send_results(&mut ctx.ctrl, &server_results).await?;
+            if let Err(e) = protocol::send_results(&mut ctx.ctrl, &server_results).await {
+                ctx.exchange_send_error = Some(exchange_send_results_error(e));
+                return Ok(());
+            }
 
             // ---- DisplayResults / IperfDone ----
-            protocol::send_state(&mut ctx.ctrl, TestState::DisplayResults).await?;
+            if let Err(e) = protocol::send_state(&mut ctx.ctrl, TestState::DisplayResults).await {
+                ctx.exchange_send_error = Some(exchange_send_message_error(e));
+                return Ok(());
+            }
 
             // Wait for client to send IperfDone
             loop {
@@ -4469,6 +4537,7 @@ mod tests {
             ctrl_closed: false,
             early_done: false,
             exchange_recv_failed: false,
+            exchange_send_error: None,
             bare_end: false,
             interrupted: None,
         }


### PR DESCRIPTION
Closes #371. The LAST feature item in the 0.9.0 filed-findings batch.

When a peer RSTs the control socket **after TEST_END**, the server's exchange-phase sends fail. riperf3 routed them through the raw-io catch-all (`error - Connection reset by peer (os error 104)` + the #330 **skeleton** doc). GT maps them to typed classes over a **populated** doc — because `reporter_callback` already ran at TEST_END, so `iperf_json_finish` emits the accumulated start/intervals/end with the error key.

## GT probes (3.21, live — mock peer RSTs at each send point, `probe371.py`)

| RST point | GT `-J` doc | error key |
|---|---|---|
| after TEST_END (fails `send_state(EXCHANGE_RESULTS)`) | populated (streams/sums/cpu/congestion), 1 interval | `error - unable to send control message - ...: Transport endpoint is not connected` |
| after client results (fails `send_results`) | populated | same (IESENDMESSAGE) |
| after server results (fails `send_state(DISPLAY_RESULTS)`) | populated | same |

GT empirically surfaces **IESENDMESSAGE** for all three — its `send_results` write buffers-and-succeeds, so the failure lands on the following state send. riperf3 diverges by cell: sub-class A → IESENDMESSAGE (matches GT); sub-class **B** → riperf3's `send_results` write FAILS deterministically (ECONNRESET) → **IESENDRESULTS(116)** where GT emits IESENDMESSAGE (recorded socket-buffering deviation); sub-class C → riperf3's DISPLAY_RESULTS buffers, the RST is caught on the next read → skeleton (filed as #406). The IESENDRESULTS mapping is GT-rule-faithful (iperf_api.c:2789).

GT classes: IESENDMESSAGE=111 ("unable to send control message - port may not be available, the other side may have stopped running, etc.", perr), IESENDRESULTS=116 ("unable to send results", perr), iperf_error.c:305-327.

## Fix

Mirrors the recv-failure path (#330): the three sends are caught (not `?`-propagated), a typed error is stored in `ctx.exchange_send_error`, and `exchange_results_phase` returns `Ok(())` — so the flow reaches the single **populated** report build + emit. The post-emit gate then returns the typed Err so the serve loop prints GT's line and keeps serving (exit 0). Two new error variants:

- `ExchangeSendMessageFailed(io::Error)` → IESENDMESSAGE (the two `send_state` writes). Phase-distinct from the pre-test `SendControlFailed` (skeleton doc), same GT sentence.
- `ExchangeSendResultsFailed(io::Error)` → IESENDRESULTS (`send_results`).

Live errno rides per the #345 honest-errno convention (riperf3's write eats the RST as ECONNRESET; GT's select loop reports the stale ENOTCONN — not mirrored). The doc key is `error - `-prefixed like the self-terminate keys.

## Tests (red-first) + mutation table

- Two Linux-only pins drive a full round then SO_LINGER(0)-RST after TEST_END. riperf3's 100 ms flush sleep runs before the first exchange send, so the RST reliably lands first (no #345 race). They assert the IESENDMESSAGE sentence + a **populated** doc (`end` non-empty + intervals) / stdout summary + exit 0 — red pre-fix (raw-io catch-all, skeleton).
- Mutation 4/4: M1 (send reverts to `?`) reds both pins; M2 (report_error arm dropped) reds the -J key; M3 (post-emit gate suppressed) reds the text line; M4 (M1 twin) reds text. Tree restored clean.
- Sub-class B (IESENDRESULTS) is deterministically reachable and has its own red-first pin; sub-class C's skeleton is the pre-#371 recv-path shape (filed #406, not a regression).

## Disclosure

One `clean_finish_reverse_exits_bounded_while_peer_holds` load flake (bounded-teardown timing family, unrelated to the send-failure path) in one of three full-workspace runs; green isolated + in the other two.
