### PR TITLE
feat: Client::run returns RunOutcome; flip library output default to quiet (#293, #294)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,19 @@ This changelog begins at 0.6.0. For earlier releases (0.1.1–0.5.4), see the
 [git history](https://github.com/therealevanhenry/riperf3/commits/main) and
 release tags.
 
-## [0.8.0] - 2026-06-28
+## [Unreleased]
+
+### Breaking
+
+- `Client::run` returns `RunOutcome { report, termination }` instead of `Report` (#293).
+  A server-terminated or relayed-error run is now `Ok` — carrying the partial report plus
+  `Termination::ServerTerminated`/`ServerError(msg)` — instead of an `Err` that discarded it;
+  `Err` is reserved for runs that produced no report. The `RiperfError::ServerTerminated` /
+  `ServerErrorRelayed` variants are removed. Migration: `client.run().await?` →
+  `client.run().await?.report`; branch on `outcome.termination` for the ending.
+- The builder output default flips to quiet (#294): a bare `run()`/`run_once()` returns the
+  report and prints nothing. Opt into iperf3's full text/JSON output with `.emit_output(true)`
+  (the CLI sets this). Wire protocol, CLI output, and exit codes are unchanged.
 
 Architecture-and-API release. Wire protocol and CLI flags unchanged; success-path
 `-J`/text output byte-identical. Breaking changes are library-API only.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,13 +17,17 @@ release tags.
 
 - `Client::run` returns `RunOutcome { report, termination }` instead of `Report` (#293).
   A server-terminated or relayed-error run is now `Ok` — carrying the partial report plus
-  `Termination::ServerTerminated`/`ServerError(msg)` — instead of an `Err` that discarded it;
-  `Err` is reserved for runs that produced no report. The `RiperfError::ServerTerminated` /
+  `Termination::ServerTerminated`/`ServerError(msg)` — instead of an `Err` that discarded it.
+  `Err` now covers runs that produced no report (connect/handshake failures; the
+  `ControlSocketClosed`/`RecvResultsFailed` classes stay `Err` for now — a follow-up).
+  The `RiperfError::ServerTerminated` /
   `ServerErrorRelayed` variants are removed. Migration: `client.run().await?` →
   `client.run().await?.report`; branch on `outcome.termination` for the ending.
 - The builder output default flips to quiet (#294): a bare `run()`/`run_once()` returns the
   report and prints nothing. Opt into iperf3's full text/JSON output with `.emit_output(true)`
   (the CLI sets this). Wire protocol, CLI output, and exit codes are unchanged.
+
+## [0.8.0] - 2026-06-28
 
 Architecture-and-API release. Wire protocol and CLI flags unchanged; success-path
 `-J`/text output byte-identical. Breaking changes are library-API only.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -793,7 +793,7 @@ dependencies = [
 
 [[package]]
 name = "riperf3"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "base64",
  "libc",
@@ -815,7 +815,7 @@ dependencies = [
 
 [[package]]
 name = "riperf3-cli"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "clap",
  "libc",
@@ -831,7 +831,7 @@ dependencies = [
 
 [[package]]
 name = "riperf3-test-support"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "serde_json",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.8.0"
+version = "0.9.0"
 authors = ["Evan Henry"]
 edition = "2021"
 # MSRV floor 1.85 (review r1, verified empirically): the locked base64ct 1.8

--- a/riperf3-cli/Cargo.toml
+++ b/riperf3-cli/Cargo.toml
@@ -14,7 +14,7 @@ readme = "../README.md"
 
 [dependencies]
 # riperf3 workspace dependencies
-riperf3 = { path = "../riperf3", version = "0.8.0" }
+riperf3 = { path = "../riperf3", version = "0.9.0" }
 
 # external dependencies
 clap.workspace = true

--- a/riperf3-cli/src/cli.rs
+++ b/riperf3-cli/src/cli.rs
@@ -573,7 +573,10 @@ impl Cli {
             return Err(END_CONDITIONS_MSG.into());
         }
 
-        let mut builder = riperf3::ClientBuilder::new(host);
+        // #294: the CLI is the faithful-output surface, so it opts INTO the
+        // full iperf3 text/JSON output explicitly. The library default is now
+        // quiet (a bare `run()` returns the Report and prints nothing).
+        let mut builder = riperf3::ClientBuilder::new(host).emit_output(true);
 
         // Format (#241): case-sensitive [kmgtKMGT], uppercase = byte-rates;
         // absent → the library's adaptive default ('a'), like iperf3 (#221).
@@ -837,7 +840,9 @@ impl Cli {
     /// here: the binary daemonizes before building the runtime, since the
     /// library cannot fork safely from inside the async runtime (#81).
     pub fn build_server(&self) -> std::result::Result<riperf3::Server, Box<dyn std::error::Error>> {
-        let mut builder = riperf3::ServerBuilder::new();
+        // #294: the CLI opts into iperf3's full output; the library default is
+        // now quiet (see build_client).
+        let mut builder = riperf3::ServerBuilder::new().emit_output(true);
 
         // Format (#242): the server-side -f was silently dropped — never
         // wired through the builder, every render site hardcoded adaptive.
@@ -1719,9 +1724,11 @@ mod cli_tests {
 
         /// A `ClientBuilder` matching the CLI's no-flag defaults. Since #221
         /// the CLI no longer forces a format: absent -f, the library's
-        /// adaptive default ('a') stands, like iperf3.
+        /// adaptive default ('a') stands, like iperf3. #294: the CLI opts into
+        /// output (the library default is now quiet), so the expected builder
+        /// carries `emit_output(true)` too.
         fn expected_client(host: &str) -> riperf3::ClientBuilder {
-            riperf3::ClientBuilder::new(host)
+            riperf3::ClientBuilder::new(host).emit_output(true)
         }
 
         #[test]
@@ -2100,7 +2107,11 @@ mod cli_tests {
             let s = build_server_from_cli(&cli);
             assert_eq!(
                 s,
-                riperf3::ServerBuilder::new().one_off(true).build().unwrap()
+                riperf3::ServerBuilder::new()
+                    .emit_output(true)
+                    .one_off(true)
+                    .build()
+                    .unwrap()
             );
         }
 
@@ -2229,6 +2240,7 @@ mod cli_tests {
             assert_eq!(
                 s,
                 riperf3::ServerBuilder::new()
+                    .emit_output(true)
                     .bind_dev("eth0")
                     .build()
                     .unwrap()
@@ -2406,6 +2418,7 @@ mod cli_tests {
             assert_eq!(
                 s,
                 riperf3::ServerBuilder::new()
+                    .emit_output(true)
                     .rcv_timeout(3000)
                     .build()
                     .unwrap()
@@ -2419,6 +2432,7 @@ mod cli_tests {
             assert_eq!(
                 s,
                 riperf3::ServerBuilder::new()
+                    .emit_output(true)
                     .idle_timeout(30)
                     .build()
                     .unwrap()
@@ -2432,6 +2446,7 @@ mod cli_tests {
             assert_eq!(
                 s,
                 riperf3::ServerBuilder::new()
+                    .emit_output(true)
                     .server_max_duration(60)
                     .build()
                     .unwrap()
@@ -2722,6 +2737,7 @@ mod cli_tests {
             assert_eq!(
                 build_server_from_cli(&cli),
                 riperf3::ServerBuilder::new()
+                    .emit_output(true)
                     .port(Some(5201))
                     .build()
                     .unwrap()
@@ -2733,7 +2749,11 @@ mod cli_tests {
             let cli = Cli::parse_from(["riperf3", "-s", "-V"]);
             assert_eq!(
                 build_server_from_cli(&cli),
-                riperf3::ServerBuilder::new().verbose(true).build().unwrap()
+                riperf3::ServerBuilder::new()
+                    .emit_output(true)
+                    .verbose(true)
+                    .build()
+                    .unwrap()
             );
         }
 
@@ -2743,6 +2763,7 @@ mod cli_tests {
             assert_eq!(
                 build_server_from_cli(&cli),
                 riperf3::ServerBuilder::new()
+                    .emit_output(true)
                     .json_output(true)
                     .build()
                     .unwrap()
@@ -2755,6 +2776,7 @@ mod cli_tests {
             assert_eq!(
                 build_server_from_cli(&cli),
                 riperf3::ServerBuilder::new()
+                    .emit_output(true)
                     .json_stream(true)
                     .build()
                     .unwrap()
@@ -2767,6 +2789,7 @@ mod cli_tests {
             assert_eq!(
                 build_server_from_cli(&cli),
                 riperf3::ServerBuilder::new()
+                    .emit_output(true)
                     .forceflush(true)
                     .build()
                     .unwrap()
@@ -2779,6 +2802,7 @@ mod cli_tests {
             assert_eq!(
                 build_server_from_cli(&cli),
                 riperf3::ServerBuilder::new()
+                    .emit_output(true)
                     .bind_address("0.0.0.0")
                     .build()
                     .unwrap()
@@ -2790,7 +2814,11 @@ mod cli_tests {
             let cli = Cli::parse_from(["riperf3", "-s", "-4"]);
             assert_eq!(
                 build_server_from_cli(&cli),
-                riperf3::ServerBuilder::new().ip_version(4).build().unwrap()
+                riperf3::ServerBuilder::new()
+                    .emit_output(true)
+                    .ip_version(4)
+                    .build()
+                    .unwrap()
             );
         }
 
@@ -2799,7 +2827,11 @@ mod cli_tests {
             let cli = Cli::parse_from(["riperf3", "-s", "-6"]);
             assert_eq!(
                 build_server_from_cli(&cli),
-                riperf3::ServerBuilder::new().ip_version(6).build().unwrap()
+                riperf3::ServerBuilder::new()
+                    .emit_output(true)
+                    .ip_version(6)
+                    .build()
+                    .unwrap()
             );
         }
 
@@ -2809,6 +2841,7 @@ mod cli_tests {
             assert_eq!(
                 build_server_from_cli(&cli),
                 riperf3::ServerBuilder::new()
+                    .emit_output(true)
                     .timestamps("%H")
                     .build()
                     .unwrap()
@@ -2821,6 +2854,7 @@ mod cli_tests {
             assert_eq!(
                 build_server_from_cli(&cli),
                 riperf3::ServerBuilder::new()
+                    .emit_output(true)
                     .server_bitrate_limit_str("100M")
                     .unwrap()
                     .build()
@@ -2840,6 +2874,7 @@ mod cli_tests {
             assert_eq!(
                 build_server_from_cli(&cli),
                 riperf3::ServerBuilder::new()
+                    .emit_output(true)
                     .server_bitrate_limit(10_000_000)
                     .build()
                     .unwrap()
@@ -2848,6 +2883,7 @@ mod cli_tests {
             assert_eq!(
                 build_server_from_cli(&cli),
                 riperf3::ServerBuilder::new()
+                    .emit_output(true)
                     .server_bitrate_limit(10_000)
                     .build()
                     .unwrap()
@@ -2856,6 +2892,7 @@ mod cli_tests {
             assert_eq!(
                 build_server_from_cli(&cli),
                 riperf3::ServerBuilder::new()
+                    .emit_output(true)
                     .server_bitrate_limit(u64::MAX - 4)
                     .build()
                     .unwrap()
@@ -2868,6 +2905,7 @@ mod cli_tests {
             assert_eq!(
                 build_server_from_cli(&cli),
                 riperf3::ServerBuilder::new()
+                    .emit_output(true)
                     .authorized_users_path("/tmp/users")
                     .build()
                     .unwrap()
@@ -2880,6 +2918,7 @@ mod cli_tests {
             assert_eq!(
                 build_server_from_cli(&cli),
                 riperf3::ServerBuilder::new()
+                    .emit_output(true)
                     .rsa_private_key_path("/tmp/priv.pem")
                     .build()
                     .unwrap()
@@ -2892,6 +2931,7 @@ mod cli_tests {
             assert_eq!(
                 build_server_from_cli(&cli),
                 riperf3::ServerBuilder::new()
+                    .emit_output(true)
                     .time_skew_threshold(5)
                     .build()
                     .unwrap()
@@ -2904,6 +2944,7 @@ mod cli_tests {
             assert_eq!(
                 build_server_from_cli(&cli),
                 riperf3::ServerBuilder::new()
+                    .emit_output(true)
                     .use_pkcs1_padding(true)
                     .build()
                     .unwrap()

--- a/riperf3-cli/src/cli.rs
+++ b/riperf3-cli/src/cli.rs
@@ -2727,9 +2727,10 @@ mod cli_tests {
 
         // -- #124: server-side wiring coverage. `build_server` is now the single
         // source of truth, so cover its setters too (previously only one_off,
-        // idle_timeout, and server_max_duration had dedicated tests). `build_server`
-        // has no unconditional defaults, so the bare `ServerBuilder::new()` is the
-        // correct baseline (unlike the client's `expected_client`).
+        // idle_timeout, and server_max_duration had dedicated tests). #294:
+        // `build_server` sets `emit_output(true)` unconditionally, so each
+        // expected baseline carries `.emit_output(true)` (like the client's
+        // `expected_client`).
 
         #[test]
         fn server_port_wired() {

--- a/riperf3-cli/src/main.rs
+++ b/riperf3-cli/src/main.rs
@@ -365,20 +365,22 @@ fn main() -> std::process::ExitCode {
             // every -J consumer. iperf3 emits exactly one. Text mode is
             // exempt: its stderr line is iperf3's errexit shape, and the
             // lib's text dump carries no error line.
-            let lib_already_rendered = e.downcast_ref::<riperf3::RiperfError>().is_some_and(|le| {
-                matches!(
-                    le,
-                    riperf3::RiperfError::ServerTerminated
-                        | riperf3::RiperfError::ServerErrorRelayed(_)
+            let lib_already_rendered = e.downcast_ref::<AbnormalExit>().is_some()
+                || e.downcast_ref::<riperf3::RiperfError>().is_some_and(|le| {
+                    matches!(
+                        le,
                         // #267: the lib emits the populated ctrl-closed doc
                         // (bare end{}) before returning this class.
-                        | riperf3::RiperfError::ControlSocketClosed
+                        riperf3::RiperfError::ControlSocketClosed
                         // #374: the client's failed results read — the lib
                         // emitted the doc with the dangling IERECVRESULTS
                         // value before returning.
                         | riperf3::RiperfError::RecvResultsFailed
-                )
-            });
+                    )
+                    // #293: ServerTerminated / ServerErrorRelayed are no longer
+                    // errors — they come back as Ok(RunOutcome) and reach here
+                    // as AbnormalExit (above).
+                });
             // #374: GT marks IERECVRESULTS perr, so its errexit line carries
             // the strerror tail — at the wedge/EOF windows that is the #248
             // dangling `: ` (GT appends a STALE errno's strerror, live
@@ -781,6 +783,26 @@ enum Exit {
     Signal(&'static str),
 }
 
+/// #293: a client run that ended abnormally — server-terminated or a relayed
+/// SERVER_ERROR. `Client::run` returns these as `Ok(RunOutcome)` (the lib
+/// already emitted its doc / SERVER-ERROR receipt during the run), but iperf3
+/// errexits (exit 1) on them. This carries the errexit message up to `main`,
+/// which renders the `riperf3: error - <msg>` line in TEXT mode and suppresses
+/// a second render in the JSON modes (the lib's doc already carried the key) —
+/// exactly the old `ServerTerminated`/`ServerErrorRelayed` behavior, now that
+/// those are `Termination`s rather than errors. Its Display IS the errexit
+/// message so `main`'s text branch renders it verbatim.
+#[derive(Debug)]
+struct AbnormalExit(String);
+
+impl std::fmt::Display for AbnormalExit {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl std::error::Error for AbnormalExit {}
+
 /// Second-signal hard exit (#158): once the orderly shutdown is underway, a
 /// repeat SIGTERM/SIGINT/SIGHUP must not be swallowed by tokio's (now
 /// shutting-down) signal machinery. Registers plain libc handlers whose body
@@ -927,7 +949,14 @@ async fn async_main(
         // on a client are both rejected up front in `main` (#65/#100), before
         // any side effects. The arg→builder mapping lives in `Cli::build_client`
         // (cli.rs) so the wiring tests exercise the same code path (#124).
-        cli.build_client()?.with_interrupt(interrupt).run().await?;
+        // #293: `run` returns a RunOutcome. A server-terminated / relayed-error
+        // run is `Ok` now (the lib rendered its doc/line during the run), but
+        // iperf3 still errexits (exit 1) on those — map the non-clean endings
+        // to the already-rendered error exit. Completed/Interrupted exit 0.
+        let outcome = cli.build_client()?.with_interrupt(interrupt).run().await?;
+        if let Some(msg) = outcome.termination.errexit_message() {
+            return Err(Box::new(AbnormalExit(msg)));
+        }
     } else if cli.server {
         // Server mode. See `Cli::build_server` (cli.rs). `-D`/`--daemon` is
         // handled before the runtime is built (daemonize block in `main`).

--- a/riperf3/src/client.rs
+++ b/riperf3/src/client.rs
@@ -325,7 +325,7 @@ impl Client {
         self
     }
 
-    pub async fn run(&self) -> Result<crate::json_report::Report> {
+    pub async fn run(&self) -> Result<crate::outcome::RunOutcome> {
         // #290: run-scoped console silence, armed FIRST so even the -V
         // preamble honors it. Construct-only-when-quiet (see the guard doc).
         let _quiet_guard = (!self.emit_output).then(crate::macros::OutputQuietGuard::set);
@@ -394,7 +394,7 @@ impl Client {
         // that already rendered its output (the interrupt dumps); the
         // clean IperfDone break is `Ok(None)`. A `return` inside the block
         // exits the BLOCK, not run().
-        let outcome: Result<Option<crate::json_report::Report>> = async {
+        let outcome: Result<Option<(crate::json_report::Report, crate::outcome::Termination)>> = async {
             loop {
                 // #231: iperf_catch_sigend is armed for the WHOLE run, so the
                 // central state wait polls the interrupt watch like the
@@ -421,7 +421,10 @@ impl Client {
                         Err(e) => return Err(e),
                     },
                     msg = wait_interrupt(ctx.interrupt.as_mut()) => {
-                        return Ok(Some(self.on_interrupted_wait(&mut ctx, &msg).await));
+                        return Ok(Some((
+                            self.on_interrupted_wait(&mut ctx, &msg).await,
+                            crate::outcome::Termination::Interrupted,
+                        )));
                     }
                 };
 
@@ -445,7 +448,9 @@ impl Client {
 
                     TestState::ExchangeResults => match self.on_exchange_results(&mut ctx).await? {
                         // #268: a signal landed inside the bulk results read.
-                        Some(report) => return Ok(Some(report)),
+                        Some(report) => {
+                            return Ok(Some((report, crate::outcome::Termination::Interrupted)))
+                        }
                         None => StepFlow::Continue,
                     },
 
@@ -461,7 +466,11 @@ impl Client {
                         // refusal (code 37 et al.) — its `end` is GT's bare {}.
                         // After TestStart the dump keeps the full structure.
                         let bare_end = !ctx.stage.started();
-                        return Err(self.on_server_error_relay(&mut ctx, bare_end).await);
+                        let (report, msg) = self.on_server_error_relay(&mut ctx, bare_end).await;
+                        return Ok(Some((
+                            report,
+                            crate::outcome::Termination::ServerError(msg),
+                        )));
                     }
 
                     // iperf_handle_message_client handles SERVER_TERMINATE in
@@ -471,7 +480,10 @@ impl Client {
                     // surface IESERVERTERM instead of dying later on a bare
                     // peer-disconnect with no dump.
                     TestState::ServerTerminate => {
-                        return Err(self.on_server_terminate(&ctx));
+                        return Ok(Some((
+                            self.on_server_terminate(&ctx),
+                            crate::outcome::Termination::ServerTerminated,
+                        )));
                     }
 
                     other => {
@@ -483,7 +495,9 @@ impl Client {
                 match flow {
                     StepFlow::Continue => {}
                     StepFlow::Break => break,
-                    StepFlow::Return(report) => return Ok(Some(*report)),
+                    StepFlow::Return(report, termination) => {
+                        return Ok(Some((*report, termination)))
+                    }
                 }
                 // #145: AUDITABILITY ONLY — advance the table cursor to the state
                 // just handled, before the next recv. Reached only by the arms that
@@ -533,10 +547,11 @@ impl Client {
             let _ = s.task.await;
         }
 
-        // The early-exit rounds (the interrupt dumps, #210/#268) already
-        // rendered their output — only the teardown above was owed.
-        if let Some(report) = outcome? {
-            return Ok(report);
+        // The abnormal-end rounds (#293) — a signal dump, a server terminate,
+        // or a relayed server error — already rendered their output; only the
+        // teardown above was owed. Each carries its `Termination`.
+        if let Some((report, termination)) = outcome? {
+            return Ok(crate::outcome::RunOutcome::new(report, termination));
         }
 
         // #222: every clean text-mode client run closes with a blank line +
@@ -556,8 +571,15 @@ impl Client {
             vprintln!("");
             vprintln!("iperf Done.");
         }
-        ctx.final_report
-            .ok_or_else(|| RiperfError::Protocol("results not displayed before IPERF_DONE".into()))
+        // #293: the clean completion — the rich report captured at
+        // DisplayResults, paired with `Completed`.
+        let report = ctx.final_report.ok_or_else(|| {
+            RiperfError::Protocol("results not displayed before IPERF_DONE".into())
+        })?;
+        Ok(crate::outcome::RunOutcome::new(
+            report,
+            crate::outcome::Termination::Completed,
+        ))
     }
 
     // -----------------------------------------------------------------------
@@ -694,6 +716,34 @@ impl Client {
             secs,
             error,
         )
+    }
+
+    /// #293: build the `Report` WITHOUT printing a text summary. The
+    /// server-error / ctrl-lost text paths print only iperf_err's one-line
+    /// receipt (GT renders no summary there), but a library caller still
+    /// wants the structured partial data in the `RunOutcome`. Same drain-once
+    /// discipline as [`emit_results`] — the collections move into the build.
+    /// (Distinct from `build_results`, which builds the client's own wire
+    /// `TestResultsJson` to SEND to the server.)
+    fn partial_report(
+        &self,
+        ctx: &RunCtx,
+        server_results: Option<&TestResultsJson>,
+        bare_end: bool,
+        secs: f64,
+        error: Option<&str>,
+    ) -> crate::json_report::Report {
+        let mut input = self.build_report_input(
+            &ctx.streams,
+            ctx.cpu_start.as_ref(),
+            server_results,
+            ctx.blksize,
+            crate::reporter::CollectedIntervals::drain(&ctx.interval_data),
+            &ctx.start_meta(bare_end),
+            secs,
+        );
+        input.error = error.map(str::to_owned);
+        input.build()
     }
 
     /// The central state wait's interrupt arm (#231): iperf_got_sigend's
@@ -879,9 +929,13 @@ impl Client {
         ctx.measured_secs = secs;
         match event {
             Some(ControlEvent::Terminated) => {
-                // SERVER_TERMINATE mid-test: same dump-and-errexit shape as
-                // the any-state arm (#170/#210) — see on_server_terminate.
-                return Err(self.on_server_terminate(ctx));
+                // SERVER_TERMINATE mid-test: same dump shape as the any-state
+                // arm (#170/#210) — see on_server_terminate. #293: Ok with the
+                // partial report + the ServerTerminated ending.
+                return Ok(StepFlow::Return(
+                    Box::new(self.on_server_terminate(ctx)),
+                    crate::outcome::Termination::ServerTerminated,
+                ));
             }
             Some(ControlEvent::Interrupted(msg)) => {
                 // iperf_got_sigend (#210): dump the accumulated
@@ -893,12 +947,20 @@ impl Client {
                 // #137: return the rich report we just dumped (the
                 // local-only partial — no peer half on a signal exit).
                 let report = self.emit_results(ctx, None, false, ctx.measured_secs, Some(&msg));
-                return Ok(StepFlow::Return(Box::new(report)));
+                return Ok(StepFlow::Return(
+                    Box::new(report),
+                    crate::outcome::Termination::Interrupted,
+                ));
             }
             Some(ControlEvent::ServerError) => {
                 // Mid-test the run is always past TestStart, so the dump
-                // keeps the full report structure (#261).
-                return Err(self.on_server_error_relay(ctx, false).await);
+                // keeps the full report structure (#261). #293: Ok with the
+                // partial report + the ServerError ending.
+                let (report, msg) = self.on_server_error_relay(ctx, false).await;
+                return Ok(StepFlow::Return(
+                    Box::new(report),
+                    crate::outcome::Termination::ServerError(msg),
+                ));
             }
             Some(ControlEvent::Closed) | None => {}
         }
@@ -982,15 +1044,23 @@ impl Client {
     /// generic re-render. `bare_end` is the caller's: a relay before
     /// TestStart is the upfront refusal (code 37 et al.) — emit GT's minimal
     /// doc (`end: {}`; the late start fields already gate on the stage) (#261).
-    async fn on_server_error_relay(&self, ctx: &mut RunCtx, bare_end: bool) -> RiperfError {
+    async fn on_server_error_relay(
+        &self,
+        ctx: &mut RunCtx,
+        bare_end: bool,
+    ) -> (crate::json_report::Report, String) {
         let msg = match protocol::read_server_error_payload(&mut ctx.ctrl).await {
             Some((i_errno, os_errno)) => crate::error::iperf3_strerror(i_errno, os_errno),
             None => "server error".to_string(),
         };
-        if self.json_output || self.json_stream {
-            self.emit_results(ctx, None, bare_end, ctx.measured_secs, Some(&msg));
+        // #293: return the partial report on every mode. JSON sinks emit the
+        // full document/events (iperf3's json_top); text prints iperf_err's
+        // one-line receipt only (GT renders no summary here) but the caller
+        // still gets the structured data via build_results.
+        let report = if self.json_output || self.json_stream {
+            self.emit_results(ctx, None, bare_end, ctx.measured_secs, Some(&msg))
         } else {
-            // #290: quiet runs surface the error via Err alone.
+            // #290: quiet runs surface the error via the RunOutcome alone.
             if !crate::macros::output_quiet() {
                 // #348: GT stamps this line too (iperf_err route). #364:
                 // and iperf_err honors the logfile — err_println follows
@@ -1001,8 +1071,9 @@ impl Client {
                     crate::macros::output_timestamp_prefix()
                 ));
             }
-        }
-        RiperfError::ServerErrorRelayed(msg)
+            self.partial_report(ctx, None, bare_end, ctx.measured_secs, Some(&msg))
+        };
+        (report, msg)
     }
 
     /// SERVER_TERMINATE, mid-test or in ANY state (#210 review r1 n2 — a
@@ -1011,15 +1082,17 @@ impl Client {
     /// renders a summary from the PARTIAL local data (no peer half), then
     /// errexits with IESERVERTERM (#170). A -J run carries the message in
     /// the blob's "error" key, like iperf_json_finish.
-    fn on_server_terminate(&self, ctx: &RunCtx) -> RiperfError {
+    fn on_server_terminate(&self, ctx: &RunCtx) -> crate::json_report::Report {
+        // #293: emit_results already builds+returns the partial report in
+        // every mode (GT dumps the summary here, #170) — hand it back so the
+        // RunOutcome carries it instead of discarding it behind an Err.
         self.emit_results(
             ctx,
             None,
             false,
             ctx.measured_secs,
             Some("the server has terminated"),
-        );
-        RiperfError::ServerTerminated
+        )
     }
 
     /// #267: the control connection was lost abruptly (GT's IECTRLCLOSE
@@ -2643,9 +2716,11 @@ enum StepFlow {
     /// The run is over (DisplayResults handled / IperfDone) — leave the loop
     /// for the cleanup tail and the captured final report.
     Break,
-    /// End the run NOW with this report (the signal-interrupt shape: dump and
-    /// exit without the cleanup tail). Boxed to keep the enum small.
-    Return(Box<crate::json_report::Report>),
+    /// End the run NOW with this report + how it ended (#293): the mid-test
+    /// abnormal endings (a signal, SERVER_TERMINATE, SERVER_ERROR) that dump
+    /// their partial report and leave without the clean cleanup tail. Boxed to
+    /// keep the enum small.
+    Return(Box<crate::json_report::Report>, crate::outcome::Termination),
 }
 
 /// The state `Client::run` threads through its per-state handlers (#289): the
@@ -2796,7 +2871,9 @@ impl Default for ClientBuilder {
             extra_data: None,
             verbose: false,
             json_output: false,
-            emit_output: true,
+            // #294: the library default is QUIET — a bare `run()` returns the
+            // Report and prints nothing. The CLI sets `emit_output(true)`.
+            emit_output: false,
             json_stream: false,
             interrupt: None,
             json_stream_full_output: false,
@@ -4737,11 +4814,17 @@ mod client_run_return_value {
             .duration(10)
             .build()
             .unwrap();
-        let err = client.run().await.expect_err("expected ServerTerminated");
+        // #293: a server-terminated run is Ok(RunOutcome) now, carrying the
+        // partial report + Termination::ServerTerminated.
+        let outcome = client
+            .run()
+            .await
+            .expect("server-terminate run returns Ok(RunOutcome)");
         let printed = capture.take();
-        assert!(
-            matches!(err, RiperfError::ServerTerminated),
-            "iperf3's IESERVERTERM class, got {err:?}"
+        assert_eq!(
+            outcome.termination,
+            crate::outcome::Termination::ServerTerminated,
+            "iperf3's IESERVERTERM class"
         );
         assert!(
             printed.contains("sender"),
@@ -4814,10 +4897,16 @@ mod client_run_return_value {
             .duration(10)
             .build()
             .unwrap();
-        let err = client.run().await.expect_err("expected ServerTerminated");
-        assert!(
-            matches!(err, RiperfError::ServerTerminated),
-            "IESERVERTERM class since #170, got {err:?}"
+        // #293: server-terminate is Ok(RunOutcome) with the ServerTerminated
+        // ending (was Err(ServerTerminated)).
+        let outcome = client
+            .run()
+            .await
+            .expect("server-terminate run returns Ok(RunOutcome)");
+        assert_eq!(
+            outcome.termination,
+            crate::outcome::Termination::ServerTerminated,
+            "IESERVERTERM class since #170"
         );
         // Kernel socket buffers legitimately hold a few MB in flight on
         // loopback; the LEAK signature is continued line-rate production

--- a/riperf3/src/error.rs
+++ b/riperf3/src/error.rs
@@ -181,11 +181,9 @@ pub enum RiperfError {
     #[error("received an unknown control message (ensure other side is iperf3 and not iperf)")]
     UnknownControlMessage,
 
-    /// iperf3's IESERVERTERM: the server sent SERVER_TERMINATE mid-test; a
-    /// partial summary is rendered from local data before this surfaces (#170).
-    #[error("the server has terminated")]
-    ServerTerminated,
-
+    // #293: IESERVERTERM is no longer a client `run` error — a
+    // server-terminated run returns `Ok(RunOutcome)` with
+    // `Termination::ServerTerminated` and the partial report.
     /// iperf3's IECLIENTTERM: the client sent CLIENT_TERMINATE mid-test; the
     /// server dumps its partial results before this surfaces (#210). iperf3
     /// prints it WITHOUT the "error - " prefix ("iperf3: the client has
@@ -197,15 +195,10 @@ pub enum RiperfError {
     /// the control connection (iperf_error.c).
     #[error("control socket has closed unexpectedly")]
     PeerDisconnected,
-
-    /// iperf3's SERVER_ERROR relay (#224): the server failed mid-test and
-    /// sent its (i_errno, errno) pair on the control connection; the client
-    /// ADOPTS the mapped iperf_strerror text as its own error, exactly like
-    /// iperf_handle_message_client (iperf_client_api.c:392). The Display is
-    /// the mapped message alone — the CLI prefixes it ("riperf3: error - …"),
-    /// matching iperf3's errexit line.
-    #[error("{0}")]
-    ServerErrorRelayed(String),
+    // #293: the SERVER_ERROR relay (#224) is no longer a client `run` error —
+    // a relayed-error run returns `Ok(RunOutcome)` with
+    // `Termination::ServerError(msg)` and the partial report. The mapped
+    // iperf_strerror text now rides `Termination::ServerError`.
 }
 
 /// iperf3's SERVER_ERROR relay rendering, client side (#224). The errno

--- a/riperf3/src/lib.rs
+++ b/riperf3/src/lib.rs
@@ -32,9 +32,10 @@ mod error;
 pub use error::{ConfigError, Result, RiperfError};
 
 mod outcome;
-// The run-result model (#293): `Client::run`/`Server::run_once` return
-// `RunOutcome` (the measured `Report` + how the run ended) rather than
-// signaling an abnormal end through `Err`.
+// The run-result model (#293): `Client::run` returns `RunOutcome` (the
+// measured `Report` + how the run ended) rather than signaling an abnormal
+// end through `Err`. (`Server::run_once` keeps its `Report` return for now;
+// its RunOutcome symmetry is a follow-up.)
 pub use outcome::{RunOutcome, Termination};
 
 mod client;
@@ -47,11 +48,13 @@ pub use server::{BoundServer, Server, ServerBuilder};
 
 // The transport enum used across the public builder API. `TestResultsJson` /
 // `StreamResultJson` are the internal control-channel exchange model and are no
-// longer re-exported (0.8.0 breaking, #137) — `Client::run` now returns `Report`.
+// longer re-exported (0.8.0 breaking, #137).
 pub use protocol::TransportProtocol;
 
-// The rich iperf3-schema result model returned by `Client::run` and
-// `Server::run_once` — the same object `-J` / `--json` serializes (#137).
+// The rich iperf3-schema result model — the same object `-J` / `--json`
+// serializes (#137). Since 0.9.0 `Client::run` returns a `RunOutcome` carrying
+// this `Report` plus a `Termination` (#293); `Server::run_once` still returns
+// the `Report` directly.
 pub use json_report::Report;
 
 pub use net::set_cpu_affinity;
@@ -71,8 +74,9 @@ pub use macros::ErrorSinkGuard;
 // Crate-private (`pub(crate)`), so nothing here is a semver commitment; the
 // few genuinely-public types are re-exported at the crate root above (#67).
 // `json_report` is the exception — it is the iperf3-schema result model that
-// `Client::run` / `Server::run_once` return, so it is a documented public
-// module (#137); its top-level `Report` is re-exported at the crate root above.
+// `Client::run` returns inside a `RunOutcome` and `Server::run_once` returns
+// directly, so it is a documented public module (#137); its top-level `Report`
+// is re-exported at the crate root above.
 // The module's PUBLIC surface is `Report` + its serialized sub-structs only;
 // the builder INPUT types (`ReportInput`/`StreamReport`/`TcpEndExtras`/
 // `UdpStreamStats`) are `pub(crate)` (incidentally exposed by #137, hidden in

--- a/riperf3/src/lib.rs
+++ b/riperf3/src/lib.rs
@@ -31,6 +31,12 @@ mod macros;
 mod error;
 pub use error::{ConfigError, Result, RiperfError};
 
+mod outcome;
+// The run-result model (#293): `Client::run`/`Server::run_once` return
+// `RunOutcome` (the measured `Report` + how the run ended) rather than
+// signaling an abnormal end through `Err`.
+pub use outcome::{RunOutcome, Termination};
+
 mod client;
 pub use client::{Client, ClientBuilder};
 

--- a/riperf3/src/outcome.rs
+++ b/riperf3/src/outcome.rs
@@ -1,0 +1,91 @@
+//! The result of a test run (#293).
+//!
+//! Before 0.9.0, [`Client::run`](crate::Client::run) and
+//! [`Server::run_once`](crate::Server::run_once) returned `Result<Report>` and
+//! signaled an abnormal end inconsistently: a local signal came back as
+//! `Ok(Report)` with the partial data, but a server-terminated or
+//! server-relayed-error run came back as `Err` — with the partial report
+//! built, printed, then discarded, unreachable to a library caller.
+//!
+//! [`RunOutcome`] unifies that: every run that produced a report returns
+//! `Ok(RunOutcome)` carrying both the [`Report`] and a [`Termination`] saying
+//! how it ended. `Err` is reserved for runs that produced NO report at all — a
+//! failed connect or a control-handshake failure. A caller that only wants the
+//! data reads `outcome.report`; one that needs to branch on the ending matches
+//! `outcome.termination`.
+//!
+//! This changes only the Rust return shape: the wire bytes, the text/JSON the
+//! CLI prints, and the process exit codes are unchanged (the CLI maps
+//! [`Termination`] to the exit code it already produced).
+
+use crate::json_report::Report;
+
+/// How a test run ended (#293).
+///
+/// `non_exhaustive`: future end states are additive, not breaking.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum Termination {
+    /// The test ran to completion (iperf3's `IPERF_DONE`). The report is full.
+    Completed,
+
+    /// A local termination signal (SIGTERM/SIGINT/SIGHUP) ended the run.
+    /// iperf3 treats this as a normal exit (process exit 0); the report carries
+    /// the stats accumulated so far (empty if the signal landed before data).
+    Interrupted,
+
+    /// The server terminated the test mid-run (`SERVER_TERMINATE`, iperf3's
+    /// IESERVERTERM). The report carries the partial LOCAL stats — no peer half.
+    ServerTerminated,
+
+    /// The server relayed an error (`SERVER_ERROR`) — e.g. an upfront refusal
+    /// (`--server-bitrate-limit`, `--server-max-duration`) or a mid-test
+    /// breach. The `String` is iperf3's mapped `iperf_strerror` message.
+    ServerError(String),
+}
+
+impl Termination {
+    /// True for the endings iperf3 treats as a clean process exit (exit 0):
+    /// a completed run or a local signal. `ServerTerminated`/`ServerError` are
+    /// non-zero-exit endings. The CLI uses this for its exit-code mapping.
+    #[must_use]
+    pub fn is_clean_exit(&self) -> bool {
+        matches!(self, Termination::Completed | Termination::Interrupted)
+    }
+
+    /// The iperf3 errexit-line message for an abnormal ending, or `None` for a
+    /// clean exit. The CLI renders `riperf3: error - <msg>` from this on the
+    /// non-zero-exit paths (the library already emitted its doc/receipt line
+    /// during the run). Matches iperf3's `iperf_errexit` text.
+    #[must_use]
+    pub fn errexit_message(&self) -> Option<String> {
+        match self {
+            Termination::Completed | Termination::Interrupted => None,
+            Termination::ServerTerminated => Some("the server has terminated".to_string()),
+            Termination::ServerError(msg) => Some(msg.clone()),
+        }
+    }
+}
+
+/// The outcome of [`Client::run`](crate::Client::run) /
+/// [`Server::run_once`](crate::Server::run_once) (#293): the measured
+/// [`Report`] plus how the run ended.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct RunOutcome {
+    /// The measured report — full on a clean run, partial on an abnormal end.
+    /// The same object `-J` / `--json` serializes.
+    pub report: Report,
+
+    /// How the run ended.
+    pub termination: Termination,
+}
+
+impl RunOutcome {
+    pub(crate) fn new(report: Report, termination: Termination) -> Self {
+        Self {
+            report,
+            termination,
+        }
+    }
+}

--- a/riperf3/src/outcome.rs
+++ b/riperf3/src/outcome.rs
@@ -7,12 +7,19 @@
 //! server-relayed-error run came back as `Err` — with the partial report
 //! built, printed, then discarded, unreachable to a library caller.
 //!
-//! [`RunOutcome`] unifies that: every run that produced a report returns
+//! [`RunOutcome`] unifies that: the four common endings — a clean run, a local
+//! signal, a server-terminate, and a relayed `SERVER_ERROR` — all return
 //! `Ok(RunOutcome)` carrying both the [`Report`] and a [`Termination`] saying
-//! how it ended. `Err` is reserved for runs that produced NO report at all — a
-//! failed connect or a control-handshake failure. A caller that only wants the
-//! data reads `outcome.report`; one that needs to branch on the ending matches
+//! how it ended. `Err` covers runs that produced no report (a failed connect
+//! or control handshake). A caller that only wants the data reads
+//! `outcome.report`; one that needs to branch on the ending matches
 //! `outcome.termination`.
+//!
+//! Two rarer abnormal endings are NOT yet folded in and still return `Err`
+//! even though they emit a populated document in the JSON modes:
+//! `RiperfError::ControlSocketClosed` (#267) and `RiperfError::RecvResultsFailed`
+//! (#374). Folding those (and the `Server::run_once` side) into `Termination`
+//! is a follow-up; the CLI already renders them faithfully.
 //!
 //! This changes only the Rust return shape: the wire bytes, the text/JSON the
 //! CLI prints, and the process exit codes are unchanged (the CLI maps
@@ -45,14 +52,6 @@ pub enum Termination {
 }
 
 impl Termination {
-    /// True for the endings iperf3 treats as a clean process exit (exit 0):
-    /// a completed run or a local signal. `ServerTerminated`/`ServerError` are
-    /// non-zero-exit endings. The CLI uses this for its exit-code mapping.
-    #[must_use]
-    pub fn is_clean_exit(&self) -> bool {
-        matches!(self, Termination::Completed | Termination::Interrupted)
-    }
-
     /// The iperf3 errexit-line message for an abnormal ending, or `None` for a
     /// clean exit. The CLI renders `riperf3: error - <msg>` from this on the
     /// non-zero-exit paths (the library already emitted its doc/receipt line

--- a/riperf3/src/protocol.rs
+++ b/riperf3/src/protocol.rs
@@ -2100,11 +2100,15 @@ mod protocol_error_tests {
             .build()
             .unwrap();
         let result = client.run().await;
-        let err = result.expect_err("client should error on ServerError");
+        // #293: a relayed SERVER_ERROR is Ok(RunOutcome) with the adopted
+        // message on Termination::ServerError.
+        let outcome = result.expect("relayed SERVER_ERROR returns Ok(RunOutcome)");
+        let crate::outcome::Termination::ServerError(msg) = outcome.termination else {
+            panic!("expected ServerError, got {:?}", outcome.termination);
+        };
         assert_eq!(
-            err.to_string(),
-            "total required bandwidth is larger than server limit",
-            "the client adopts the relayed iperf_strerror(27): {err:?}"
+            msg, "total required bandwidth is larger than server limit",
+            "the client adopts the relayed iperf_strerror(27)"
         );
         let _ = server_task.await;
     }
@@ -2141,17 +2145,21 @@ mod protocol_error_tests {
             .build()
             .unwrap();
         let result = client.run().await;
-        let err = result.expect_err("client should error on ServerError");
+        // #293: Ok(RunOutcome) with the adopted perr-class message.
+        let outcome = result.expect("relayed SERVER_ERROR returns Ok(RunOutcome)");
+        let crate::outcome::Termination::ServerError(msg) = outcome.termination else {
+            panic!("expected ServerError, got {:?}", outcome.termination);
+        };
         assert_eq!(
-            err.to_string(),
-            "server test duration expired: ",
-            "the client adopts the relayed perr-class strerror(160) with GT's dangling ': ' (#248): {err:?}"
+            msg, "server test duration expired: ",
+            "the client adopts the relayed perr-class strerror(160) with GT's dangling ': ' (#248)"
         );
         let _ = server_task.await;
     }
 
     /// A SERVER_ERROR whose payload never arrives (peer died mid-relay, or a
-    /// pre-payload sender): still an error, never a hang or a panic.
+    /// pre-payload sender): still classified as a server error (#293:
+    /// Ok(RunOutcome) with the "server error" fallback), never a hang or panic.
     #[tokio::test]
     async fn client_handles_server_error_without_payload() {
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -2175,7 +2183,15 @@ mod protocol_error_tests {
             .build()
             .unwrap();
         let result = client.run().await;
-        assert!(result.is_err(), "bare SERVER_ERROR is still an error");
+        let outcome = result.expect("payload-less SERVER_ERROR returns Ok(RunOutcome)");
+        assert!(
+            matches!(
+                outcome.termination,
+                crate::outcome::Termination::ServerError(_)
+            ),
+            "bare SERVER_ERROR is still classified as a server error, got {:?}",
+            outcome.termination
+        );
         let _ = server_task.await;
     }
 

--- a/riperf3/src/protocol.rs
+++ b/riperf3/src/protocol.rs
@@ -2195,6 +2195,46 @@ mod protocol_error_tests {
         let _ = server_task.await;
     }
 
+    /// #293/#210: SERVER_TERMINATE arriving in ANY state (here pre-TestStart,
+    /// at the central state wait — distinct from the mid-test arm covered by
+    /// the client-side lib tests) returns Ok(RunOutcome) with
+    /// Termination::ServerTerminated, not an Err.
+    #[tokio::test]
+    async fn client_handles_server_terminate_any_state() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        let server_task = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let mut cookie = [0u8; 37];
+            tokio::io::AsyncReadExt::read_exact(&mut stream, &mut cookie)
+                .await
+                .unwrap();
+            // SERVER_TERMINATE before ParamExchange — the any-state arm.
+            protocol::send_state(&mut stream, TestState::ServerTerminate)
+                .await
+                .unwrap();
+            // Hold the socket so the client reads the state, not a bare EOF.
+            tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+        });
+
+        let client = crate::ClientBuilder::new("127.0.0.1")
+            .port(Some(addr.port()))
+            .duration(1)
+            .build()
+            .unwrap();
+        let outcome = client
+            .run()
+            .await
+            .expect("any-state SERVER_TERMINATE returns Ok(RunOutcome)");
+        assert_eq!(
+            outcome.termination,
+            crate::outcome::Termination::ServerTerminated,
+            "the central-wait ServerTerminate arm maps to Termination::ServerTerminated"
+        );
+        let _ = server_task.await;
+    }
+
     #[tokio::test]
     async fn client_handles_peer_disconnect_during_handshake() {
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -4099,7 +4099,8 @@ impl Default for ServerBuilder {
             time_skew_threshold: 10,
             use_pkcs1_padding: false,
             json_output: false,
-            emit_output: true,
+            // #294: quiet by default (see ClientBuilder); the CLI opts in.
+            emit_output: false,
             json_stream: false,
             interrupt: None,
             json_stream_full_output: false,

--- a/riperf3/tests/bound_server.rs
+++ b/riperf3/tests/bound_server.rs
@@ -18,6 +18,7 @@ async fn run_client(port: u16) -> riperf3::Report {
         .await
         .expect("client hung")
         .expect("client errored")
+        .report
 }
 
 /// One bind, two sequential tests on the same listener — the accept()-style

--- a/riperf3/tests/integration.rs
+++ b/riperf3/tests/integration.rs
@@ -1811,8 +1811,16 @@ mod unimplemented_flags {
             .expect("the interrupt must be honored in the setup-phase wait (#231)")
             .expect("join");
         // GT dumps + returns normally (iperf_got_sigend's client arm has no
-        // phase gate); the signal-normal EXIT is the CLI's business.
-        assert!(res.is_ok(), "{res:?}");
+        // phase gate); the signal-normal EXIT is the CLI's business. #293: the
+        // run is Ok(RunOutcome) with Termination::Interrupted — distinct from
+        // Completed, and since BOTH exit 0, this is the only assertion that
+        // catches an Interrupted↔Completed mis-map.
+        let outcome = res.expect("interrupt run returns Ok(RunOutcome)");
+        assert_eq!(
+            outcome.termination,
+            riperf3::Termination::Interrupted,
+            "a local signal ends Interrupted"
+        );
         mock.abort();
     }
 

--- a/riperf3/tests/integration.rs
+++ b/riperf3/tests/integration.rs
@@ -397,7 +397,7 @@ async fn tcp_reverse_bytes_limit_terminates() {
     // rate the 100ms end-condition poll overshoots the target (a pre-existing
     // characteristic shared with forward `-n`), so this guards termination +
     // floor, not an exact byte count.
-    let transferred: u64 = res.end.sum_sent.as_ref().unwrap().bytes;
+    let transferred: u64 = res.report.end.sum_sent.as_ref().unwrap().bytes;
     assert!(
         transferred >= target,
         "transferred {transferred} < requested {target}"
@@ -433,7 +433,7 @@ async fn tcp_reverse_blocks_limit_terminates() {
     let result = tokio::time::timeout(Duration::from_secs(15), client.run()).await;
     assert!(result.is_ok(), "-R -k hung — issue #60 regression");
     let res = result.unwrap().expect("-R -k errored");
-    let transferred: u64 = res.end.sum_sent.as_ref().unwrap().bytes;
+    let transferred: u64 = res.report.end.sum_sent.as_ref().unwrap().bytes;
     assert!(
         transferred >= blocks * blksize as u64,
         "transferred {transferred} < requested {blocks} blocks"
@@ -470,7 +470,7 @@ async fn tcp_byte_limit_overshoot_bounded_forward() {
         .await
         .expect("client hung")
         .expect("client errored");
-    let bytes: u64 = result.end.sum_received.as_ref().unwrap().bytes;
+    let bytes: u64 = result.report.end.sum_received.as_ref().unwrap().bytes;
     assert!(
         bytes > target / 2,
         "transferred {bytes} far below target {target}"
@@ -505,7 +505,7 @@ async fn tcp_byte_limit_overshoot_bounded_reverse() {
         .await
         .expect("client hung")
         .expect("client errored");
-    let bytes: u64 = result.end.sum_sent.as_ref().unwrap().bytes;
+    let bytes: u64 = result.report.end.sum_sent.as_ref().unwrap().bytes;
     assert!(
         bytes > target / 2,
         "transferred {bytes} far below target {target}"
@@ -548,7 +548,7 @@ async fn tcp_bitrate_is_paced() {
         .expect("client hung")
         .expect("client errored");
     // run() returns the rich report; forward → server received ≈ what we sent.
-    let bytes: u64 = result.end.sum_received.as_ref().unwrap().bytes;
+    let bytes: u64 = result.report.end.sum_received.as_ref().unwrap().bytes;
     let achieved = bytes * 8 / secs;
     // Unpaced this is line rate (tens of Gbit/s, >100x target). Paced lands near
     // target; allow a generous band for burst/timing slack.
@@ -591,7 +591,7 @@ async fn tcp_low_bitrate_no_overshoot() {
         .await
         .expect("client hung")
         .expect("client errored");
-    let bytes: u64 = result.end.sum_received.as_ref().unwrap().bytes;
+    let bytes: u64 = result.report.end.sum_received.as_ref().unwrap().bytes;
     let budget = (target / 8 * secs) as f64; // 250 KB
     let bound = budget * 1.25 + (128 * 1024) as f64;
     assert!(
@@ -623,7 +623,7 @@ async fn tcp_unlimited_is_not_paced() {
         .await
         .expect("client hung")
         .expect("client errored");
-    let bytes: u64 = result.end.sum_received.as_ref().unwrap().bytes;
+    let bytes: u64 = result.report.end.sum_received.as_ref().unwrap().bytes;
     // A 200 Mbit cap would yield ~25 MB in 1 s; unthrottled loopback moves far
     // more. >200 MB confirms pacing didn't leak into the rate-0 path.
     assert!(
@@ -661,7 +661,7 @@ async fn tcp_bitrate_reverse_is_paced() {
         .expect("client hung")
         .expect("client errored");
     // Reverse: the server sends; its reported bytes ≈ what it paced out.
-    let bytes: u64 = result.end.sum_sent.as_ref().unwrap().bytes;
+    let bytes: u64 = result.report.end.sum_sent.as_ref().unwrap().bytes;
     let achieved = bytes * 8 / secs;
     assert!(
         achieved < target * 2,
@@ -1843,11 +1843,16 @@ mod unimplemented_flags {
             elapsed.as_secs() < 4,
             "the refusal is upfront — no transfer, no timer wait: {elapsed:?}"
         );
-        let err = result.expect_err("the relayed SERVER_ERROR is the client's error");
+        // #293: Ok(RunOutcome) carrying the adopted message.
+        let outcome = result.expect("the relayed SERVER_ERROR returns Ok(RunOutcome)");
         assert_eq!(
-            err.to_string(),
-            "client's requested duration exceeds the server's maximum permitted limit",
-            "{err:?}"
+            outcome.termination,
+            riperf3::Termination::ServerError(
+                "client's requested duration exceeds the server's maximum permitted limit"
+                    .to_string()
+            ),
+            "{:?}",
+            outcome.termination
         );
         // The server side errors to ITS sink but run() is Ok - iperf3's
         // one-off exits 0 on the refusal path (live-verified, the #224 wart).
@@ -1884,12 +1889,16 @@ mod unimplemented_flags {
             "bitrate limit didn't cut test: {elapsed:?}"
         );
         // #224 ground truth (iperf 3.21): SERVER_ERROR + IETOTALRATE, the
-        // client adopts iperf_strerror(27); no generic ServerTerminated.
-        let err = result.expect_err("the relayed SERVER_ERROR is the client's error");
+        // client adopts iperf_strerror(27). #293: Ok(RunOutcome) with the
+        // ServerError ending.
+        let outcome = result.expect("the relayed SERVER_ERROR returns Ok(RunOutcome)");
         assert_eq!(
-            err.to_string(),
-            "total required bandwidth is larger than server limit",
-            "{err:?}"
+            outcome.termination,
+            riperf3::Termination::ServerError(
+                "total required bandwidth is larger than server limit".to_string()
+            ),
+            "{:?}",
+            outcome.termination
         );
         let joined = server_task.await.expect("server task");
         assert!(
@@ -2378,7 +2387,8 @@ mod client_run_return_value {
             .build()
             .unwrap();
 
-        let report = client.run().await.expect("client run failed");
+        // #293: run() returns a RunOutcome; this test inspects the report.
+        let report = client.run().await.expect("client run failed").report;
 
         // The end block carries both halves on a forward run.
         assert!(
@@ -2540,9 +2550,15 @@ async fn server_refuses_over_limit_rate_upfront() {
         let server_result = server_task.await.expect("server task");
 
         if refused {
+            // #293: a relayed SERVER_ERROR is Ok(RunOutcome) now, carrying the
+            // partial report + Termination::ServerError(msg).
             match result {
-                Err(riperf3::RiperfError::ServerErrorRelayed(msg)) => {
-                    assert_eq!(msg, MSG, "GT strerror(27), perr=0 — no trailing colon");
+                Ok(outcome) => {
+                    assert_eq!(
+                        outcome.termination,
+                        riperf3::Termination::ServerError(MSG.to_string()),
+                        "GT strerror(27), perr=0 — no trailing colon"
+                    );
                 }
                 other => panic!(
                     "bw={bw} fq={fq} P={streams} bidir={bidir}: expected the \
@@ -2610,9 +2626,13 @@ async fn both_violations_relay_total_rate_like_gt() {
         .expect("client hung");
     let _ = server_task.await;
     match result {
-        Err(riperf3::RiperfError::ServerErrorRelayed(msg)) => {
+        // #293: Ok(RunOutcome) with the ServerError termination.
+        Ok(outcome) => {
             assert_eq!(
-                msg, "total required bandwidth is larger than server limit",
+                outcome.termination,
+                riperf3::Termination::ServerError(
+                    "total required bandwidth is larger than server limit".to_string()
+                ),
                 "the rate refusal wins over the duration refusal (GT last-assignment)"
             );
         }
@@ -2648,7 +2668,8 @@ async fn server_paces_reverse_with_the_client_fq_rate() {
     let report = tokio::time::timeout(Duration::from_secs(25), client.run())
         .await
         .expect("client hung")
-        .expect("client errored");
+        .expect("client errored")
+        .report;
     let bps = report.end.sum_received.as_ref().unwrap().bits_per_second;
     assert!(
         bps < 20_000_000.0,

--- a/riperf3/tests/integration.rs
+++ b/riperf3/tests/integration.rs
@@ -2387,8 +2387,15 @@ mod client_run_return_value {
             .build()
             .unwrap();
 
-        // #293: run() returns a RunOutcome; this test inspects the report.
-        let report = client.run().await.expect("client run failed").report;
+        // #293: run() returns a RunOutcome; a clean run ends Completed, and
+        // this test inspects the report it carries.
+        let outcome = client.run().await.expect("client run failed");
+        assert_eq!(
+            outcome.termination,
+            riperf3::Termination::Completed,
+            "a clean run ends Completed"
+        );
+        let report = outcome.report;
 
         // The end block carries both halves on a forward run.
         assert!(

--- a/riperf3/tests/quiet_output.rs
+++ b/riperf3/tests/quiet_output.rs
@@ -53,13 +53,20 @@ fn child_quiet_server_then_loud_pair() {
 
         // Phase 2: a fully LOUD pair in the same process — proves every quiet
         // guard dropped back to zero (a leaked increment would silence this).
-        let server = riperf3::ServerBuilder::new().port(Some(0)).build().unwrap();
+        // #294: the library default is now quiet, so the loud pair opts in
+        // explicitly with emit_output(true).
+        let server = riperf3::ServerBuilder::new()
+            .port(Some(0))
+            .emit_output(true)
+            .build()
+            .unwrap();
         let bound = server.bind().await.unwrap();
         let port = bound.local_addr().unwrap().port();
         let server_task = tokio::spawn(async move { bound.run_once().await });
         let client = riperf3::ClientBuilder::new("127.0.0.1")
             .port(Some(port))
             .duration(1)
+            .emit_output(true)
             .build()
             .unwrap();
         client.run().await.expect("phase-2 client");
@@ -91,7 +98,7 @@ fn child_quiet_json_stream() {
             .emit_output(false)
             .build()
             .unwrap();
-        let report = client.run().await.expect("client run");
+        let report = client.run().await.expect("client run").report;
         assert!(
             report.end.sum_sent.as_ref().unwrap().bytes > 0,
             "quiet json-stream still returns the report"
@@ -124,7 +131,7 @@ fn child_run(quiet: bool) {
             .emit_output(!quiet)
             .build()
             .unwrap();
-        let report = client.run().await.expect("client run");
+        let report = client.run().await.expect("client run").report;
         assert!(
             report.end.sum_sent.as_ref().unwrap().bytes > 0,
             "the quiet run still returns a real report"

--- a/riperf3/tests/stream_thread_readiness.rs
+++ b/riperf3/tests/stream_thread_readiness.rs
@@ -74,7 +74,8 @@ fn udp_bidir_window_waits_for_stream_threads() {
                 tokio::task::spawn_blocking(move || std::thread::sleep(HOG_LIFETIME));
             }
             match client.run().await {
-                Ok(r) => break r,
+                // #293: run() returns a RunOutcome; this test inspects the report.
+                Ok(r) => break r.report,
                 Err(RiperfError::Io(e))
                     if e.kind() == std::io::ErrorKind::ConnectionRefused
                         && tokio::time::Instant::now() < deadline =>


### PR DESCRIPTION
Closes #293. Closes #294. The 0.9.0 library-first `run` contract migration (client side).

Both issues reshape the same "library-first `run`" surface, so they ship together.

## #293 — `Client::run` returns `RunOutcome`

`Client::run` now returns `Result<RunOutcome>`, where `RunOutcome { report, termination }` and `Termination` is `Completed | Interrupted | ServerTerminated | ServerError(String)`. The rule:

- **`Ok(RunOutcome)`** for every run that produced a report — the measured `Report` plus how it ended.
- **`Err`** for runs that produced no report (failed connect / control handshake). Two rarer classes — `ControlSocketClosed` (#267) and `RecvResultsFailed` (#374) — still return `Err` despite emitting a doc; folding them in is a follow-up (noted in the module docs).

This fixes both problems the issue names:
1. **Lossy** — a server-terminated or relayed-`SERVER_ERROR` run used to build + print the partial report and then discard it behind an `Err`; a library caller couldn't reach it. Now it's `Ok(RunOutcome)` carrying that report.
2. **Inconsistent** — "ended early with partial data" was signaled two ways (interrupt = `Ok(Report{error})`, server-terminate = `Err`). Now every such ending is `Ok(RunOutcome)` with the ending in `termination`, and the compiler forces callers to handle each case.

The `RiperfError::ServerTerminated` / `ServerErrorRelayed` variants are **removed** (they're `Termination`s now).

### Faithfulness / scope

This changes **only the Rust return shape** — the wire bytes, the text/JSON the CLI prints, and the process exit codes are byte-identical. The CLI reads `termination` and maps it to the exit code it already produced: `Completed`/`Interrupted` → 0, `ServerTerminated`/`ServerError` → 1 (via `AbnormalExit`, which carries the errexit message so the `riperf3: error - <msg>` line renders exactly as before; the JSON modes suppress a second render since the lib already emitted the doc). iperf3 has no analogous inconsistency — it returns a bare `int` and prints in-band — so this is a pure library-API-ergonomics improvement, not a divergence.

**`Server::run_once` keeps its `Report` return in this PR.** #293 notes it "should get the same treatment for symmetry," but the server's termination taxonomy is much richer (client-terminated, control-closed, the #371 send classes, self-terminate, unknown-message) and needs its own design — filed as a follow-up, stacked on this PR (task/issue to follow).

## #294 — quiet library default

The builder `emit_output` default flips to `false`: a bare `run()`/`run_once()` returns the report and prints nothing. The faithful-output contract belongs to the **CLI**, which now sets `.emit_output(true)` explicitly. `-J`, `--json-stream`, text, `--get-server-output` — all unchanged for CLI users.

## Tests + verification

- Rewrote the ~6 server-terminate / relayed-error tests to the new contract (`Ok` + `termination` match) and swept the ~30 report-field call sites (`.report.end` etc.); added a `Completed`-on-clean pin and a pin for the previously-untested **any-state** `ServerTerminate` arm (a pre-existing gap the mutation check exposed).
- Mutation-checked the key mappings: mid-test + any-state `ServerTerminated` arms and the `errexit_message` mapping all red their pins.
- Green: 414 lib tests, all integration / quiet_output / bound_server / stream / teardown suites, full CLI suite (bar the known #349-family load flakes, green isolated). `fmt` + `clippy -D warnings` clean.

## Migration (for library consumers)

```
let report = client.run().await?;            // before
let report = client.run().await?.report;     // after (or match .termination)
```

Bare library runs are now silent; add `.emit_output(true)` to restore iperf3's printed output.
