### PR TITLE
fix: close the 0.9.0-span review-sweep findings (docs, pins, quiet-gate)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,22 @@ release tags.
   report and prints nothing. Opt into iperf3's full text/JSON output with `.emit_output(true)`
   (the CLI sets this). Wire protocol, CLI output, and exit codes are unchanged.
 
+### Added
+
+- `riperf3::ErrorSinkGuard`: the CLI's `--logfile` hook for the library's error lines (#364).
+- `Termination::errexit_message()`: the CLI's exit-code hook for the client's abnormal endings (#293).
+- `riperf3::outcome` is a public module documenting the #293 run contract.
+
+### Fixed
+
+- `--logfile` receives the SERVER-ERROR relay receipt and the interrupt notice like iperf3's
+  `iperf_err` routing; both previously went to stderr (#364).
+- Wire-blob parsing mirrors cJSON's UTF-8 BOM skip and non-object params root; four residual
+  strictness divergences are recorded deviations (#367).
+- Rate-breach and duration-watchdog `-J` documents render a bare `end: {}` like iperf3 (#368).
+- Exchange-phase send failures map to iperf3's IESENDMESSAGE/IESENDRESULTS classes over the
+  populated document instead of a raw-io skeleton (#371).
+
 ## [0.8.0] - 2026-06-28
 
 Architecture-and-API release. Wire protocol and CLI flags unchanged; success-path

--- a/riperf3-cli/src/cli.rs
+++ b/riperf3-cli/src/cli.rs
@@ -993,7 +993,7 @@ fn atoi_like_os() -> impl clap::builder::TypedValueParser<Value = i64> {
 /// scanf can't push back more than one byte, so it FAILS outright where
 /// strtod would back up (`1e`, `0x`); modeling with strtod's backed-up
 /// prefix instead is outcome-identical for unit_atoi, because the leftover
-/// byte at the prefix boundary ('e', 'x', '.') is never in [tTgGmMkK] —
+/// byte at the prefix boundary ('e', 'x', '.') is never in `[tTgGmMkK]` —
 /// both roads end at IEUNITVAL (live-probed: `-n 1e`, `-n 1ex`, `-n 0x`
 /// all reject; `-n 0x10` parses as 16).
 fn c_strtod_prefix(s: &[u8]) -> Option<(f64, usize)> {
@@ -1125,7 +1125,7 @@ fn c_strtod_prefix(s: &[u8]) -> Option<(f64, usize)> {
 }
 
 /// The shared suffix step of GT's unit parsers: the number's C-double
-/// prefix, then AT MOST ONE suffix char in [tTgGmMkK] scaling by base^n;
+/// prefix, then AT MOST ONE suffix char in `[tTgGmMkK]` scaling by base^n;
 /// end-of-string means no scaling; junk AFTER a valid suffix is IGNORED
 /// (`10Kx` is 10240: sscanf never reads the x); any OTHER byte right after
 /// the number — or an unparseable number — is Err (IEUNITVAL).
@@ -1269,7 +1269,7 @@ fn unit_atoi_os(arg: &std::ffi::OsStr) -> Result<f64, String> {
 
 /// #263: GT's `-f` parse (iperf_api.c:1236-1256) reads `*optarg` — the
 /// FIRST character only, so `-f kilobits` is `-f k` — and accepts exactly
-/// [kmgtKMGT]; anything else is IEBADFORMAT. 'B'/'b' stay lib-only in both
+/// `[kmgtKMGT]`; anything else is IEBADFORMAT. 'B'/'b' stay lib-only in both
 /// tools (GT's getopt rejects them; unit_snprintf supports them).
 pub fn parse_format_char(arg: &str) -> Option<char> {
     arg.chars().next().filter(|c| "kmgtKMGT".contains(*c))

--- a/riperf3-cli/src/main.rs
+++ b/riperf3-cli/src/main.rs
@@ -955,7 +955,7 @@ async fn async_main(
         // to the already-rendered error exit. Completed/Interrupted exit 0.
         let outcome = cli.build_client()?.with_interrupt(interrupt).run().await?;
         if let Some(msg) = outcome.termination.errexit_message() {
-            return Err(Box::new(AbnormalExit(msg)));
+            return Err(Box::new(AbnormalExit(msg.to_string())));
         }
     } else if cli.server {
         // Server mode. See `Cli::build_server` (cli.rs). `-D`/`--daemon` is

--- a/riperf3/src/client.rs
+++ b/riperf3/src/client.rs
@@ -337,9 +337,9 @@ impl Client {
     /// [`ServerTerminated`](crate::Termination::ServerTerminated), or
     /// [`ServerError`](crate::Termination::ServerError) carrying the server's
     /// relayed message — the report holds the partial stats on the abnormal
-    /// endings. `Err` is reserved for a run with no report: a failed connect
-    /// or control handshake (plus two rarer classes not yet folded in — see
-    /// the [`outcome`](crate::outcome) module notes). The CLI derives iperf3's
+    /// endings. `Err` is reserved for a run with no report — e.g. a failed
+    /// connect or control handshake (plus two rarer classes not yet folded
+    /// in; see the [`outcome`](crate::outcome) module notes). The CLI derives iperf3's
     /// exit code from the `Termination` via
     /// [`errexit_message`](crate::Termination::errexit_message).
     ///

--- a/riperf3/src/client.rs
+++ b/riperf3/src/client.rs
@@ -325,6 +325,27 @@ impl Client {
         self
     }
 
+    /// Run the configured test and return its [`RunOutcome`](crate::RunOutcome):
+    /// the measured [`Report`](crate::Report) — the same object `-J` / `--json`
+    /// serializes — plus a [`Termination`](crate::Termination) saying how the
+    /// run ended (#293).
+    ///
+    /// A run that produced a report comes back `Ok`, clean or not:
+    /// [`Completed`](crate::Termination::Completed),
+    /// [`Interrupted`](crate::Termination::Interrupted) (a wired
+    /// [`interrupt`](ClientBuilder::interrupt) watch fired),
+    /// [`ServerTerminated`](crate::Termination::ServerTerminated), or
+    /// [`ServerError`](crate::Termination::ServerError) carrying the server's
+    /// relayed message — the report holds the partial stats on the abnormal
+    /// endings. `Err` is reserved for a run with no report: a failed connect
+    /// or control handshake (plus two rarer classes not yet folded in — see
+    /// the [`outcome`](crate::outcome) module notes). The CLI derives iperf3's
+    /// exit code from the `Termination` via
+    /// [`errexit_message`](crate::Termination::errexit_message).
+    ///
+    /// Quiet by default (#294): nothing is printed unless the client was
+    /// built with [`emit_output(true)`](ClientBuilder::emit_output), which
+    /// prints iperf3's full text/JSON output exactly like the CLI.
     pub async fn run(&self) -> Result<crate::outcome::RunOutcome> {
         // #290: run-scoped console silence, armed FIRST so even the -V
         // preamble honors it. Construct-only-when-quiet (see the guard doc).
@@ -3075,13 +3096,13 @@ impl ClientBuilder {
         self
     }
 
-    /// Console output from `run` (#290). `true` (the default) keeps today's
-    /// behavior: the crate prints the mode's report (text banners/summary,
-    /// the `-J` document, or `--json-stream` events) to the host process's
-    /// stdout, exactly like the CLI. `false` runs silently — the returned
-    /// [`Report`](crate::Report) is the only output; nothing is written to
-    /// stdout or stderr. Wire behavior is unaffected either way (a quiet
-    /// server still relays `--get-server-output` text to the peer).
+    /// Console output from `run` (#290). `false` (the default since 0.9.0,
+    /// #294) runs silently — the returned [`RunOutcome`](crate::RunOutcome)
+    /// is the only output; nothing is written to stdout or stderr. `true`
+    /// prints the mode's report (text banners/summary, the `-J` document, or
+    /// `--json-stream` events) to the host process's stdout, exactly like
+    /// the CLI (which sets it). Wire behavior is unaffected either way (a
+    /// quiet server still relays `--get-server-output` text to the peer).
     ///
     /// Note: with authentication configured but no password provided, a run
     /// still BLOCKS reading the password from stdin — quiet suppresses the

--- a/riperf3/src/lib.rs
+++ b/riperf3/src/lib.rs
@@ -1,5 +1,34 @@
 //! # riperf3
 //!
+//! A wire- and API-faithful replacement for iperf3 (3.21) in idiomatic Rust:
+//! the same protocol, flags, output, and JSON schema, usable as a CLI or as
+//! this library crate.
+//!
+//! Run a test and read its result — quiet by default (#294), with the
+//! measured [`Report`] and a [`Termination`] saying how the run ended
+//! (#293, see the [`outcome`] module):
+//!
+//! ```no_run
+//! # async fn demo() -> riperf3::Result<()> {
+//! let client = riperf3::ClientBuilder::new("198.51.100.7")
+//!     .duration(5)
+//!     .build()?;
+//! let outcome = client.run().await?;
+//! if outcome.termination != riperf3::Termination::Completed {
+//!     eprintln!("test ended early: {:?}", outcome.termination);
+//! }
+//! if let Some(sent) = &outcome.report.end.sum_sent {
+//!     println!("{} bytes sent", sent.bytes);
+//! }
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! The server side mirrors it: [`ServerBuilder`] builds a [`Server`], and
+//! [`Server::run_once`] (or [`Server::bind`] + [`BoundServer::run_once`])
+//! returns the same [`RunOutcome`] per served test, while [`Server::run`]
+//! is the persistent daemon loop the CLI drives.
+//!
 //! ## Unsafe audit
 //!
 //! All unsafe blocks are raw kernel syscalls with no safe Rust wrapper.
@@ -31,10 +60,12 @@ mod macros;
 mod error;
 pub use error::{ConfigError, Result, RiperfError};
 
-mod outcome;
 // The run-result model (#293): `Client::run` and `Server::run_once` both return
 // `RunOutcome` (the measured `Report` + how the run ended) rather than signaling
-// an abnormal end through `Err`.
+// an abnormal end through `Err`. Public as a MODULE (review sweep): its
+// module-level narrative is the #293 contract documentation, which a private
+// `mod` would keep off docs.rs entirely (the `json_report` precedent).
+pub mod outcome;
 pub use outcome::{RunOutcome, Termination};
 
 mod client;

--- a/riperf3/src/net.rs
+++ b/riperf3/src/net.rs
@@ -767,7 +767,13 @@ pub fn apply_fq_rate(fd: &impl std::os::unix::io::AsFd, rate_bits_per_sec: u64) 
         return;
     }
     if set_fq_rate(fd, rate_bits_per_sec).is_err() {
-        eprintln!("warning: Unable to set socket pacing");
+        // The #290 quiet-guard contract wins for embedded library runs, like
+        // protocol.rs's gt_warning (the r1 F6 decision): a quiet caller gets
+        // silence, everyone else gets GT's exact line. Widened to matter by
+        // the #294 default flip — this was the one warning site left ungated.
+        if !crate::macros::output_quiet() {
+            eprintln!("warning: Unable to set socket pacing");
+        }
     }
 }
 

--- a/riperf3/src/outcome.rs
+++ b/riperf3/src/outcome.rs
@@ -107,10 +107,10 @@ impl Termination {
     /// on setup failures (rc < -1), the #224 wart — so they do not drive a
     /// non-zero exit through this path.
     #[must_use]
-    pub fn errexit_message(&self) -> Option<String> {
+    pub fn errexit_message(&self) -> Option<&str> {
         match self {
-            Termination::ServerTerminated => Some("the server has terminated".to_string()),
-            Termination::ServerError(msg) => Some(msg.clone()),
+            Termination::ServerTerminated => Some("the server has terminated"),
+            Termination::ServerError(msg) => Some(msg),
             // Clean exits + all server-side endings (no client errexit).
             Termination::Completed
             | Termination::Interrupted
@@ -143,6 +143,40 @@ impl RunOutcome {
         Self {
             report,
             termination,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Termination;
+
+    /// The errexit contract: only the two client-side "the server ended it"
+    /// classes drive a non-zero exit through this path — iperf3's server
+    /// keeps serving (one-off exits 0) on a failed round, the #224 wart, so
+    /// every server-side ending is `None`. The CLI relies on the split; a
+    /// variant drifting across it flips a process exit code.
+    #[test]
+    fn errexit_message_is_some_only_for_the_client_server_ended_classes() {
+        assert_eq!(
+            Termination::ServerTerminated.errexit_message(),
+            Some("the server has terminated"),
+        );
+        assert_eq!(
+            Termination::ServerError("busy".into()).errexit_message(),
+            Some("busy"),
+        );
+        for none in [
+            Termination::Completed,
+            Termination::Interrupted,
+            Termination::ClientTerminated,
+            Termination::ControlClosed,
+            Termination::UnknownMessage,
+            Termination::RecvResultsFailed,
+            Termination::SendFailed("send failed".into()),
+            Termination::SelfTerminated("limit".into()),
+        ] {
+            assert_eq!(none.errexit_message(), None, "{none:?} must not errexit");
         }
     }
 }

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -526,8 +526,8 @@ impl Server {
     ///
     /// A failed round does not end the loop: like iperf3's server, the round's
     /// error line is printed and the next client is served (#224). `Err` from
-    /// this method means the LOOP ended abnormally — a failed bind, or the
-    /// one-off `--idle-timeout` expiring — never a failed test.
+    /// this method means a failed bind — never a failed test (even the one-off
+    /// `--idle-timeout` expiry ends the loop with `Ok(())`).
     ///
     /// Quiet by default like every lib run (#294): build with
     /// [`emit_output(true)`](ServerBuilder::emit_output) for iperf3's banners
@@ -1038,11 +1038,11 @@ impl Server {
             let was_captured = server_output_text.is_some();
             // #353: an exchange Err reaches the gate through this `?` —
             // counts are frozen at build_result_streams, so the teardown is
-            // safe on this path. Post-#405 the send failures (ExchangeResults
-            // state write, send_results) are caught into
-            // ctx.exchange_send_error and return Ok instead, so the live Err
-            // here is the residual raw-Io recv_state error in the IperfDone
-            // loop.
+            // safe on this path. Post-#405 the send failures (the
+            // ExchangeResults and DisplayResults state writes, send_results)
+            // are caught into ctx.exchange_send_error and return Ok instead,
+            // so the live Err here is the residual raw-Io recv_state error
+            // in the IperfDone loop.
             self.exchange_results_phase(
                 &mut ctx,
                 &end,

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -526,7 +526,8 @@ impl Server {
     ///
     /// A failed round does not end the loop: like iperf3's server, the round's
     /// error line is printed and the next client is served (#224). `Err` from
-    /// this method means a failed bind — never a failed test (even the one-off
+    /// this method means a failed listener setup (the bind, a bad bind
+    /// address, `--bind-dev`) — never a failed test (even the one-off
     /// `--idle-timeout` expiry ends the loop with `Ok(())`).
     ///
     /// Quiet by default like every lib run (#294): build with

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -515,6 +515,23 @@ impl Server {
         }
     }
 
+    /// Run the persistent server: bind the configured listener, print the
+    /// "Server listening" banner, and serve iperf3's accept loop — one test
+    /// round per client, round after round — until a wired
+    /// [`interrupt`](ServerBuilder::interrupt) fires or `-1/--one-off` ends
+    /// it after the first round. This is the daemon-shaped entry the CLI
+    /// drives; per-round reports are not returned — use [`Server::run_once`]
+    /// or [`Server::bind`] + [`BoundServer::run_once`] to get each round's
+    /// [`RunOutcome`](crate::RunOutcome).
+    ///
+    /// A failed round does not end the loop: like iperf3's server, the round's
+    /// error line is printed and the next client is served (#224). `Err` from
+    /// this method means the LOOP ended abnormally — a failed bind, or the
+    /// one-off `--idle-timeout` expiring — never a failed test.
+    ///
+    /// Quiet by default like every lib run (#294): build with
+    /// [`emit_output(true)`](ServerBuilder::emit_output) for iperf3's banners
+    /// and reports.
     pub async fn run(&self) -> Result<()> {
         // #290: run-scoped console silence, armed FIRST so the listening
         // banner honors it. Construct-only-when-quiet (see the guard doc).
@@ -760,15 +777,18 @@ impl Server {
         Ok(())
     }
 
-    /// Serve exactly one test and return its rich JSON [`Report`](crate::Report) — the same
-    /// object [`Client::run`](crate::Client::run) returns and `-s -J` prints.
+    /// Serve exactly one test and return its [`RunOutcome`](crate::RunOutcome)
+    /// — the rich JSON [`Report`](crate::Report) the test measured (the same
+    /// object [`Client::run`](crate::Client::run) returns and `-s -J` prints)
+    /// plus how the round ended.
     ///
     /// Binds its own listener, accepts one client, runs the test to completion,
     /// and returns. This is the one-shot building block, mirroring
     /// `tokio::net::TcpListener::accept`; use [`Server::run`] for the long-lived
     /// accept loop. Unlike `run`, it does not print the "Server listening"
-    /// banner — it is a library entry point, not the daemon. The test report is
-    /// still printed to stdout in `-J` / text mode, like `Client::run`.
+    /// banner — it is a library entry point, not the daemon. Like `Client::run`,
+    /// it is quiet by default (#294): build with `emit_output(true)` to print
+    /// iperf3's full `-J` / text output.
     ///
     /// #293: returns a [`RunOutcome`](crate::RunOutcome) — the measured
     /// [`Report`](crate::Report) plus a [`Termination`](crate::Termination)
@@ -1016,10 +1036,13 @@ impl Server {
             let (server_output_text, server_output_json, report_source) =
                 self.finish_server_output(&mut ctx, &end, collected);
             let was_captured = server_output_text.is_some();
-            // #353: the exchange's own Err (e.g. the ExchangeResults state
-            // write failing against an RST'd ctrl) reaches the gate through
-            // this `?` — counts are frozen at build_result_streams, so the
-            // teardown is safe on this path.
+            // #353: an exchange Err reaches the gate through this `?` —
+            // counts are frozen at build_result_streams, so the teardown is
+            // safe on this path. Post-#405 the send failures (ExchangeResults
+            // state write, send_results) are caught into
+            // ctx.exchange_send_error and return Ok instead, so the live Err
+            // here is the residual raw-Io recv_state error in the IperfDone
+            // loop.
             self.exchange_results_phase(
                 &mut ctx,
                 &end,
@@ -4044,9 +4067,9 @@ impl BoundServer {
     /// Serve exactly one test on the held listener and return its
     /// [`RunOutcome`](crate::RunOutcome) — the same contract as
     /// [`Server::run_once`], minus the per-call rebind. No "Server
-    /// listening" banner (a library entry point, not the daemon); the test
-    /// report still prints in `-J` / text mode unless the server was built
-    /// with `emit_output(false)` (#290).
+    /// listening" banner (a library entry point, not the daemon); quiet by
+    /// default like every lib run (#294) — the test report prints in `-J` /
+    /// text mode only if the server was built with `emit_output(true)`.
     pub async fn run_once(&self) -> Result<crate::outcome::RunOutcome> {
         self.server.serve_once(&self.listener).await
     }
@@ -4145,10 +4168,11 @@ impl ServerBuilder {
         self
     }
 
-    /// Console output from `run`/`run_once` (#290). `true` (the default)
-    /// keeps today's behavior; `false` runs silently — reports flow only via
-    /// the return value and the wire (`--get-server-output` still relays the
-    /// text report to the requesting client). See
+    /// Console output from `run`/`run_once` (#290). `false` (the default
+    /// since 0.9.0, #294) runs silently — reports flow only via the return
+    /// value and the wire (`--get-server-output` still relays the text
+    /// report to the requesting client); `true` prints iperf3's full
+    /// text/JSON output, exactly like the CLI (which sets it). See
     /// [`ClientBuilder::emit_output`](crate::ClientBuilder::emit_output).
     pub fn emit_output(mut self, enabled: bool) -> Self {
         self.emit_output = enabled;

--- a/riperf3/tests/integration.rs
+++ b/riperf3/tests/integration.rs
@@ -2719,6 +2719,68 @@ async fn server_run_once_self_terminates_on_runtime_bitrate_breach() {
     );
 }
 
+/// The server-side `Interrupted` cell of the same invisibility class: a
+/// mid-test interrupt on `run_once` comes back `Ok(RunOutcome)` with
+/// `Termination::Interrupted`. Like `SelfTerminated` above, an
+/// `Interrupted`↔`Completed` mis-map hits `Server::run`'s silent `_ =>` arm
+/// and both exit 0, so only a lib-level assertion catches it. The client
+/// sees the SERVER_TERMINATE half (iperf_got_sigend's server arm).
+#[tokio::test]
+async fn server_run_once_interrupt_mid_test_ends_interrupted() {
+    let (tx, rx) = tokio::sync::watch::channel::<Option<String>>(None);
+    let server = ServerBuilder::new()
+        .port(Some(0))
+        .interrupt(rx)
+        .emit_output(false)
+        .build()
+        .unwrap();
+    let bound = server.bind().await.expect("bind");
+    let port = bound.local_addr().unwrap().port();
+    let server_task = tokio::spawn(async move { bound.run_once().await });
+
+    let client = ClientBuilder::new("127.0.0.1")
+        .port(Some(port))
+        .duration(6)
+        .emit_output(false)
+        .build()
+        .unwrap();
+    let client_task =
+        tokio::spawn(
+            async move { tokio::time::timeout(Duration::from_secs(20), client.run()).await },
+        );
+    // 1.5 s into a 6 s test: the loopback handshake is millis-class even
+    // under CI contention (the breach test above rides the same margin), so
+    // the watch fires in TEST_RUNNING, not the setup phase (which is the
+    // documented Err path instead).
+    tokio::time::sleep(Duration::from_millis(1500)).await;
+    tx.send(Some(
+        "interrupt - the server has terminated by signal Terminated(15)".into(),
+    ))
+    .unwrap();
+
+    let server_result = tokio::time::timeout(Duration::from_secs(10), server_task)
+        .await
+        .expect("server hung after the interrupt")
+        .expect("server task");
+    let outcome = server_result.expect("an interrupted mid-test round still carries its report");
+    assert_eq!(
+        outcome.termination,
+        riperf3::Termination::Interrupted,
+        "a local signal mid-test ends Interrupted"
+    );
+
+    let cli = client_task
+        .await
+        .expect("client task")
+        .expect("client hung")
+        .expect("client run");
+    assert_eq!(
+        cli.termination,
+        riperf3::Termination::ServerTerminated,
+        "the client sees SERVER_TERMINATE — the symmetric half"
+    );
+}
+
 /// #302: GT enables SO_MAX_PACING_RATE on its ACCEPTED data sockets too
 /// (iperf_tcp.c:138-153), so a client's --fq-rate paces the server's
 /// reverse send path. Live GT reverse --fq-rate 5M ≈ 6.3 Mbps where the

--- a/riperf3/tests/quiet_output.rs
+++ b/riperf3/tests/quiet_output.rs
@@ -49,7 +49,7 @@ fn child_quiet_server_then_loud_pair() {
             .emit_output(false)
             .build()
             .unwrap();
-        let _ = server.run().await; // idle timeout -> Err(Aborted), fine
+        let _ = server.run().await; // one-off idle timeout ends the loop Ok(())
 
         // Phase 2: a fully LOUD pair in the same process — proves every quiet
         // guard dropped back to zero (a leaked increment would silence this).
@@ -150,7 +150,10 @@ fn child_run(quiet: bool) {
 /// is process-global, so a same-process server's correct default would mask a
 /// reverted client default (which is exactly why a bare PAIR pins nothing —
 /// the review's revert probe survived the whole suite). A `true` client
-/// default prints the "Connecting to host" banner before the interrupt fires.
+/// default leaks the interrupt dump (the `- - - - -` separator + interval
+/// header) — r1: the connect banner does NOT leak here, it waits on a
+/// PARAM_EXCHANGE the mock never sends; the dump is synchronous with the
+/// interrupt in any phase, so the pin doesn't ride the 500 ms timing.
 fn child_bare_default_client() {
     let rt = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
@@ -366,7 +369,7 @@ fn quiet_server_daemon_is_silent_and_loudness_recovers() {
 /// #294 (review sweep): a client built with NO `emit_output` call is quiet —
 /// the flipped DEFAULT itself is under test, in a process with no riperf3
 /// server whose own guard could mask a revert. Reverting the ClientBuilder
-/// default to `true` fails this (the connect banner leaks).
+/// default to `true` fails this (the interrupt dump lines leak).
 #[test]
 fn bare_default_client_is_quiet() {
     if std::env::var("RIPERF3_QUIET_CHILD").is_ok() {

--- a/riperf3/tests/quiet_output.rs
+++ b/riperf3/tests/quiet_output.rs
@@ -143,6 +143,86 @@ fn child_run(quiet: bool) {
     eprintln!("QUIET_CHILD_DONE");
 }
 
+/// Child arm (#294 pin, CLIENT half): a BARE client — no `emit_output` call,
+/// so the flipped default itself is what's exercised — against a mock server
+/// that accepts, reads the cookie, and goes silent; the interrupt watch ends
+/// the run. Crucially NO riperf3 server runs in this process: the quiet guard
+/// is process-global, so a same-process server's correct default would mask a
+/// reverted client default (which is exactly why a bare PAIR pins nothing —
+/// the review's revert probe survived the whole suite). A `true` client
+/// default prints the "Connecting to host" banner before the interrupt fires.
+fn child_bare_default_client() {
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    rt.block_on(async {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let mock = tokio::spawn(async move {
+            if let Ok((mut sock, _)) = listener.accept().await {
+                use tokio::io::AsyncReadExt;
+                let mut cookie = [0u8; 37];
+                let _ = sock.read_exact(&mut cookie).await;
+                tokio::time::sleep(std::time::Duration::from_secs(10)).await;
+            }
+        });
+        let (tx, rx) = tokio::sync::watch::channel::<Option<String>>(None);
+        let client = riperf3::ClientBuilder::new("127.0.0.1")
+            .port(Some(port))
+            .duration(5)
+            .interrupt(rx)
+            .build()
+            .unwrap();
+        let run = tokio::spawn(async move { client.run().await });
+        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+        tx.send(Some(
+            "interrupt - the client has terminated by signal Terminated(15)".into(),
+        ))
+        .unwrap();
+        tokio::time::timeout(std::time::Duration::from_secs(5), run)
+            .await
+            .expect("interrupt honored")
+            .expect("join")
+            .expect("interrupted run is Ok");
+        mock.abort();
+    });
+    eprintln!("QUIET_CHILD_DONE");
+}
+
+/// Child arm (#294 pin, SERVER half): a BARE `-J` server — no `emit_output`
+/// call — serving one test from an explicitly LOUD text client. The loud
+/// client arms no quiet guard, so the server's own default alone decides
+/// whether its `-J` document reaches stdout: a reverted `true` default
+/// prints it (a line starting with `{`); the correct quiet default prints
+/// nothing server-side (its guard silences the loud client too — the
+/// process-global overlap — so the parent just asserts no `{` line).
+fn child_bare_default_server() {
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    rt.block_on(async {
+        let server = riperf3::ServerBuilder::new()
+            .port(Some(0))
+            .json_output(true)
+            .build()
+            .unwrap();
+        let bound = server.bind().await.unwrap();
+        let port = bound.local_addr().unwrap().port();
+        let server_task = tokio::spawn(async move { bound.run_once().await });
+        let client = riperf3::ClientBuilder::new("127.0.0.1")
+            .port(Some(port))
+            .duration(1)
+            .emit_output(true)
+            .build()
+            .unwrap();
+        client.run().await.expect("client run");
+        let _ = server_task.await.expect("server task").expect("run_once");
+    });
+    eprintln!("QUIET_CHILD_DONE");
+}
+
 fn spawn_child(quiet: bool, test_name: &str) -> std::process::Output {
     Command::new(std::env::current_exe().unwrap())
         .args([test_name, "--exact", "--nocapture"])
@@ -197,6 +277,14 @@ fn quiet_run_writes_nothing_to_stdout() {
     }
     if std::env::var("RIPERF3_QUIET_CHILD").as_deref() == Ok("json-stream") {
         child_quiet_json_stream();
+        return;
+    }
+    if std::env::var("RIPERF3_QUIET_CHILD").as_deref() == Ok("bare-client") {
+        child_bare_default_client();
+        return;
+    }
+    if std::env::var("RIPERF3_QUIET_CHILD").as_deref() == Ok("bare-server") {
+        child_bare_default_server();
         return;
     }
     if std::env::var("RIPERF3_QUIET_CHILD").as_deref() == Ok("0") {
@@ -272,6 +360,74 @@ fn quiet_server_daemon_is_silent_and_loudness_recovers() {
         stdout.contains("iperf Done."),
         "the loud phase after quiet runs printed nothing — a quiet guard \
          leaked its increment (r1 mutation a): {stdout}"
+    );
+}
+
+/// #294 (review sweep): a client built with NO `emit_output` call is quiet —
+/// the flipped DEFAULT itself is under test, in a process with no riperf3
+/// server whose own guard could mask a revert. Reverting the ClientBuilder
+/// default to `true` fails this (the connect banner leaks).
+#[test]
+fn bare_default_client_is_quiet() {
+    if std::env::var("RIPERF3_QUIET_CHILD").is_ok() {
+        return;
+    }
+    let out = Command::new(std::env::current_exe().unwrap())
+        .args([
+            "quiet_run_writes_nothing_to_stdout",
+            "--exact",
+            "--nocapture",
+        ])
+        .env("RIPERF3_QUIET_CHILD", "bare-client")
+        .output()
+        .expect("re-exec child");
+    assert!(out.status.success(), "child failed: {out:?}");
+    let err = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        err.contains("QUIET_CHILD_DONE"),
+        "the child arm must have run: {err}"
+    );
+    let leaked = non_harness_stdout(&out.stdout);
+    assert!(
+        leaked.is_empty(),
+        "a bare (no emit_output call) client must write NOTHING to stdout \
+         — the #294 client default regressed: {leaked:#?}"
+    );
+    assert_stderr_only_marker(&out);
+}
+
+/// #294 (review sweep), server half: a `-J` server built with NO
+/// `emit_output` call emits no JSON document. Reverting the ServerBuilder
+/// default to `true` fails this (the doc's `{` line leaks — the driving
+/// client is explicitly loud, so no other guard is in play).
+#[test]
+fn bare_default_server_is_quiet() {
+    if std::env::var("RIPERF3_QUIET_CHILD").is_ok() {
+        return;
+    }
+    let out = Command::new(std::env::current_exe().unwrap())
+        .args([
+            "quiet_run_writes_nothing_to_stdout",
+            "--exact",
+            "--nocapture",
+        ])
+        .env("RIPERF3_QUIET_CHILD", "bare-server")
+        .output()
+        .expect("re-exec child");
+    assert!(out.status.success(), "child failed: {out:?}");
+    let err = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        err.contains("QUIET_CHILD_DONE"),
+        "the child arm must have run: {err}"
+    );
+    let json_leak: Vec<String> = non_harness_stdout(&out.stdout)
+        .into_iter()
+        .filter(|l| l.trim_start().starts_with('{'))
+        .collect();
+    assert!(
+        json_leak.is_empty(),
+        "a bare (no emit_output call) -J server must not print its document \
+         — the #294 server default regressed: {json_leak:#?}"
     );
 }
 


### PR DESCRIPTION
## What

Closes the findings from a three-lens cold review of the full 0.9.0 span to date (`16a5db4^..a461cb3`: #397 #400 #403 #405 #407 #408 #409). The review found **zero behavioral blockers** — the span is GT-faithful on every probed surface and both #409 invariants (termination-precedence lockstep, ctx-flag mutual exclusivity) were independently re-verified — but real release debt on 0.9.0's own breaking changes.

## Fixes

**CHANGELOG** — `[Unreleased]` listed only the three Breaking bullets; the span's four user-visible fixes (#364 #367 #368 #371) and the new `ErrorSinkGuard` / `errexit_message` API were unlisted. Added terse `Added`/`Fixed` sections.

**Docs** —
- Four rustdocs stated the pre-#294 output default or the pre-#293 `Report` return: `ClientBuilder::emit_output`, `ServerBuilder::emit_output`, `Server::run_once`, `BoundServer::run_once`.
- `Client::run` and `Server::run` had **no rustdoc at all** — the 0.9.0 headline API rendered empty on docs.rs. Both get full #293/#294 contract paragraphs.
- `mod outcome` was **private**, so the #293 module narrative never rendered on docs.rs. Now `pub mod` (the `json_report` precedent).
- lib.rs front page: crate intro + a compiling `no_run` example of the `RunOutcome` pattern (the crate's first doctest).
- Stale #353 comment on the exchange `?` (post-#405 the send failures are caught, not propagated); three unescaped bracket "links" in cli.rs rustdoc. The two clap doc comments (`<host>`, `[kmgtKMGT]`) are deliberately untouched — they render into `--help`, which must stay byte-faithful to GT's usage text.

**Test pins** —
- **#294 default flip was unpinned**: reverting either builder default survived the entire suite (mutation-verified by the review). Two new re-exec child arms pin each default in isolation. A naive bare *pair* pins nothing — the quiet guard is process-global, so the partner's correct default masks a revert (first attempt, caught by its own red-proof). The client arm runs against a cookie-swallowing mock; the server arm is driven by an explicitly loud client. Red-proofed: each pin fails on exactly its own builder's revert and ignores the other's.
- Server-side `Interrupted` lib pin: mid-test interrupt on `run_once` → `Ok(RunOutcome)` + `Termination::Interrupted` (the same silent-`_ =>`-arm invisibility class as the `SelfTerminated` pin), plus the client's `ServerTerminated` half. 3/3 stable at 1.6 s on a 2-core constraint.
- `errexit_message` unit test: `Some` for exactly the two client "server ended it" classes, `None` for every server-side ending (the #224 exit-0 contract the CLI's exit code relies on).

**Behavior (two small items)** —
- `net.rs` pacing warning (`warning: Unable to set socket pacing`) was the one warning site outside the #290 quiet gate — widened to matter by the #294 default flip. Now gated like `protocol.rs`'s `gt_warning` (the r1-F6 decision). No direct pin: the trigger needs a deterministic setsockopt failure and the assertion needs the re-exec harness; same untested status as the sibling `gt_warning` gate.
- `Termination::errexit_message()` returns `Option<&str>` instead of `Option<String>` (allocation-free; the API is unreleased so this is free polish).

## Also from the same sweep

- Filed #410 (`--server-bitrate-limit` whole-test-average vs GT's 5-interval moving window).
- #398 addendum: the #405 `SendFailed` serve-loop line joins the logfile-sink sweep checklist.

## Verification

- fmt / clippy `-D warnings` / rustdoc `-D rustdoc::broken_intra_doc_links` / full workspace suite: clean.
- Wire-neutral: no protocol or CLI-output change (the net.rs gate only affects quiet *library* callers; the CLI is always loud).
