### PR TITLE
fix: a dropped run()/run_once() future aborts its stream tasks (#380)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,9 @@ release tags.
   skip rule; NUL stays a terminator like iperf3's strlen-based parse entry (#402). A
   wrong-typed params field stays a strict IERECVPARAMS error where iperf3 warns and
   defaults the field — a recorded deviation (#401).
+- A `run()`/`run_once()` future dropped mid-test (`tokio::time::timeout`, `select!`) no
+  longer leaks parked stream tasks and their sockets: an abort guard fires on cancellation,
+  disarmed by the normal teardown paths (#380).
 - `--logfile` receives the SERVER-ERROR relay receipt and the interrupt notice like iperf3's
   `iperf_err` routing; both previously went to stderr (#364).
 - Wire-blob parsing mirrors cJSON's UTF-8 BOM skip and non-object params root; four residual

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,7 +64,7 @@ release tags.
   defaults the field — a recorded deviation (#401).
 - A `run()`/`run_once()` future dropped mid-test (`tokio::time::timeout`, `select!`) no
   longer leaks parked stream tasks and their sockets: an abort guard fires on cancellation,
-  disarmed by the normal teardown paths (#380).
+  disarmed by the normal teardown paths; a cancel mid-setup remains #381's scope (#380).
 - `--logfile` receives the SERVER-ERROR relay receipt and the interrupt notice like iperf3's
   `iperf_err` routing; both previously went to stderr (#364).
 - Wire-blob parsing mirrors cJSON's UTF-8 BOM skip and non-object params root; four residual

--- a/riperf3/src/client.rs
+++ b/riperf3/src/client.rs
@@ -405,6 +405,12 @@ impl Client {
         // `done` is set before ctx's fields (the control socket) drop, the
         // monolith's drop order (r1 F1).
         let _done_guard = stream::DoneOnDrop(ctx.done.clone());
+        // #380: if THIS FUTURE is dropped (timeout/select cancellation) the
+        // teardown gate below never runs and `done` can't wake a parked
+        // read — this guard abort()s the stream tasks instead. Armed at
+        // CreateStreams, disarmed at the gate (which then abort-and-JOINs
+        // as before).
+        let mut abort_guard = stream::AbortStreamsOnDrop::new();
 
         // ---- State machine: react to server-driven transitions ----
         // #375: the whole dispatch loop runs inside this block so EVERY
@@ -457,6 +463,8 @@ impl Client {
 
                     TestState::CreateStreams => {
                         self.on_create_streams(&mut ctx).await?;
+                        // #380: the spawned tasks are now cancel-exposed.
+                        abort_guard.arm(ctx.streams.iter().map(|s| s.task.abort_handle()));
                         StepFlow::Continue
                     }
 
@@ -555,6 +563,8 @@ impl Client {
         // only when this gate is the FIRST to stop the streams (errors
         // between CreateStreams and the data phase) — and never when no
         // streams were spawned at all.
+        // #380: the gate is running — it owns the stop from here.
+        abort_guard.disarm();
         let grace_owed = !ctx.done.swap(true, Ordering::Relaxed);
         if grace_owed && !ctx.streams.is_empty() {
             tokio::time::sleep(Duration::from_millis(100)).await;

--- a/riperf3/src/client.rs
+++ b/riperf3/src/client.rs
@@ -399,18 +399,21 @@ impl Client {
             stage: RunStage::PreTestStart { connect_millis: 0 },
             prev_state: TestState::IperfStart,
         };
+        // #380: if THIS FUTURE is dropped (timeout/select cancellation) the
+        // teardown gate below never runs and `done` can't wake a parked
+        // read — this guard abort()s the stream tasks instead. Armed at
+        // CreateStreams, disarmed after the gate's joins (which abort-and-
+        // JOIN as before). Declared BEFORE _done_guard so the cancel-drop
+        // stores `done` first, then aborts — the gate's own order (r1 F1
+        // of #426: a detached reporter tick must see `done` before any
+        // stream fd can be recycled).
+        let mut abort_guard = stream::AbortStreamsOnDrop::new();
         // Signal `done` on every exit path (incl. early `?` returns) so a UDP
         // sender parked on the start barrier can't leak if setup fails (#5).
         // Declared AFTER ctx so an early return drops the guard FIRST —
         // `done` is set before ctx's fields (the control socket) drop, the
         // monolith's drop order (r1 F1).
         let _done_guard = stream::DoneOnDrop(ctx.done.clone());
-        // #380: if THIS FUTURE is dropped (timeout/select cancellation) the
-        // teardown gate below never runs and `done` can't wake a parked
-        // read — this guard abort()s the stream tasks instead. Armed at
-        // CreateStreams, disarmed at the gate (which then abort-and-JOINs
-        // as before).
-        let mut abort_guard = stream::AbortStreamsOnDrop::new();
 
         // ---- State machine: react to server-driven transitions ----
         // #375: the whole dispatch loop runs inside this block so EVERY
@@ -464,6 +467,10 @@ impl Client {
                     TestState::CreateStreams => {
                         self.on_create_streams(&mut ctx).await?;
                         // #380: the spawned tasks are now cancel-exposed.
+                        // RESIDUAL: a cancel landing INSIDE on_create_streams
+                        // leaves the already-spawned subset unguarded (the
+                        // tasks park un-wakeably from spawn) — the mid-setup
+                        // teardown-skip class, #381's scope for both roles.
                         abort_guard.arm(ctx.streams.iter().map(|s| s.task.abort_handle()));
                         StepFlow::Continue
                     }
@@ -563,8 +570,6 @@ impl Client {
         // only when this gate is the FIRST to stop the streams (errors
         // between CreateStreams and the data phase) — and never when no
         // streams were spawned at all.
-        // #380: the gate is running — it owns the stop from here.
-        abort_guard.disarm();
         let grace_owed = !ctx.done.swap(true, Ordering::Relaxed);
         if grace_owed && !ctx.streams.is_empty() {
             tokio::time::sleep(Duration::from_millis(100)).await;
@@ -575,6 +580,12 @@ impl Client {
         for s in ctx.streams.drain(..) {
             let _ = s.task.await;
         }
+        // #380 (#426 r1 F1): disarmed only NOW — the guard stays armed
+        // through the gate's own awaits (the grace sleep, the joins),
+        // where a cancel would otherwise land disarmed-but-unaborted and
+        // leak. abort() is idempotent, so the guard firing mid-join is
+        // free.
+        abort_guard.disarm();
 
         // The abnormal-end rounds (#293) — a signal dump, a server terminate,
         // or a relayed server error — already rendered their output; only the

--- a/riperf3/src/client.rs
+++ b/riperf3/src/client.rs
@@ -404,7 +404,7 @@ impl Client {
         // read — this guard abort()s the stream tasks instead. Armed at
         // CreateStreams, disarmed after the gate's joins (which abort-and-
         // JOIN as before). Declared BEFORE _done_guard so the cancel-drop
-        // stores `done` first, then aborts — the gate's own order (r1 F1
+        // stores `done` first, then aborts — the gate's own order (r1 F3
         // of #426: a detached reporter tick must see `done` before any
         // stream fd can be recycled).
         let mut abort_guard = stream::AbortStreamsOnDrop::new();

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -1039,6 +1039,12 @@ impl Server {
         // `done` is set before ctx's fields (the control socket, the capture
         // guard) drop, the monolith's drop order (r1 F1).
         let _done_guard = stream::DoneOnDrop(ctx.done.clone());
+        // #380: if THIS FUTURE is dropped (a run_once wrapped in
+        // timeout/select) the abort/join gate below never runs and `done`
+        // can't wake a parked read — this guard abort()s the stream tasks
+        // (+ the UDP demux) instead. Armed after setup, disarmed at the
+        // gate (which then abort-and-JOINs as before).
+        let mut abort_guard = stream::AbortStreamsOnDrop::new();
 
         // ---- CreateStreams ----
         if let SetupFlow::ClientDone = self.setup_data_streams(&mut ctx, listener).await? {
@@ -1046,6 +1052,13 @@ impl Server {
             // no error surface, keep-serving like a refusal (Ok(None)).
             return Ok(None);
         }
+        // #380: the spawned tasks are now cancel-exposed.
+        abort_guard.arm(
+            ctx.streams
+                .iter()
+                .map(|s| s.task.abort_handle())
+                .chain(ctx.udp_demux_handle.iter().map(|h| h.abort_handle())),
+        );
 
         // #372: every phase from TestStart to the final output runs inside
         // this block, so every `?` — start_test's sends, await_test_end's
@@ -1198,6 +1211,8 @@ impl Server {
         // fd — while an abort could kill a text-mode emit mid-line. The
         // done-store-BEFORE-abort order also keeps a post-close reporter
         // tick from sampling a recycled raw_fd.
+        // #380: the gate is running — it owns the stop from here.
+        abort_guard.disarm();
         ctx.done.store(true, Ordering::Relaxed);
         for s in &ctx.streams {
             s.task.abort();

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -1033,18 +1033,23 @@ impl Server {
             bare_end: false,
             interrupted: None,
         };
+        // #380: if THIS FUTURE is dropped (a run_once wrapped in
+        // timeout/select) the abort/join gate below never runs and `done`
+        // can't wake a parked read — this guard abort()s the stream tasks
+        // instead. (The chained UDP demux handle only stops a queued-not-
+        // yet-started runner: the demux is spawn_blocking, and abort() is
+        // a no-op once it runs — it exits via `done` + its 500 ms poll.)
+        // Armed after setup, disarmed after the gate's joins. Declared
+        // BEFORE _done_guard so the cancel-drop stores `done` first, then
+        // aborts — the gate's done-store-BEFORE-abort order (the recycled-
+        // raw_fd record below).
+        let mut abort_guard = stream::AbortStreamsOnDrop::new();
         // Signal `done` on every exit path (incl. early `?` returns) so a UDP
         // sender parked on the start barrier can't leak if setup fails (#5).
         // Declared AFTER ctx so an early return drops the guard FIRST —
         // `done` is set before ctx's fields (the control socket, the capture
         // guard) drop, the monolith's drop order (r1 F1).
         let _done_guard = stream::DoneOnDrop(ctx.done.clone());
-        // #380: if THIS FUTURE is dropped (a run_once wrapped in
-        // timeout/select) the abort/join gate below never runs and `done`
-        // can't wake a parked read — this guard abort()s the stream tasks
-        // (+ the UDP demux) instead. Armed after setup, disarmed at the
-        // gate (which then abort-and-JOINs as before).
-        let mut abort_guard = stream::AbortStreamsOnDrop::new();
 
         // ---- CreateStreams ----
         if let SetupFlow::ClientDone = self.setup_data_streams(&mut ctx, listener).await? {
@@ -1053,6 +1058,10 @@ impl Server {
             return Ok(None);
         }
         // #380: the spawned tasks are now cancel-exposed.
+        // RESIDUAL: a cancel landing INSIDE setup_data_streams leaves the
+        // already-accepted subset unguarded (the tasks park un-wakeably
+        // from spawn) — the mid-setup teardown-skip class, #381's scope
+        // for both roles.
         abort_guard.arm(
             ctx.streams
                 .iter()
@@ -1211,8 +1220,6 @@ impl Server {
         // fd — while an abort could kill a text-mode emit mid-line. The
         // done-store-BEFORE-abort order also keeps a post-close reporter
         // tick from sampling a recycled raw_fd.
-        // #380: the gate is running — it owns the stop from here.
-        abort_guard.disarm();
         ctx.done.store(true, Ordering::Relaxed);
         for s in &ctx.streams {
             s.task.abort();
@@ -1228,6 +1235,11 @@ impl Server {
         if let Some(h) = ctx.udp_demux_handle.take() {
             let _ = h.await;
         }
+        // #380 (#426 r1 F1): disarmed only NOW — the guard stays armed
+        // through the gate's own join awaits, where a cancel would
+        // otherwise land disarmed-but-unaborted and leak. abort() is
+        // idempotent, so the guard firing mid-join is free.
+        abort_guard.disarm();
 
         let report = outcome?;
 

--- a/riperf3/src/stream.rs
+++ b/riperf3/src/stream.rs
@@ -1179,6 +1179,60 @@ impl Drop for DoneOnDrop {
     }
 }
 
+/// #380: abort-on-cancel guard for the spawned stream tasks. A `run()`
+/// future dropped mid-test (timeout/select cancellation — the pattern
+/// every library consumer reaches for) skips every teardown gate:
+/// [`DoneOnDrop`] still fires, but `done` cannot wake a task parked in
+/// `read()`/`write().await` (the recorded #372/#375 caveat) and Drop
+/// cannot await joins (the #372 async-RAII limitation). This non-async
+/// guard `abort()`s instead — armed right after the streams spawn,
+/// DISARMED at the teardown gate (the normal paths abort-and-JOIN there,
+/// exactly as before). Aborted tokio tasks drop their sockets at the next
+/// await point on the still-live runtime; the `spawn_blocking` UDP
+/// runners are out of abort's reach and keep riding `done` + their 500 ms
+/// poll (the recorded residual).
+pub struct AbortStreamsOnDrop {
+    handles: Vec<tokio::task::AbortHandle>,
+    armed: bool,
+}
+
+impl AbortStreamsOnDrop {
+    pub fn new() -> Self {
+        Self {
+            handles: Vec::new(),
+            armed: false,
+        }
+    }
+
+    /// Arm with the current task set (idempotent: re-arming replaces).
+    pub fn arm(&mut self, handles: impl IntoIterator<Item = tokio::task::AbortHandle>) {
+        self.handles = handles.into_iter().collect();
+        self.armed = true;
+    }
+
+    /// The teardown gate owns the stop from here (abort + JOIN).
+    pub fn disarm(&mut self) {
+        self.armed = false;
+        self.handles.clear();
+    }
+}
+
+impl Default for AbortStreamsOnDrop {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Drop for AbortStreamsOnDrop {
+    fn drop(&mut self) {
+        if self.armed {
+            for h in &self.handles {
+                h.abort();
+            }
+        }
+    }
+}
+
 /// High-performance UDP sender using blocking I/O on a dedicated OS thread.
 /// No `unsafe` code — uses `std::net::UdpSocket` and batch pacing with
 /// `std::thread::sleep` + spin-loop for sub-microsecond precision.

--- a/riperf3/src/stream.rs
+++ b/riperf3/src/stream.rs
@@ -1186,8 +1186,12 @@ impl Drop for DoneOnDrop {
 /// `read()`/`write().await` (the recorded #372/#375 caveat) and Drop
 /// cannot await joins (the #372 async-RAII limitation). This non-async
 /// guard `abort()`s instead — armed right after the streams spawn,
-/// DISARMED at the teardown gate (the normal paths abort-and-JOIN there,
-/// exactly as before). Aborted tokio tasks drop their sockets at the next
+/// DISARMED only after the teardown gate's joins (the normal paths
+/// abort-and-JOIN there, exactly as before): the guard must stay armed
+/// through the gate's own awaits — the grace sleep, the joins — where a
+/// cancel would otherwise land disarmed-but-unaborted (#426 r1 F1);
+/// `abort()` is idempotent, so the guard firing after the gate's own
+/// abort is free. Aborted tokio tasks drop their sockets at the next
 /// await point on the still-live runtime; the `spawn_blocking` UDP
 /// runners are out of abort's reach and keep riding `done` + their 500 ms
 /// poll (the recorded residual).
@@ -1210,7 +1214,7 @@ impl AbortStreamsOnDrop {
         self.armed = true;
     }
 
-    /// The teardown gate owns the stop from here (abort + JOIN).
+    /// The teardown gate reaped the tasks (abort + JOIN complete).
     pub fn disarm(&mut self) {
         self.armed = false;
         self.handles.clear();

--- a/riperf3/tests/teardown.rs
+++ b/riperf3/tests/teardown.rs
@@ -137,8 +137,13 @@ fn mock_fin_after_create_streams(
         read_exact(&mut data, 37); // data-stream cookie
         datas.push(data);
     }
-    drop(ctrl); // FIN mid-setup — the gate will owe the grace
+    // setup_done BEFORE the FIN (#426 r2 F1): the grace clock starts at
+    // the client's FIN observation, the cancel clock at this send — a
+    // mock stall between the two must delay the GATE (safe: an early
+    // cancel lands pre-gate, still guarded), never the cancel (a late
+    // cancel could miss a finished gate and trip the res assert).
     let _ = setup_done.send(());
+    drop(ctrl); // FIN mid-setup — the gate will owe the grace
     let _ = hold.recv_timeout(Duration::from_secs(10));
     let mut reads = Vec::new();
     for data in &mut datas {
@@ -158,7 +163,7 @@ fn mock_fin_after_create_streams(
 /// absolute deadline, so a slow runner degrades to an earlier —
 /// still-guarded — cancel point instead of a mistimed miss. run() can't
 /// win the select: this path owes ≥100 ms of grace after a FIN that
-/// precedes setup_done.
+/// never precedes the setup_done send.
 #[test]
 fn client_cancelled_during_grace_window_aborts_stream_tasks() {
     let rt = tokio::runtime::Builder::new_multi_thread()

--- a/riperf3/tests/teardown.rs
+++ b/riperf3/tests/teardown.rs
@@ -111,6 +111,100 @@ fn mock_hold_mid_running(
     reads
 }
 
+/// #380 (r1 F1): the mock completes setup through CreateStreams, then
+/// FINs ctrl WITHOUT TestStart — the client errors at the next
+/// recv_state and reaches the gate as the FIRST to stop the streams, so
+/// it owes the 100 ms grace sleep. `setup_done` fires right after the
+/// FIN so the caller can time its cancel INTO that sleep: a disarm
+/// placed before the grace await leaves a window where the guard is
+/// dead but the gate's own abort hasn't run — the drop leaks exactly
+/// like an unguarded cancel.
+fn mock_fin_after_create_streams(
+    listener: std::net::TcpListener,
+    parallel: usize,
+    setup_done: tokio::sync::oneshot::Sender<()>,
+    hold: std::sync::mpsc::Receiver<()>,
+) -> Vec<Result<usize, std::io::ErrorKind>> {
+    let (mut ctrl, _) = listener.accept().expect("ctrl accept");
+    read_exact(&mut ctrl, 37); // cookie
+    ctrl.write_all(&[9u8]).unwrap(); // ParamExchange
+    let len = u32::from_be_bytes(read_exact(&mut ctrl, 4).try_into().unwrap()) as usize;
+    read_exact(&mut ctrl, len); // the client's params blob
+    ctrl.write_all(&[10u8]).unwrap(); // CreateStreams
+    let mut datas = Vec::new();
+    for _ in 0..parallel {
+        let (mut data, _) = listener.accept().expect("data accept");
+        read_exact(&mut data, 37); // data-stream cookie
+        datas.push(data);
+    }
+    drop(ctrl); // FIN mid-setup — the gate will owe the grace
+    let _ = setup_done.send(());
+    let _ = hold.recv_timeout(Duration::from_secs(10));
+    let mut reads = Vec::new();
+    for data in &mut datas {
+        data.set_read_timeout(Some(Duration::from_secs(4)))
+            .expect("set_read_timeout");
+        let mut buf = [0u8; 16];
+        reads.push(data.read(&mut buf).map_err(|e| e.kind()));
+    }
+    reads
+}
+
+/// #380 r1 F1: a cancel landing INSIDE the gate's grace sleep (the
+/// 100 ms owed when the gate is first to stop the streams) must still
+/// abort — the guard has to stay armed through every await between the
+/// gate's entry and its abort loop. The cancel is timed off the mock's
+/// setup_done signal (+60 ms of purely local client work), not an
+/// absolute deadline, so a slow runner degrades to an earlier —
+/// still-guarded — cancel point instead of a mistimed miss. run() can't
+/// win the select: this path owes ≥100 ms of grace after a FIN that
+/// precedes setup_done.
+#[test]
+fn client_cancelled_during_grace_window_aborts_stream_tasks() {
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(2)
+        .enable_all()
+        .build()
+        .expect("runtime");
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind mock");
+    let port = listener.local_addr().unwrap().port();
+    let (setup_tx, setup_rx) = tokio::sync::oneshot::channel();
+    let (dropped_tx, dropped_rx) = std::sync::mpsc::channel();
+    let mock = std::thread::spawn(move || {
+        mock_fin_after_create_streams(listener, 2, setup_tx, dropped_rx)
+    });
+
+    let client = ClientBuilder::new("127.0.0.1")
+        .port(Some(port))
+        .reverse(true)
+        .num_streams(2)
+        .duration(30)
+        .json_output(true)
+        .build()
+        .expect("build client");
+    let res = rt.block_on(async {
+        tokio::select! {
+            r = client.run() => Some(r),
+            _ = async {
+                let _ = setup_rx.await;
+                tokio::time::sleep(Duration::from_millis(60)).await;
+            } => None, // the run() future is dropped as select! returns
+        }
+    });
+    assert!(res.is_none(), "the cancel wins — run() owes the grace");
+    dropped_tx.send(()).expect("mock alive");
+
+    let reads = mock.join().expect("mock");
+    for (i, r) in reads.iter().enumerate() {
+        assert!(
+            matches!(r, Ok(0) | Err(std::io::ErrorKind::ConnectionReset)),
+            "stream {i}: a cancel inside the grace window must still abort \
+             the stream tasks (#380 r1 F1): {r:?}"
+        );
+    }
+    drop(rt);
+}
+
 /// #380: a run() future dropped mid-TEST_RUNNING (tokio::time::timeout —
 /// the pattern every library consumer reaches for) must not leak the
 /// parked stream tasks: the drop skips every teardown gate, `done` can't
@@ -139,8 +233,10 @@ fn client_cancelled_run_aborts_stream_tasks() {
         .build()
         .expect("build client");
     let res = rt.block_on(async {
-        // ~1 s: past the mock's 300 ms burst + parked silence.
-        tokio::time::timeout(Duration::from_secs(1), client.run()).await
+        // ~3 s: past the mock's 300 ms burst + parked silence, with margin
+        // for a starved 2-core runner (a cancel BEFORE setup completes
+        // would pass vacuously; the mock holds for 10 s either way).
+        tokio::time::timeout(Duration::from_secs(3), client.run()).await
     });
     assert!(res.is_err(), "the timeout cancels the run — no result");
     // The future is dropped; tell the mock to start its bounded reads.
@@ -210,8 +306,9 @@ fn server_cancelled_run_once_aborts_stream_tasks() {
     });
 
     let res = rt.block_on(async {
-        // ~1 s: past the burst + parked silence; the future drops here.
-        tokio::time::timeout(Duration::from_secs(1), bound.run_once()).await
+        // ~3 s: past the burst + parked silence (starved-runner margin,
+        // like the client cell); the future drops here.
+        tokio::time::timeout(Duration::from_secs(3), bound.run_once()).await
     });
     assert!(res.is_err(), "the timeout cancels run_once — no result");
     dropped_tx.send(()).expect("mock alive");

--- a/riperf3/tests/teardown.rs
+++ b/riperf3/tests/teardown.rs
@@ -65,6 +65,166 @@ fn mock_fin_mid_running(
     reads
 }
 
+/// #380: like [`mock_fin_mid_running`] but the mock NEVER kills the round —
+/// it holds ctrl and data open, silent, while the caller CANCELS `run()`
+/// (a dropped future skips every teardown gate). The bounded reads then
+/// tell leak from abort.
+fn mock_hold_mid_running(
+    listener: std::net::TcpListener,
+    parallel: usize,
+    hold: std::sync::mpsc::Receiver<()>,
+) -> Vec<Result<usize, std::io::ErrorKind>> {
+    let (mut ctrl, _) = listener.accept().expect("ctrl accept");
+    read_exact(&mut ctrl, 37); // cookie
+    ctrl.write_all(&[9u8]).unwrap(); // ParamExchange
+    let len = u32::from_be_bytes(read_exact(&mut ctrl, 4).try_into().unwrap()) as usize;
+    read_exact(&mut ctrl, len); // the client's params blob
+    ctrl.write_all(&[10u8]).unwrap(); // CreateStreams
+    let mut datas = Vec::new();
+    for _ in 0..parallel {
+        let (mut data, _) = listener.accept().expect("data accept");
+        read_exact(&mut data, 37); // data-stream cookie
+        datas.push(data);
+    }
+    ctrl.write_all(&[1u8]).unwrap(); // TestStart
+    ctrl.write_all(&[2u8]).unwrap(); // TestRunning
+    let t0 = std::time::Instant::now();
+    while t0.elapsed() < Duration::from_millis(300) {
+        for data in &mut datas {
+            data.write_all(&[0u8; 8192]).expect("reverse burst");
+        }
+        std::thread::sleep(Duration::from_millis(5));
+    }
+    // Silence: the receivers drain and PARK (the #354 timing lesson) —
+    // then wait for the caller to have dropped the run() future.
+    let _ = hold.recv_timeout(Duration::from_secs(10));
+    let mut reads = Vec::new();
+    for data in &mut datas {
+        data.set_read_timeout(Some(Duration::from_secs(4)))
+            .expect("set_read_timeout");
+        let mut buf = [0u8; 16];
+        reads.push(data.read(&mut buf).map_err(|e| e.kind()));
+    }
+    // ctrl stayed open the whole time: the round was never killed by the
+    // peer — only the cancellation ended it.
+    drop(ctrl);
+    reads
+}
+
+/// #380: a run() future dropped mid-TEST_RUNNING (tokio::time::timeout —
+/// the pattern every library consumer reaches for) must not leak the
+/// parked stream tasks: the drop skips every teardown gate, `done` can't
+/// wake a parked read, and Drop can't await joins — the abort guard is
+/// the only thing standing between the cancel and a leaked fd. The
+/// runtime stays alive (dropping it would reap the tasks and mask the
+/// leak).
+#[test]
+fn client_cancelled_run_aborts_stream_tasks() {
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(2)
+        .enable_all()
+        .build()
+        .expect("runtime");
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind mock");
+    let port = listener.local_addr().unwrap().port();
+    let (dropped_tx, dropped_rx) = std::sync::mpsc::channel();
+    let mock = std::thread::spawn(move || mock_hold_mid_running(listener, 2, dropped_rx));
+
+    let client = ClientBuilder::new("127.0.0.1")
+        .port(Some(port))
+        .reverse(true)
+        .num_streams(2)
+        .duration(30) // the CANCEL at ~1 s ends the run, not the timer
+        .json_output(true)
+        .build()
+        .expect("build client");
+    let res = rt.block_on(async {
+        // ~1 s: past the mock's 300 ms burst + parked silence.
+        tokio::time::timeout(Duration::from_secs(1), client.run()).await
+    });
+    assert!(res.is_err(), "the timeout cancels the run — no result");
+    // The future is dropped; tell the mock to start its bounded reads.
+    dropped_tx.send(()).expect("mock alive");
+
+    let reads = mock.join().expect("mock");
+    for (i, r) in reads.iter().enumerate() {
+        assert!(
+            matches!(r, Ok(0) | Err(std::io::ErrorKind::ConnectionReset)),
+            "stream {i}: a cancelled run() must abort its stream tasks — \
+             the held data socket sees a bounded close (#380): {r:?}"
+        );
+    }
+    drop(rt);
+}
+
+/// #380, server half: a `BoundServer::run_once` future dropped
+/// mid-TEST_RUNNING must abort ITS stream tasks (+ the UDP demux) the same
+/// way. A mock client completes setup (forward TCP — the server's receiver
+/// parks in read() once the burst stops), holds everything open, and the
+/// bounded read on the held data socket tells leak from abort.
+#[test]
+fn server_cancelled_run_once_aborts_stream_tasks() {
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(2)
+        .enable_all()
+        .build()
+        .expect("runtime");
+    let (bound, port) = rt.block_on(async {
+        let server = riperf3::ServerBuilder::new()
+            .port(Some(0))
+            .emit_output(false)
+            .build()
+            .unwrap();
+        let bound = server.bind().await.expect("bind");
+        let port = bound.local_addr().unwrap().port();
+        (bound, port)
+    });
+    let (dropped_tx, dropped_rx) = std::sync::mpsc::channel::<()>();
+    let mock = std::thread::spawn(move || {
+        let cookie = [b'x'; 37];
+        let mut ctrl = std::net::TcpStream::connect(("127.0.0.1", port)).expect("ctrl");
+        ctrl.write_all(&cookie).unwrap();
+        assert_eq!(read_exact(&mut ctrl, 1)[0], 9, "ParamExchange");
+        let params = br#"{"tcp":true,"time":30,"parallel":1,"len":4096}"#;
+        ctrl.write_all(&(params.len() as u32).to_be_bytes())
+            .unwrap();
+        ctrl.write_all(params).unwrap();
+        assert_eq!(read_exact(&mut ctrl, 1)[0], 10, "CreateStreams");
+        let mut data = std::net::TcpStream::connect(("127.0.0.1", port)).expect("data");
+        data.write_all(&cookie).unwrap();
+        assert_eq!(read_exact(&mut ctrl, 1)[0], 1, "TestStart");
+        assert_eq!(read_exact(&mut ctrl, 1)[0], 2, "TestRunning");
+        // Forward burst, then SILENCE — the server's receiver parks.
+        let t0 = std::time::Instant::now();
+        while t0.elapsed() < Duration::from_millis(300) {
+            data.write_all(&[0u8; 8192]).expect("forward burst");
+            std::thread::sleep(Duration::from_millis(5));
+        }
+        let _ = dropped_rx.recv_timeout(Duration::from_secs(10));
+        data.set_read_timeout(Some(Duration::from_secs(4)))
+            .expect("set_read_timeout");
+        let mut buf = [0u8; 16];
+        let r = data.read(&mut buf).map_err(|e| e.kind());
+        drop(ctrl);
+        r
+    });
+
+    let res = rt.block_on(async {
+        // ~1 s: past the burst + parked silence; the future drops here.
+        tokio::time::timeout(Duration::from_secs(1), bound.run_once()).await
+    });
+    assert!(res.is_err(), "the timeout cancels run_once — no result");
+    dropped_tx.send(()).expect("mock alive");
+
+    let read = mock.join().expect("mock");
+    assert!(
+        matches!(read, Ok(0) | Err(std::io::ErrorKind::ConnectionReset)),
+        "a cancelled run_once must abort its stream tasks — the held data \
+         socket sees a bounded close (#380): {read:?}"
+    );
+    drop(rt);
+}
+
 /// #375: reverse -P 2 (a partial teardown — stream 0 only — still reds),
 /// ctrl FIN mid-running.
 #[test]


### PR DESCRIPTION
## Problem

A library consumer wrapping `Client::run()` or `BoundServer::run_once()` in `tokio::time::timeout` / `select!` leaked detached parked stream tasks on the cancel branch. The future drops between stream-spawn and the teardown gate, so the gate never runs; `DoneOnDrop` fires but `done` cannot wake a task parked in `read()`/`write().await` (the recorded #372/#375 caveat), and `Drop` cannot await joins (the #372 async-RAII limitation). The leaked tasks hold their sockets on the still-live runtime — the teardown-skip family (#331/#353/#354/#372/#375), reached by cancellation instead of an early return.

## Fix

`stream::AbortStreamsOnDrop` — a non-async `Drop` guard holding the stream `AbortHandle`s (plus the server's UDP demux handle):

- **armed** immediately after the streams spawn (client: the `CreateStreams` arm; server: after `setup_data_streams`, chaining in `udp_demux_handle`);
- **disarmed** at each role's teardown gate (client: before the `grace_owed` gate; server: before the unconditional `done.store` + join gate), which then abort-and-JOINs exactly as before — the normal paths are unchanged.

No joins on the cancel path (`Drop` can't await): aborted tokio tasks drop their sockets at the next await point on the live runtime. The `spawn_blocking` UDP runners are out of abort's reach and keep riding `done` + their 500 ms poll — the recorded residual, unchanged.

## Pins

The #375 in-process harness, hold-variant (`mock_hold_mid_running`): the mock completes setup through `TEST_RUNNING`, bursts ~300 ms, goes silent (the receivers park — the #354 timing lesson), and HOLDS the round open while the caller cancels via a 1 s `tokio::time::timeout` on a live runtime. The mock's 4 s bounded reads on the held data sockets tell leak (`WouldBlock` — the pre-fix red) from abort (`Ok(0)`/`ConnectionReset`).

- `client_cancelled_run_aborts_stream_tasks` — red-first: pre-fix failed with the `WouldBlock` leak signature on both streams.
- `server_cancelled_run_once_aborts_stream_tasks` — inline mock client (cookie/params/data-sock/`TestStart`/`TestRunning`/forward burst/hold).
- Red-proofed via the neutered-guard mutant (`arm()` setting `armed = false`): both cancel pins red, the #375 pin stayed green — both roles' arms are load-bearing.

Closes #380
