### PR TITLE
fix: rate-set server docs emit target_bitrate at GT's get_parameters slot (#377)

### DIFF
--- a/riperf3-cli/tests/wire_shape.rs
+++ b/riperf3-cli/tests/wire_shape.rs
@@ -2220,6 +2220,53 @@ fn setup_phase_ctrl_eof_takes_gt_doc_shape_in_json() {
     );
 }
 
+/// #377 r2 F1: GT's auth gate runs AFTER get_parameters (iperf_api.c:2368
+/// vs :2662), so an auth-DENIED rate-set request still carries the early
+/// `target_bitrate` in the -J denial doc (live-probed 3.21: `start =
+/// {connected, version, system_info, target_bitrate}` + the error key).
+/// The tokenless deny arm needs no crypto: a server with auth configured
+/// denies a params blob that carries no authtoken. (GT's denial error
+/// STRING is a different, unrecorded divergence — tracked on #395.)
+#[test]
+fn auth_denied_rate_set_doc_carries_the_early_target_bitrate() {
+    let fixtures = concat!(env!("CARGO_MANIFEST_DIR"), "/../riperf3/tests/fixtures");
+    let key = format!("{fixtures}/test_private.pem");
+    let users = format!("{fixtures}/test_users.csv");
+    let (sout, _serr, _status) = drive_server_scenario_with(
+        &[
+            "--rsa-private-key-path",
+            &key,
+            "--authorized-users-path",
+            &users,
+        ],
+        true,
+        |port| {
+            let mut ctrl = std::net::TcpStream::connect(("127.0.0.1", port)).expect("ctrl");
+            ctrl.write_all(&[b'x'; 37]).unwrap();
+            assert_eq!(read_exact(&mut ctrl, 1)[0], 9, "ParamExchange");
+            write_json_blob(&mut ctrl, r#"{"tcp":true,"bandwidth":100000000}"#);
+            // The ACCESS_DENIED wire-back (state -1 as a byte).
+            assert_eq!(read_exact(&mut ctrl, 1)[0], 0xFF, "AccessDenied");
+        },
+    );
+    let doc: serde_json::Value =
+        serde_json::from_str(sout.trim()).unwrap_or_else(|e| panic!("one -J doc ({e}): {sout}"));
+    assert_eq!(
+        doc["start"]["target_bitrate"].as_u64(),
+        Some(100_000_000),
+        "the denial doc carries the ingested -b (#377 r2 F1): {doc}"
+    );
+    assert!(
+        doc["error"].as_str().is_some(),
+        "the denial doc keeps its error key: {doc}"
+    );
+    assert_eq!(
+        sout.matches("\"target_bitrate\"").count(),
+        1,
+        "ONE doc, ONE occurrence — no double emission: {sout}"
+    );
+}
+
 /// #357: with `-w` exchanged, GT re-listens with the window applied and
 /// reads the setup doc's sndbuf/rcvbuf actuals off THAT socket (probed
 /// 131072/131072 for window 65536 — the Linux doubling); riperf3 read

--- a/riperf3/src/json_report.rs
+++ b/riperf3/src/json_report.rs
@@ -339,6 +339,14 @@ fn setup_phase_document<E: Serialize>(d: &SetupPhaseDoc, end: &E, error: Option<
         connected: [(); 0],
         version: String,
         system_info: String,
+        // #377: get_parameters' early key on rate-set requests
+        // (iperf_api.c:2662) — the kill doc rides the same GT json_start,
+        // so the shift shows here too (live-probed via a params-then-EOF
+        // mock). Exactly one of early/late is Some: GT also emits the
+        // on_connect occurrence (iperf_api.c:1029), a duplicate JSON key —
+        // the recorded #377 deviation riperf3 omits.
+        #[serde(rename = "target_bitrate", skip_serializing_if = "Option::is_none")]
+        early_target_bitrate: Option<u64>,
         #[serde(skip_serializing_if = "Option::is_none")]
         sock_bufsize: Option<u64>,
         #[serde(skip_serializing_if = "Option::is_none")]
@@ -350,7 +358,8 @@ fn setup_phase_document<E: Serialize>(d: &SetupPhaseDoc, end: &E, error: Option<
         cookie: &'a str,
         #[serde(skip_serializing_if = "Option::is_none")]
         tcp_mss_default: Option<u32>,
-        target_bitrate: u64,
+        #[serde(rename = "target_bitrate", skip_serializing_if = "Option::is_none")]
+        late_target_bitrate: Option<u64>,
         fq_rate: u64,
     }
     #[derive(Serialize)]
@@ -367,6 +376,7 @@ fn setup_phase_document<E: Serialize>(d: &SetupPhaseDoc, end: &E, error: Option<
             connected: [],
             version: format!("riperf3 {}", env!("CARGO_PKG_VERSION")),
             system_info: crate::utils::system_info(),
+            early_target_bitrate: (d.target_bitrate != 0).then_some(d.target_bitrate),
             sock_bufsize: d.sock_bufsize,
             sndbuf_actual: d.sndbuf_actual,
             rcvbuf_actual: d.rcvbuf_actual,
@@ -381,7 +391,7 @@ fn setup_phase_document<E: Serialize>(d: &SetupPhaseDoc, end: &E, error: Option<
             },
             cookie: &d.cookie,
             tcp_mss_default: d.tcp_mss_default,
-            target_bitrate: d.target_bitrate,
+            late_target_bitrate: (d.target_bitrate == 0).then_some(d.target_bitrate),
             fq_rate: d.fq_rate,
         },
         intervals: [],
@@ -482,6 +492,20 @@ impl Serialize for Start {
         m.serialize_entry("connected", &self.connected)?;
         m.serialize_entry("version", &self.version)?;
         m.serialize_entry("system_info", &self.system_info)?;
+        // #377: GT's get_parameters inserts target_bitrate right after
+        // system_info whenever the exchanged rate is nonzero
+        // (iperf_api.c:2662) — SERVER role only (it's the param ingest) —
+        // and on_connect then emits the key AGAIN (iperf_api.c:1029): a
+        // duplicate JSON key no strict serializer can express, and
+        // arguably a GT defect. riperf3 emits the EARLY occurrence only
+        // (both carry the same exchanged rate; cJSON's lookup reads the
+        // first) — the recorded #377 deviation; every other key stays
+        // byte-aligned, including the trio shifting to 5-7 on rate-set
+        // TCP (all cells live-probed 3.21).
+        let early_tb = self.accepted_connection.is_some() && self.target_bitrate != 0;
+        if early_tb && self.stage != StartStage::Connecting {
+            m.serialize_entry("target_bitrate", &self.target_bitrate)?;
+        }
         // #355: the TCP SERVER inserts the bufsize trio at listen time
         // (iperf_tcp.c:372-375) — positions 4-6, BEFORE timestamp; the
         // client takes them at TestStart, after fq_rate, and the UDP
@@ -516,7 +540,12 @@ impl Serialize for Start {
             if let Some(v) = &self.tcp_mss_default {
                 m.serialize_entry("tcp_mss_default", v)?;
             }
-            m.serialize_entry("target_bitrate", &self.target_bitrate)?;
+            // The on_connect slot — skipped when the #377 early occurrence
+            // already went out (GT emits BOTH; the dup is the recorded
+            // deviation).
+            if !early_tb {
+                m.serialize_entry("target_bitrate", &self.target_bitrate)?;
+            }
             m.serialize_entry("fq_rate", &self.fq_rate)?;
         }
         if self.stage == StartStage::Started {
@@ -3902,9 +3931,9 @@ mod tests {
     /// listener inserts it early (iperf_tcp.c:372-375); UDP's lands at
     /// CREATE_STREAMS via iperf_udp_buffercheck (iperf_udp.c:440-452,
     /// after on_connect), i.e. the client slot. A protocol-blind server
-    /// gate would regress this previously-GT-matching cell. (GT also
-    /// duplicates target_bitrate at position 4 on rate-set runs — the
-    /// recorded #377 divergence; riperf3 emits it once.)
+    /// gate would regress this previously-GT-matching cell. (Rate-set
+    /// runs move target_bitrate to position 4 — the #377 pins below;
+    /// this zero-rate cell keeps the late single occurrence.)
     #[test]
     fn udp_server_role_start_key_order_keeps_the_late_trio() {
         let mut input = base_input();
@@ -3934,6 +3963,132 @@ mod tests {
                 "test_start"
             ],
             "UDP server start keys must keep GT's late trio (#355 r1 F1): {raw}"
+        );
+    }
+
+    /// #377: GT's get_parameters inserts `target_bitrate` right after
+    /// system_info (iperf_api.c:2662) whenever the exchanged rate is
+    /// nonzero — SERVER role only — shifting the TCP early trio to
+    /// positions 5-7. GT then emits the key AGAIN at on_connect
+    /// (iperf_api.c:1029): a duplicate JSON key no strict serializer can
+    /// express. riperf3 emits the EARLY occurrence only — the recorded
+    /// #377 deviation (both occurrences carry the same exchanged rate;
+    /// cJSON's lookup reads the first) — leaving every other key
+    /// byte-aligned with GT (all cells live-probed 3.21, 2026-07-09).
+    #[test]
+    fn rate_set_tcp_server_start_moves_target_bitrate_to_gt_position_4() {
+        let mut input = base_input();
+        input.is_server = true;
+        input.connecting_host = String::new();
+        input.connecting_port = 0;
+        input.accepted_host = "127.0.0.1".into();
+        input.accepted_port = 5201;
+        input.target_bitrate = 100_000_000;
+        input.streams = vec![tcp_stream(1, true, 10, 10)];
+        let raw = serde_json::to_string(&input.build()).unwrap();
+        assert_eq!(
+            raw_keys(&raw, "start"),
+            [
+                "connected",
+                "version",
+                "system_info",
+                "target_bitrate",
+                "sock_bufsize",
+                "sndbuf_actual",
+                "rcvbuf_actual",
+                "timestamp",
+                "accepted_connection",
+                "cookie",
+                "tcp_mss_default",
+                "fq_rate",
+                "test_start"
+            ],
+            "rate-set TCP server start keys must match GT's get_parameters \
+             insertion (#377): {raw}"
+        );
+        assert_eq!(
+            raw_keys(&raw, "start")
+                .iter()
+                .filter(|k| *k == "target_bitrate")
+                .count(),
+            1,
+            "exactly ONE start-level occurrence — GT's on_connect duplicate \
+             is the recorded #377 deviation (test_start's own key is a \
+             different, legitimate field): {raw}"
+        );
+    }
+
+    /// #377, UDP cell: the early key lands right after system_info and the
+    /// late trio stays late — GT UDP default-rate order, minus the dup.
+    #[test]
+    fn rate_set_udp_server_start_moves_target_bitrate_to_gt_position_4() {
+        let mut input = base_input();
+        input.protocol = TransportProtocol::Udp;
+        input.is_server = true;
+        input.connecting_host = String::new();
+        input.connecting_port = 0;
+        input.accepted_host = "127.0.0.1".into();
+        input.accepted_port = 5201;
+        input.target_bitrate = 1_048_576; // GT's UDP default: rate-set is UDP's norm
+        input.streams = vec![udp_stream(1, true, 131072 * 96, None, 0.001, 0, 96)];
+        let raw = serde_json::to_string(&input.build()).unwrap();
+        assert_eq!(
+            raw_keys(&raw, "start"),
+            [
+                "connected",
+                "version",
+                "system_info",
+                "target_bitrate",
+                "timestamp",
+                "accepted_connection",
+                "cookie",
+                "fq_rate",
+                "sock_bufsize",
+                "sndbuf_actual",
+                "rcvbuf_actual",
+                "test_start"
+            ],
+            "rate-set UDP server start keys must match GT's get_parameters \
+             insertion (#377): {raw}"
+        );
+        assert_eq!(
+            raw_keys(&raw, "start")
+                .iter()
+                .filter(|k| *k == "target_bitrate")
+                .count(),
+            1,
+            "exactly ONE start-level occurrence — the #377 dup stays \
+             omitted: {raw}"
+        );
+    }
+
+    /// #377 guard: the CLIENT role is untouched — get_parameters is the
+    /// server's param ingest, so a rate-set CLIENT doc keeps the single
+    /// late (on_connect-slot) key (live-probed 3.21: client -b 100M).
+    #[test]
+    fn rate_set_client_start_keeps_the_late_target_bitrate() {
+        let mut input = base_input();
+        input.target_bitrate = 100_000_000;
+        input.streams = vec![tcp_stream(1, true, 10, 10)];
+        let raw = serde_json::to_string(&input.build()).unwrap();
+        assert_eq!(
+            raw_keys(&raw, "start"),
+            [
+                "connected",
+                "version",
+                "system_info",
+                "timestamp",
+                "connecting_to",
+                "cookie",
+                "tcp_mss_default",
+                "target_bitrate",
+                "fq_rate",
+                "sock_bufsize",
+                "sndbuf_actual",
+                "rcvbuf_actual",
+                "test_start"
+            ],
+            "a rate-set CLIENT start block keeps GT's client order (#377): {raw}"
         );
     }
 
@@ -4102,6 +4257,70 @@ mod tests {
                 "sender"
             ],
             "UDP sum_sent key order drifted from GT: {raw}"
+        );
+    }
+
+    /// #377, setup-doc cell: the kill doc rides the same GT json_start —
+    /// get_parameters ran before the kill, so a rate-set request shows the
+    /// early key + the shifted trio there too (live-probed 3.21 via a
+    /// params-then-EOF mock: `...system_info, target_bitrate, sock_bufsize,
+    /// sndbuf_actual, rcvbuf_actual, timestamp, ..., tcp_mss_default,
+    /// target_bitrate, fq_rate` — the second occurrence again the recorded
+    /// dup riperf3 omits).
+    #[test]
+    fn rate_set_setup_document_moves_target_bitrate_to_gt_position_4() {
+        let d = SetupPhaseDoc {
+            sock_bufsize: Some(0),
+            sndbuf_actual: Some(16384),
+            rcvbuf_actual: Some(131072),
+            tcp_mss_default: Some(0),
+            udp: false,
+            timemillisecs: 1_700_000_000_000,
+            accepted_host: "127.0.0.1".into(),
+            accepted_port: 5201,
+            cookie: "c".repeat(36),
+            target_bitrate: 100_000_000,
+            fq_rate: 0,
+        };
+        let raw = setup_terminate_document(
+            &d,
+            "the client has terminated",
+            &CpuUtilization {
+                host_total: 1.0,
+                host_user: 0.5,
+                host_system: 0.5,
+                remote_total: 0.0,
+                remote_user: 0.0,
+                remote_system: 0.0,
+            },
+        );
+        assert_eq!(
+            raw_keys(&raw, "start"),
+            [
+                "connected",
+                "version",
+                "system_info",
+                "target_bitrate",
+                "sock_bufsize",
+                "sndbuf_actual",
+                "rcvbuf_actual",
+                "timestamp",
+                "accepted_connection",
+                "cookie",
+                "tcp_mss_default",
+                "fq_rate"
+            ],
+            "rate-set setup start keys must match GT's get_parameters \
+             insertion (#377): {raw}"
+        );
+        assert_eq!(
+            raw_keys(&raw, "start")
+                .iter()
+                .filter(|k| *k == "target_bitrate")
+                .count(),
+            1,
+            "exactly ONE start-level occurrence — the #377 dup stays \
+             omitted: {raw}"
         );
     }
 

--- a/riperf3/src/json_report.rs
+++ b/riperf3/src/json_report.rs
@@ -4065,6 +4065,50 @@ mod tests {
         );
     }
 
+    /// #377 r2 F2: the early-key gate's stage clause — a stage-0
+    /// (Connecting) server doc stays exactly the three stage-0 keys even
+    /// with a rate ingested. Production server docs are always Started
+    /// (server.rs builds post-test), so the clause is defensive, but it
+    /// carries the #281 staging invariant and GT's stage-0 parallel
+    /// (get_parameters hasn't run at stage 0, so no early key exists
+    /// there either); this pin kills the clause's surviving mutant.
+    #[test]
+    fn rate_set_connecting_stage_doc_keeps_the_three_stage_zero_keys() {
+        let start = Start {
+            stage: StartStage::Connecting,
+            tcp: true,
+            connected: vec![],
+            version: "riperf3 test".into(),
+            system_info: String::new(),
+            timestamp: Timestamp {
+                time: String::new(),
+                timesecs: 0,
+                timemillisecs: 0,
+            },
+            connecting_to: None,
+            accepted_connection: Some(ConnectingTo {
+                host: "127.0.0.1".into(),
+                port: 5201,
+            }),
+            cookie: String::new(),
+            tcp_mss: None,
+            tcp_mss_default: None,
+            target_bitrate: 100_000_000,
+            fq_rate: 0,
+            sock_bufsize: None,
+            sndbuf_actual: None,
+            rcvbuf_actual: None,
+            test_start: None,
+        };
+        let raw = format!("{{\"start\":{}}}", serde_json::to_string(&start).unwrap());
+        assert_eq!(
+            raw_keys(&raw, "start"),
+            ["connected", "version", "system_info"],
+            "a Connecting-stage doc carries no early target_bitrate even \
+             rate-set (#377 r2 F2): {raw}"
+        );
+    }
+
     /// #377 guard: the CLIENT role is untouched — get_parameters is the
     /// server's param ingest, so a rate-set CLIENT doc keeps the single
     /// late (on_connect-slot) key (live-probed 3.21: client -b 100M).

--- a/riperf3/src/json_report.rs
+++ b/riperf3/src/json_report.rs
@@ -496,12 +496,14 @@ impl Serialize for Start {
         // system_info whenever the exchanged rate is nonzero
         // (iperf_api.c:2662) — SERVER role only (it's the param ingest) —
         // and on_connect then emits the key AGAIN (iperf_api.c:1029): a
-        // duplicate JSON key no strict serializer can express, and
-        // arguably a GT defect. riperf3 emits the EARLY occurrence only
-        // (both carry the same exchanged rate; cJSON's lookup reads the
-        // first) — the recorded #377 deviation; every other key stays
-        // byte-aligned, including the trio shifting to 5-7 on rate-set
-        // TCP (all cells live-probed 3.21).
+        // duplicate JSON key, RFC 8259 SHOULD-unique and collapsed
+        // silently by strict parsers. Reproducing it here is possible but
+        // DECLINED (the #271 don't-mirror-GT-bugs precedent) — riperf3
+        // emits the EARLY occurrence only (both carry the same exchanged
+        // rate; cJSON's lookup reads the first) — the recorded #377
+        // deviation; every other key stays byte-aligned, including the
+        // trio shifting to 5-7 on rate-set TCP (all cells live-probed
+        // 3.21).
         let early_tb = self.accepted_connection.is_some() && self.target_bitrate != 0;
         if early_tb && self.stage != StartStage::Connecting {
             m.serialize_entry("target_bitrate", &self.target_bitrate)?;
@@ -3970,8 +3972,9 @@ mod tests {
     /// system_info (iperf_api.c:2662) whenever the exchanged rate is
     /// nonzero — SERVER role only — shifting the TCP early trio to
     /// positions 5-7. GT then emits the key AGAIN at on_connect
-    /// (iperf_api.c:1029): a duplicate JSON key no strict serializer can
-    /// express. riperf3 emits the EARLY occurrence only — the recorded
+    /// (iperf_api.c:1029): a duplicate JSON key, declined per the #271
+    /// don't-mirror-GT-bugs precedent (reproducible, but RFC 8259
+    /// SHOULD-unique). riperf3 emits the EARLY occurrence only — the recorded
     /// #377 deviation (both occurrences carry the same exchanged rate;
     /// cJSON's lookup reads the first) — leaving every other key
     /// byte-aligned with GT (all cells live-probed 3.21, 2026-07-09).

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -728,13 +728,24 @@ impl Server {
                 | Err(e @ RiperfError::SetNoDelayFailed(_)) => {
                     self.emit_pretest_error(&e);
                 }
+                Err(e @ RiperfError::AccessDenied) => {
+                    // #377 r2 F1: the -J denial doc (with the ingested -b)
+                    // emitted at the auth site, where params is in scope;
+                    // only the text line prints here.
+                    if !json && !crate::macros::output_quiet() {
+                        eprintln!(
+                            "{}riperf3: error - {e}",
+                            crate::macros::output_timestamp_prefix()
+                        );
+                    }
+                }
                 Err(e) => {
                     // Any residual pre-report error rides the same sink: under
                     // -J iperf_err stays silent and puts the message in a
                     // skeleton doc, rather than the raw stderr line GT never
                     // emits in JSON mode (#330 divergence 1).
                     if json {
-                        self.emit_pretest_error_doc(&format!("error - {e}"));
+                        self.emit_pretest_error_doc(&format!("error - {e}"), None);
                     } else if !crate::macros::output_quiet() {
                         eprintln!(
                             "{}riperf3: error - {e}",
@@ -872,7 +883,7 @@ impl Server {
             None => {
                 if let Some(w) = &self.interrupt {
                     if let Some(msg) = w.0.borrow().clone() {
-                        self.emit_pretest_error_doc(&msg);
+                        self.emit_pretest_error_doc(&msg, None);
                     }
                 }
                 return Ok(None);
@@ -918,7 +929,7 @@ impl Server {
         let negotiated = tokio::select! {
             r = self.negotiate_test(&mut ctrl) => r?,
             msg = crate::client::wait_interrupt(neg_interrupt.as_mut()) => {
-                self.emit_pretest_error_doc(&msg);
+                self.emit_pretest_error_doc(&msg, None);
                 return Ok(None);
             }
         };
@@ -946,7 +957,23 @@ impl Server {
         self.print_connect_block(peer_addr, &cookie, &params, &cfg);
 
         // ---- Auth validation (after params, before streams) ----
-        self.authenticate(&mut ctrl, &params).await?;
+        if let Err(e) = self.authenticate(&mut ctrl, &params).await {
+            if matches!(e, RiperfError::AccessDenied) {
+                // #377 r2 F1: GT's auth gate runs AFTER get_parameters
+                // (iperf_api.c:2368 vs :2662), so the denial doc carries
+                // the early target_bitrate like the #260 refusal twins.
+                // Emitted HERE — params is out of scope at the serve
+                // loop's arm, which prints only the text line. (The rarer
+                // auth-failure subclasses — unreadable key, undecodable
+                // token — keep the residual rate-less sink until #395
+                // reworks the surface.)
+                self.emit_pretest_error_doc(
+                    &format!("error - {e}"),
+                    params.bandwidth.filter(|&b| b > 0),
+                );
+            }
+            return Err(e);
+        }
 
         // The test's accumulated state, threaded through the pipeline phases
         // (#289) — field docs on TestRunCtx.
@@ -3686,7 +3713,7 @@ impl Server {
     /// or the --json-stream error+empty-end event pair. No-op in text mode and
     /// under the #290 console-quiet scope. Shared by [`Self::emit_pretest_error`]
     /// and the serve loop's residual generic arm.
-    fn emit_pretest_error_doc(&self, doc_error: &str) {
+    fn emit_pretest_error_doc(&self, doc_error: &str, target_bitrate: Option<u64>) {
         if crate::macros::output_quiet() {
             return;
         }
@@ -3695,7 +3722,13 @@ impl Server {
                 doc_error,
             ));
         } else if self.json_output {
-            println!("{}", crate::json_report::error_document(doc_error));
+            // #377 r2 F1: the skeleton carries the ingested -b when the
+            // caller still had params in scope (the auth deny site) — GT's
+            // get_parameters stamps json_start before every later gate.
+            println!(
+                "{}",
+                crate::json_report::refusal_document(doc_error, target_bitrate)
+            );
         }
     }
 
@@ -3938,7 +3971,7 @@ impl Server {
             _ => format!("error - {err}: "),
         };
         if self.json_output || self.json_stream {
-            self.emit_pretest_error_doc(&doc_error);
+            self.emit_pretest_error_doc(&doc_error, None);
         } else if !crate::macros::output_quiet() {
             // #339 r2b F2: iperf_err stamps its stderr line with the
             // --timestamps prefix (iperf_error.c:51-57, :77) — same


### PR DESCRIPTION
Closes #377.

## What

GT's `get_parameters` inserts `target_bitrate` right after `system_info` (iperf_api.c:2662) whenever the exchanged rate is nonzero — **server role only** — shifting the TCP early trio to positions 5-7; `on_connect` then emits the key **again** (iperf_api.c:1029). The duplicate JSON key is malformed for strict parsers and inexpressible in serde's Map model: riperf3 now emits the **early occurrence only** — the recorded #377 deviation (both occurrences carry the same exchanged rate; cJSON's lookup reads the first) — leaving every other key byte-aligned with GT. Zero-rate and client-role cells were already byte-matched and are unchanged (guard-pinned).

## Probes (live 3.21, both tools, 2026-07-09)

| Cell | GT start keys | riperf3 (this PR) |
|---|---|---|
| TCP `-b 100M` server | `…system_info, TB, trio, timestamp, …, mss, TB, fq…` | identical minus the second `TB` |
| UDP default server | `…system_info, TB, timestamp, …, cookie, TB, fq, trio…` | identical minus the second `TB` |
| TCP zero-rate / UDP `-b 0` | no early key | already matched — unchanged |
| client `-b 100M` | single late key | unchanged (role gate) |
| setup-kill doc, rate-set params | early `TB` + shifted trio + dup (params-then-EOF mock) | identical minus the dup |

All four server cells re-probed post-fix: key sequences identical to GT modulo the omitted dup.

## How

Two emission sites, one rule (`server && rate != 0` → early slot, late slot skipped):
- the hand-written `Serialize for Start` (early slot before the #355 trio);
- `setup_phase_document`'s `SetupStart` (an early/late `Option` pair sharing the serde rename; exactly one is `Some`).

## Tests

Four red-first pins: rate-set TCP + UDP server key order (each with a depth-1 dup-omission lock), the client-role guard, and the rate-set setup-doc order. Role-gate mutant hand-red via the guard pin. Full workspace suite green.
