### PR TITLE
feat: Server::run_once returns RunOutcome (server-side #293 symmetry)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,11 @@ release tags.
   The `RiperfError::ServerTerminated` /
   `ServerErrorRelayed` variants are removed. Migration: `client.run().await?` →
   `client.run().await?.report`; branch on `outcome.termination` for the ending.
+- `Server::run_once` / `BoundServer::run_once` likewise return `RunOutcome` instead of `Report`
+  (#293): a report-producing abnormal end (client-terminate, control-close, a
+  `--server-bitrate-limit`/`--server-max-duration` self-terminate) is now `Ok` with the partial
+  report plus a server-side `Termination`, not an `Err` that discarded it. Migration:
+  `server.run_once().await?` → `server.run_once().await?.report`.
 - The builder output default flips to quiet (#294): a bare `run()`/`run_once()` returns the
   report and prints nothing. Opt into iperf3's full text/JSON output with `.emit_output(true)`
   (the CLI sets this). Wire protocol, CLI output, and exit codes are unchanged.

--- a/riperf3/src/error.rs
+++ b/riperf3/src/error.rs
@@ -45,11 +45,13 @@ pub enum RiperfError {
     #[error("test aborted: {0}")]
     Aborted(String),
 
-    /// iperf3's IECTRLCLOSE: the control connection died mid-test — the
-    /// client's class (#170), and since #330 the SERVER's doc'd mid/end-loop
-    /// EOF return from `run_once` (the doc/stderr carry GT's read-site
-    /// sentence "the client has unexpectedly closed the connection"; the
-    /// round is clean in GT, exit 0).
+    /// iperf3's IECTRLCLOSE: the control connection died — the client's mid-test
+    /// class (#170) and the SERVER's SETUP-phase EOF (since #330), before any
+    /// report exists. Post-#293/#409 the server's mid/end-loop EOF is instead
+    /// `Termination::ControlClosed` (an `Ok(RunOutcome)` carrying the partial
+    /// report), so on the server this `Err` is setup-phase-only. The doc/stderr
+    /// carry GT's read-site sentence "the client has unexpectedly closed the
+    /// connection"; the round is clean in GT, exit 0.
     #[error("control socket has closed unexpectedly")]
     ControlSocketClosed,
 

--- a/riperf3/src/lib.rs
+++ b/riperf3/src/lib.rs
@@ -32,10 +32,9 @@ mod error;
 pub use error::{ConfigError, Result, RiperfError};
 
 mod outcome;
-// The run-result model (#293): `Client::run` returns `RunOutcome` (the
-// measured `Report` + how the run ended) rather than signaling an abnormal
-// end through `Err`. (`Server::run_once` keeps its `Report` return for now;
-// its RunOutcome symmetry is a follow-up.)
+// The run-result model (#293): `Client::run` and `Server::run_once` both return
+// `RunOutcome` (the measured `Report` + how the run ended) rather than signaling
+// an abnormal end through `Err`.
 pub use outcome::{RunOutcome, Termination};
 
 mod client;
@@ -52,9 +51,8 @@ pub use server::{BoundServer, Server, ServerBuilder};
 pub use protocol::TransportProtocol;
 
 // The rich iperf3-schema result model — the same object `-J` / `--json`
-// serializes (#137). Since 0.9.0 `Client::run` returns a `RunOutcome` carrying
-// this `Report` plus a `Termination` (#293); `Server::run_once` still returns
-// the `Report` directly.
+// serializes (#137). Since 0.9.0 both `Client::run` and `Server::run_once`
+// return a `RunOutcome` carrying this `Report` plus a `Termination` (#293).
 pub use json_report::Report;
 
 pub use net::set_cpu_affinity;
@@ -74,9 +72,9 @@ pub use macros::ErrorSinkGuard;
 // Crate-private (`pub(crate)`), so nothing here is a semver commitment; the
 // few genuinely-public types are re-exported at the crate root above (#67).
 // `json_report` is the exception — it is the iperf3-schema result model that
-// `Client::run` returns inside a `RunOutcome` and `Server::run_once` returns
-// directly, so it is a documented public module (#137); its top-level `Report`
-// is re-exported at the crate root above.
+// `Client::run` and `Server::run_once` both return inside a `RunOutcome`, so it
+// is a documented public module (#137); its top-level `Report` is re-exported
+// at the crate root above.
 // The module's PUBLIC surface is `Report` + its serialized sub-structs only;
 // the builder INPUT types (`ReportInput`/`StreamReport`/`TcpEndExtras`/
 // `UdpStreamStats`) are `pub(crate)` (incidentally exposed by #137, hidden in

--- a/riperf3/src/outcome.rs
+++ b/riperf3/src/outcome.rs
@@ -29,18 +29,28 @@ use crate::json_report::Report;
 
 /// How a test run ended (#293).
 ///
+/// Shared by [`Client::run`](crate::Client::run) and
+/// [`Server::run_once`](crate::Server::run_once). Some variants are role-
+/// specific: `ServerTerminated`/`ServerError` only occur on the client side
+/// (the server told the client), and `ClientTerminated`/`ControlClosed`/
+/// `ProtocolError`/`SelfTerminated` only on the server side (what the server
+/// saw). `Completed` and `Interrupted` occur on both.
+///
 /// `non_exhaustive`: future end states are additive, not breaking.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum Termination {
     /// The test ran to completion (iperf3's `IPERF_DONE`). The report is full.
+    /// (Both roles.)
     Completed,
 
     /// A local termination signal (SIGTERM/SIGINT/SIGHUP) ended the run.
     /// iperf3 treats this as a normal exit (process exit 0); the report carries
     /// the stats accumulated so far (empty if the signal landed before data).
+    /// (Both roles.)
     Interrupted,
 
+    // --- Client-side endings (the server told the client) ---
     /// The server terminated the test mid-run (`SERVER_TERMINATE`, iperf3's
     /// IESERVERTERM). The report carries the partial LOCAL stats — no peer half.
     ServerTerminated,
@@ -49,19 +59,62 @@ pub enum Termination {
     /// (`--server-bitrate-limit`, `--server-max-duration`) or a mid-test
     /// breach. The `String` is iperf3's mapped `iperf_strerror` message.
     ServerError(String),
+
+    // --- Server-side endings (what the server observed) ---
+    /// The client sent `CLIENT_TERMINATE` mid-test (iperf3's IECLIENTTERM —
+    /// the symmetric counterpart of [`Self::ServerTerminated`]). The report
+    /// carries the server's partial stats.
+    ClientTerminated,
+
+    /// The client's control connection closed abruptly mid/post-test (iperf3's
+    /// IECTRLCLOSE). The report carries the accumulated stats.
+    ControlClosed,
+
+    /// The client sent an unrecognized control message (iperf3's IEMESSAGE).
+    /// The report carries the accumulated stats.
+    UnknownMessage,
+
+    /// The post-test results exchange failed (iperf3's IERECVRESULTS). The
+    /// report carries the accumulated stats.
+    RecvResultsFailed,
+
+    /// An exchange-phase send to the client failed (iperf3's IESENDMESSAGE /
+    /// IESENDRESULTS, #371). The `String` is iperf3's mapped message. The
+    /// report carries the accumulated stats.
+    SendFailed(String),
+
+    /// The server ended the test on its OWN limit — `--server-bitrate-limit`,
+    /// the `--server-max-duration` watchdog, or the idle watchdog (the symmetric
+    /// counterpart, server-side, of the client's [`Self::ServerError`]). The
+    /// `String` is the reason. The report carries the partial stats.
+    SelfTerminated(String),
 }
 
 impl Termination {
-    /// The iperf3 errexit-line message for an abnormal ending, or `None` for a
-    /// clean exit. The CLI renders `riperf3: error - <msg>` from this on the
-    /// non-zero-exit paths (the library already emitted its doc/receipt line
-    /// during the run). Matches iperf3's `iperf_errexit` text.
+    /// The iperf3 errexit-line message for a CLIENT abnormal ending that exits
+    /// non-zero, or `None` otherwise. The CLI renders `riperf3: error - <msg>`
+    /// from this on the client's non-zero-exit paths (the library already
+    /// emitted its doc/receipt line during the run). Matches iperf3's
+    /// `iperf_errexit` text.
+    ///
+    /// The server-side endings return `None`: iperf3's server keeps serving
+    /// (or a one-off exits 0) even on a failed round — `main` errexits only
+    /// on setup failures (rc < -1), the #224 wart — so they do not drive a
+    /// non-zero exit through this path.
     #[must_use]
     pub fn errexit_message(&self) -> Option<String> {
         match self {
-            Termination::Completed | Termination::Interrupted => None,
             Termination::ServerTerminated => Some("the server has terminated".to_string()),
             Termination::ServerError(msg) => Some(msg.clone()),
+            // Clean exits + all server-side endings (no client errexit).
+            Termination::Completed
+            | Termination::Interrupted
+            | Termination::ClientTerminated
+            | Termination::ControlClosed
+            | Termination::UnknownMessage
+            | Termination::RecvResultsFailed
+            | Termination::SendFailed(_)
+            | Termination::SelfTerminated(_) => None,
         }
     }
 }

--- a/riperf3/src/outcome.rs
+++ b/riperf3/src/outcome.rs
@@ -7,19 +7,23 @@
 //! server-relayed-error run came back as `Err` — with the partial report
 //! built, printed, then discarded, unreachable to a library caller.
 //!
-//! [`RunOutcome`] unifies that: the four common endings — a clean run, a local
-//! signal, a server-terminate, and a relayed `SERVER_ERROR` — all return
-//! `Ok(RunOutcome)` carrying both the [`Report`] and a [`Termination`] saying
-//! how it ended. `Err` covers runs that produced no report (a failed connect
-//! or control handshake). A caller that only wants the data reads
+//! [`RunOutcome`] unifies that: a report-producing run — clean or abnormal —
+//! returns `Ok(RunOutcome)` carrying both the [`Report`] and a [`Termination`]
+//! saying how it ended. The client's endings are a clean run, a local signal, a
+//! `SERVER_TERMINATE`, and a relayed `SERVER_ERROR`; the server's are a clean
+//! run, a local signal, and each peer/self abnormal end ([`Termination`]
+//! enumerates them). `Err` is reserved for a round that produced no report at
+//! all — a failed connect or control handshake, or a server round interrupted
+//! before any test started. A caller that only wants the data reads
 //! `outcome.report`; one that needs to branch on the ending matches
 //! `outcome.termination`.
 //!
-//! Two rarer abnormal endings are NOT yet folded in and still return `Err`
-//! even though they emit a populated document in the JSON modes:
+//! Two rarer CLIENT-side abnormal endings are not yet folded in and still
+//! return `Err` even though they emit a populated document in the JSON modes:
 //! `RiperfError::ControlSocketClosed` (#267) and `RiperfError::RecvResultsFailed`
-//! (#374). Folding those (and the `Server::run_once` side) into `Termination`
-//! is a follow-up; the CLI already renders them faithfully.
+//! (#374). Folding those client paths into a [`Termination`] is a follow-up;
+//! the CLI already renders them faithfully. (The server side is complete — its
+//! `ControlClosed`/`RecvResultsFailed` endings are [`Termination`] variants.)
 //!
 //! This changes only the Rust return shape: the wire bytes, the text/JSON the
 //! CLI prints, and the process exit codes are unchanged (the CLI maps
@@ -33,8 +37,9 @@ use crate::json_report::Report;
 /// [`Server::run_once`](crate::Server::run_once). Some variants are role-
 /// specific: `ServerTerminated`/`ServerError` only occur on the client side
 /// (the server told the client), and `ClientTerminated`/`ControlClosed`/
-/// `ProtocolError`/`SelfTerminated` only on the server side (what the server
-/// saw). `Completed` and `Interrupted` occur on both.
+/// `UnknownMessage`/`RecvResultsFailed`/`SendFailed`/`SelfTerminated` only on
+/// the server side (what the server saw). `Completed` and `Interrupted` occur
+/// on both.
 ///
 /// `non_exhaustive`: future end states are additive, not breaking.
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -570,25 +570,62 @@ impl Server {
             let mut idle_restart = false;
             match self.handle_one_test(&listener).await {
                 // #137: the daemon loop discards each test's Report; library
-                // users who want it call `run_once`.
-                Ok(_) => {}
+                // users who want it call `run_once`. #293: a completed round
+                // returns its Termination — the per-class stderr line that used
+                // to hang off the returned Err now hangs off this match.
+                Ok(Some((_report, termination))) => {
+                    if !json && !crate::macros::output_quiet() {
+                        use crate::outcome::Termination;
+                        let prefix = crate::macros::output_timestamp_prefix();
+                        match &termination {
+                            // #210: IECLIENTTERM, no "error - " prefix.
+                            Termination::ClientTerminated => {
+                                eprintln!("{prefix}riperf3: {}", RiperfError::ClientTerminated)
+                            }
+                            // #330: the mid/end-loop control EOF read-site line.
+                            Termination::ControlClosed => {
+                                eprintln!("{prefix}riperf3: {CTRL_CLOSED_MSG}")
+                            }
+                            // #325: IEMESSAGE, one line.
+                            Termination::UnknownMessage => eprintln!(
+                                "{prefix}riperf3: error - {}",
+                                RiperfError::UnknownControlMessage
+                            ),
+                            // #330: IERECVRESULTS, the #248 errno-0 dangling ": ".
+                            Termination::RecvResultsFailed => eprintln!(
+                                "{prefix}riperf3: error - {}: ",
+                                RiperfError::RecvResultsFailed
+                            ),
+                            // #371: IESENDMESSAGE/IESENDRESULTS — the live errno
+                            // rides the carried message (no dangling ": ").
+                            Termination::SendFailed(msg) => {
+                                eprintln!("{prefix}riperf3: error - {msg}")
+                            }
+                            // Completed / Interrupted / SelfTerminated print no
+                            // line here: a clean round is silent, and the
+                            // interrupt notice / self-terminate line are emitted
+                            // elsewhere (the CLI signal path / shutdown_and_flush).
+                            _ => {}
+                        }
+                    }
+                }
+                // A no-report round (idle-interrupt, refusal, mid-setup DONE):
+                // keep serving, nothing to print here.
+                Ok(None) => {}
                 Err(RiperfError::Aborted(msg)) if msg == "idle timeout" => {
                     idle_restart = true;
                 }
+                // #293: the MID/END-loop versions of these classes (a report
+                // exists) now arrive as `Ok(Some((_, termination)))` above and
+                // print via that arm's Termination match. The arms below remain
+                // for the PRE-REPORT / setup-phase versions, which still return
+                // `Err` (no report) after emitting their own setup doc — the arm
+                // matches (and, under -J, does nothing) so the generic `Err(e)`
+                // sink below does NOT append a second document.
                 Err(RiperfError::ControlSocketClosed) => {
-                    // #330: the mid-test / end-loop control EOF — GT prints
-                    // its read-site sentence once (iperf_server_api.c:
-                    // 249-254) and keeps serving; under -J the doc carried
-                    // it (sink rule). (r1 F3: the old PeerDisconnected arm
-                    // is gone — both server recv_state sites convert EOF to
-                    // this class now, so it had no constructor left.
-                    // Pre-test EOFs like port scans are caught earlier by the
-                    // cookie read and take GT's IERECVCOOKIE surface via the
-                    // RecvCookieFailed arm below (#330), not this mid-test one.)
-                    // #344: iperf_err stamps its stderr lines with the
-                    // --timestamps prefix (iperf_error.c:51-57, :77) — every
-                    // arm below rides output_timestamp_prefix() like the
-                    // pre-test emit (#339) and the stdout banner.
+                    // #330: a setup-phase control EOF. GT prints its read-site
+                    // sentence once and keeps serving; under -J the setup doc
+                    // already carried it. #344: --timestamps stamps the line.
                     if !json && !crate::macros::output_quiet() {
                         eprintln!(
                             "{}riperf3: {CTRL_CLOSED_MSG}",
@@ -597,11 +634,8 @@ impl Server {
                     }
                 }
                 Err(RiperfError::ClientTerminated) => {
-                    // iperf3 prints IECLIENTTERM WITHOUT the "error - "
-                    // prefix ("iperf3: the client has terminated",
-                    // live-captured) and keeps serving (#210). In the JSON
-                    // modes the doc/event carried it — stderr stays silent
-                    // like iperf_err (review r1 f1/f3).
+                    // #210: a setup-phase CLIENT_TERMINATE. IECLIENTTERM, no
+                    // "error - " prefix; -J carried it in the setup doc.
                     if !json && !crate::macros::output_quiet() {
                         eprintln!(
                             "{}riperf3: {}",
@@ -610,43 +644,9 @@ impl Server {
                         );
                     }
                 }
-                Err(RiperfError::RecvResultsFailed) => {
-                    // #330: GT text prints `iperf3: error - unable to
-                    // receive results: ` once (the #248 dangling perr form
-                    // at errno 0 — see the ctx field's deviation record);
-                    // under -J the doc carried it and stderr keeps only
-                    // the read-site warning.
-                    if !json && !crate::macros::output_quiet() {
-                        eprintln!(
-                            "{}riperf3: error - {}: ",
-                            crate::macros::output_timestamp_prefix(),
-                            RiperfError::RecvResultsFailed
-                        );
-                    }
-                }
-                Err(e @ RiperfError::ExchangeSendMessageFailed(_))
-                | Err(e @ RiperfError::ExchangeSendResultsFailed(_)) => {
-                    // #371: the POST-TEST_END exchange-send failure — the
-                    // POPULATED doc rendered at the site (GT's json_finish
-                    // over the TEST_END reporter output). Text prints GT's
-                    // IESENDMESSAGE/IESENDRESULTS line with the live strerror
-                    // (no dangling ": ", the Display carries the errno);
-                    // -J/json-stream carried it in the doc. Keep-serving,
-                    // exit 0 (GT's rc -1 class).
-                    if !json && !crate::macros::output_quiet() {
-                        eprintln!(
-                            "{}riperf3: error - {e}",
-                            crate::macros::output_timestamp_prefix()
-                        );
-                    }
-                }
                 Err(RiperfError::UnknownControlMessage) => {
-                    // #325: GT main.c:174 prints `iperf3: error - <IEMESSAGE
-                    // sentence>` once and keeps serving; a failed test is
-                    // rc -1, which main errexits on only below -1 (setup
-                    // failures), so one-off still exits 0 (r1 F1, #224).
-                    // Under -J iperf_err's sink carried it in the doc —
-                    // stderr stays silent, like the terminate arm above.
+                    // #325: a setup-phase unrecognized byte. IEMESSAGE, one
+                    // line; -J carried it in the setup doc.
                     if !json && !crate::macros::output_quiet() {
                         eprintln!(
                             "{}riperf3: error - {}",
@@ -770,15 +770,17 @@ impl Server {
     /// banner — it is a library entry point, not the daemon. The test report is
     /// still printed to stdout in `-J` / text mode, like `Client::run`.
     ///
-    /// Peer-caused test endings surface as errors AFTER the report was
-    /// rendered to the active sink: a CLIENT_TERMINATE returns
-    /// [`RiperfError::ClientTerminated`], an unhandled control byte
-    /// returns [`RiperfError::UnknownControlMessage`] (#325), a
-    /// control-connection EOF returns [`RiperfError::ControlSocketClosed`]
-    /// (#330), and a setup phase that makes no progress for `--rcv-timeout`
-    /// returns [`RiperfError::DataIdleTimeout`] (#338) — all mirror GT
-    /// rounds its one-off still exits 0 on.
-    pub async fn run_once(&self) -> Result<crate::json_report::Report> {
+    /// #293: returns a [`RunOutcome`](crate::RunOutcome) — the measured
+    /// [`Report`](crate::Report) plus a [`Termination`](crate::Termination)
+    /// saying how the round ended. A peer-caused ending that still produced a
+    /// report is `Ok` with the matching server-side `Termination`
+    /// (`ClientTerminated`, `ControlClosed`, `UnknownMessage`,
+    /// `RecvResultsFailed`, `SendFailed`), or `SelfTerminated` when the server
+    /// ended the test on its own limit; the report carries the partial stats.
+    /// `Err` is reserved for rounds that produced NO report — a pre-test
+    /// cookie/param/accept failure, or a round interrupted before any test
+    /// started.
+    pub async fn run_once(&self) -> Result<crate::outcome::RunOutcome> {
         let listener = self.listen().await?;
         self.serve_once(&listener).await
     }
@@ -816,15 +818,15 @@ impl Server {
     async fn serve_once(
         &self,
         listener: &tokio::net::TcpListener,
-    ) -> Result<crate::json_report::Report> {
+    ) -> Result<crate::outcome::RunOutcome> {
         // #290: run-scoped console silence for this test.
         let _quiet_guard = (!self.emit_output).then(crate::macros::OutputQuietGuard::set);
         match self.handle_one_test(listener).await? {
-            Some(report) => Ok(report),
+            // #293: every report-producing round returns its Termination.
+            Some((report, termination)) => Ok(crate::outcome::RunOutcome::new(report, termination)),
             // The no-report rounds: interrupted while idle (an interrupt
-            // watch), a refused test, or IPERF_DONE mid-setup (#356). The
-            // interrupt-flavored message for all three is a recorded
-            // #293/#294 candidate.
+            // watch), a refused test, or IPERF_DONE mid-setup (#356) — no
+            // report exists, so `Err` per the #293 rule.
             None => Err(RiperfError::Aborted(
                 "interrupted before a test started".into(),
             )),
@@ -834,7 +836,7 @@ impl Server {
     async fn handle_one_test(
         &self,
         listener: &tokio::net::TcpListener,
-    ) -> Result<Option<crate::json_report::Report>> {
+    ) -> Result<Option<(crate::json_report::Report, crate::outcome::Termination)>> {
         // ---- Accept control connection (with optional idle timeout) ----
         let (mut ctrl, peer_addr) = match self.accept_control(listener).await? {
             Some(accepted) => accepted,
@@ -1137,38 +1139,31 @@ impl Server {
 
         let report = outcome?;
 
-        if ctx.client_terminated {
-            // The dump above already rendered; the caller prints iperf3's
-            // "the client has terminated" (no "error - " prefix) (#210).
-            return Err(RiperfError::ClientTerminated);
-        }
-        if ctx.unknown_message {
-            // #325: the dump above rendered with the in-doc `error - ` form;
-            // the caller prints GT's single stderr line (text mode only) and
-            // keeps serving. A failed TEST is rc -1 in GT, which main.c does
-            // NOT errexit on even for one-off (`if (rc < -1)` — setup
-            // failures only), so this must not become a process error (#224).
-            return Err(RiperfError::UnknownControlMessage);
-        }
-        if ctx.ctrl_closed {
-            // #330: distinct from the broad PeerDisconnected so the serve
-            // loop prints GT's read-site line for exactly this class (the
-            // doc'd mid/end-loop EOF), while pre-test EOFs stay quiet.
-            return Err(RiperfError::ControlSocketClosed);
-        }
-        if ctx.exchange_recv_failed {
-            // #330: the doc rendered above; the caller prints GT's text
-            // line (json keeps stderr to the warning alone) and keeps
-            // serving — a failed test is rc -1, one-off exit 0.
-            return Err(RiperfError::RecvResultsFailed);
-        }
-        if let Some(err) = ctx.exchange_send_error.take() {
-            // #371: the populated doc rendered above (its key came from
-            // report_error); the caller prints GT's IESENDMESSAGE/
-            // IESENDRESULTS line (text only) and keeps serving, exit 0.
-            return Err(err);
-        }
-        Ok(Some(report))
+        // #293: the doc above already rendered on every abnormal path. Derive
+        // how the round ended — this drives BOTH run_once's RunOutcome and
+        // run()'s per-class stderr line (run() matches this Termination now,
+        // where it used to match the returned Err). The comments on each class
+        // (rc -1 keep-serving, GT's read-site line, the errno-0 dangling ": ",
+        // etc.) live on the corresponding run() arm.
+        let termination = if ctx.client_terminated {
+            crate::outcome::Termination::ClientTerminated
+        } else if ctx.unknown_message {
+            crate::outcome::Termination::UnknownMessage
+        } else if ctx.ctrl_closed {
+            crate::outcome::Termination::ControlClosed
+        } else if ctx.exchange_recv_failed {
+            crate::outcome::Termination::RecvResultsFailed
+        } else if let Some(err) = ctx.exchange_send_error.take() {
+            crate::outcome::Termination::SendFailed(err.to_string())
+        } else if ctx.interrupted.is_some() {
+            crate::outcome::Termination::Interrupted
+        } else if let Some(msg) = ctx.server_error {
+            crate::outcome::Termination::SelfTerminated(msg.to_string())
+        } else {
+            // Clean completion (incl. the #330 mid-test IPERF_DONE bare-end).
+            crate::outcome::Termination::Completed
+        };
+        Ok(Some((report, termination)))
     }
 
     // -----------------------------------------------------------------------
@@ -4037,13 +4032,13 @@ impl BoundServer {
         self.listener.local_addr().map_err(RiperfError::Io)
     }
 
-    /// Serve exactly one test on the held listener and return its rich
-    /// [`Report`](crate::Report) — the same contract as
+    /// Serve exactly one test on the held listener and return its
+    /// [`RunOutcome`](crate::RunOutcome) — the same contract as
     /// [`Server::run_once`], minus the per-call rebind. No "Server
     /// listening" banner (a library entry point, not the daemon); the test
     /// report still prints in `-J` / text mode unless the server was built
     /// with `emit_output(false)` (#290).
-    pub async fn run_once(&self) -> Result<crate::json_report::Report> {
+    pub async fn run_once(&self) -> Result<crate::outcome::RunOutcome> {
         self.server.serve_once(&self.listener).await
     }
 }

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -1145,8 +1145,21 @@ impl Server {
         // where it used to match the returned Err). The comments on each class
         // (rc -1 keep-serving, GT's read-site line, the errno-0 dangling ": ",
         // etc.) live on the corresponding run() arm.
-        let termination = if ctx.client_terminated {
+        //
+        // r1 F4: the precedence matches report_error's derivation (the -J doc's
+        // `error` key) at both its sites — interrupt first, then the peer
+        // terminate, the self-terminate, then the exchange classes (server.rs
+        // ~2247 and ~1037). The flags are mutually exclusive today (each
+        // abnormal arm breaks the data loop and the exchange phase is gated off
+        // once any is set), so ordering is behavior-neutral now; keeping the two
+        // derivations in lockstep means run_once's Termination and the doc's key
+        // stay consistent if a future change ever let two co-occur.
+        let termination = if ctx.interrupted.is_some() {
+            crate::outcome::Termination::Interrupted
+        } else if ctx.client_terminated {
             crate::outcome::Termination::ClientTerminated
+        } else if let Some(msg) = ctx.server_error {
+            crate::outcome::Termination::SelfTerminated(msg.to_string())
         } else if ctx.unknown_message {
             crate::outcome::Termination::UnknownMessage
         } else if ctx.ctrl_closed {
@@ -1155,10 +1168,6 @@ impl Server {
             crate::outcome::Termination::RecvResultsFailed
         } else if let Some(err) = ctx.exchange_send_error.take() {
             crate::outcome::Termination::SendFailed(err.to_string())
-        } else if ctx.interrupted.is_some() {
-            crate::outcome::Termination::Interrupted
-        } else if let Some(msg) = ctx.server_error {
-            crate::outcome::Termination::SelfTerminated(msg.to_string())
         } else {
             // Clean completion (incl. the #330 mid-test IPERF_DONE bare-end).
             crate::outcome::Termination::Completed

--- a/riperf3/tests/bound_server.rs
+++ b/riperf3/tests/bound_server.rs
@@ -43,7 +43,9 @@ async fn bind_once_serves_sequential_tests_on_one_port() {
             run_client(port).await
         };
         let (srv, cli) = tokio::join!(server_run, client_run);
-        let srv = srv.unwrap_or_else(|e| panic!("server run_once #{i} errored: {e}"));
+        let srv = srv
+            .unwrap_or_else(|e| panic!("server run_once #{i} errored: {e}"))
+            .report;
         assert!(
             srv.end.sum_received.as_ref().unwrap().bytes > 0,
             "test #{i}: the server measured the transfer"
@@ -68,6 +70,6 @@ async fn run_once_still_serves_one_test() {
     tokio::time::sleep(Duration::from_millis(150)).await;
     let cli = run_client(port).await;
     assert!(cli.end.sum_sent.as_ref().unwrap().bytes > 0);
-    let srv = server_task.await.unwrap().expect("run_once");
+    let srv = server_task.await.unwrap().expect("run_once").report;
     assert!(srv.end.sum_received.as_ref().unwrap().bytes > 0);
 }

--- a/riperf3/tests/integration.rs
+++ b/riperf3/tests/integration.rs
@@ -2488,10 +2488,17 @@ mod client_run_return_value {
             .unwrap();
         let _ = client.run().await.expect("client run failed");
 
-        let report = server_task
+        // #293: run_once returns a RunOutcome; a clean round ends Completed.
+        let outcome = server_task
             .await
             .expect("server task panicked")
             .expect("server run_once failed");
+        assert_eq!(
+            outcome.termination,
+            riperf3::Termination::Completed,
+            "a clean server round ends Completed"
+        );
+        let report = outcome.report;
         assert!(
             !report.end.streams.is_empty(),
             "server report.end should carry the served test's streams"

--- a/riperf3/tests/integration.rs
+++ b/riperf3/tests/integration.rs
@@ -2662,6 +2662,63 @@ async fn both_violations_relay_total_rate_like_gt() {
     }
 }
 
+/// #293 r1 F3: the SERVER half of a RUNTIME self-terminate through `run_once`.
+/// The upfront-refusal tests above assert the CLIENT's `ServerError` and leave
+/// the server report-less (`run_once` errs); this pins the OTHER half. A
+/// runtime `--server-bitrate-limit` breach BUILDS a partial server report, so
+/// `run_once` returns `Ok(RunOutcome)` with `Termination::SelfTerminated` (the
+/// server-side counterpart of the client's `ServerError`). Load-bearing
+/// because a `SelfTerminated`↔`Completed` mis-map is invisible to every other
+/// test — both hit `Server::run`'s silent `_ =>` arm (the stderr line is
+/// emitted independently), so only a lib-level `run_once` assertion catches it.
+#[tokio::test]
+async fn server_run_once_self_terminates_on_runtime_bitrate_breach() {
+    const MSG: &str = "total required bandwidth is larger than server limit";
+    let server = ServerBuilder::new()
+        .port(Some(0))
+        .server_bitrate_limit(1_000) // 1 Kbit/s: any real transfer trips the 1 Hz check
+        .emit_output(false)
+        .build()
+        .unwrap();
+    let bound = server.bind().await.expect("bind");
+    let port = bound.local_addr().unwrap().port();
+    let server_task = tokio::spawn(async move { bound.run_once().await });
+
+    // Default TCP bandwidth is 0 (unlimited): the upfront total-rate check
+    // (total = 0) lets the test START, then loopback throughput blows past
+    // 1 Kbit/s and the RUNTIME breach fires. An explicit `-b 2M` would instead
+    // be refused UPFRONT (no server report — the other tests' path).
+    let client = ClientBuilder::new("127.0.0.1")
+        .port(Some(port))
+        .duration(2)
+        .emit_output(false)
+        .build()
+        .unwrap();
+    let result = tokio::time::timeout(Duration::from_secs(15), client.run())
+        .await
+        .expect("client hung");
+    let server_result = server_task.await.expect("server task");
+
+    // Server: the runtime breach produced a report → Ok (an Err here is exactly
+    // the pre-#293 regression, the partial report discarded); it ended
+    // SelfTerminated with the bare IETOTALRATE message.
+    let outcome =
+        server_result.expect("run_once errored on a runtime breach — partial report discarded");
+    assert_eq!(
+        outcome.termination,
+        riperf3::Termination::SelfTerminated(MSG.to_string()),
+        "the server's own rate-limit breach ends SelfTerminated"
+    );
+
+    // Client half of the SAME breach: the relayed SERVER_ERROR.
+    let cli = result.expect("client run errored");
+    assert_eq!(
+        cli.termination,
+        riperf3::Termination::ServerError(MSG.to_string()),
+        "the client sees the relayed SERVER_ERROR — the symmetric half"
+    );
+}
+
 /// #302: GT enables SO_MAX_PACING_RATE on its ACCEPTED data sockets too
 /// (iperf_tcp.c:138-153), so a client's --fq-rate paces the server's
 /// reverse send path. Live GT reverse --fq-rate 5M ≈ 6.3 Mbps where the


### PR DESCRIPTION
The `Server::run_once` RunOutcome symmetry — the server-side follow-up to #293 (stacked on the client migration, now merged). Closes the same lossy/inconsistent problem on the server's abnormal-end paths.

## What changes

`Server::run_once` and `BoundServer::run_once` now return `Result<RunOutcome>` (was `Result<Report>`), matching `Client::run`. The server's report-producing abnormal ends — which used to emit their doc and then return an `Err` that discarded the report — now return `Ok(RunOutcome)` carrying the partial report plus a server-side `Termination`:

`Termination` gains (additive, `non_exhaustive`): `ClientTerminated`, `ControlClosed`, `UnknownMessage`, `RecvResultsFailed`, `SendFailed(String)`, `SelfTerminated(String)`. `Completed`/`Interrupted` are shared with the client. `Err` is reserved for no-report rounds (a pre-test cookie/param/accept failure, or a round interrupted before any test started).

**Taxonomy note (open to your steer):** I went fine-grained (one variant per iperf3 class) rather than a coarse `PeerLeft`/`Aborted` grouping, because `run()`'s persistent loop prints a *different* stderr line per class — fine-grained lets the loop match the `Termination` directly (one signal drives both `run()`'s text and `run_once`'s outcome) and is more faithful. Say the word if you'd rather a coarser set.

## The delicate part — `run()` faithfulness

`Server::run` (the persistent loop) and `run_once` share `serve_once`/`handle_one_test`. The loop used to print its per-class stderr line by matching the returned `Err`. Now `handle_one_test` returns `Ok(Some((report, termination)))` for report-producing rounds, so:

- The **mid/end-loop** per-class lines moved from `run()`'s `Err` arms into an `Ok(Some((_, termination)))` match — byte-identical lines.
- The **setup-phase** versions of `ControlClosed`/`ClientTerminated`/`UnknownMessage` still return `Err` (they emit their setup doc before a report exists), so those `Err` arms **stay** — matched so the generic `Err(e)` sink doesn't append a second `-J` document. (This double-doc was a regression I caught and fixed mid-development: deleting those arms let setup-phase EOFs fall through to the catch-all.)

The wire protocol, the CLI's text/JSON output, and the process exit codes are unchanged (the CLI drives `Server::run`, whose behavior is preserved byte-for-byte).

## No version bump

0.9.0 is already on main (the client PR bumped it); this rides it. `cargo-semver-checks` passes (the 0.x major-equivalent bump already permits the break).

## Verification

- Lib 414 + wire_shape 131 + full CLI suite (23 binaries) + integration/bound_server/quiet_output/stream/teardown — all green. `fmt` + `clippy -D warnings` clean.
- The `bound_server` + `integration::server_run_once_returns_rich_report` tests read `.report` and assert `Completed`.

Coverage note: like the client PR, the abnormal server `Termination`s are exercised end-to-end by the CLI wire_shape tests (via `Server::run`), but I have not yet added lib-level `run_once` assertions for each abnormal variant — flagging for the review to say whether that's wanted (mirrors the client's N1).
