### PR TITLE
fix: negative -w renders verbatim; setup trio computed once at param ingest (#392)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ release tags.
 - The builder output default flips to quiet (#294): a bare `run()`/`run_once()` returns the
   report and prints nothing. Opt into iperf3's full text/JSON output with `.emit_output(true)`
   (the CLI sets this). Wire protocol, CLI output, and exit codes are unchanged.
+- `Start::sock_bufsize` is `Option<i64>` (was `Option<u64>`): iperf3 renders the requested
+  `-w` verbatim, negatives included (#392).
 
 ### Added
 
@@ -46,6 +48,10 @@ release tags.
 - `--get-server-output` no longer alphabetizes the embedded server document
   (serde_json `preserve_order`); the params/results wire blobs now match iperf3's key
   order too (#378).
+- `-w -1` renders `sock_bufsize: -1` like iperf3 in every document (was clamped to 0, or
+  u64-wrapped in the setup doc); the setup-doc buffer actuals are computed once at param
+  ingest like iperf3, so emit-time fd exhaustion can't blank them, and on the listener's
+  address family (#392).
 - `--logfile` receives the SERVER-ERROR relay receipt and the interrupt notice like iperf3's
   `iperf_err` routing; both previously went to stderr (#364).
 - Wire-blob parsing mirrors cJSON's UTF-8 BOM skip and non-object params root; four residual

--- a/riperf3-cli/tests/wire_shape.rs
+++ b/riperf3-cli/tests/wire_shape.rs
@@ -2343,6 +2343,89 @@ fn setup_doc_window_zero_reads_the_listener_like_no_window() {
     assert!(zero.0.is_some() && zero.1.is_some(), "the trio is present");
 }
 
+/// #392: the setup doc renders a NEGATIVE exchanged window verbatim like
+/// GT (`-w -1` is real-client-reachable, iperf_api.c:1446 — GT's doc
+/// carries sock_bufsize: -1); pre-fix riperf3's `w as u64` wrapped it to
+/// 18446744073709551615.
+#[test]
+fn setup_doc_negative_window_renders_minus_one() {
+    let (sout, _serr, status) = drive_server_scenario(true, |port| {
+        let mut ctrl = std::net::TcpStream::connect(("127.0.0.1", port)).expect("ctrl");
+        ctrl.write_all(&[b'x'; 37]).unwrap();
+        assert_eq!(read_exact(&mut ctrl, 1)[0], 9, "ParamExchange");
+        write_json_blob(&mut ctrl, r#"{"tcp":true,"window":-1}"#);
+        assert_eq!(read_exact(&mut ctrl, 1)[0], 10, "CreateStreams");
+        drop(ctrl);
+        std::thread::sleep(std::time::Duration::from_millis(300));
+    });
+    assert!(status.success());
+    let doc: serde_json::Value =
+        serde_json::from_str(sout.trim()).unwrap_or_else(|e| panic!("one -J doc ({e}): {sout}"));
+    assert_eq!(
+        doc["start"]["sock_bufsize"].as_i64(),
+        Some(-1),
+        "a negative exchanged window renders verbatim, not u64-wrapped (#392): {doc}"
+    );
+}
+
+/// #392: GT computes the setup trio ONCE at param ingest (protocol->listen
+/// runs right after get_parameters, iperf_api.c:2373-2382) and caches it —
+/// fd exhaustion at EMIT time cannot blank the keys. riperf3's per-emit
+/// scratch socket() failed EMFILE there and dropped sndbuf/rcvbuf_actual
+/// (and the same per-emit alloc was IPv4-hardcoded, the v6-only corner).
+/// prlimit-after-params clamps the server's fd table to its first free
+/// slot (the #387 technique), then the EOF triggers the setup emit.
+#[cfg(target_os = "linux")]
+#[test]
+fn setup_doc_trio_survives_emit_time_fd_exhaustion() {
+    let _serial = EMFILE_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind");
+    let port = listener.local_addr().unwrap().port();
+    drop(listener);
+    let ps = port.to_string();
+    let mut server = common::ChildGuard(
+        std::process::Command::new(env!("CARGO_BIN_EXE_riperf3"))
+            .args(["-s", "-1", "-p", &ps, "-J"])
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::null())
+            .spawn()
+            .expect("spawn server"),
+    );
+    let pid = server.0.id();
+    let sout_reader =
+        riperf3_test_support::drain_reader(server.0.stdout.take().expect("piped stdout"));
+    std::thread::sleep(std::time::Duration::from_millis(400));
+
+    let mut ctrl = std::net::TcpStream::connect(("127.0.0.1", port)).expect("ctrl");
+    ctrl.write_all(&[b'x'; 37]).unwrap();
+    assert_eq!(read_exact(&mut ctrl, 1)[0], 9, "ParamExchange");
+    write_json_blob(&mut ctrl, r#"{"tcp":true,"window":65536}"#);
+    assert_eq!(read_exact(&mut ctrl, 1)[0], 10, "CreateStreams");
+    // Params are ingested; NOW exhaust the fd table, then kill the round.
+    clamp_fd_table(pid);
+    drop(ctrl);
+
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+    while server.0.try_wait().expect("try_wait").is_none() {
+        assert!(std::time::Instant::now() < deadline, "server did not exit");
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+    let sout = sout_reader.join().expect("drain stdout");
+    let doc: serde_json::Value =
+        serde_json::from_str(sout.trim()).unwrap_or_else(|e| panic!("one -J doc ({e}): {sout}"));
+    assert_eq!(
+        doc["start"]["sndbuf_actual"].as_u64(),
+        Some(131072),
+        "the windowed read-back survives emit-time EMFILE — computed once \
+         at param ingest like GT (#392): {doc}"
+    );
+    assert_eq!(
+        doc["start"]["rcvbuf_actual"].as_u64(),
+        Some(131072),
+        "the windowed read-back survives emit-time EMFILE (#392): {doc}"
+    );
+}
+
 const IDLE_TIMEOUT_MSG: &str = "idle timeout for receiving data";
 
 /// HOLD-variant driver: park in CREATE_STREAMS with the ctrl open, read the

--- a/riperf3/src/client.rs
+++ b/riperf3/src/client.rs
@@ -2475,16 +2475,17 @@ impl Client {
             // suppresses tcp_mss_default. build() does the TCP/UDP gating.
             mss: self.mss.filter(|&m| m > 0).map(|m| m as u32),
             fq_rate: self.fq_rate.unwrap_or(0),
-            // iperf3's start.sock_bufsize is the requested -w value (0 if unset);
-            // sndbuf/rcvbuf_actual are the kernel's actual sizes on a data socket.
-            // .max(0): the public builder accepts an i32 window; clamp so a
-            // negative can't wrap to a huge u64 (the CLI path is already >= 0).
+            // iperf3's start.sock_bufsize is the requested -w value (0 if unset),
+            // rendered VERBATIM — negatives included: GT accepts `-w -1` (only
+            // the upper bound is range-checked, iperf_api.c:1446) and emits -1
+            // (#392; the old .max(0) clamp rendered 0). sndbuf/rcvbuf_actual
+            // are the kernel's actual sizes on a data socket.
             // #261: `Some(..)` on a run that set up streams (build() gates them
             // out on the upfront-refusal path via the stage gate, #281); a
             // success run always carries them, so the shape is unchanged. A
             // missing kernel readback still yields `Some(0)` on a real run, like
             // iperf3.
-            sock_bufsize: Some(self.window.map(|w| w.max(0) as u64).unwrap_or(0)),
+            sock_bufsize: Some(self.window.map(i64::from).unwrap_or(0)),
             sndbuf_actual: Some(
                 streams
                     .first()

--- a/riperf3/src/json_report.rs
+++ b/riperf3/src/json_report.rs
@@ -209,7 +209,7 @@ pub(crate) fn refusal_document(error: &str, target_bitrate: Option<u64>) -> Stri
 /// accept (iperf_udp.c:439-452), which never runs in a setup-phase wedge
 /// (live key-diff probed) — so the builder passes None for all four.
 pub(crate) struct SetupPhaseDoc {
-    pub sock_bufsize: Option<u64>,
+    pub sock_bufsize: Option<i64>,
     pub sndbuf_actual: Option<u64>,
     pub rcvbuf_actual: Option<u64>,
     pub tcp_mss_default: Option<u32>,
@@ -349,7 +349,7 @@ fn setup_phase_document<E: Serialize>(d: &SetupPhaseDoc, end: &E, error: Option<
         #[serde(rename = "target_bitrate", skip_serializing_if = "Option::is_none")]
         early_target_bitrate: Option<u64>,
         #[serde(skip_serializing_if = "Option::is_none")]
-        sock_bufsize: Option<u64>,
+        sock_bufsize: Option<i64>,
         #[serde(skip_serializing_if = "Option::is_none")]
         sndbuf_actual: Option<u64>,
         #[serde(skip_serializing_if = "Option::is_none")]
@@ -479,7 +479,7 @@ pub struct Start {
     // GT (iperf 3.21) OMITS them entirely — the document carries the early start
     // metadata (timestamp, cookie, connecting_to) and an empty `end`. Gated by
     // `stage == Started` in the manual Serialize impl (#261/#281).
-    pub sock_bufsize: Option<u64>,
+    pub sock_bufsize: Option<i64>,
     pub sndbuf_actual: Option<u64>,
     pub rcvbuf_actual: Option<u64>,
     pub test_start: Option<TestStart>,
@@ -1066,7 +1066,7 @@ pub(crate) struct ReportInput {
     /// Socket buffer sizes (`start.sock_bufsize` / `sndbuf_actual` /
     /// `rcvbuf_actual`). `None` on a path that never set up data sockets (the
     /// upfront-refusal path), so `build()` omits them like GT (#261).
-    pub sock_bufsize: Option<u64>,
+    pub sock_bufsize: Option<i64>,
     pub sndbuf_actual: Option<u64>,
     pub rcvbuf_actual: Option<u64>,
     /// How far the run progressed when this document is built (#281): drives

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -3845,6 +3845,12 @@ impl Server {
                             sc.recv_buffer_size().ok().map(|v| v as u64),
                         )
                     }
+                    // RECORDED DEVIATION (#416 r1, the no-re-listen
+                    // umbrella): fd exhaustion at INGEST time with -w set —
+                    // GT's re-listen socket() fails and IESTREAMLISTEN
+                    // aborts the round; riperf3 has no re-listen
+                    // (deliberate), caches absent keys, and the round
+                    // proceeds.
                     Err(_) => (None, None),
                 }
             }

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -228,6 +228,12 @@ struct TestRunCtx {
     /// the on-connect stamp, not the emit time (#356 r1 F4): at the default
     /// 120 s rcv-timeout those differ by two minutes.
     accepted_millis: u64,
+    /// #392: the setup-doc (sndbuf_actual, rcvbuf_actual) pair, computed
+    /// ONCE at ctx construction — GT computes its trio at param ingest
+    /// (protocol->listen right after get_parameters, iperf_api.c:2373-2382)
+    /// and caches it, so fd exhaustion at EMIT time can't blank the keys.
+    /// See [`Server::compute_setup_bufs`].
+    setup_bufs: (Option<u64>, Option<u64>),
     cookie: [u8; protocol::COOKIE_SIZE],
     params: TestParams,
     cfg: TestConfig,
@@ -981,6 +987,8 @@ impl Server {
             ctrl,
             accepted_host,
             accepted_port,
+            // #392: param ingest is GT's compute point for the setup trio.
+            setup_bufs: Self::compute_setup_bufs(&cfg, listener),
             accepted_millis: std::time::SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)
                 .map(|d| d.as_millis() as u64)
@@ -1575,7 +1583,6 @@ impl Server {
                                             RiperfError::StreamConnectFailed(e);
                                         self.emit_setup_phase_error(
                                             ctx,
-                                            listener,
                                             &format!("error - {err}"),
                                         );
                                         return Err(err);
@@ -1670,7 +1677,6 @@ impl Server {
                                         .await;
                                         self.emit_setup_phase_error(
                                             ctx,
-                                            listener,
                                             &format!(
                                                 "error - {}: ",
                                                 RiperfError::RecvDataCookieFailed
@@ -1693,12 +1699,12 @@ impl Server {
                                 Ok(CtrlActivity::Eof) => {
                                     abort_setup_streams(ctx).await;
                                     let _ = protocol::send_server_error(&mut ctx.ctrl, 109).await;
-                                    self.emit_setup_phase_error(ctx, listener, CTRL_CLOSED_MSG);
+                                    self.emit_setup_phase_error(ctx, CTRL_CLOSED_MSG);
                                     return Err(RiperfError::ControlSocketClosed);
                                 }
                                 Ok(CtrlActivity::Data) => {
                                     if let SetupFlow::ClientDone =
-                                        self.dispatch_setup_ctrl_byte(ctx, listener).await?
+                                        self.dispatch_setup_ctrl_byte(ctx).await?
                                     {
                                         return Ok(SetupFlow::ClientDone);
                                     }
@@ -1714,7 +1720,6 @@ impl Server {
                                 let _ = protocol::send_server_error(&mut ctx.ctrl, 144).await;
                                 self.emit_setup_phase_error(
                                     ctx,
-                                    listener,
                                     &format!("error - {}", RiperfError::DataIdleTimeout),
                                 );
                                 return Err(RiperfError::DataIdleTimeout);
@@ -1840,10 +1845,10 @@ impl Server {
                 // as the TCP arm, so they can dispatch ctrl bytes — a
                 // ClientDone (IPERF_DONE) surfaces here like TCP's.
                 let flow = if udp_use_demux {
-                    self.setup_udp_demux_streams(ctx, listener, recv_count, total, max_duration)
+                    self.setup_udp_demux_streams(ctx, recv_count, total, max_duration)
                         .await?
                 } else {
-                    self.setup_udp_recycling_streams(ctx, listener, recv_count, total, max_duration)
+                    self.setup_udp_recycling_streams(ctx, recv_count, total, max_duration)
                         .await?
                 };
                 if let SetupFlow::ClientDone = flow {
@@ -2808,7 +2813,6 @@ impl Server {
     async fn setup_udp_recycling_streams(
         &self,
         ctx: &mut TestRunCtx,
-        listener: &tokio::net::TcpListener,
         recv_count: u32,
         total: u32,
         max_duration: Option<std::time::Duration>,
@@ -2892,12 +2896,12 @@ impl Server {
                         Ok(CtrlActivity::Eof) => {
                             abort_setup_streams(ctx).await;
                             let _ = protocol::send_server_error(&mut ctx.ctrl, 109).await;
-                            self.emit_setup_phase_error(ctx, listener, CTRL_CLOSED_MSG);
+                            self.emit_setup_phase_error(ctx, CTRL_CLOSED_MSG);
                             return Err(RiperfError::ControlSocketClosed);
                         }
                         Ok(CtrlActivity::Data) => {
                             if let SetupFlow::ClientDone =
-                                self.dispatch_setup_ctrl_byte(ctx, listener).await?
+                                self.dispatch_setup_ctrl_byte(ctx).await?
                             {
                                 return Ok(SetupFlow::ClientDone);
                             }
@@ -2912,7 +2916,6 @@ impl Server {
                         let _ = protocol::send_server_error(&mut ctx.ctrl, 144).await;
                         self.emit_setup_phase_error(
                             ctx,
-                            listener,
                             &format!("error - {}", RiperfError::DataIdleTimeout),
                         );
                         return Err(RiperfError::DataIdleTimeout);
@@ -3056,7 +3059,6 @@ impl Server {
     async fn setup_udp_demux_streams(
         &self,
         ctx: &mut TestRunCtx,
-        listener: &tokio::net::TcpListener,
         recv_count: u32,
         total: u32,
         max_duration: Option<std::time::Duration>,
@@ -3166,12 +3168,12 @@ impl Server {
                     Ok(CtrlActivity::Eof) => {
                         abort_setup_streams(ctx).await;
                         let _ = protocol::send_server_error(&mut ctx.ctrl, 109).await;
-                        self.emit_setup_phase_error(ctx, listener, CTRL_CLOSED_MSG);
+                        self.emit_setup_phase_error(ctx, CTRL_CLOSED_MSG);
                         return Err(RiperfError::ControlSocketClosed);
                     }
                     Ok(CtrlActivity::Data) => {
                         if let SetupFlow::ClientDone =
-                            self.dispatch_setup_ctrl_byte(ctx, listener).await?
+                            self.dispatch_setup_ctrl_byte(ctx).await?
                         {
                             return Ok(SetupFlow::ClientDone);
                         }
@@ -3186,7 +3188,6 @@ impl Server {
                     let _ = protocol::send_server_error(&mut ctx.ctrl, 144).await;
                     self.emit_setup_phase_error(
                         ctx,
-                        listener,
                         &format!("error - {}", RiperfError::DataIdleTimeout),
                     );
                     return Err(RiperfError::DataIdleTimeout);
@@ -3606,7 +3607,9 @@ impl Server {
             tcp_mss_default: 0,
             mss: cfg.mss.filter(|&m| m > 0).map(|m| m as u32),
             fq_rate: params.fqrate.unwrap_or(0),
-            sock_bufsize: Some(cfg.window.map(|w| w.max(0) as u64).unwrap_or(0)),
+            // The exchanged -w, rendered VERBATIM like GT — negatives included
+            // (#392; the old .max(0) clamp rendered 0 where GT emits -1).
+            sock_bufsize: Some(cfg.window.map(i64::from).unwrap_or(0)),
             sndbuf_actual: Some(
                 streams
                     .first()
@@ -3744,11 +3747,7 @@ impl Server {
     /// (live: the report skeleton, an EXCHANGE_RESULTS byte, then a
     /// stale-errno IERECVRESULTS "Bad file descriptor" tangle) —
     /// nonconforming-only, not mirrored.
-    async fn dispatch_setup_ctrl_byte(
-        &self,
-        ctx: &mut TestRunCtx,
-        listener: &tokio::net::TcpListener,
-    ) -> Result<SetupFlow> {
+    async fn dispatch_setup_ctrl_byte(&self, ctx: &mut TestRunCtx) -> Result<SetupFlow> {
         match protocol::recv_state(&mut ctx.ctrl).await {
             // GT's no-op arm — keep waiting (the recreated sleep IS the
             // clock reset: a received byte is progress). RECORDED DEVIATION
@@ -3762,12 +3761,12 @@ impl Server {
             Ok(TestState::ClientTerminate) => {
                 abort_setup_streams(ctx).await;
                 let _ = protocol::send_server_error(&mut ctx.ctrl, 119).await;
-                self.emit_setup_phase_terminate(ctx, listener);
+                self.emit_setup_phase_terminate(ctx);
                 Err(RiperfError::ClientTerminated)
             }
             Ok(TestState::IperfDone) => {
                 abort_setup_streams(ctx).await;
-                self.emit_setup_phase_done(ctx, listener);
+                self.emit_setup_phase_done(ctx);
                 Ok(SetupFlow::ClientDone)
             }
             Ok(_) | Err(RiperfError::UnknownControlMessage) => {
@@ -3775,7 +3774,6 @@ impl Server {
                 let _ = protocol::send_server_error(&mut ctx.ctrl, 110).await;
                 self.emit_setup_phase_error(
                     ctx,
-                    listener,
                     &format!("error - {}", RiperfError::UnknownControlMessage),
                 );
                 Err(RiperfError::UnknownControlMessage)
@@ -3786,7 +3784,7 @@ impl Server {
             Err(RiperfError::PeerDisconnected) => {
                 abort_setup_streams(ctx).await;
                 let _ = protocol::send_server_error(&mut ctx.ctrl, 109).await;
-                self.emit_setup_phase_error(ctx, listener, CTRL_CLOSED_MSG);
+                self.emit_setup_phase_error(ctx, CTRL_CLOSED_MSG);
                 Err(RiperfError::ControlSocketClosed)
             }
             Err(e) => Err(e),
@@ -3798,58 +3796,79 @@ impl Server {
     /// same socket (best-effort: a failed getsockopt omits the key rather
     /// than inventing one). The timestamp is the on-connect stamp carried
     /// on ctx, not the emit time (#356 r1 F4).
-    fn setup_phase_doc_input(
-        &self,
-        ctx: &TestRunCtx,
+    ///
+    /// #357: with -w exchanged, GT re-listens with the window applied and
+    /// reads the actuals off THAT socket (probed 131072/131072 for window
+    /// 65536); riperf3 has no re-listen step (deliberate), so a scratch
+    /// socket with the same window applied yields the identical kernel
+    /// read-back. Without -w the un-windowed listener matches GT's
+    /// re-listened defaults.
+    /// RECORDED DEVIATION (#391 r1 F3, pre-existing design consequence):
+    /// at a window past 2x wmem_max GT fires IESETBUF2 at its re-listen
+    /// (error doc, no trio, fe frame instead of CreateStreams); riperf3
+    /// has no re-listen (deliberate) and its #97 check lives on data
+    /// sockets, which never arrive in wedge cells — the doc carries the
+    /// clamped actuals instead (probed w=16M: GT errors, riperf3 emits
+    /// 8388608/8388608).
+    /// #391 r1 F1: GT's buffer-APPLY guard is C truthiness (the re-listen
+    /// decision is iperf_tcp.c:195, the apply gate :257 — r2 F2 cite) —
+    /// an exchanged window:0 is NOT applied; it reads the listener like
+    /// the no-window state (probed: GT 16384/131072 for window:0, and the
+    /// nodelay-forced re-listen without buffer-apply reads the same
+    /// defaults). Negative windows ARE applied (truthiness; both tools
+    /// clamp identically — probed w=-1).
+    /// #392: all of the above runs ONCE, at ctx construction — GT
+    /// computes its trio at param ingest (protocol->listen right after
+    /// get_parameters, iperf_api.c:2373-2382) and caches, so fd
+    /// exhaustion at emit time can't blank the keys (the per-emit scratch
+    /// failed EMFILE there), and the scratch follows the LISTENER's
+    /// address family (the v6-only corner: an IPV4-hardcoded scratch read
+    /// nothing on a v6-only stack).
+    fn compute_setup_bufs(
+        cfg: &TestConfig,
         listener: &tokio::net::TcpListener,
-    ) -> crate::json_report::SetupPhaseDoc {
-        let sock = socket2::SockRef::from(listener);
-        // #383 r1 F1a: the four TCP-flavored keys are absent for UDP —
-        // see the SetupPhaseDoc doc for the GT gates.
-        let udp = matches!(ctx.cfg.protocol, TransportProtocol::Udp);
-        // #357: with -w exchanged, GT re-listens with the window applied
-        // and reads the actuals off THAT socket (probed 131072/131072 for
-        // window 65536); riperf3 has no re-listen step (deliberate), so a
-        // scratch socket with the same window applied yields the identical
-        // kernel read-back. Without -w the un-windowed listener matches
-        // GT's re-listened defaults.
-        // RECORDED DEVIATION (#391 r1 F3, pre-existing design consequence):
-        // at a window past 2x wmem_max GT fires IESETBUF2 at its re-listen
-        // (error doc, no trio, fe frame instead of CreateStreams); riperf3
-        // has no re-listen (deliberate) and its #97 check lives on data
-        // sockets, which never arrive in wedge cells — the doc carries the
-        // clamped actuals instead (probed w=16M: GT errors, riperf3 emits
-        // 8388608/8388608).
-        // #391 r1 F1: GT's buffer-APPLY guard is C truthiness (the
-        // re-listen decision is iperf_tcp.c:195, the apply gate :257 — r2
-        // F2 cite) — an exchanged window:0 is NOT applied; it reads the
-        // listener like the no-window state (probed: GT 16384/131072 for
-        // window:0, and the nodelay-forced re-listen without buffer-apply
-        // reads the same defaults). Negative windows ARE applied (truthiness; both tools
-        // clamp identically — probed w=-1).
-        let (sndbuf_actual, rcvbuf_actual) = match (udp, ctx.cfg.window) {
-            (false, Some(w)) if w != 0 => {
-                let scratch =
-                    socket2::Socket::new(socket2::Domain::IPV4, socket2::Type::STREAM, None).ok();
-                match scratch {
-                    Some(sc) => {
+    ) -> (Option<u64>, Option<u64>) {
+        if matches!(cfg.protocol, TransportProtocol::Udp) {
+            return (None, None);
+        }
+        match cfg.window {
+            Some(w) if w != 0 => {
+                let domain = match listener.local_addr() {
+                    Ok(std::net::SocketAddr::V6(_)) => socket2::Domain::IPV6,
+                    _ => socket2::Domain::IPV4,
+                };
+                match socket2::Socket::new(domain, socket2::Type::STREAM, None) {
+                    Ok(sc) => {
                         net::apply_socket_window(&socket2::SockRef::from(&sc), Some(w));
                         (
                             sc.send_buffer_size().ok().map(|v| v as u64),
                             sc.recv_buffer_size().ok().map(|v| v as u64),
                         )
                     }
-                    None => (None, None),
+                    Err(_) => (None, None),
                 }
             }
-            (false, _) => (
-                sock.send_buffer_size().ok().map(|v| v as u64),
-                sock.recv_buffer_size().ok().map(|v| v as u64),
-            ),
-            (true, _) => (None, None),
-        };
+            _ => {
+                let sock = socket2::SockRef::from(listener);
+                (
+                    sock.send_buffer_size().ok().map(|v| v as u64),
+                    sock.recv_buffer_size().ok().map(|v| v as u64),
+                )
+            }
+        }
+    }
+
+    fn setup_phase_doc_input(&self, ctx: &TestRunCtx) -> crate::json_report::SetupPhaseDoc {
+        // #383 r1 F1a: the four TCP-flavored keys are absent for UDP —
+        // see the SetupPhaseDoc doc for the GT gates.
+        let udp = matches!(ctx.cfg.protocol, TransportProtocol::Udp);
+        // #392: computed ONCE at ctx construction (GT's param-ingest
+        // timing) — see compute_setup_bufs for the machinery and records.
+        let (sndbuf_actual, rcvbuf_actual) = ctx.setup_bufs;
         crate::json_report::SetupPhaseDoc {
-            sock_bufsize: (!udp).then(|| ctx.cfg.window.map(|w| w as u64).unwrap_or(0)),
+            // Verbatim like GT, negatives included (#392 — `as u64` wrapped
+            // an exchanged -1 to 18446744073709551615).
+            sock_bufsize: (!udp).then(|| ctx.cfg.window.map(i64::from).unwrap_or(0)),
             sndbuf_actual,
             rcvbuf_actual,
             // The server never reads the ctrl MSS — 0, the #50 convention.
@@ -3871,12 +3890,7 @@ impl Server {
     /// live-probed — see json_report::setup_error_document); --json-stream:
     /// the same error+end event pair GT emits here (live-probed, no start
     /// event); text: nothing — the serve loop's arms print the stderr line.
-    fn emit_setup_phase_error(
-        &self,
-        ctx: &TestRunCtx,
-        listener: &tokio::net::TcpListener,
-        doc_error: &str,
-    ) {
+    fn emit_setup_phase_error(&self, ctx: &TestRunCtx, doc_error: &str) {
         if crate::macros::output_quiet() {
             return;
         }
@@ -3886,7 +3900,7 @@ impl Server {
             ));
         } else if self.json_output {
             let doc = crate::json_report::setup_error_document(
-                &self.setup_phase_doc_input(ctx, listener),
+                &self.setup_phase_doc_input(ctx),
                 doc_error,
             );
             println!("{doc}");
@@ -3898,7 +3912,7 @@ impl Server {
     /// ran); --json-stream the error + zeros-end pair; text prints the
     /// report skeleton on stdout here (the serve loop's arm adds the
     /// stderr sentence).
-    fn emit_setup_phase_terminate(&self, ctx: &TestRunCtx, listener: &tokio::net::TcpListener) {
+    fn emit_setup_phase_terminate(&self, ctx: &TestRunCtx) {
         if crate::macros::output_quiet() {
             return;
         }
@@ -3926,7 +3940,7 @@ impl Server {
             ));
         } else if self.json_output {
             let doc = crate::json_report::setup_terminate_document(
-                &self.setup_phase_doc_input(ctx, listener),
+                &self.setup_phase_doc_input(ctx),
                 &error,
                 &cpu,
             );
@@ -3939,15 +3953,14 @@ impl Server {
     /// #356 r1 F1: the IPERF_DONE-at-setup surfaces — GT's clean arm: the
     /// errorless setup doc under -J, one bare end event under
     /// --json-stream, silence in text.
-    fn emit_setup_phase_done(&self, ctx: &TestRunCtx, listener: &tokio::net::TcpListener) {
+    fn emit_setup_phase_done(&self, ctx: &TestRunCtx) {
         if crate::macros::output_quiet() {
             return;
         }
         if self.json_stream {
             crate::reporter::emit_json_stream_line(&crate::json_report::done_stream_events());
         } else if self.json_output {
-            let doc =
-                crate::json_report::setup_done_document(&self.setup_phase_doc_input(ctx, listener));
+            let doc = crate::json_report::setup_done_document(&self.setup_phase_doc_input(ctx));
             println!("{doc}");
         }
     }
@@ -4581,6 +4594,7 @@ mod tests {
             accepted_host: "127.0.0.1".into(),
             accepted_port: 0,
             accepted_millis: 0,
+            setup_bufs: (None, None),
             cookie: [b'x'; 37],
             params,
             cfg,
@@ -4642,7 +4656,7 @@ mod tests {
 
         let client = udp_tos_probe_client(format!("127.0.0.1:{port}").parse().unwrap());
 
-        srv.setup_udp_recycling_streams(&mut ctx, &l, 0, 1, None)
+        srv.setup_udp_recycling_streams(&mut ctx, 0, 1, None)
             .await
             .unwrap();
         ctx.start.store(true, Ordering::Relaxed);
@@ -4686,7 +4700,7 @@ mod tests {
 
         let client = udp_tos_probe_client(format!("127.0.0.1:{port}").parse().unwrap());
 
-        srv.setup_udp_demux_streams(&mut ctx, &l, 0, 1, None)
+        srv.setup_udp_demux_streams(&mut ctx, 0, 1, None)
             .await
             .unwrap();
         ctx.start.store(true, Ordering::Relaxed);

--- a/riperf3/tests/integration.rs
+++ b/riperf3/tests/integration.rs
@@ -2719,6 +2719,44 @@ async fn server_run_once_self_terminates_on_runtime_bitrate_breach() {
     );
 }
 
+/// #392: GT renders a NEGATIVE requested window verbatim — `-w -1` is
+/// real-client-reachable (unit_atof keeps the sign; only the upper bound
+/// is range-checked, iperf_api.c:1446) and BOTH roles' `-J` docs carry
+/// `sock_bufsize: -1` with kernel-truth actuals (live-probed 3.21; the
+/// actuals were already identical on both tools — only the render
+/// diverged: riperf3's `.max(0)` clamps emitted 0).
+#[tokio::test]
+async fn negative_window_renders_minus_one_like_gt() {
+    let server = ServerBuilder::new()
+        .port(Some(0))
+        .emit_output(false)
+        .build()
+        .unwrap();
+    let bound = server.bind().await.expect("bind");
+    let port = bound.local_addr().unwrap().port();
+    let server_task = tokio::spawn(async move { bound.run_once().await });
+    let client = ClientBuilder::new("127.0.0.1")
+        .port(Some(port))
+        .duration(1)
+        .window(-1)
+        .emit_output(false)
+        .build()
+        .unwrap();
+    let cli = tokio::time::timeout(Duration::from_secs(15), client.run())
+        .await
+        .expect("client hung")
+        .expect("client run");
+    let srv = server_task.await.expect("join").expect("server run_once");
+    for (role, outcome) in [("client", &cli), ("server", &srv)] {
+        let v = serde_json::to_value(&outcome.report).unwrap();
+        assert_eq!(
+            v["start"]["sock_bufsize"].as_i64(),
+            Some(-1),
+            "the {role} doc renders the requested -w -1 verbatim (#392): {v}"
+        );
+    }
+}
+
 /// The server-side `Interrupted` cell of the same invisibility class: a
 /// mid-test interrupt on `run_once` comes back `Ok(RunOutcome)` with
 /// `Termination::Interrupted`. Like `SelfTerminated` above, an


### PR DESCRIPTION
Closes #392.

## What

Two halves, both probe-backed (GT 3.21 live, both tools):

**Negative-window renders** — GT accepts `-w -1` (unit_atof keeps the sign; only the upper bound is range-checked, iperf_api.c:1446) and renders `sock_bufsize: -1` in every doc. riperf3's `.max(0)` clamps emitted `0` in both roles' normal docs, and the setup doc's `as u64` wrapped it to `18446744073709551615`. The actuals were already identical on both tools (kernel truth) — only the render diverged. **Breaking:** `Start::sock_bufsize` is `Option<i64>` (was `Option<u64>`).

**Compute-once** — GT computes the setup trio once at param ingest (`protocol->listen` right after `get_parameters`, iperf_api.c:2373-2382) and caches it; riperf3 allocated a fresh scratch socket at *every* setup-phase emit, so fd exhaustion at emit time blanked `sndbuf`/`rcvbuf_actual` where GT emits its cached values — and the scratch was IPv4-hardcoded (absent keys on v6-only stacks). The pair now computes at `TestRunCtx` construction with the scratch following the listener's address family. The `listener` parameter threading through the whole setup-emit path fell away with it.

## Probes

| Cell | GT | riperf3 pre-fix | post-fix |
|---|---|---|---|
| `-w -1` both roles, normal doc | `sock_bufsize: -1` | `0` | `-1` ✔ MATCH (actuals identical throughout) |
| setup doc, exchanged `window:-1` | `-1` | u64 wrap | `-1` ✔ |
| `-w 65536` / `-w -1` parity sweep | — | — | MATCH both regimes |
| `-w 0` parity | `[0, 16384, 131072]` | `[0, 4608, 2304]` | unchanged — **pre-existing**, confirmed on the pre-fix deployed build; filed as #415 (the data-socket apply path applies 0 where GT's truthiness guard skips — a live throughput divergence, out of this PR's render/compute scope) |

## Tests (all red-first)

- Lib: `-w -1` real pair → both roles' docs render `-1` (via `Value`, type-agnostic red).
- CLI: setup-doc mock `{"tcp":true,"window":-1}` → `-1` (was the wrap).
- CLI (Linux): the EMFILE-at-emit cell — prlimit-after-params to the first free fd slot (the #387 technique), then EOF → the trio survives with the windowed `131072` read-back (the per-emit scratch went absent).

Full workspace suite green; the #357/#391 window pins pass unchanged (same values, computed earlier).
