### PR TITLE
fix: preserve the #300-class key order through every Value round-trip (#378)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,12 @@ release tags.
 
 ### Fixed
 
+- Rate-set server documents place `target_bitrate` at iperf3's get_parameters slot (right
+  after `system_info`, shifting the TCP trio); the duplicate on_connect emission is a
+  recorded deviation (#377).
+- `--get-server-output` no longer alphabetizes the embedded server document
+  (serde_json `preserve_order`); the params/results wire blobs now match iperf3's key
+  order too (#378).
 - `--logfile` receives the SERVER-ERROR relay receipt and the interrupt notice like iperf3's
   `iperf_err` routing; both previously went to stderr (#364).
 - Wire-blob parsing mirrors cJSON's UTF-8 BOM skip and non-object params root; four residual

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -920,6 +920,7 @@ version = "1.0.133"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7fceb2473b9166b2294ef05efcb65a3db80803f0b03ef86a5fc88a2b85ee377"
 dependencies = [
+ "indexmap",
  "itoa",
  "memchr",
  "ryu",

--- a/riperf3-cli/tests/get_server_output.rs
+++ b/riperf3-cli/tests/get_server_output.rs
@@ -211,7 +211,20 @@ fn raw_keys(raw: &str, obj: &str) -> Vec<String> {
                 }
             }
             b'"' => {
-                let close = raw[i + 1..].find('"').unwrap() + i + 1;
+                // Skip escaped quotes (r1 F3): a value like "a \": b" must
+                // not fake a key.
+                let mut close = i;
+                loop {
+                    close += 1 + raw[close + 1..].find('"').unwrap();
+                    let backslashes = raw[..close]
+                        .bytes()
+                        .rev()
+                        .take_while(|b| *b == b'\\')
+                        .count();
+                    if backslashes % 2 == 0 {
+                        break;
+                    }
+                }
                 if depth == 1 && bytes.get(close + 1) == Some(&b':') {
                     out.push(raw[i + 1..close].to_string());
                 }

--- a/riperf3-cli/tests/get_server_output.rs
+++ b/riperf3-cli/tests/get_server_output.rs
@@ -192,6 +192,94 @@ fn json_client_gets_server_output_json() {
     );
 }
 
+/// Depth-1 keys of the object at the first `"obj":` in `raw` — a raw-string
+/// walk, because parsed `Value` asserts are order-blind (the json_report
+/// unit pins' technique). Slice `raw` first to scope into a nested object.
+fn raw_keys(raw: &str, obj: &str) -> Vec<String> {
+    let from = raw.find(&format!("\"{obj}\":")).unwrap() + obj.len() + 3;
+    let bytes = raw.as_bytes();
+    let mut depth = 0i32;
+    let mut i = from;
+    let mut out = Vec::new();
+    while i < bytes.len() {
+        match bytes[i] {
+            b'{' | b'[' => depth += 1,
+            b'}' | b']' => {
+                depth -= 1;
+                if depth == 0 {
+                    break;
+                }
+            }
+            b'"' => {
+                let close = raw[i + 1..].find('"').unwrap() + i + 1;
+                if depth == 1 && bytes.get(close + 1) == Some(&b':') {
+                    out.push(raw[i + 1..close].to_string());
+                }
+                i = close;
+            }
+            _ => {}
+        }
+        i += 1;
+    }
+    out
+}
+
+/// #378: the embedded server doc must keep the SERVER's hand-serialized key
+/// order end-to-end — GT splices the cJSON subtree as received, so a GT-GT
+/// run shows `server_output_json.start` in the #355 server insertion order
+/// (live-probed 3.21). A `serde_json::Value` round-trip alphabetizes the
+/// whole subtree at BOTH hops (the server's attach and this client's
+/// re-emit), destroying the #300-class wire order.
+#[test]
+fn server_output_json_keeps_the_server_key_order() {
+    let port = free_port();
+    let ps = port.to_string();
+    let server = spawn_server_capturing(&["-J"], &ps);
+    let out = run_capturing(
+        &[
+            "-c",
+            "127.0.0.1",
+            "-p",
+            &ps,
+            "-t",
+            "1",
+            "-J",
+            "--get-server-output",
+        ],
+        Duration::from_secs(20),
+        "client",
+    );
+    let _ = collect_stdout(server);
+
+    let soj_at = out.find("\"server_output_json\":").expect("attachment");
+    let embedded = &out[soj_at..];
+    assert_eq!(
+        raw_keys(embedded, "server_output_json"),
+        ["start", "intervals", "end"],
+        "the embedded doc keeps GT's top-level order (#378): {out}"
+    );
+    assert_eq!(
+        raw_keys(embedded, "start"),
+        [
+            "connected",
+            "version",
+            "system_info",
+            "sock_bufsize",
+            "sndbuf_actual",
+            "rcvbuf_actual",
+            "timestamp",
+            "accepted_connection",
+            "cookie",
+            "tcp_mss_default",
+            "target_bitrate",
+            "fq_rate",
+            "test_start"
+        ],
+        "the embedded start keeps the #355 server insertion order, not \
+         the alphabetized Value round-trip (#378): {out}"
+    );
+}
+
 /// Without the flag nothing changes: no Server output section, no keys.
 #[test]
 fn no_flag_no_server_output() {

--- a/riperf3/Cargo.toml
+++ b/riperf3/Cargo.toml
@@ -27,7 +27,13 @@ sha2.workspace = true
 # serde_json::value::RawValue. A workspace-only feature does NOT flatten on
 # publish, which would leave the published crate free-riding on a consumer to
 # enable raw_value — the same socket2 #92 trap as `all` below.
-serde_json = { workspace = true, features = ["raw_value"] }
+# preserve_order (#378): GT is cJSON end-to-end — insertion order everywhere —
+# so an alphabetizing serde_json::Map is the ONE traitor to the #300-class key
+# order wherever a doc round-trips through Value (the --get-server-output
+# attach + re-emit, the params/results wire blobs). IndexMap-backed maps make
+# every Value round-trip order-preserving; the hand-written serializers
+# already emit GT's order. Crate-level for the same publish-flattening reason.
+serde_json = { workspace = true, features = ["raw_value", "preserve_order"] }
 socket2 = { workspace = true, features = ["all"] }
 thiserror.workspace = true
 tokio.workspace = true

--- a/riperf3/src/client.rs
+++ b/riperf3/src/client.rs
@@ -2001,10 +2001,10 @@ impl Client {
             }
             if self.get_server_output {
                 if let Some(server) = remote_cpu {
-                    // Through the shared envelope helper — a hand-built
-                    // serde_json::json! map serializes alphabetically
-                    // ("data" before "event"), breaking the {"event":..,
-                    // "data":..} contract every other event keeps (#168 r1 n1).
+                    // Through the shared envelope helper, keeping the
+                    // {"event":.., "data":..} contract every other event
+                    // keeps (#168 r1 n1; pre-#378 a hand-built json! map
+                    // also alphabetized — moot under preserve_order).
                     if let Some(json) = &server.server_output_json {
                         crate::reporter::emit_json_stream_line(
                             &crate::json_report::json_stream_event("server_output_json", json),

--- a/riperf3/src/json_report.rs
+++ b/riperf3/src/json_report.rs
@@ -168,9 +168,10 @@ pub fn error_document(error: &str) -> String {
 /// kinds carry it. `error_document` (public, signature frozen) delegates
 /// with `None`.
 pub(crate) fn refusal_document(error: &str, target_bitrate: Option<u64>) -> String {
-    // Field-ordered structs, not serde_json::json! — its maps serialize
-    // alphabetically, breaking iperf3's start/intervals/end/error order
-    // (the #168 envelope lesson).
+    // Field-ordered structs, not serde_json::json! — explicit declaration
+    // order documents iperf3's start/intervals/end/error contract (the
+    // #168 envelope lesson; json! also alphabetized before #378's
+    // preserve_order made maps insertion-ordered).
     #[derive(Serialize)]
     struct ErrStart {
         connected: [(); 0],
@@ -4384,15 +4385,15 @@ mod tests {
         input.congestion_used = None;
         let v = serde_json::to_value(input.build()).unwrap();
 
-        // serde_json::Value re-orders keys alphabetically, so assert the SET
-        // here; the on-wire order is the manual impl's entry order.
+        // #378: preserve_order makes to_value keep the manual impl's entry
+        // order, so this pins the ORDER outright (it used to sort and
+        // assert the set).
         let start = v["start"].as_object().expect("start object");
-        let mut keys: Vec<_> = start.keys().map(String::as_str).collect();
-        keys.sort_unstable();
+        let keys: Vec<_> = start.keys().map(String::as_str).collect();
         assert_eq!(
             keys,
-            ["connected", "system_info", "version"],
-            "GT stage 0 is exactly these three: {v}"
+            ["connected", "version", "system_info"],
+            "GT stage 0 is exactly these three, in insertion order: {v}"
         );
         assert_eq!(v["end"]["streams"].as_array().map(Vec::len), Some(0));
     }

--- a/riperf3/src/lib.rs
+++ b/riperf3/src/lib.rs
@@ -4,6 +4,12 @@
 //! the same protocol, flags, output, and JSON schema, usable as a CLI or as
 //! this library crate.
 //!
+//! Note for embedders: this crate enables serde_json's `preserve_order`
+//! feature (iperf3 is cJSON end-to-end, so JSON key order is part of the
+//! faithfulness contract, #378). Through Cargo feature unification your
+//! build's `serde_json::Map` becomes insertion-ordered too (`remove` takes
+//! on swap-remove semantics).
+//!
 //! Run a test and read its result — quiet by default (#294), with the
 //! measured [`Report`] and a [`Termination`] saying how the run ended
 //! (#293, see the [`outcome`] module):

--- a/riperf3/src/protocol.rs
+++ b/riperf3/src/protocol.rs
@@ -377,15 +377,26 @@ pub struct TestParams {
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub len: Option<i32>,
 
+    // #378 r1 F1: with preserve_order the wire bytes carry this FIELD
+    // order, so from here down the declaration mirrors GT's
+    // send_parameters insertion order exactly (iperf_api.c:2416-2519):
+    // bandwidth → fqrate → pacing_timer → burst → GSO/GRO; title/
+    // extra_data before congestion/congestion_used; authtoken before
+    // client_version. Deserialization is by-name, so reordering is
+    // wire-read-neutral. Pinned by params_blob_key_order_mirrors_gt_
+    // send_parameters.
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub bandwidth: Option<u64>,
+
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub fqrate: Option<u64>,
+
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub pacing_timer: Option<i32>,
 
     /// `-b rate/burst` block count; iperf3 sends it only when nonzero (#160).
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub burst: Option<i32>,
-
-    #[serde(skip_serializing_if = "Option::is_none", default)]
-    pub fqrate: Option<u64>,
 
     // #316: GT sends the UDP GSO/GRO block unconditionally for UDP
     // ("Always send these fields to allow server to use GSO/GRO even if
@@ -402,9 +413,6 @@ pub struct TestParams {
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub gro_bf_size: Option<i64>,
 
-    #[serde(skip_serializing_if = "Option::is_none", default)]
-    pub pacing_timer: Option<i32>,
-
     #[serde(rename = "TOS", skip_serializing_if = "Option::is_none", default)]
     pub tos: Option<i32>,
 
@@ -412,16 +420,16 @@ pub struct TestParams {
     pub flowlabel: Option<i32>,
 
     #[serde(skip_serializing_if = "Option::is_none", default)]
-    pub congestion: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none", default)]
-    pub congestion_used: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none", default)]
     pub title: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub extra_data: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub congestion: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub congestion_used: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub get_server_output: Option<i32>,
@@ -435,11 +443,13 @@ pub struct TestParams {
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub dont_fragment: Option<i32>,
 
-    #[serde(skip_serializing_if = "Option::is_none", default)]
-    pub client_version: Option<String>,
-
+    // GT sends authtoken BEFORE client_version (iperf_api.c:2500-2516 —
+    // client_version is always last).
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub authtoken: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub client_version: Option<String>,
 }
 
 impl TestParams {
@@ -1018,6 +1028,112 @@ pub async fn udp_connect_server(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// #378 r1 F1: with preserve_order the params blob's wire bytes carry
+    /// TestParams' FIELD order, so the declaration must mirror GT's
+    /// send_parameters insertion order exactly (iperf_api.c:2416-2519) —
+    /// bandwidth → fqrate → pacing_timer → burst → the GSO/GRO block;
+    /// title/extra_data BEFORE congestion/congestion_used; authtoken
+    /// BEFORE client_version. Keys riperf3 doesn't implement (sctp,
+    /// server_affinity, mptcp, zerocopy, skip_rx_copy) drop out without
+    /// disturbing the relative order. All-Some so every key emits.
+    #[test]
+    fn params_blob_key_order_mirrors_gt_send_parameters() {
+        let p = TestParams {
+            tcp: Some(true),
+            // GT sends only the ACTIVE protocol key (tcp OR udp, never
+            // both) — a false udp stays off the wire.
+            udp: None,
+            omit: Some(1),
+            time: Some(10),
+            num: Some(1),
+            blockcount: Some(1),
+            mss: Some(1400),
+            nodelay: Some(true),
+            parallel: Some(2),
+            reverse: Some(false),
+            bidirectional: Some(false),
+            window: Some(65536),
+            len: Some(131072),
+            bandwidth: Some(5_000_000),
+            fqrate: Some(1_000_000),
+            pacing_timer: Some(1000),
+            burst: Some(10),
+            gso: Some(1),
+            gso_dg_size: Some(1400),
+            gso_bf_size: Some(65000),
+            gro: Some(1),
+            gro_bf_size: Some(65000),
+            tos: Some(2),
+            flowlabel: Some(3),
+            title: Some("t".into()),
+            extra_data: Some("x".into()),
+            congestion: Some("cubic".into()),
+            congestion_used: Some("cubic".into()),
+            get_server_output: Some(1),
+            udp_counters_64bit: Some(1),
+            repeating_payload: Some(1),
+            dont_fragment: Some(1),
+            authtoken: Some("a".into()),
+            client_version: Some("3.21".into()),
+        };
+        let raw = serde_json::to_string(&p).unwrap();
+        // Flat object with controlled values (no ':' after any in-string
+        // quote), so a quote-span followed by ':' is exactly a key.
+        let mut keys = Vec::new();
+        let bytes = raw.as_bytes();
+        let mut i = 0;
+        while i < bytes.len() {
+            if bytes[i] == b'"' {
+                let close = raw[i + 1..].find('"').unwrap() + i + 1;
+                if bytes.get(close + 1) == Some(&b':') {
+                    keys.push(&raw[i + 1..close]);
+                }
+                i = close;
+            }
+            i += 1;
+        }
+        assert_eq!(
+            keys,
+            [
+                "tcp",
+                "omit",
+                "time",
+                "num",
+                "blockcount",
+                "MSS",
+                "nodelay",
+                "parallel",
+                "reverse",
+                "bidirectional",
+                "window",
+                "len",
+                "bandwidth",
+                "fqrate",
+                "pacing_timer",
+                "burst",
+                "gso",
+                "gso_dg_size",
+                "gso_bf_size",
+                "gro",
+                "gro_bf_size",
+                "TOS",
+                "flowlabel",
+                "title",
+                "extra_data",
+                "congestion",
+                "congestion_used",
+                "get_server_output",
+                "udp_counters_64bit",
+                "repeating_payload",
+                "dont_fragment",
+                "authtoken",
+                "client_version"
+            ],
+            "TestParams field order must mirror GT's send_parameters \
+             insertion order (#378 r1 F1): {raw}"
+        );
+    }
 
     #[test]
     fn normalize_unlimited_maps_zero_to_none() {


### PR DESCRIPTION
Closes #378.

## What

GT is cJSON end-to-end — insertion order everywhere — so serde_json's alphabetizing `BTreeMap` was the one traitor to the #300-class key order wherever a doc round-trips through `Value`: the `--get-server-output` attachment (`to_value(&report)` at the server, then the client's parse + re-emit) and the params/results wire blobs. The fix is the `preserve_order` feature (IndexMap-backed maps), enabled crate-level so it flattens into the published manifest (the `raw_value`/#57 precedent). The hand-written serializers already emit GT's order — **no code change**.

Why not the issue's `RawValue` sketch: a raw splice preserves the wire hop but re-emits compact bytes inside the pretty client doc, and the client's parse hop still needs an order-preserving in-memory form. `preserve_order` fixes both hops and the wire blobs in one move.

## Probes (live 3.21, both tools)

| Cell | Before | After |
|---|---|---|
| riperf3↔riperf3 `-J --get-server-output` | `server_output_json` wholesale alphabetized (`end, intervals, start`) | GT-GT reference order (`start, intervals, end`; `.start` = the #355 server insertion order) |
| riperf3 server + **GT client** | GT re-emits riperf3's attachment alphabetized (wire bytes were alphabetized) | ordered — the wire hop fixed |
| GT server + **riperf3 client** | riperf3 re-emits GT's ordered subtree alphabetized | GT's order preserved — the parse/re-emit hop fixed |
| client params wire blob | alphabetized on the wire | **matches GT key-for-key** (`tcp, omit, time, num, blockcount, parallel, len, bandwidth, pacing_timer, client_version`) — `TestParams` field order already mirrored GT's send order |

## Blast-radius audit (the flip is crate-wide)

- Full workspace suite green — zero pinned-shape flips.
- The json-stream envelope is a derived struct (`event` before `data`, GT-matching) — unchanged.
- The only production `json!` sites are empty objects (`json!({})`); everything else is typed structs whose field order the flip doesn't touch.
- New transitive dep: `indexmap` (via the serde_json feature) — ubiquitous, actively maintained.

## Tests

Red-first CLI pin: raw depth-1 key order of `server_output_json` and its `.start` in a real `-J --get-server-output` pair (parsed-`Value` asserts are order-blind, so it walks the raw string).
