### PR TITLE
fix: the client's SERVER_ERROR relay renders GT's bare end at any stage (#404)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,9 @@ release tags.
   u64-wrapped in the setup doc); the setup-doc buffer actuals are computed once at param
   ingest like iperf3, so emit-time fd exhaustion can't blank them, and on the listener's
   address family (#392).
+- The client's SERVER_ERROR relay renders iperf3's bare `end: {}` at any stage — a mid-run
+  breach no longer emits the populated finalize end; on a `Termination::ServerError` ending
+  `outcome.report.end` is bare in every mode (partial stats ride `intervals`) (#404).
 - `--logfile` receives the SERVER-ERROR relay receipt and the interrupt notice like iperf3's
   `iperf_err` routing; both previously went to stderr (#364).
 - Wire-blob parsing mirrors cJSON's UTF-8 BOM skip and non-object params root; four residual

--- a/riperf3-cli/tests/self_terminate.rs
+++ b/riperf3-cli/tests/self_terminate.rs
@@ -143,11 +143,11 @@ fn bitrate_limit_json_client_single_doc_with_relayed_error() {
         Some(BITRATE_MSG),
         "the doc adopts the relayed strerror: {doc}"
     );
-    // #404: the relay is a KILL, not a finalize — GT's client errexits via
-    // iperf_json_finish before end processing, so the doc's `end` is BARE
-    // regardless of stage (live-probed 3.21, -t 20 vs 1K limit: GT end
-    // keys [], riperf3 pre-fix rendered the populated finalize end). The
-    // accumulated intervals stay.
+    // #404: the relay is a KILL, not a finalize — GT's reporter switch
+    // no-ops on state SERVER_ERROR, so json_end is never filled and the
+    // doc's `end` is BARE regardless of stage (live-probed 3.21, -t 20 vs
+    // 1K limit: GT end keys [], riperf3 pre-fix rendered the populated
+    // finalize end). The accumulated intervals stay.
     assert!(
         doc["end"].as_object().is_some_and(|m| m.is_empty()),
         "a mid-run SERVER_ERROR relay renders GT's bare end (#404): {doc}"

--- a/riperf3-cli/tests/self_terminate.rs
+++ b/riperf3-cli/tests/self_terminate.rs
@@ -143,6 +143,19 @@ fn bitrate_limit_json_client_single_doc_with_relayed_error() {
         Some(BITRATE_MSG),
         "the doc adopts the relayed strerror: {doc}"
     );
+    // #404: the relay is a KILL, not a finalize — GT's client errexits via
+    // iperf_json_finish before end processing, so the doc's `end` is BARE
+    // regardless of stage (live-probed 3.21, -t 20 vs 1K limit: GT end
+    // keys [], riperf3 pre-fix rendered the populated finalize end). The
+    // accumulated intervals stay.
+    assert!(
+        doc["end"].as_object().is_some_and(|m| m.is_empty()),
+        "a mid-run SERVER_ERROR relay renders GT's bare end (#404): {doc}"
+    );
+    assert!(
+        !doc["intervals"].as_array().expect("intervals").is_empty(),
+        "the accumulated intervals stay in the doc: {doc}"
+    );
 }
 
 /// -J server: the accumulated intervals emit over a BARE `end: {}` (#368) —

--- a/riperf3/src/client.rs
+++ b/riperf3/src/client.rs
@@ -1061,10 +1061,12 @@ impl Client {
     /// SERVER_TERMINATE's). JSON sinks: render the full document/events with
     /// the error inside, like iperf3's json_top; the CLI suppresses its
     /// generic re-render. The `end` is BARE regardless of stage (#404): the
-    /// relay is a KILL, not a finalize — GT's client errexits via
-    /// iperf_json_finish before end processing (live-probed 3.21: bare on
-    /// the upfront refusal AND the mid-run breach; contrast
-    /// SERVER_TERMINATE, which GT end-processes and both tools populate).
+    /// relay is a KILL, not a finalize — GT's reporter switch no-ops on
+    /// state SERVER_ERROR (iperf_api.c:4622-4637, reached via
+    /// cleanup_and_fail → iperf_client_end), so json_end is never filled
+    /// before iperf_json_finish dumps (live-probed 3.21: bare on the
+    /// upfront refusal AND the mid-run breach; contrast SERVER_TERMINATE,
+    /// which flips to DISPLAY_RESULTS and populates on both tools).
     /// The late start fields still gate on the stage (#261).
     async fn on_server_error_relay(
         &self,

--- a/riperf3/src/client.rs
+++ b/riperf3/src/client.rs
@@ -483,11 +483,9 @@ impl Client {
                         return Err(RiperfError::AccessDenied);
                     }
                     TestState::ServerError => {
-                        // #261: a relay arriving before TestStart is the upfront
-                        // refusal (code 37 et al.) — its `end` is GT's bare {}.
-                        // After TestStart the dump keeps the full structure.
-                        let bare_end = !ctx.stage.started();
-                        let (report, msg) = self.on_server_error_relay(&mut ctx, bare_end).await;
+                        // The relay is a kill — bare end at ANY stage (#404;
+                        // the pre-TestStart refusal was already bare, #261).
+                        let (report, msg) = self.on_server_error_relay(&mut ctx).await;
                         return Ok(Some((
                             report,
                             crate::outcome::Termination::ServerError(msg),
@@ -974,10 +972,10 @@ impl Client {
                 ));
             }
             Some(ControlEvent::ServerError) => {
-                // Mid-test the run is always past TestStart, so the dump
-                // keeps the full report structure (#261). #293: Ok with the
-                // partial report + the ServerError ending.
-                let (report, msg) = self.on_server_error_relay(ctx, false).await;
+                // #404: the mid-test relay renders GT's BARE end too — the
+                // kill never end-processes (see on_server_error_relay).
+                // #293: Ok with the partial report + the ServerError ending.
+                let (report, msg) = self.on_server_error_relay(ctx).await;
                 return Ok(StepFlow::Return(
                     Box::new(report),
                     crate::outcome::Termination::ServerError(msg),
@@ -1062,13 +1060,15 @@ impl Client {
     /// receipt line only (iperf_err's shape; no summary dump — that is
     /// SERVER_TERMINATE's). JSON sinks: render the full document/events with
     /// the error inside, like iperf3's json_top; the CLI suppresses its
-    /// generic re-render. `bare_end` is the caller's: a relay before
-    /// TestStart is the upfront refusal (code 37 et al.) — emit GT's minimal
-    /// doc (`end: {}`; the late start fields already gate on the stage) (#261).
+    /// generic re-render. The `end` is BARE regardless of stage (#404): the
+    /// relay is a KILL, not a finalize — GT's client errexits via
+    /// iperf_json_finish before end processing (live-probed 3.21: bare on
+    /// the upfront refusal AND the mid-run breach; contrast
+    /// SERVER_TERMINATE, which GT end-processes and both tools populate).
+    /// The late start fields still gate on the stage (#261).
     async fn on_server_error_relay(
         &self,
         ctx: &mut RunCtx,
-        bare_end: bool,
     ) -> (crate::json_report::Report, String) {
         let msg = match protocol::read_server_error_payload(&mut ctx.ctrl).await {
             Some((i_errno, os_errno)) => crate::error::iperf3_strerror(i_errno, os_errno),
@@ -1079,7 +1079,7 @@ impl Client {
         // one-line receipt only (GT renders no summary here) but the caller
         // still gets the structured data via build_results.
         let report = if self.json_output || self.json_stream {
-            self.emit_results(ctx, None, bare_end, ctx.measured_secs, Some(&msg))
+            self.emit_results(ctx, None, true, ctx.measured_secs, Some(&msg))
         } else {
             // #290: quiet runs surface the error via the RunOutcome alone.
             if !crate::macros::output_quiet() {
@@ -1092,7 +1092,9 @@ impl Client {
                     crate::macros::output_timestamp_prefix()
                 ));
             }
-            self.partial_report(ctx, None, bare_end, ctx.measured_secs, Some(&msg))
+            // Bare end here too (#404): the RunOutcome's report carries the
+            // same shape in every output mode.
+            self.partial_report(ctx, None, true, ctx.measured_secs, Some(&msg))
         };
         (report, msg)
     }

--- a/riperf3/src/json_report.rs
+++ b/riperf3/src/json_report.rs
@@ -730,10 +730,14 @@ pub struct IntervalSum {
 #[derive(Debug, Clone)]
 #[non_exhaustive]
 pub struct End {
-    /// #261/#281: true on the upfront-refusal path and the mid-test IEMESSAGE dump (#325) — the whole object
-    /// serializes as GT's bare `{}`. Every other dump (success, mid-test or
-    /// pre-TestStart interrupt, SERVER_TERMINATE) renders the full structure,
-    /// including `streams: []` when no stream ever existed.
+    /// True where GT's dump never end-processes — the whole object
+    /// serializes as GT's bare `{}`: the upfront-refusal path (#261/#281),
+    /// the mid-test IEMESSAGE dump (#325), the mid-test ctrl-EOF (#267),
+    /// the server's rate/duration/idle kills (#368), and the client's
+    /// SERVER_ERROR relay at ANY stage (#404). Every other dump (success,
+    /// mid-test or pre-TestStart interrupt, SERVER_TERMINATE — which GT
+    /// end-processes) renders the full structure, including `streams: []`
+    /// when no stream ever existed.
     pub(crate) bare: bool,
     pub streams: Vec<EndStream>,
     /// UDP only: the datagram aggregate iperf3 emits as `sum` — BEFORE the

--- a/riperf3/src/json_report.rs
+++ b/riperf3/src/json_report.rs
@@ -733,11 +733,12 @@ pub struct End {
     /// True where GT's dump never end-processes — the whole object
     /// serializes as GT's bare `{}`: the upfront-refusal path (#261/#281),
     /// the mid-test IEMESSAGE dump (#325), the mid-test ctrl-EOF (#267),
-    /// the server's rate/duration/idle kills (#368), and the client's
-    /// SERVER_ERROR relay at ANY stage (#404). Every other dump (success,
-    /// mid-test or pre-TestStart interrupt, SERVER_TERMINATE — which GT
-    /// end-processes) renders the full structure, including `streams: []`
-    /// when no stream ever existed.
+    /// the failed results read (#374), the server's rate/duration/idle
+    /// kills (#368), and the client's SERVER_ERROR relay at ANY stage
+    /// (#404). Every other dump (success, mid-test or pre-TestStart
+    /// interrupt, SERVER_TERMINATE — which GT end-processes) renders the
+    /// full structure, including `streams: []` when no stream ever
+    /// existed.
     pub(crate) bare: bool,
     pub streams: Vec<EndStream>,
     /// UDP only: the datagram aggregate iperf3 emits as `sum` — BEFORE the

--- a/riperf3/src/outcome.rs
+++ b/riperf3/src/outcome.rs
@@ -63,6 +63,10 @@ pub enum Termination {
     /// The server relayed an error (`SERVER_ERROR`) — e.g. an upfront refusal
     /// (`--server-bitrate-limit`, `--server-max-duration`) or a mid-test
     /// breach. The `String` is iperf3's mapped `iperf_strerror` message.
+    /// The report's `end` is BARE (sums/CPU `None`) at any stage — iperf3
+    /// never end-processes this kill; the partial stats ride `intervals`
+    /// (#404). Contrast [`Self::ServerTerminated`], which iperf3
+    /// end-processes into a full `end`.
     ServerError(String),
 
     // --- Server-side endings (what the server observed) ---

--- a/riperf3/tests/integration.rs
+++ b/riperf3/tests/integration.rs
@@ -1908,6 +1908,15 @@ mod unimplemented_flags {
             "{:?}",
             outcome.termination
         );
+        // #404 r1 F2: the relay report's end is BARE in every mode — this
+        // bare-builder (quiet-default) client rides the text-path
+        // partial_report, the half no CLI pin reaches; GT never
+        // end-processes a SERVER_ERROR kill at any stage.
+        assert!(
+            outcome.report.end.sum_sent.is_none() && outcome.report.end.sum_received.is_none(),
+            "the SERVER_ERROR relay report carries GT's bare end (#404): {:?}",
+            outcome.report.end
+        );
         let joined = server_task.await.expect("server task");
         assert!(
             joined.is_ok(),


### PR DESCRIPTION
Closes #404.

A mid-run SERVER_ERROR relay rendered the POPULATED finalize end on the riperf3 client where GT renders a BARE `end: {}` — GT errexits via `iperf_json_finish` before end processing at ANY stage. The `!stage.started()` gate (which already made the upfront refusal bare, #261) is now unconditional; the `bare_end` parameter fell away from `on_server_error_relay` (both call sites + the text-mode `partial_report`, so the `RunOutcome` report carries one shape in every mode).

Probes (GT 3.21 live): the `-t 20` vs `--server-bitrate-limit 1K` cell — GT `end: []` + relayed error + exit 1; riperf3 post-fix byte-class MATCH (the issue's `-t 5` cell is polluted by #410's breach-timing difference). Contrast-probed: mid-run SERVER_TERMINATE renders the POPULATED end on BOTH tools — deliberately untouched.

Pin (red-first): the `-J` single-doc relay test asserts the bare end + retained intervals. Full suite green, zero collateral.
