### PR TITLE
fix: completed-exchange RST takes IERECVMESSAGE over the populated doc (#406)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,9 @@ release tags.
 - The client's SERVER_ERROR relay renders iperf3's bare `end: {}` at any stage — a mid-run
   breach no longer emits the populated finalize end; on a `Termination::ServerError` ending
   `outcome.report.end` is bare in every mode (partial stats ride `intervals`) (#404).
+- A peer RST after the completed results exchange takes iperf3's IERECVMESSAGE class over
+  the populated document instead of a raw-io skeleton; `Termination::RecvMessageFailed` is
+  the new server-side ending (#406).
 - `--logfile` receives the SERVER-ERROR relay receipt and the interrupt notice like iperf3's
   `iperf_err` routing; both previously went to stderr (#364).
 - Wire-blob parsing mirrors cJSON's UTF-8 BOM skip and non-object params root; four residual

--- a/riperf3-cli/tests/wire_shape.rs
+++ b/riperf3-cli/tests/wire_shape.rs
@@ -718,6 +718,7 @@ fn end_loop_eof_prints_summary_and_the_line_in_text() {
 /// timing-deviation precedent). Pre-fix: skeleton doc + raw io key.
 /// Sentence-prefix asserts per the #387 CI lesson (strerror text is
 /// platform-local); Linux-gated like every RST-timing cell.
+#[cfg(target_os = "linux")]
 const RECVMSG_SENTENCE: &str = "unable to receive control message - port may not be available, \
      the other side may have stopped running, etc.";
 

--- a/riperf3-cli/tests/wire_shape.rs
+++ b/riperf3-cli/tests/wire_shape.rs
@@ -110,6 +110,48 @@ fn drive_mock_round(port: u16, final_byte: u8, junk_mid_test: bool) {
 /// `final_action`: Some(byte) sends the byte; None closes both sockets —
 /// the abrupt-EOF cells (#330).
 fn drive_mock_round_full(port: u16, final_action: Option<u8>, mid_test: bool, params: &str) {
+    let (mut ctrl, data) = drive_round_sockets(port, mid_test, params);
+    match final_action {
+        Some(b) => ctrl.write_all(&[b]).unwrap(),
+        None => drop((ctrl, data)), // abrupt EOF, both sockets (#330)
+    }
+    std::thread::sleep(std::time::Duration::from_millis(500));
+}
+
+/// #406: the completed-exchange RST cell — the round runs through
+/// DisplayResults, then the ctrl RSTs (SO_LINGER 0, the #345 helper's
+/// libc pattern) instead of sending IperfDone or a clean FIN. Linux-only
+/// like every RST-timing cell (the #339 SO_LINGER lesson).
+#[cfg(target_os = "linux")]
+fn drive_mock_round_rst(port: u16) {
+    let (ctrl, data) = drive_round_sockets(port, false, MOCK_PARAMS);
+    let linger = libc::linger {
+        l_onoff: 1,
+        l_linger: 0,
+    };
+    let rc = unsafe {
+        use std::os::fd::AsRawFd;
+        libc::setsockopt(
+            ctrl.as_raw_fd(),
+            libc::SOL_SOCKET,
+            libc::SO_LINGER,
+            std::ptr::from_ref(&linger).cast(),
+            std::mem::size_of::<libc::linger>() as libc::socklen_t,
+        )
+    };
+    assert_eq!(rc, 0, "SO_LINGER(0)");
+    drop((ctrl, data));
+    std::thread::sleep(std::time::Duration::from_millis(500));
+}
+
+/// The shared round body: cookie → params → data stream → (unless
+/// `mid_test`) TestEnd → results exchange → DisplayResults. Returns the
+/// live sockets for the caller's final action.
+fn drive_round_sockets(
+    port: u16,
+    mid_test: bool,
+    params: &str,
+) -> (std::net::TcpStream, std::net::TcpStream) {
     let cookie = [b'x'; 37];
     let mut ctrl = std::net::TcpStream::connect(("127.0.0.1", port)).expect("ctrl");
     ctrl.write_all(&cookie).unwrap();
@@ -128,11 +170,7 @@ fn drive_mock_round_full(port: u16, final_action: Option<u8>, mid_test: bool, pa
         read_json_blob(&mut ctrl); // server results
         assert_eq!(read_exact(&mut ctrl, 1)[0], 14); // DisplayResults
     }
-    match final_action {
-        Some(b) => ctrl.write_all(&[b]).unwrap(),
-        None => drop((ctrl, data)), // abrupt EOF, both sockets (#330)
-    }
-    std::thread::sleep(std::time::Duration::from_millis(500));
+    (ctrl, data)
 }
 
 /// One scenario run against a one-off server: spawn, drive one mock round,
@@ -668,6 +706,58 @@ fn end_loop_eof_prints_summary_and_the_line_in_text() {
         "the completed round prints its summary: {sout}"
     );
     assert!(status.success(), "clean exit like GT");
+}
+
+/// #406: a peer RST after the COMPLETED exchange — GT's read site takes
+/// IERECVMESSAGE (iperf_server_api.c:256, rval<0) over the POPULATED end.
+/// RECORDED DEVIATION: GT's own loopback observable is IESENDMESSAGE + a
+/// stale ENOTCONN — its cleanup tries send_state(SERVER_ERROR) on the dead
+/// ctrl and the double-fault CLOBBERS i_errno (debug-traced:
+/// DISPLAY_RESULTS → SERVER_ERROR state-send fails). riperf3 keeps the
+/// honest read class + live errno (#248/#345 convention; the #371-B
+/// timing-deviation precedent). Pre-fix: skeleton doc + raw io key.
+/// Sentence-prefix asserts per the #387 CI lesson (strerror text is
+/// platform-local); Linux-gated like every RST-timing cell.
+const RECVMSG_SENTENCE: &str = "unable to receive control message - port may not be available, \
+     the other side may have stopped running, etc.";
+
+#[cfg(target_os = "linux")]
+#[test]
+fn end_loop_rst_takes_ierecvmessage_over_the_populated_doc() {
+    let (sout, serr, status) = drive_server_scenario(true, drive_mock_round_rst);
+    let doc: serde_json::Value =
+        serde_json::from_str(sout.trim()).unwrap_or_else(|e| panic!("one -J doc ({e}): {sout}"));
+    let key = doc["error"].as_str().unwrap_or_default();
+    assert!(
+        key.starts_with(&format!("error - {RECVMSG_SENTENCE}: ")),
+        "the honest IERECVMESSAGE class with the live strerror suffix (#406): {doc}"
+    );
+    assert!(
+        doc["end"]["streams"]
+            .as_array()
+            .is_some_and(|a| !a.is_empty()),
+        "the exchange completed — end stays POPULATED, not the skeleton (#406): {doc}"
+    );
+    assert!(serr.trim().is_empty(), "-J stderr silent: {serr}");
+    assert!(status.success(), "keep-serving class — one-off exits 0");
+}
+
+/// #406, text half: one summary dump (the exchange completed) + the line.
+#[cfg(target_os = "linux")]
+#[test]
+fn end_loop_rst_prints_summary_and_the_line_in_text() {
+    let (sout, serr, status) = drive_server_scenario(false, drive_mock_round_rst);
+    assert!(
+        serr.trim()
+            .starts_with(&format!("riperf3: error - {RECVMSG_SENTENCE}: ")),
+        "GT's sentence + live strerror suffix: {serr:?}"
+    );
+    assert_eq!(
+        sout.matches(SUMMARY_SEPARATOR).count(),
+        1,
+        "the completed round prints its summary: {sout}"
+    );
+    assert!(status.success(), "one-off exits 0");
 }
 
 /// #330: a KNOWN state (ParamExchange=9) landing mid-test is GT's same

--- a/riperf3/src/error.rs
+++ b/riperf3/src/error.rs
@@ -131,6 +131,20 @@ pub enum RiperfError {
     #[error("unable to send results: {0}")]
     ExchangeSendResultsFailed(std::io::Error),
 
+    /// iperf3's IERECVMESSAGE: the IperfDone-wait read failed HARD after a
+    /// COMPLETED exchange — the peer RST'd instead of sending IperfDone or
+    /// a clean FIN (#406; iperf_server_api.c:256's rval<0 arm — the EOF
+    /// sibling is IECTRLCLOSE). GT's sentence, perr; the populated-doc
+    /// surface (TEST_END processing ran). RECORDED DEVIATION
+    /// (debug-traced 3.21): GT's loopback observable is usually
+    /// IESENDMESSAGE + a stale ENOTCONN — its cleanup tries
+    /// send_state(SERVER_ERROR) on the dead ctrl and the double-fault
+    /// CLOBBERS i_errno (State: DISPLAY_RESULTS → SERVER_ERROR). riperf3
+    /// keeps the honest read class + live errno (the #248/#345
+    /// convention; the #371-B timing-deviation precedent).
+    #[error("unable to receive control message - port may not be available, the other side may have stopped running, etc.: {0}")]
+    ExchangeRecvMessageFailed(std::io::Error),
+
     /// iperf3's IEACCEPT(104): the control accept() failed
     /// (iperf_server_api.c:163; herr+perr). The site-captured errno rides
     /// — and MATCHES GT's text surface in this pre-test cell (#387 r2 F1

--- a/riperf3/src/outcome.rs
+++ b/riperf3/src/outcome.rs
@@ -37,7 +37,8 @@ use crate::json_report::Report;
 /// [`Server::run_once`](crate::Server::run_once). Some variants are role-
 /// specific: `ServerTerminated`/`ServerError` only occur on the client side
 /// (the server told the client), and `ClientTerminated`/`ControlClosed`/
-/// `UnknownMessage`/`RecvResultsFailed`/`SendFailed`/`SelfTerminated` only on
+/// `UnknownMessage`/`RecvResultsFailed`/`SendFailed`/`RecvMessageFailed`/
+/// `SelfTerminated` only on
 /// the server side (what the server saw). `Completed` and `Interrupted` occur
 /// on both.
 ///
@@ -92,6 +93,13 @@ pub enum Termination {
     /// report carries the accumulated stats.
     SendFailed(String),
 
+    /// The post-exchange IperfDone wait read failed HARD — the client RST'd
+    /// after the completed exchange (iperf3's IERECVMESSAGE, #406; the
+    /// abrupt-EOF sibling is [`Self::ControlClosed`]). The `String` is
+    /// iperf3's mapped message with the live errno. The report carries the
+    /// FULL stats — the exchange completed.
+    RecvMessageFailed(String),
+
     /// The server ended the test on its OWN limit — `--server-bitrate-limit`,
     /// the `--server-max-duration` watchdog, or the idle watchdog (the symmetric
     /// counterpart, server-side, of the client's [`Self::ServerError`]). The
@@ -123,6 +131,7 @@ impl Termination {
             | Termination::UnknownMessage
             | Termination::RecvResultsFailed
             | Termination::SendFailed(_)
+            | Termination::RecvMessageFailed(_)
             | Termination::SelfTerminated(_) => None,
         }
     }
@@ -178,6 +187,7 @@ mod tests {
             Termination::UnknownMessage,
             Termination::RecvResultsFailed,
             Termination::SendFailed("send failed".into()),
+            Termination::RecvMessageFailed("recv failed".into()),
             Termination::SelfTerminated("limit".into()),
         ] {
             assert_eq!(none.errexit_message(), None, "{none:?} must not errexit");

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -326,6 +326,13 @@ struct TestRunCtx {
     /// IERECVRESULTS surface for every close-type and file upstream rather
     /// than reproduce the misleading flip.
     exchange_recv_failed: bool,
+    /// #406: the IperfDone-wait read failed HARD (peer RST after the
+    /// completed exchange) — GT's IERECVMESSAGE read-site class, the error
+    /// sibling of `ctrl_closed`'s EOF. Holds the typed
+    /// [`RiperfError::ExchangeRecvMessageFailed`] (the #371
+    /// exchange_send_error pattern) so the doc key and the Termination
+    /// share one rendering.
+    exchange_recv_message_error: Option<RiperfError>,
     /// #371: a POST-TEST_END exchange-phase SEND failed (the state writes →
     /// IESENDMESSAGE, `send_results` → IESENDRESULTS). Set instead of
     /// propagating the raw io Err so the finalize renders the POPULATED doc
@@ -623,6 +630,11 @@ impl Server {
                             // #371: IESENDMESSAGE/IESENDRESULTS — the live errno
                             // rides the carried message (no dangling ": ").
                             Termination::SendFailed(msg) => {
+                                eprintln!("{prefix}riperf3: error - {msg}")
+                            }
+                            // #406: IERECVMESSAGE — the completed-exchange RST
+                            // read; live errno in the carried message.
+                            Termination::RecvMessageFailed(msg) => {
                                 eprintln!("{prefix}riperf3: error - {msg}")
                             }
                             // Completed / Interrupted / SelfTerminated print no
@@ -1016,6 +1028,7 @@ impl Server {
             ctrl_closed: false,
             early_done: false,
             exchange_recv_failed: false,
+            exchange_recv_message_error: None,
             exchange_send_error: None,
             bare_end: false,
             interrupted: None,
@@ -1072,13 +1085,13 @@ impl Server {
             let (server_output_text, server_output_json, report_source) =
                 self.finish_server_output(&mut ctx, &end, collected);
             let was_captured = server_output_text.is_some();
-            // #353: an exchange Err reaches the gate through this `?` —
+            // #353: an exchange Err would reach the gate through this `?` —
             // counts are frozen at build_result_streams, so the teardown is
-            // safe on this path. Post-#405 the send failures (the
-            // ExchangeResults and DisplayResults state writes, send_results)
-            // are caught into ctx.exchange_send_error and return Ok instead,
-            // so the live Err here is the residual raw-Io recv_state error
-            // in the IperfDone loop.
+            // safe on this path. Post-#405 the send failures are caught into
+            // ctx.exchange_send_error, and post-#406 the IperfDone-loop hard
+            // read error is caught into ctx.exchange_recv_message_error —
+            // every exchange ending now returns Ok with its ctx flag, so no
+            // LIVE Err remains through this `?` (defensive only).
             self.exchange_results_phase(
                 &mut ctx,
                 &end,
@@ -1120,6 +1133,11 @@ impl Server {
                     // #371: GT's IESENDMESSAGE/IESENDRESULTS key over the
                     // populated doc — prefixed like the self-terminate keys,
                     // with the live strerror the variant's Display carries.
+                    end.report_error = Some(format!("error - {err}"));
+                } else if let Some(err) = &ctx.exchange_recv_message_error {
+                    // #406: GT's IERECVMESSAGE key over the populated doc —
+                    // prefixed, live strerror (see the variant's deviation
+                    // record for GT's clobbered loopback observable).
                     end.report_error = Some(format!("error - {err}"));
                 }
             }
@@ -1227,6 +1245,9 @@ impl Server {
             crate::outcome::Termination::RecvResultsFailed
         } else if let Some(err) = ctx.exchange_send_error.take() {
             crate::outcome::Termination::SendFailed(err.to_string())
+        } else if let Some(err) = ctx.exchange_recv_message_error.take() {
+            // #406: same slot order as report_error's site above.
+            crate::outcome::Termination::RecvMessageFailed(err.to_string())
         } else {
             // Clean completion (incl. the #330 mid-test IPERF_DONE bare-end).
             crate::outcome::Termination::Completed
@@ -2712,6 +2733,18 @@ impl Server {
                     Err(RiperfError::PeerDisconnected) => {
                         let _ = protocol::send_server_error(&mut ctx.ctrl, 109).await;
                         ctx.ctrl_closed = true;
+                        break;
+                    }
+                    // #406: a HARD read error (the peer RST'd after the
+                    // completed exchange) — GT's read-site rval<0 arm is
+                    // IERECVMESSAGE (iperf_server_api.c:256) over the
+                    // POPULATED end, the error sibling of the EOF arm
+                    // above. No relay: the ctrl is dead. See the
+                    // ExchangeRecvMessageFailed deviation record for GT's
+                    // clobbered-class loopback observable.
+                    Err(RiperfError::Io(e)) => {
+                        ctx.exchange_recv_message_error =
+                            Some(RiperfError::ExchangeRecvMessageFailed(e));
                         break;
                     }
                     Err(e) => return Err(e),
@@ -4624,6 +4657,7 @@ mod tests {
             ctrl_closed: false,
             early_done: false,
             exchange_recv_failed: false,
+            exchange_recv_message_error: None,
             exchange_send_error: None,
             bare_end: false,
             interrupted: None,

--- a/riperf3/tests/integration.rs
+++ b/riperf3/tests/integration.rs
@@ -2766,6 +2766,102 @@ async fn negative_window_renders_minus_one_like_gt() {
     }
 }
 
+/// #406 (r1): the `RecvMessageFailed`↔`SendFailed` cell of the same
+/// invisibility class — the repo's first RENDERING-IDENTICAL variant pair
+/// (both print `error - {msg}` with the carried message and both errexit
+/// to None), so only a lib-level `run_once` assertion discriminates them.
+/// A raw mock completes the full round through DisplayResults, then
+/// SO_LINGER(0)-RSTs instead of IperfDone — the IperfDone-wait read fails
+/// hard (IERECVMESSAGE) over the POPULATED report. Linux-gated like every
+/// RST-timing cell (the #339 lesson).
+#[cfg(target_os = "linux")]
+#[tokio::test]
+async fn server_run_once_exchange_rst_ends_recv_message_failed() {
+    let server = ServerBuilder::new()
+        .port(Some(0))
+        .emit_output(false)
+        .build()
+        .unwrap();
+    let bound = server.bind().await.expect("bind");
+    let port = bound.local_addr().unwrap().port();
+    let server_task = tokio::spawn(async move { bound.run_once().await });
+
+    // The raw round runs on a blocking thread (std sockets).
+    let mock = tokio::task::spawn_blocking(move || {
+        use std::io::{Read, Write};
+        let rd1 = |s: &mut std::net::TcpStream| {
+            let mut b = [0u8; 1];
+            s.read_exact(&mut b).expect("state byte");
+            b[0]
+        };
+        let blob_w = |s: &mut std::net::TcpStream, p: &str| {
+            s.write_all(&(p.len() as u32).to_be_bytes()).unwrap();
+            s.write_all(p.as_bytes()).unwrap();
+        };
+        let cookie = [b'x'; 37];
+        let mut ctrl = std::net::TcpStream::connect(("127.0.0.1", port)).expect("ctrl");
+        ctrl.write_all(&cookie).unwrap();
+        assert_eq!(rd1(&mut ctrl), 9, "ParamExchange");
+        blob_w(
+            &mut ctrl,
+            r#"{"tcp":true,"time":1,"parallel":1,"len":4096}"#,
+        );
+        assert_eq!(rd1(&mut ctrl), 10, "CreateStreams");
+        let mut data = std::net::TcpStream::connect(("127.0.0.1", port)).expect("data");
+        data.write_all(&cookie).unwrap();
+        assert_eq!(rd1(&mut ctrl), 1, "TestStart");
+        assert_eq!(rd1(&mut ctrl), 2, "TestRunning");
+        data.write_all(&[0u8; 4096]).unwrap();
+        ctrl.write_all(&[4u8]).unwrap(); // TestEnd
+        assert_eq!(rd1(&mut ctrl), 13, "ExchangeResults");
+        blob_w(
+            &mut ctrl,
+            r#"{"cpu_util_total":1.0,"cpu_util_user":0.5,"cpu_util_system":0.5,"sender_has_retransmits":1,"streams":[{"id":1,"bytes":4096,"retransmits":0,"jitter":0,"errors":0,"packets":0,"start_time":0,"end_time":1}]}"#,
+        );
+        // Read the server's results blob, then DisplayResults.
+        let mut len = [0u8; 4];
+        ctrl.read_exact(&mut len).unwrap();
+        let mut blob = vec![0u8; u32::from_be_bytes(len) as usize];
+        ctrl.read_exact(&mut blob).unwrap();
+        assert_eq!(rd1(&mut ctrl), 14, "DisplayResults");
+        // The #406 cell: RST instead of IperfDone/FIN.
+        let linger = libc::linger {
+            l_onoff: 1,
+            l_linger: 0,
+        };
+        let rc = unsafe {
+            use std::os::fd::AsRawFd;
+            libc::setsockopt(
+                ctrl.as_raw_fd(),
+                libc::SOL_SOCKET,
+                libc::SO_LINGER,
+                std::ptr::from_ref(&linger).cast(),
+                std::mem::size_of::<libc::linger>() as libc::socklen_t,
+            )
+        };
+        assert_eq!(rc, 0, "SO_LINGER(0)");
+        drop((ctrl, data));
+    });
+
+    let outcome = tokio::time::timeout(Duration::from_secs(15), server_task)
+        .await
+        .expect("server hung")
+        .expect("join")
+        .expect("the completed-exchange RST is a report-producing round (#406)");
+    mock.await.expect("mock");
+    match &outcome.termination {
+        riperf3::Termination::RecvMessageFailed(msg) => assert!(
+            msg.starts_with("unable to receive control message"),
+            "the carried IERECVMESSAGE message: {msg:?}"
+        ),
+        other => panic!("expected RecvMessageFailed, got {other:?}"),
+    }
+    assert!(
+        !outcome.report.end.streams.is_empty(),
+        "the exchange completed — the report keeps the POPULATED end (#406)"
+    );
+}
+
 /// The server-side `Interrupted` cell of the same invisibility class: a
 /// mid-test interrupt on `run_once` comes back `Ok(RunOutcome)` with
 /// `Termination::Interrupted`. Like `SelfTerminated` above, an


### PR DESCRIPTION
Closes #406.

A peer that completes the results exchange then RSTs landed on the IperfDone-wait loop's residual raw-Io `Err` → skeleton doc + raw io key, where GT emits the **populated** doc. The read error is now caught into a ctx flag (the #371 `exchange_send_error` pattern) → populated doc + GT's IERECVMESSAGE sentence with the live strerror + the additive `Termination::RecvMessageFailed` + keep-serving. The new class slots after `SendFailed` in **both** `report_error` and the Termination derivation (the #409 F4 lockstep); post-fix **no live `Err` remains** through the exchange `?`.

**Recorded deviation** (debug-traced 3.21): GT's read fails first (IERECVMESSAGE per iperf_server_api.c:256) but its cleanup tries `send_state(SERVER_ERROR)` on the dead ctrl and the double-fault **clobbers** `i_errno` → GT's loopback observable is IESENDMESSAGE + a stale ENOTCONN (`State: DISPLAY_RESULTS → SERVER_ERROR` in `-d` output). riperf3 keeps the honest read class + live errno (the #248/#345 convention; the #371-B timing-deviation precedent). Post-fix probe: end key sets **identical** to GT.

Pins (red-first, Linux-gated, sentence-prefix asserts): `-J` populated end + class key; text one-summary + one-line; one-off exit 0.
