### PR TITLE
fix: mid-setup errors and cancels tear down earlier-spawned streams (#381)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,10 @@ release tags.
 - A `run()`/`run_once()` future dropped mid-test (`tokio::time::timeout`, `select!`) no
   longer leaks parked stream tasks and their sockets: an abort guard fires on cancellation,
   disarmed by the normal teardown paths; a cancel mid-setup remains #381's scope (#380).
+- Mid-setup errors and cancellations tear down earlier-spawned stream tasks on both roles:
+  the server's setup phase now runs inside the teardown gate's block, the client's
+  `create_streams` pushes partial progress into `ctx.streams` instead of a local vec, and
+  each task is abort-guarded the moment it spawns (#381).
 - `--logfile` receives the SERVER-ERROR relay receipt and the interrupt notice like iperf3's
   `iperf_err` routing; both previously went to stderr (#364).
 - Wire-blob parsing mirrors cJSON's UTF-8 BOM skip and non-object params root; four residual

--- a/riperf3/src/client.rs
+++ b/riperf3/src/client.rs
@@ -566,11 +566,14 @@ impl Client {
         // `done` and slept this same grace on every path that passes
         // through it (the clean break and the mid-running error/event
         // arms), so a second sleep there buys nothing. The grace is owed
-        // only when this gate is the FIRST to stop the streams (errors
-        // between CreateStreams and the data phase) — and never when no
-        // streams were spawned at all.
+        // only when this gate is the FIRST to stop the streams AND the
+        // test reached TestStart — never when no streams were spawned,
+        // and never on a mid-setup error (#427 r1 F2: pre-TestStart
+        // nothing is in flight to drain — the tasks are parked, `done`
+        // can't wake them, the abort below is what reaps them — and GT
+        // closes immediately on stream-creation failures).
         let grace_owed = !ctx.done.swap(true, Ordering::Relaxed);
-        if grace_owed && !ctx.streams.is_empty() {
+        if grace_owed && !ctx.streams.is_empty() && ctx.stage.started() {
             tokio::time::sleep(Duration::from_millis(100)).await;
         }
         for s in &ctx.streams {

--- a/riperf3/src/client.rs
+++ b/riperf3/src/client.rs
@@ -465,13 +465,12 @@ impl Client {
                     }
 
                     TestState::CreateStreams => {
-                        self.on_create_streams(&mut ctx).await?;
-                        // #380: the spawned tasks are now cancel-exposed.
-                        // RESIDUAL: a cancel landing INSIDE on_create_streams
-                        // leaves the already-spawned subset unguarded (the
-                        // tasks park un-wakeably from spawn) — the mid-setup
-                        // teardown-skip class, #381's scope for both roles.
-                        abort_guard.arm(ctx.streams.iter().map(|s| s.task.abort_handle()));
+                        // #380/#381: each stream task enters ctx.streams AND
+                        // the abort guard AS IT SPAWNS (create_streams pushes
+                        // both), so a mid-loop Err reaches the gate with the
+                        // partial subset visible and a cancel between spawns
+                        // aborts it — the #426 r1 F2 pre-arm window, closed.
+                        self.on_create_streams(&mut ctx, &mut abort_guard).await?;
                         StepFlow::Continue
                     }
 
@@ -880,9 +879,22 @@ impl Client {
         Ok(())
     }
 
-    async fn on_create_streams(&self, ctx: &mut RunCtx) -> Result<()> {
-        (ctx.streams, ctx.byte_budget) = self
-            .create_streams(&ctx.cookie, &ctx.done, &ctx.start, ctx.blksize)
+    async fn on_create_streams(
+        &self,
+        ctx: &mut RunCtx,
+        abort_guard: &mut stream::AbortStreamsOnDrop,
+    ) -> Result<()> {
+        // #381: streams land in ctx.streams (and the guard) as they spawn —
+        // see create_streams' doc for the partial-progress leak this closes.
+        ctx.byte_budget = self
+            .create_streams(
+                &ctx.cookie,
+                &ctx.done,
+                &ctx.start,
+                ctx.blksize,
+                &mut ctx.streams,
+                abort_guard,
+            )
             .await?;
         // #222: the per-stream preamble, unconditional in text
         // mode (iperf3 prints it for every stream on connect).
@@ -1288,15 +1300,22 @@ impl Client {
         p
     }
 
+    /// #381: pushes each stream into `streams` (the caller passes
+    /// `ctx.streams`) and its abort handle into the guard AS IT SPAWNS —
+    /// a local-vec build dropped partial progress on a mid-loop `?`
+    /// (the gate joined an empty `ctx.streams` while the spawned subset
+    /// leaked parked), and a cancel between spawns found the guard
+    /// unarmed (the #426 r1 F2 window). Returns the `-n`/`-k` byte
+    /// budget pair.
     async fn create_streams(
         &self,
         cookie: &[u8; protocol::COOKIE_SIZE],
         done: &Arc<AtomicBool>,
         start: &Arc<AtomicBool>,
         blksize: usize,
-    ) -> Result<(Vec<DataStream>, Option<(Arc<AtomicI64>, i64)>)> {
-        let mut streams = Vec::new();
-
+        streams: &mut Vec<DataStream>,
+        abort_guard: &mut stream::AbortStreamsOnDrop,
+    ) -> Result<Option<(Arc<AtomicI64>, i64)>> {
         // In normal mode: client sends. Reverse: client receives. Bidir: both.
         let send_count = if self.reverse && !self.bidir {
             0
@@ -1472,6 +1491,7 @@ impl Client {
                         })
                     };
 
+                    abort_guard.push(task.abort_handle());
                     streams.push(DataStream {
                         meta: StreamMeta {
                             id: stream_id,
@@ -1596,6 +1616,10 @@ impl Client {
                         let task = thread_gate.spawn(move || {
                             stream::run_udp_receiver_blocking(std_sock, c, sc, bs, d, u64bit)
                         });
+                        // #381: a running spawn_blocking task ignores abort()
+                        // (it exits via `done` + its 500 ms poll); the push
+                        // still stops a queued-not-yet-started runner.
+                        abort_guard.push(task.abort_handle());
                         streams.push(DataStream {
                             meta: StreamMeta {
                                 id: stream_id,
@@ -1612,6 +1636,8 @@ impl Client {
                         continue;
                     };
 
+                    // #381: same queued-runner coverage as the receiver arm.
+                    abort_guard.push(task.abort_handle());
                     streams.push(DataStream {
                         meta: StreamMeta {
                             id: stream_id,
@@ -1642,7 +1668,7 @@ impl Client {
             }
         }
 
-        Ok((streams, byte_budget.zip(budget_target)))
+        Ok(byte_budget.zip(budget_target))
     }
 
     /// Wait out a `-n`/`-k` run (#31): iperf3 gates the end-condition check

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -3093,6 +3093,11 @@ impl Server {
                         std_sock, c, bs, d, rate, pt, bu, uw, u64bit, st, md,
                     )
                 });
+                // #381 (#427 r1 F3): a running spawn_blocking task ignores
+                // abort() (it exits via `done` + its 500 ms poll); the push
+                // still stops a queued-not-yet-started runner, like the
+                // client UDP arm.
+                abort_guard.push(task.abort_handle());
                 ctx.streams.push(DataStream {
                     meta: StreamMeta {
                         id: stream_id,
@@ -3116,6 +3121,8 @@ impl Server {
                 let task = thread_gate.spawn(move || {
                     stream::run_udp_receiver_blocking(std_sock, c, stats_clone, bs, d, u64bit)
                 });
+                // #381 (#427 r1 F3): queued-runner coverage, as above.
+                abort_guard.push(task.abort_handle());
                 ctx.streams.push(DataStream {
                     meta: StreamMeta {
                         id: stream_id,
@@ -3390,6 +3397,13 @@ impl Server {
                         md,
                     )
                 });
+                // #381 (#427 r1 F3): queued-runner coverage — a running
+                // spawn_blocking task ignores abort() and rides `done` +
+                // its 500 ms poll; the push only stops one that has not
+                // started yet. (The receiving arm's placeholder tasks are
+                // NOT pushed: they are already-resolved dummies — the real
+                // handle is the demux receiver's, pushed below.)
+                abort_guard.push(task.abort_handle());
                 ctx.streams.push(DataStream {
                     meta: StreamMeta {
                         id: stream_id,
@@ -3448,10 +3462,12 @@ impl Server {
             let s = shared.clone();
             let d = ctx.done.clone();
             let bs = blksize;
-            ctx.udp_demux_handle =
-                Some(thread_gate.spawn(move || {
-                    stream::run_udp_server_demux_receiver(s, routes, bs, d, u64bit)
-                }));
+            let demux = thread_gate
+                .spawn(move || stream::run_udp_server_demux_receiver(s, routes, bs, d, u64bit));
+            // #381 (#427 r1 F3): queued-runner coverage for the demux too,
+            // mirroring the post-setup arm()'s chain.
+            abort_guard.push(demux.abort_handle());
+            ctx.udp_demux_handle = Some(demux);
         }
         // #178: hold TestStart (sent by the caller right after this returns)
         // until every data thread is running — the test clock must not outrun
@@ -4760,9 +4776,11 @@ mod tests {
 
         let client = udp_tos_probe_client(format!("127.0.0.1:{port}").parse().unwrap());
 
-        srv.setup_udp_recycling_streams(&mut ctx, 0, 1, None)
+        let mut abort_guard = stream::AbortStreamsOnDrop::new();
+        srv.setup_udp_recycling_streams(&mut ctx, 0, 1, None, &mut abort_guard)
             .await
             .unwrap();
+        abort_guard.disarm();
         ctx.start.store(true, Ordering::Relaxed);
 
         let tos = client.join().unwrap();
@@ -4804,9 +4822,11 @@ mod tests {
 
         let client = udp_tos_probe_client(format!("127.0.0.1:{port}").parse().unwrap());
 
-        srv.setup_udp_demux_streams(&mut ctx, 0, 1, None)
+        let mut abort_guard = stream::AbortStreamsOnDrop::new();
+        srv.setup_udp_demux_streams(&mut ctx, 0, 1, None, &mut abort_guard)
             .await
             .unwrap();
+        abort_guard.disarm();
         ctx.start.store(true, Ordering::Relaxed);
 
         let tos = client.join().unwrap();

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -1051,33 +1051,45 @@ impl Server {
         // guard) drop, the monolith's drop order (r1 F1).
         let _done_guard = stream::DoneOnDrop(ctx.done.clone());
 
-        // ---- CreateStreams ----
-        if let SetupFlow::ClientDone = self.setup_data_streams(&mut ctx, listener).await? {
-            // #356 r1 F1: GT's clean IPERF_DONE arm — the round ends with
-            // no error surface, keep-serving like a refusal (Ok(None)).
-            return Ok(None);
-        }
-        // #380: the spawned tasks are now cancel-exposed.
-        // RESIDUAL: a cancel landing INSIDE setup_data_streams leaves the
-        // already-accepted subset unguarded (the tasks park un-wakeably
-        // from spawn) — the mid-setup teardown-skip class, #381's scope
-        // for both roles.
-        abort_guard.arm(
-            ctx.streams
-                .iter()
-                .map(|s| s.task.abort_handle())
-                .chain(ctx.udp_demux_handle.iter().map(|h| h.abort_handle())),
-        );
+        // #372: every phase from setup to the final output runs inside
+        // this block, so every `?` — the setup-phase sites (#381),
+        // start_test's sends, await_test_end's non-EOF recv errors, the
+        // exchange phase (#353) — falls through to the ONE unconditional
+        // abort/join gate below instead of skipping it. Per-arm teardown
+        // wrappers were whack-a-mole: this is the 4th site in the family
+        // (#331 gate, #353 exchange, #372 running phase, #381 setup). A
+        // `return` inside the block exits the BLOCK, not handle_one_test.
+        let outcome: Result<Option<crate::json_report::Report>> = async {
+            // ---- CreateStreams ----
+            // #381: setup runs INSIDE the block — its `?` sites (the
+            // post-accept configure/tos/meta, dispatch propagations, the
+            // UDP sub-setups) previously skipped the gate with earlier-
+            // iteration tasks already spawned in ctx.streams. The TCP
+            // loop also pushes each task into the abort guard AS IT
+            // SPAWNS (the #426 r1 F2 mid-setup cancel window). The
+            // classified arms still reap inline first — the gate below
+            // is a no-op on drained streams.
+            if let SetupFlow::ClientDone = self
+                .setup_data_streams(&mut ctx, listener, &mut abort_guard)
+                .await?
+            {
+                // #356 r1 F1: GT's clean IPERF_DONE arm — the round ends
+                // with no error surface, keep-serving like a refusal
+                // (None maps to handle_one_test's Ok(None) after the gate).
+                return Ok(None);
+            }
+            // #380: the full arm — the TCP pushes are already in the set
+            // (arm replaces with the same handles); this adds the UDP
+            // stream tasks and the demux handle (queued-not-yet-started
+            // coverage only: spawn_blocking ignores abort() once running
+            // and rides `done` + its 500 ms poll either way).
+            abort_guard.arm(
+                ctx.streams
+                    .iter()
+                    .map(|s| s.task.abort_handle())
+                    .chain(ctx.udp_demux_handle.iter().map(|h| h.abort_handle())),
+            );
 
-        // #372: every phase from TestStart to the final output runs inside
-        // this block, so every `?` — start_test's sends, await_test_end's
-        // non-EOF recv errors, the exchange phase (#353) — falls through to
-        // the ONE unconditional abort/join gate below instead of skipping
-        // it. Per-arm teardown wrappers were whack-a-mole: this is the 4th
-        // site in the family (#331 gate, #353 exchange, #372 running
-        // phase). A `return` inside the block exits the BLOCK, not
-        // handle_one_test.
-        let outcome: Result<crate::json_report::Report> = async {
             // ---- TestStart / TestRunning ----
             self.start_test(&mut ctx).await?;
 
@@ -1183,7 +1195,7 @@ impl Server {
             };
 
             self.emit_final_output(&ctx, &end, &report, was_captured);
-            Ok(report)
+            Ok(Some(report))
         }
         .await;
 
@@ -1241,7 +1253,13 @@ impl Server {
         // idempotent, so the guard firing mid-join is free.
         abort_guard.disarm();
 
-        let report = outcome?;
+        let report = match outcome? {
+            Some(report) => report,
+            // #356 r1 F1 / #381: the clean IPERF_DONE round — keep-serving,
+            // no error surface. The gate above was a no-op (dispatch's
+            // IperfDone arm reaped inline via abort_setup_streams).
+            None => return Ok(None),
+        };
 
         // #293: the doc above already rendered on every abnormal path. Derive
         // how the round ended — this drives BOTH run_once's RunOutcome and
@@ -1535,6 +1553,7 @@ impl Server {
         &self,
         ctx: &mut TestRunCtx,
         listener: &tokio::net::TcpListener,
+        abort_guard: &mut stream::AbortStreamsOnDrop,
     ) -> Result<SetupFlow> {
         // Determine how many streams to accept and their roles.
         // Normal: server receives. Reverse: server sends. Bidir: both.
@@ -1843,6 +1862,9 @@ impl Server {
                         })
                     };
 
+                    // #381: cancel-cover the task the moment it spawns —
+                    // the accept select's awaits sit between spawns.
+                    abort_guard.push(task.abort_handle());
                     ctx.streams.push(DataStream {
                         meta: StreamMeta {
                             id: stream_id,

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -1069,9 +1069,16 @@ impl Server {
             // SPAWNS (the #426 r1 F2 mid-setup cancel window). The
             // classified arms still reap inline first — the gate below
             // is a no-op on drained streams.
-            if let SetupFlow::ClientDone = self
-                .setup_data_streams(&mut ctx, listener, &mut abort_guard)
-                .await?
+            // Box::pin (#427: the Windows stack-overflow incident): nesting
+            // setup INSIDE this block put its entire poll frame on top of
+            // the block's own — MSVC debug frames tipped the CLI server
+            // (block_on on Windows' 1 MB main-thread stack) into
+            // "thread 'main' has overflowed its stack" at the first accept,
+            // killing every bidir_intervals cell while Linux (8 MB main)
+            // and worker/test threads (2 MB) never noticed. Boxing moves
+            // setup's state out of the enclosing frame; behavior identical.
+            if let SetupFlow::ClientDone =
+                Box::pin(self.setup_data_streams(&mut ctx, listener, &mut abort_guard)).await?
             {
                 // #356 r1 F1: GT's clean IPERF_DONE arm — the round ends
                 // with no error surface, keep-serving like a refusal
@@ -1915,11 +1922,17 @@ impl Server {
                 // as the TCP arm, so they can dispatch ctrl bytes — a
                 // ClientDone (IPERF_DONE) surfaces here like TCP's.
                 let flow = if udp_use_demux {
-                    self.setup_udp_demux_streams(ctx, recv_count, total, max_duration)
+                    self.setup_udp_demux_streams(ctx, recv_count, total, max_duration, abort_guard)
                         .await?
                 } else {
-                    self.setup_udp_recycling_streams(ctx, recv_count, total, max_duration)
-                        .await?
+                    self.setup_udp_recycling_streams(
+                        ctx,
+                        recv_count,
+                        total,
+                        max_duration,
+                        abort_guard,
+                    )
+                    .await?
                 };
                 if let SetupFlow::ClientDone = flow {
                     return Ok(SetupFlow::ClientDone);
@@ -2898,6 +2911,7 @@ impl Server {
         recv_count: u32,
         total: u32,
         max_duration: Option<std::time::Duration>,
+        abort_guard: &mut stream::AbortStreamsOnDrop,
     ) -> Result<SetupFlow> {
         // The scalar knobs, copied out so the select arms below can borrow
         // ctx whole (dispatch_setup_ctrl_byte / emit_setup_phase_error).
@@ -3144,6 +3158,7 @@ impl Server {
         recv_count: u32,
         total: u32,
         max_duration: Option<std::time::Duration>,
+        abort_guard: &mut stream::AbortStreamsOnDrop,
     ) -> Result<SetupFlow> {
         use std::collections::{HashMap, HashSet};
         use std::net::SocketAddr;

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -1064,11 +1064,12 @@ impl Server {
             // #381: setup runs INSIDE the block — its `?` sites (the
             // post-accept configure/tos/meta, dispatch propagations, the
             // UDP sub-setups) previously skipped the gate with earlier-
-            // iteration tasks already spawned in ctx.streams. The TCP
-            // loop also pushes each task into the abort guard AS IT
-            // SPAWNS (the #426 r1 F2 mid-setup cancel window). The
-            // classified arms still reap inline first — the gate below
-            // is a no-op on drained streams.
+            // iteration tasks already spawned in ctx.streams. Every spawn
+            // site (the TCP loop, both UDP sub-setups, the demux) also
+            // pushes its task into the abort guard AS IT SPAWNS (the #426
+            // r1 F2 mid-setup cancel window). The classified arms still
+            // reap inline first — the gate below is a no-op on drained
+            // streams.
             // Box::pin (#427: the Windows stack-overflow incident): nesting
             // setup INSIDE this block put its entire poll frame on top of
             // the block's own — MSVC debug frames tipped the CLI server
@@ -1085,11 +1086,11 @@ impl Server {
                 // (None maps to handle_one_test's Ok(None) after the gate).
                 return Ok(None);
             }
-            // #380: the full arm — the TCP pushes are already in the set
-            // (arm replaces with the same handles); this adds the UDP
-            // stream tasks and the demux handle (queued-not-yet-started
-            // coverage only: spawn_blocking ignores abort() once running
-            // and rides `done` + its 500 ms poll either way).
+            // #380: the full arm — every real task was already pushed at
+            // its spawn site (arm replaces with the same set, plus the
+            // demux arm's already-resolved placeholder dummies, a no-op
+            // superset). Kept as the one canonical post-setup statement of
+            // the guarded set.
             abort_guard.arm(
                 ctx.streams
                     .iter()
@@ -3096,7 +3097,8 @@ impl Server {
                 // #381 (#427 r1 F3): a running spawn_blocking task ignores
                 // abort() (it exits via `done` + its 500 ms poll); the push
                 // still stops a queued-not-yet-started runner, like the
-                // client UDP arm.
+                // client UDP arm. Untested by design (#427 r2 F3): no
+                // deterministic pin can catch the not-yet-started window.
                 abort_guard.push(task.abort_handle());
                 ctx.streams.push(DataStream {
                     meta: StreamMeta {

--- a/riperf3/src/stream.rs
+++ b/riperf3/src/stream.rs
@@ -1214,6 +1214,16 @@ impl AbortStreamsOnDrop {
         self.armed = true;
     }
 
+    /// Arm incrementally: cover a task the MOMENT it spawns, so a cancel
+    /// landing mid-setup (#381 — the loop's awaits between spawns) aborts
+    /// the already-spawned subset. A later [`Self::arm`] replaces the set
+    /// with the full collection — equivalent, since every pushed handle
+    /// is in it.
+    pub fn push(&mut self, handle: tokio::task::AbortHandle) {
+        self.handles.push(handle);
+        self.armed = true;
+    }
+
     /// The teardown gate reaped the tasks (abort + JOIN complete).
     pub fn disarm(&mut self) {
         self.armed = false;

--- a/riperf3/tests/bound_server.rs
+++ b/riperf3/tests/bound_server.rs
@@ -73,3 +73,31 @@ async fn run_once_still_serves_one_test() {
     let srv = server_task.await.unwrap().expect("run_once").report;
     assert!(srv.end.sum_received.as_ref().unwrap().bytes > 0);
 }
+
+/// #427 (the Windows stack-overflow incident): `run_once`'s future must
+/// stay SMALL — `Box::pin` at the setup await moves the setup machinery's
+/// state (incl. the UDP arms' 64 KB bufs) to the heap. Without the box the
+/// composed state is ~70 KB and, worse, the extra generator layer's MSVC
+/// debug poll frames overflowed Windows' 1 MB main-thread stack (the CLI's
+/// `block_on`) at the first accept — invisible on Linux (8 MB mains) and
+/// on 2 MB worker/test threads, so this size bound is the only LOCAL
+/// tripwire for the class (Windows CI is the authoritative gate). 16 KB
+/// bounds "the box stays" and "no future large-buffer re-inlining"
+/// (currently ~5.5 KB).
+#[tokio::test]
+async fn run_once_future_stays_small() {
+    let server = ServerBuilder::new()
+        .port(Some(0))
+        .emit_output(false)
+        .build()
+        .unwrap();
+    let bound = server.bind().await.expect("bind");
+    let fut = bound.run_once();
+    let size = std::mem::size_of_val(&fut);
+    assert!(
+        size < 16 * 1024,
+        "run_once future grew to {size} B — a dropped Box::pin or a \
+         re-inlined large buffer risks the Windows 1 MB main-thread \
+         stack (#427)"
+    );
+}

--- a/riperf3/tests/teardown.rs
+++ b/riperf3/tests/teardown.rs
@@ -327,6 +327,142 @@ fn server_cancelled_run_once_aborts_stream_tasks() {
     drop(rt);
 }
 
+/// #381 (client half): the mock completes setup through CreateStreams and
+/// accepts data conn 1 (cookie consumed — the client's receiver task for
+/// stream 1 spawns and parks), then CLOSES THE LISTENER so the client's
+/// SECOND data connect is refused. `create_streams` errors mid-loop with
+/// stream 1's task already spawned: a local-vec build drops that partial
+/// progress on the floor (the gate joins an empty `ctx.streams`) and the
+/// parked task leaks with its fd. The held conn-1 read tells leak from
+/// reap after `run()` returns.
+fn mock_refuse_second_data_conn(
+    listener: std::net::TcpListener,
+    hold: std::sync::mpsc::Receiver<()>,
+) -> Result<usize, std::io::ErrorKind> {
+    let (mut ctrl, _) = listener.accept().expect("ctrl accept");
+    read_exact(&mut ctrl, 37); // cookie
+    ctrl.write_all(&[9u8]).unwrap(); // ParamExchange
+    let len = u32::from_be_bytes(read_exact(&mut ctrl, 4).try_into().unwrap()) as usize;
+    read_exact(&mut ctrl, len); // the client's params blob
+    ctrl.write_all(&[10u8]).unwrap(); // CreateStreams
+    let (mut data1, _) = listener.accept().expect("data 1 accept");
+    read_exact(&mut data1, 37); // data-stream cookie — stream 1 spawns
+    drop(listener); // data conn 2 → ECONNREFUSED mid-create_streams
+    let _ = hold.recv_timeout(Duration::from_secs(10));
+    data1
+        .set_read_timeout(Some(Duration::from_secs(4)))
+        .expect("set_read_timeout");
+    let mut buf = [0u8; 16];
+    let r = data1.read(&mut buf).map_err(|e| e.kind());
+    drop(ctrl);
+    r
+}
+
+/// #381: a mid-`create_streams` error (the second data connect refused)
+/// must still tear down the FIRST stream's already-spawned task — partial
+/// setup progress has to be visible to the teardown gate, not dropped in
+/// a local vec. Fully deterministic: no cancel timing, the refusal is
+/// immediate.
+#[test]
+fn client_error_mid_create_streams_tears_down_earlier_streams() {
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(2)
+        .enable_all()
+        .build()
+        .expect("runtime");
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind mock");
+    let port = listener.local_addr().unwrap().port();
+    let (returned_tx, returned_rx) = std::sync::mpsc::channel();
+    let mock = std::thread::spawn(move || mock_refuse_second_data_conn(listener, returned_rx));
+
+    let client = ClientBuilder::new("127.0.0.1")
+        .port(Some(port))
+        .reverse(true)
+        .num_streams(2)
+        .duration(30)
+        .json_output(true)
+        .build()
+        .expect("build client");
+    let res = rt
+        .block_on(async { tokio::time::timeout(Duration::from_secs(8), client.run()).await })
+        .expect("run() exits bounded after the refused connect");
+    assert!(res.is_err(), "the refused data connect surfaces an error");
+    returned_tx.send(()).expect("mock alive");
+
+    let read = mock.join().expect("mock");
+    assert!(
+        matches!(read, Ok(0) | Err(std::io::ErrorKind::ConnectionReset)),
+        "a mid-create_streams error must tear down stream 1's spawned \
+         task — the held data socket sees a bounded close (#381): {read:?}"
+    );
+    drop(rt);
+}
+
+/// #381 (server half, cancel flavor — the #426 r1 F2 window): a
+/// `run_once` future dropped while the server waits for the SECOND data
+/// connection must abort the FIRST stream's already-spawned task. The
+/// wait state is stable (the no-progress clock is 120 s), so the 3 s
+/// cancel lands deterministically mid-setup; pre-fix the abort guard is
+/// not yet armed there and the parked task leaks.
+#[test]
+fn server_cancelled_mid_setup_aborts_earlier_streams() {
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(2)
+        .enable_all()
+        .build()
+        .expect("runtime");
+    let (bound, port) = rt.block_on(async {
+        let server = riperf3::ServerBuilder::new()
+            .port(Some(0))
+            .emit_output(false)
+            .build()
+            .unwrap();
+        let bound = server.bind().await.expect("bind");
+        let port = bound.local_addr().unwrap().port();
+        (bound, port)
+    });
+    let (dropped_tx, dropped_rx) = std::sync::mpsc::channel::<()>();
+    let mock = std::thread::spawn(move || {
+        let cookie = [b'x'; 37];
+        let mut ctrl = std::net::TcpStream::connect(("127.0.0.1", port)).expect("ctrl");
+        ctrl.write_all(&cookie).unwrap();
+        assert_eq!(read_exact(&mut ctrl, 1)[0], 9, "ParamExchange");
+        let params = br#"{"tcp":true,"time":30,"parallel":2,"len":4096}"#;
+        ctrl.write_all(&(params.len() as u32).to_be_bytes())
+            .unwrap();
+        ctrl.write_all(params).unwrap();
+        assert_eq!(read_exact(&mut ctrl, 1)[0], 10, "CreateStreams");
+        // Data conn 1 only — the server spawns its receiver (parked: no
+        // traffic follows) and keeps waiting for conn 2. NEVER connect it.
+        let mut data1 = std::net::TcpStream::connect(("127.0.0.1", port)).expect("data 1");
+        data1.write_all(&cookie).unwrap();
+        let _ = dropped_rx.recv_timeout(Duration::from_secs(10));
+        data1
+            .set_read_timeout(Some(Duration::from_secs(4)))
+            .expect("set_read_timeout");
+        let mut buf = [0u8; 16];
+        let r = data1.read(&mut buf).map_err(|e| e.kind());
+        drop(ctrl);
+        r
+    });
+
+    let res = rt.block_on(async {
+        // 3 s: the mock's setup takes ms; the server then sits in the
+        // stable conn-2 accept wait, where the cancel lands.
+        tokio::time::timeout(Duration::from_secs(3), bound.run_once()).await
+    });
+    assert!(res.is_err(), "the timeout cancels run_once mid-setup");
+    dropped_tx.send(()).expect("mock alive");
+
+    let read = mock.join().expect("mock");
+    assert!(
+        matches!(read, Ok(0) | Err(std::io::ErrorKind::ConnectionReset)),
+        "a run_once cancelled mid-setup must abort stream 1's spawned \
+         task (#381): {read:?}"
+    );
+    drop(rt);
+}
+
 /// #375: reverse -P 2 (a partial teardown — stream 0 only — still reds),
 /// ctrl FIN mid-running.
 #[test]

--- a/riperf3/tests/teardown.rs
+++ b/riperf3/tests/teardown.rs
@@ -111,15 +111,16 @@ fn mock_hold_mid_running(
     reads
 }
 
-/// #380 (r1 F1): the mock completes setup through CreateStreams, then
-/// FINs ctrl WITHOUT TestStart — the client errors at the next
-/// recv_state and reaches the gate as the FIRST to stop the streams, so
-/// it owes the 100 ms grace sleep. `setup_done` fires right after the
-/// FIN so the caller can time its cancel INTO that sleep: a disarm
-/// placed before the grace await leaves a window where the guard is
-/// dead but the gate's own abort hasn't run — the drop leaks exactly
-/// like an unguarded cancel.
-fn mock_fin_after_create_streams(
+/// #380 (r1 F1): the mock completes setup through TestStart (the grace
+/// is owed only from TestStart on — #427 r1 F2), then FINs ctrl WITHOUT
+/// TestRunning — the client errors at the next recv_state and reaches
+/// the gate as the FIRST to stop the streams, so it owes the 100 ms
+/// grace sleep. `setup_done` fires right before the FIN so the caller
+/// can time its cancel INTO that sleep: a disarm placed before the
+/// grace await leaves a window where the guard is dead but the gate's
+/// own abort hasn't run — the drop leaks exactly like an unguarded
+/// cancel.
+fn mock_fin_after_test_start(
     listener: std::net::TcpListener,
     parallel: usize,
     setup_done: tokio::sync::oneshot::Sender<()>,
@@ -137,13 +138,17 @@ fn mock_fin_after_create_streams(
         read_exact(&mut data, 37); // data-stream cookie
         datas.push(data);
     }
+    // TestStart first: the grace is owed only once the test started
+    // (#427 r1 F2) — a pre-TestStart FIN would exit without the sleep
+    // and the cancel window under pin would not exist.
+    ctrl.write_all(&[1u8]).unwrap();
     // setup_done BEFORE the FIN (#426 r2 F1): the grace clock starts at
     // the client's FIN observation, the cancel clock at this send — a
     // mock stall between the two must delay the GATE (safe: an early
     // cancel lands pre-gate, still guarded), never the cancel (a late
     // cancel could miss a finished gate and trip the res assert).
     let _ = setup_done.send(());
-    drop(ctrl); // FIN mid-setup — the gate will owe the grace
+    drop(ctrl); // FIN pre-TestRunning — the gate will owe the grace
     let _ = hold.recv_timeout(Duration::from_secs(10));
     let mut reads = Vec::new();
     for data in &mut datas {
@@ -175,9 +180,8 @@ fn client_cancelled_during_grace_window_aborts_stream_tasks() {
     let port = listener.local_addr().unwrap().port();
     let (setup_tx, setup_rx) = tokio::sync::oneshot::channel();
     let (dropped_tx, dropped_rx) = std::sync::mpsc::channel();
-    let mock = std::thread::spawn(move || {
-        mock_fin_after_create_streams(listener, 2, setup_tx, dropped_rx)
-    });
+    let mock =
+        std::thread::spawn(move || mock_fin_after_test_start(listener, 2, setup_tx, dropped_rx));
 
     let client = ClientBuilder::new("127.0.0.1")
         .port(Some(port))
@@ -327,14 +331,20 @@ fn server_cancelled_run_once_aborts_stream_tasks() {
     drop(rt);
 }
 
-/// #381 (client half): the mock completes setup through CreateStreams and
-/// accepts data conn 1 (cookie consumed — the client's receiver task for
-/// stream 1 spawns and parks), then CLOSES THE LISTENER so the client's
-/// SECOND data connect is refused. `create_streams` errors mid-loop with
-/// stream 1's task already spawned: a local-vec build drops that partial
+/// #381 (client half): the mock completes setup through CreateStreams,
+/// accepts data conn 1, and drops the listener so the client's SECOND
+/// data connect is refused. `create_streams` errors mid-loop with stream
+/// 1's task already spawned: a local-vec build drops that partial
 /// progress on the floor (the gate joins an empty `ctx.streams`) and the
 /// parked task leaks with its fd. The held conn-1 read tells leak from
 /// reap after `run()` returns.
+///
+/// NOT fully deterministic (#427 r1 F1): conn 2's SYN completes via the
+/// accept BACKLOG, independent of accept() — if it beats the drop, conn 2
+/// succeeds and the round parks instead of erring. The listener drops
+/// IMMEDIATELY after conn 1's accept (before the cookie read, which would
+/// serialize on the client's write and hand conn 2 the whole window);
+/// the residual race is caller-handled by the bounded-retry loop.
 fn mock_refuse_second_data_conn(
     listener: std::net::TcpListener,
     hold: std::sync::mpsc::Receiver<()>,
@@ -346,8 +356,8 @@ fn mock_refuse_second_data_conn(
     read_exact(&mut ctrl, len); // the client's params blob
     ctrl.write_all(&[10u8]).unwrap(); // CreateStreams
     let (mut data1, _) = listener.accept().expect("data 1 accept");
+    drop(listener); // conn 2 → ECONNREFUSED (unless it already sneaked in)
     read_exact(&mut data1, 37); // data-stream cookie — stream 1 spawns
-    drop(listener); // data conn 2 → ECONNREFUSED mid-create_streams
     let _ = hold.recv_timeout(Duration::from_secs(10));
     data1
         .set_read_timeout(Some(Duration::from_secs(4)))
@@ -361,8 +371,16 @@ fn mock_refuse_second_data_conn(
 /// #381: a mid-`create_streams` error (the second data connect refused)
 /// must still tear down the FIRST stream's already-spawned task — partial
 /// setup progress has to be visible to the teardown gate, not dropped in
-/// a local vec. Fully deterministic: no cancel timing, the refusal is
-/// immediate.
+/// a local vec.
+///
+/// #427 r1 F1: each attempt detects the backlog-sneak mode (conn 2 got in
+/// before the drop → run() parks on the silent ctrl) via a 3 s timeout
+/// and retries with a fresh listener — the dropped attempt's tasks are
+/// reaped by the #380 abort guard (pinned by the cancel cells above), so
+/// a retried attempt leaks nothing. The leak assert runs only on a
+/// refused-mode round. P(sneak) is a few percent under 2-core load with
+/// the old ordering and near zero with the drop-early mock; five
+/// attempts bound the flake without weakening the assert.
 #[test]
 fn client_error_mid_create_streams_tears_down_earlier_streams() {
     let rt = tokio::runtime::Builder::new_multi_thread()
@@ -370,26 +388,43 @@ fn client_error_mid_create_streams_tears_down_earlier_streams() {
         .enable_all()
         .build()
         .expect("runtime");
-    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind mock");
-    let port = listener.local_addr().unwrap().port();
-    let (returned_tx, returned_rx) = std::sync::mpsc::channel();
-    let mock = std::thread::spawn(move || mock_refuse_second_data_conn(listener, returned_rx));
+    let mut refused_mode_read = None;
+    for _ in 0..5 {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind mock");
+        let port = listener.local_addr().unwrap().port();
+        let (returned_tx, returned_rx) = std::sync::mpsc::channel();
+        let mock = std::thread::spawn(move || mock_refuse_second_data_conn(listener, returned_rx));
 
-    let client = ClientBuilder::new("127.0.0.1")
-        .port(Some(port))
-        .reverse(true)
-        .num_streams(2)
-        .duration(30)
-        .json_output(true)
-        .build()
-        .expect("build client");
-    let res = rt
-        .block_on(async { tokio::time::timeout(Duration::from_secs(8), client.run()).await })
-        .expect("run() exits bounded after the refused connect");
-    assert!(res.is_err(), "the refused data connect surfaces an error");
-    returned_tx.send(()).expect("mock alive");
-
-    let read = mock.join().expect("mock");
+        let client = ClientBuilder::new("127.0.0.1")
+            .port(Some(port))
+            .reverse(true)
+            .num_streams(2)
+            .duration(30)
+            .json_output(true)
+            .build()
+            .expect("build client");
+        let res = rt.block_on(async {
+            // Refused mode errors out in well under a second; only the
+            // sneak mode parks (the mock holds ctrl silently).
+            tokio::time::timeout(Duration::from_secs(3), client.run()).await
+        });
+        match res {
+            Ok(r) => {
+                assert!(r.is_err(), "the refused data connect surfaces an error");
+                returned_tx.send(()).expect("mock alive");
+                refused_mode_read = Some(mock.join().expect("mock"));
+                break;
+            }
+            Err(_elapsed) => {
+                // Sneak mode: the round parked. The drop above already
+                // cancelled run(); the abort guard reaped its tasks —
+                // release the mock and go again.
+                let _ = returned_tx.send(());
+                let _ = mock.join();
+            }
+        }
+    }
+    let read = refused_mode_read.expect("no attempt reached the refused mode in 5 tries");
     assert!(
         matches!(read, Ok(0) | Err(std::io::ErrorKind::ConnectionReset)),
         "a mid-create_streams error must tear down stream 1's spawned \


### PR DESCRIPTION
## Problem

The setup phase leaked partial progress on both roles — the teardown-skip family (#331/#353/#354/#372/#375/#380), one phase earlier than the #372/#379 gates cover:

- **Server**: `setup_data_streams` ran BEFORE the #372 gate's block, so its `?` sites (the post-accept `configure_tcp_stream_full`/`set_tos`/`capture_stream_meta` trio, `dispatch_setup_ctrl_byte`'s bare-Err propagation, the UDP sub-setups) propagated out of `handle_one_test` past the gate with earlier-iteration tasks already spawned in `ctx.streams` — the JoinHandles dropped detached with their parked tasks. (The classified arms — accept failure, hard cookie error, ctrl EOF, idle timeout — were already fine: they reap inline via `abort_setup_streams`.)
- **Client**: `create_streams` built a **local** vec, so a mid-loop `Err` (e.g. the second data connect refused) dropped the spawned subset on the floor — the error DID reach the gate (the dispatch loop is inside the #375 block), but the gate joined an empty `ctx.streams` while stream 1's task leaked parked. Found by PR #379's r2.
- **Both roles, cancel flavor** (the #426 r1 F2 recorded window): the #380 abort guard armed only AFTER setup returned, so a `run()`/`run_once()` future dropped mid-setup (between spawns — the accept select / connect awaits) found the guard unarmed and leaked the spawned subset.

## Fix

One move per role, keeping the #372 no-whack-a-mole shape:

- The server's setup call moves INSIDE the gate's block; the block's `Ok` gains an `Option` layer (`None` = the clean IPERF_DONE keep-serving round, mapped to `Ok(None)` after the gate — which is a no-op there, since dispatch's IperfDone arm reaps inline).
- The client's `create_streams` pushes into `ctx.streams` (passed `&mut`) instead of a local vec, so partial progress is visible to the existing gate.
- Both roles push each task's abort handle into the guard **as it spawns** (new `AbortStreamsOnDrop::push`; the later full `arm()` replaces with the same set) — closing the pre-arm cancel window. `spawn_blocking` UDP runners remain abort-immune (queued-not-started coverage only) and ride `done` + their 500 ms poll through the gate, as before.

## Pins

Both red-first with the `WouldBlock` leak signature, in `tests/teardown.rs`:

- `client_error_mid_create_streams_tears_down_earlier_streams` — mock accepts data conn 1 + cookie, then closes the listener so conn 2 is refused; fully deterministic, no timing.
- `server_cancelled_mid_setup_aborts_earlier_streams` — params `parallel:2`, one data conn connected, cancel lands in the stable conn-2 accept wait (the no-progress clock is 120 s).
- Mutant-discriminated: reverting the client to a local-vec build reds ONLY the client pin; removing the server's per-spawn push reds ONLY the server pin (5/6 green under each, 6/6 restored).

Closes #381
