### PR TITLE
docs: reframe fidelity as wire- and API-faithful in idiomatic Rust

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to riperf3
 
-Thanks for your interest! riperf3 is a faithful, wire-compatible iperf3 drop-in — the ethos is **fidelity first**: where iperf3 accepts an option, riperf3 implements it to behave the same way (quirks included); it never rejects, renames, or works around iperf3's semantics. Behavioral claims in PRs should cite the iperf3 source (file/function) or a live run against a real iperf3 binary.
+Thanks for your interest! riperf3 is a wire- and API-faithful replacement for iperf3 in idiomatic Rust — the ethos is **fidelity first**: where iperf3 accepts an option, riperf3 implements it to behave the same way; it never rejects, renames, or works around iperf3's semantics. Behavioral claims in PRs should cite the iperf3 source (file/function) or a live run against a real iperf3 binary.
 
 ## Workflow
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A ground-up, idiomatic Rust implementation of [iperf3](https://github.com/esnet/iperf), the standard network performance measurement tool — not a C port or a binding, but a faithful reimplementation in safe, async Rust.
 
-riperf3 speaks iperf3's exact wire protocol: a riperf3 client interoperates with an iperf3 server, and vice versa, across every mode. Fidelity is the guiding principle — riperf3 matches iperf3 flag for flag and quirk for quirk rather than reinventing the interface. Where iperf3 accepts an option, riperf3 implements it to behave the same way; it does not reject, rename, or work around iperf3's semantics. The goal is a drop-in you can swap in without your scripts, dashboards, or muscle memory noticing.
+riperf3 speaks iperf3's exact wire protocol: a riperf3 client interoperates with an iperf3 server, and vice versa, across every mode. It's a wire- and API-faithful replacement for iperf3 in idiomatic Rust — the protocol and the CLI/flag surface match iperf3, so where iperf3 accepts an option, riperf3 implements it to behave the same way; it does not reject, rename, or work around iperf3's semantics. The goal is a drop-in you can swap in without your scripts, dashboards, or muscle memory noticing.
 
 ## Highlights
 


### PR DESCRIPTION
Drops the "quirk for quirk" (README) / "(quirks included)" (CONTRIBUTING) framing per Evan, reframing the fidelity statement as a wire- and API-faithful replacement for iperf3 in idiomatic Rust. Docs-only; wording dictated by the maintainer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)