### PR TITLE
fix: refused rounds park until client EOF, like GT's cleanup drain (#386)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,10 @@ release tags.
   the server's setup phase now runs inside the teardown gate's block, the client's
   `create_streams` pushes partial progress into `ctx.streams` instead of a local vec, and
   each task is abort-guarded the moment it spawns (#381).
+- Refused rounds (`--server-max-duration`/`--server-bitrate-limit`) park until the client
+  closes, mirroring iperf3's cleanup drain: the refusal doc renders at round end, and a
+  signal landing in the park abandons it — the interrupt skeleton emits alone, carrying the
+  refused round's `target_bitrate` (#386).
 - `--logfile` receives the SERVER-ERROR relay receipt and the interrupt notice like iperf3's
   `iperf_err` routing; both previously went to stderr (#364).
 - Wire-blob parsing mirrors cJSON's UTF-8 BOM skip and non-object params root; four residual

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,9 +70,9 @@ release tags.
   `create_streams` pushes partial progress into `ctx.streams` instead of a local vec, and
   each task is abort-guarded the moment it spawns (#381).
 - Refused rounds (`--server-max-duration`/`--server-bitrate-limit`) park until the client
-  closes, mirroring iperf3's cleanup drain: the refusal doc renders at round end, and a
-  signal landing in the park abandons it — the interrupt skeleton emits alone, carrying the
-  refused round's `target_bitrate` (#386).
+  closes or 10 s of control-socket silence, mirroring iperf3's bounded cleanup drain: the
+  refusal doc renders at round end, and a signal landing in the park abandons it — the
+  interrupt skeleton emits alone, carrying the refused round's `target_bitrate` (#386).
 - `--logfile` receives the SERVER-ERROR relay receipt and the interrupt notice like iperf3's
   `iperf_err` routing; both previously went to stderr (#364).
 - Wire-blob parsing mirrors cJSON's UTF-8 BOM skip and non-object params root; four residual

--- a/riperf3-cli/tests/self_terminate.rs
+++ b/riperf3-cli/tests/self_terminate.rs
@@ -811,3 +811,67 @@ fn upfront_max_duration_line_carries_the_timestamps_prefix() {
     assert_eq!(scode, 0);
     assert_stamped_line(&serr, &format!("riperf3: error - {MAXDUR_MSG}"));
 }
+
+/// #386, the signal cell (GT live-probed both cells 2026-07-10): a refused
+/// round PARKS doc-less until client EOF — a SIGTERM landing in that park
+/// abandons the unprinted refusal doc, and the server emits the interrupt
+/// skeleton ALONE (one doc, carrying the parked round's target_bitrate —
+/// GT's json_start was stamped at get_parameters and json_finish renders
+/// it). riperf3 printed the refusal doc immediately, so the same sequence
+/// yielded TWO docs (probed 30/30 vs GT 10/10 in #385's r1 hammer). The
+/// park makes this cell deterministic: no race, the mock just holds.
+#[cfg(unix)]
+#[test]
+fn sigterm_during_refusal_park_abandons_the_refusal_doc() {
+    use std::io::Write;
+
+    let port = common::free_port();
+    let ps = port.to_string();
+    let server = spawn_server(&["-J", "--server-max-duration", "1"], &ps);
+    std::thread::sleep(Duration::from_millis(300));
+
+    // Raw mock: violate, read the fe+37 relay, HOLD the ctrl.
+    let mut ctrl = std::net::TcpStream::connect(("127.0.0.1", port)).expect("ctrl");
+    ctrl.write_all(&[b'x'; 37]).unwrap();
+    let mut b = [0u8; 1];
+    ctrl.read_exact(&mut b).unwrap();
+    assert_eq!(b[0], 9, "ParamExchange");
+    let params = br#"{"tcp":true,"time":30,"parallel":1,"len":4096,"bandwidth":2000000}"#;
+    ctrl.write_all(&(params.len() as u32).to_be_bytes())
+        .unwrap();
+    ctrl.write_all(params).unwrap();
+    let mut relay = [0u8; 9];
+    ctrl.read_exact(&mut relay).unwrap();
+    assert_eq!(relay[0], 0xfe, "SERVER_ERROR state");
+
+    // The park is stable state — signal lands inside it deterministically.
+    std::thread::sleep(Duration::from_millis(300));
+    let pid = server.0.id() as i32;
+    unsafe { libc::kill(pid, libc::SIGTERM) };
+
+    let (sout, _serr, scode) = finish(server, Duration::from_secs(10), "server");
+    assert_eq!(scode, 0, "signal-normal exit");
+    drop(ctrl);
+
+    let docs: Vec<serde_json::Value> = serde_json::Deserializer::from_str(&sout)
+        .into_iter::<serde_json::Value>()
+        .collect::<Result<_, _>>()
+        .unwrap_or_else(|e| panic!("server -J stream ({e}): {sout}"));
+    assert_eq!(
+        docs.len(),
+        1,
+        "the abandoned refusal must not print — the interrupt skeleton \
+         ALONE (#386): {sout}"
+    );
+    let err = docs[0]["error"].as_str().unwrap_or_default();
+    assert!(
+        err.starts_with("interrupt - "),
+        "the one doc is the interrupt skeleton: {err:?}"
+    );
+    assert_eq!(
+        docs[0]["start"]["target_bitrate"].as_u64(),
+        Some(2_000_000),
+        "the skeleton carries the PARKED round's -b (GT cell B): {}",
+        docs[0]
+    );
+}

--- a/riperf3/src/protocol.rs
+++ b/riperf3/src/protocol.rs
@@ -709,7 +709,7 @@ fn gt_warning(msg: std::fmt::Arguments<'_>) {
 /// overall ends the read with the partial count — the warnings then carry
 /// that count like any short read (r1 F3: without these a peer that
 /// half-sends and HOLDS parked the exchange forever; GT self-recovers).
-const NREAD_IDLE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+pub(crate) const NREAD_IDLE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
 const NREAD_OVERALL_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
 
 /// GT's `NET_HARDERROR` (net.h:50): the value `Nrecv` returns on a hard read

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -453,8 +453,9 @@ enum SetupFlow {
     ClientDone,
 }
 
-/// GT's IETOTALRATE(27) strerror — the #260 upfront total-rate refusal
-/// (get_parameters, iperf_api.c:2672-2684) AND the in-flight 1 Hz breach.
+/// GT's IETOTALRATE(27) strerror, wired here to the #260 upfront
+/// total-rate refusal only (get_parameters, iperf_api.c:2672-2684); the
+/// in-flight 1 Hz breach carries the same strerror through its own site.
 const TOTAL_RATE_REFUSAL_MSG: &str = "total required bandwidth is larger than server limit";
 
 /// GT's IEMAXSERVERTESTDURATIONEXCEEDED(37) strerror — the #230 upfront
@@ -978,11 +979,13 @@ impl Server {
         let (cookie, params, cfg) = match negotiated {
             NegotiateOutcome::Proceed(negotiated) => *negotiated,
             // Refused before any test ran → no report. #386: the round does
-            // NOT end at the relay — it parks until the client closes (GT
-            // cleanup_server's sync-close drain), and only then renders the
-            // refusal sinks; a signal landing in the park ABANDONS the
-            // refusal doc and emits the interrupt skeleton alone, carrying
-            // the parked round's target_bitrate (GT stamps json_start at
+            // NOT end at the relay — it parks until the client closes OR
+            // 10 s of ctrl silence (GT cleanup_server's sync-close drain,
+            // which is BOUNDED by Nread's front-select — see
+            // park_refused_round), and only then renders the refusal
+            // sinks; a signal landing in the park ABANDONS the refusal doc
+            // and emits the interrupt skeleton alone, carrying the parked
+            // round's target_bitrate (GT stamps json_start at
             // get_parameters and sigend's json_finish renders it — cell B
             // live-probed). The park sits OUTSIDE the #361 select above so
             // that select's rate-less skeleton can't win the signal race.
@@ -1399,11 +1402,11 @@ impl Server {
 
     /// Cookie read + ParamExchange + config derivation, plus the #230/#260
     /// upfront refusal checks. A `Refused` outcome has SENT its relay but
-    /// NOT emitted its doc: the round must first PARK until client EOF
-    /// (#386 — GT cleanup_server's sync-close drain), owned by
-    /// handle_one_test so the park is not raced by the #361 negotiate-phase
-    /// interrupt select (whose skeleton carries no target_bitrate — the
-    /// parked round's must, GT cell B).
+    /// NOT emitted its doc: the round must first PARK until client EOF or
+    /// GT's 10 s drain bound (#386 — cleanup_server's sync-close drain),
+    /// owned by handle_one_test so the park is not raced by the #361
+    /// negotiate-phase interrupt select (whose skeleton carries no
+    /// target_bitrate — the parked round's must, GT cell B).
     async fn negotiate_test(&self, ctrl: &mut tokio::net::TcpStream) -> Result<NegotiateOutcome> {
         // ---- Cookie ----
         // #330: a failed cookie read is GT's IERECVCOOKIE(106) — iperf_accept
@@ -3847,14 +3850,19 @@ impl Server {
 
     /// #386: GT's refused round does not END at the relay — cleanup_server
     /// closes the ctrl through iperf_sync_close_socket (net.c:877-886):
-    /// shutdown(SHUT_WR), then READ UNTIL EOF. The round parks until the
-    /// CLIENT closes — unbounded, like GT (a signal is the only other
-    /// exit; a wedged client holds GT's server the same way). Returns the
-    /// interrupt message if a signal ended the park — the refusal doc is
-    /// then ABANDONED (GT's sigend longjmps past the unprinted doc and
-    /// emits the interrupt skeleton alone; cells A/B live-probed
-    /// 2026-07-10) — or None on client EOF/RST (emit the refusal doc,
-    /// GT's Nread <= 0 drain exit).
+    /// shutdown(SHUT_WR), then a drain loop `while (Nread(...) > 0)`. The
+    /// drain is BOUNDED, not read-until-EOF (#429 r1 F1 — GT's own "Read
+    /// until EOF" comment misleads): each Nread front-selects with
+    /// nread_read_timeout = 10 s (net.c:75, :415-436) and returns 0 on
+    /// silence, which fails the `> 0` test exactly like EOF — GT
+    /// live-probed self-freeing at ~10 s against a wedged holder, refusal
+    /// doc rendered. So the park ends on client EOF/RST, 10 s of ctrl
+    /// silence (both -> None: emit the refusal doc), or a signal (Some:
+    /// the doc is ABANDONED — GT's sigend longjmps past the unprinted doc
+    /// and emits the interrupt skeleton alone; cells A/B live-probed
+    /// 2026-07-10). The idle clock is per-read, like GT's per-Nread
+    /// select: a dripping peer can extend the park (the recorded
+    /// nread_step nuance in protocol.rs).
     async fn park_refused_round(&self, ctrl: &mut tokio::net::TcpStream) -> Option<String> {
         use tokio::io::{AsyncReadExt, AsyncWriteExt};
         let _ = ctrl.shutdown().await; // GT's SHUT_WR half-close
@@ -3866,6 +3874,7 @@ impl Server {
                     Ok(0) | Err(_) => return None,
                     Ok(_) => continue, // drain, like GT's read loop
                 },
+                _ = tokio::time::sleep(protocol::NREAD_IDLE_TIMEOUT) => return None,
                 msg = crate::client::wait_interrupt(interrupt.as_mut()) => {
                     return Some(msg);
                 }

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -453,6 +453,30 @@ enum SetupFlow {
     ClientDone,
 }
 
+/// GT's IETOTALRATE(27) strerror — the #260 upfront total-rate refusal
+/// (get_parameters, iperf_api.c:2672-2684) AND the in-flight 1 Hz breach.
+const TOTAL_RATE_REFUSAL_MSG: &str = "total required bandwidth is larger than server limit";
+
+/// GT's IEMAXSERVERTESTDURATIONEXCEEDED(37) strerror — the #230 upfront
+/// requested-duration refusal (get_parameters, iperf_api.c:2666).
+const MAX_DURATION_REFUSAL_MSG: &str =
+    "client's requested duration exceeds the server's maximum permitted limit";
+
+/// How the cookie/param phase ended (#386). A refusal has SENT its
+/// SERVER_ERROR relay but NOT emitted any doc — the round first parks
+/// until client EOF (GT cleanup_server's sync-close drain), and only the
+/// park's outcome decides between the refusal doc (EOF) and the interrupt
+/// skeleton (signal, doc abandoned).
+enum NegotiateOutcome {
+    /// Params accepted — run the test (boxed: the tuple dwarfs Refused).
+    Proceed(Box<([u8; protocol::COOKIE_SIZE], TestParams, TestConfig)>),
+    /// Refused upfront (#230/#260): relay sent, doc deferred to post-park.
+    Refused {
+        error_line: &'static str,
+        refused_rate: Option<u64>,
+    },
+}
+
 /// What the #338 setup-phase ctrl watch saw.
 enum CtrlActivity {
     /// The peer closed the control connection (read-half EOF).
@@ -952,9 +976,26 @@ impl Server {
             }
         };
         let (cookie, params, cfg) = match negotiated {
-            Some(negotiated) => negotiated,
-            // Refused before any test ran → no report.
-            None => return Ok(None),
+            NegotiateOutcome::Proceed(negotiated) => *negotiated,
+            // Refused before any test ran → no report. #386: the round does
+            // NOT end at the relay — it parks until the client closes (GT
+            // cleanup_server's sync-close drain), and only then renders the
+            // refusal sinks; a signal landing in the park ABANDONS the
+            // refusal doc and emits the interrupt skeleton alone, carrying
+            // the parked round's target_bitrate (GT stamps json_start at
+            // get_parameters and sigend's json_finish renders it — cell B
+            // live-probed). The park sits OUTSIDE the #361 select above so
+            // that select's rate-less skeleton can't win the signal race.
+            NegotiateOutcome::Refused {
+                error_line,
+                refused_rate,
+            } => {
+                match self.park_refused_round(&mut ctrl).await {
+                    None => self.emit_refusal(error_line, refused_rate),
+                    Some(msg) => self.emit_pretest_error_doc(&msg, refused_rate),
+                }
+                return Ok(None);
+            }
         };
 
         // --get-server-output (#33): when the client asks and this server is
@@ -1356,12 +1397,14 @@ impl Server {
         }
     }
 
-    /// Cookie read + ParamExchange + config derivation, plus the #230 upfront
-    /// max-duration check. `Ok(None)` = refused (no test ran, no report).
-    async fn negotiate_test(
-        &self,
-        ctrl: &mut tokio::net::TcpStream,
-    ) -> Result<Option<([u8; protocol::COOKIE_SIZE], TestParams, TestConfig)>> {
+    /// Cookie read + ParamExchange + config derivation, plus the #230/#260
+    /// upfront refusal checks. A `Refused` outcome has SENT its relay but
+    /// NOT emitted its doc: the round must first PARK until client EOF
+    /// (#386 — GT cleanup_server's sync-close drain), owned by
+    /// handle_one_test so the park is not raced by the #361 negotiate-phase
+    /// interrupt select (whose skeleton carries no target_bitrate — the
+    /// parked round's must, GT cell B).
+    async fn negotiate_test(&self, ctrl: &mut tokio::net::TcpStream) -> Result<NegotiateOutcome> {
         // ---- Cookie ----
         // #330: a failed cookie read is GT's IERECVCOOKIE(106) — iperf_accept
         // errors and cleanup_server relays SERVER_ERROR(-2) + the code before
@@ -1448,15 +1491,23 @@ impl Server {
         // (iperf_api.c:2662), so both refusal docs carry the client's -b.
         let refused_rate = params.bandwidth.filter(|&b| b > 0);
         if rate_violated {
-            // Refused before any test ran → no report.
-            self.refuse_total_rate(ctrl, refused_rate).await?;
-            return Ok(None);
+            // #260: cleanup_server's relay — SERVER_ERROR + (IETOTALRATE=27,
+            // errno) — then the #386 park before any doc renders.
+            protocol::send_server_error(ctrl, 27).await?;
+            return Ok(NegotiateOutcome::Refused {
+                error_line: TOTAL_RATE_REFUSAL_MSG,
+                refused_rate,
+            });
         }
         if duration_violated {
-            self.refuse_max_duration(ctrl, refused_rate).await?;
-            return Ok(None);
+            // #230: the IEMAXSERVERTESTDURATIONEXCEEDED(37) relay, same shape.
+            protocol::send_server_error(ctrl, 37).await?;
+            return Ok(NegotiateOutcome::Refused {
+                error_line: MAX_DURATION_REFUSAL_MSG,
+                refused_rate,
+            });
         }
-        Ok(Some((cookie, params, cfg)))
+        Ok(NegotiateOutcome::Proceed(Box::new((cookie, params, cfg))))
     }
 
     /// #222: the connect text block, in GT's order and GT's TIMING —
@@ -3794,36 +3845,61 @@ impl Server {
         }
     }
 
-    /// #260: the upfront IETOTALRATE(27) refusal — GT's get_parameters
-    /// total-rate check. Same sink shape as the max-duration refusal below;
-    /// iperf_strerror(27) is perr=0, so the message carries no trailing ': '.
-    async fn refuse_total_rate(
-        &self,
-        ctrl: &mut tokio::net::TcpStream,
-        target_bitrate: Option<u64>,
-    ) -> Result<()> {
-        const MSG: &str = "total required bandwidth is larger than server limit";
-        protocol::send_server_error(ctrl, 27).await?;
+    /// #386: GT's refused round does not END at the relay — cleanup_server
+    /// closes the ctrl through iperf_sync_close_socket (net.c:877-886):
+    /// shutdown(SHUT_WR), then READ UNTIL EOF. The round parks until the
+    /// CLIENT closes — unbounded, like GT (a signal is the only other
+    /// exit; a wedged client holds GT's server the same way). Returns the
+    /// interrupt message if a signal ended the park — the refusal doc is
+    /// then ABANDONED (GT's sigend longjmps past the unprinted doc and
+    /// emits the interrupt skeleton alone; cells A/B live-probed
+    /// 2026-07-10) — or None on client EOF/RST (emit the refusal doc,
+    /// GT's Nread <= 0 drain exit).
+    async fn park_refused_round(&self, ctrl: &mut tokio::net::TcpStream) -> Option<String> {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+        let _ = ctrl.shutdown().await; // GT's SHUT_WR half-close
+        let mut interrupt = self.interrupt.clone().map(|w| w.0);
+        let mut buf = [0u8; 128];
+        loop {
+            tokio::select! {
+                r = ctrl.read(&mut buf) => match r {
+                    Ok(0) | Err(_) => return None,
+                    Ok(_) => continue, // drain, like GT's read loop
+                },
+                msg = crate::client::wait_interrupt(interrupt.as_mut()) => {
+                    return Some(msg);
+                }
+            }
+        }
+    }
+
+    /// The refusal sinks, rendered at ROUND END (post-park, #386) — GT's
+    /// refusal shapes per output mode (live-captured, iperf 3.21): text
+    /// gets the one stderr line (#344: iperf_err's --timestamps stamp —
+    /// the refusal reaches main.c:174's iperf_err via the -1 return); -J
+    /// gets the skeleton error document (no accepted_connection/cookie —
+    /// GT skips on_connect on this path); a --json-stream server gets the
+    /// error + empty-end event pair with no start event (#198's pre-test
+    /// tail, byte-identical to GT's refusal events). iperf_strerror is
+    /// perr=0 for both classes, so no trailing ': '.
+    fn emit_refusal(&self, msg: &str, target_bitrate: Option<u64>) {
         if self.json_stream {
             crate::reporter::emit_json_stream_line(&crate::json_report::error_stream_events(
-                &format!("error - {MSG}"),
+                &format!("error - {msg}"),
             ));
         } else if self.json_output {
             if !crate::macros::output_quiet() {
                 println!(
                     "{}",
-                    crate::json_report::refusal_document(&format!("error - {MSG}"), target_bitrate)
+                    crate::json_report::refusal_document(&format!("error - {msg}"), target_bitrate)
                 );
             }
         } else if !crate::macros::output_quiet() {
-            // #344: iperf_err's --timestamps stamp (the refusal reaches
-            // main.c:174's iperf_err via the -1 return).
             eprintln!(
-                "{}riperf3: error - {MSG}",
+                "{}riperf3: error - {msg}",
                 crate::macros::output_timestamp_prefix()
             );
         }
-        Ok(())
     }
 
     /// #330: the JSON half of a pre-test error's iperf_err sink — the -J
@@ -4115,47 +4191,6 @@ impl Server {
                 crate::macros::output_timestamp_prefix()
             );
         }
-    }
-
-    /// #230: refuse a test at param exchange (GT's upfront requested-duration
-    /// check). Sends cleanup_server's relay — SERVER_ERROR + the
-    /// (IEMAXSERVERTESTDURATIONEXCEEDED=37, errno) pair — then renders GT's
-    /// refusal shapes per output mode (live-captured, iperf 3.21): text gets
-    /// the one stderr line; -J gets the skeleton error document (no
-    /// accepted_connection/cookie — GT skips on_connect on this path); a
-    /// --json-stream server gets the error + empty-end event pair with no
-    /// start event. Returns Ok: iperf3's one-off exits 0 here, and a
-    /// persistent server goes on to serve the next test.
-    async fn refuse_max_duration(
-        &self,
-        ctrl: &mut tokio::net::TcpStream,
-        target_bitrate: Option<u64>,
-    ) -> Result<()> {
-        const MSG: &str =
-            "client's requested duration exceeds the server's maximum permitted limit";
-        protocol::send_server_error(ctrl, 37).await?;
-        if self.json_stream {
-            // #198's pre-test error tail (error event + empty end event) is
-            // byte-identical to GT's refusal events — reuse it (r1 item 8),
-            // routed through the stream emitter for its flush.
-            crate::reporter::emit_json_stream_line(&crate::json_report::error_stream_events(
-                &format!("error - {MSG}"),
-            ));
-        } else if self.json_output {
-            if !crate::macros::output_quiet() {
-                println!(
-                    "{}",
-                    crate::json_report::refusal_document(&format!("error - {MSG}"), target_bitrate)
-                );
-            }
-        } else if !crate::macros::output_quiet() {
-            // #344: iperf_err's --timestamps stamp, like the total-rate twin.
-            eprintln!(
-                "{}riperf3: error - {MSG}",
-                crate::macros::output_timestamp_prefix()
-            );
-        }
-        Ok(())
     }
 
     /// `--json-stream`: emit the server's `end` event (#62). The interval events

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -3861,8 +3861,12 @@ impl Server {
     /// the doc is ABANDONED — GT's sigend longjmps past the unprinted doc
     /// and emits the interrupt skeleton alone; cells A/B live-probed
     /// 2026-07-10). The idle clock is per-read, like GT's per-Nread
-    /// select: a dripping peer can extend the park (the recorded
-    /// nread_step nuance in protocol.rs).
+    /// select: a dripping peer extends the park on BOTH tools (probed,
+    /// 1 byte/5 s). Recorded micro-deviation (#429 r2 F2): after the LAST
+    /// dripped byte riperf3 frees at exactly the bound (10.0 s) while
+    /// GT's >0 partial return restarts a full Nread, so its tail runs up
+    /// to ~2x (probed 15.2 s) — adversarial-peer-only, boundedness
+    /// matches.
     async fn park_refused_round(&self, ctrl: &mut tokio::net::TcpStream) -> Option<String> {
         use tokio::io::{AsyncReadExt, AsyncWriteExt};
         let _ = ctrl.shutdown().await; // GT's SHUT_WR half-close

--- a/riperf3/tests/integration.rs
+++ b/riperf3/tests/integration.rs
@@ -1826,12 +1826,13 @@ mod unimplemented_flags {
 
     /// #386: GT's refused round does not END at the relay — cleanup_server
     /// closes the ctrl through iperf_sync_close_socket (net.c:877-886):
-    /// shutdown(SHUT_WR), then READ UNTIL the client EOFs. The round (and
-    /// its refusal doc) completes only when the client closes; riperf3
+    /// shutdown(SHUT_WR), then the BOUNDED drain (per-Nread 10 s idle —
+    /// see the bound pin below). The round (and its refusal doc) completes
+    /// at the client's close or the bound, whichever first; riperf3
     /// completed immediately (probed 30/30 vs GT 10/10 under the #385 r1
     /// signal race). A mock that reads the fe+37 relay and HOLDS must see
     /// (a) the server's FIN promptly (the SHUT_WR half) while (b) run_once
-    /// stays parked; the mock's close ends the round.
+    /// stays parked well under the bound; the mock's close ends the round.
     #[tokio::test]
     async fn refused_round_parks_until_client_eof() {
         use std::io::{Read, Write};

--- a/riperf3/tests/integration.rs
+++ b/riperf3/tests/integration.rs
@@ -1824,6 +1824,71 @@ mod unimplemented_flags {
         mock.abort();
     }
 
+    /// #386: GT's refused round does not END at the relay — cleanup_server
+    /// closes the ctrl through iperf_sync_close_socket (net.c:877-886):
+    /// shutdown(SHUT_WR), then READ UNTIL the client EOFs. The round (and
+    /// its refusal doc) completes only when the client closes; riperf3
+    /// completed immediately (probed 30/30 vs GT 10/10 under the #385 r1
+    /// signal race). A mock that reads the fe+37 relay and HOLDS must see
+    /// (a) the server's FIN promptly (the SHUT_WR half) while (b) run_once
+    /// stays parked; the mock's close ends the round.
+    #[tokio::test]
+    async fn refused_round_parks_until_client_eof() {
+        use std::io::{Read, Write};
+
+        let server = ServerBuilder::new()
+            .port(Some(0))
+            .server_max_duration(2)
+            .emit_output(false)
+            .build()
+            .unwrap();
+        let bound = server.bind().await.expect("bind");
+        let port = bound.local_addr().unwrap().port();
+        let handle = tokio::spawn(async move { bound.run_once().await });
+
+        let held = tokio::task::spawn_blocking(move || {
+            let mut ctrl = std::net::TcpStream::connect(("127.0.0.1", port)).expect("ctrl");
+            ctrl.write_all(&[b'x'; 37]).unwrap();
+            let mut b = [0u8; 1];
+            ctrl.read_exact(&mut b).unwrap();
+            assert_eq!(b[0], 9, "ParamExchange");
+            let params = br#"{"tcp":true,"time":30,"parallel":1,"len":4096}"#;
+            ctrl.write_all(&(params.len() as u32).to_be_bytes())
+                .unwrap();
+            ctrl.write_all(params).unwrap();
+            let mut relay = [0u8; 9];
+            ctrl.read_exact(&mut relay).unwrap();
+            assert_eq!(relay[0], 0xfe, "SERVER_ERROR state");
+            assert_eq!(
+                u32::from_be_bytes(relay[1..5].try_into().unwrap()),
+                37,
+                "IEMAXSERVERTESTDURATIONEXCEEDED"
+            );
+            // (a) the server half-closes promptly (GT's SHUT_WR): the next
+            // read is EOF, not a hang.
+            ctrl.set_read_timeout(Some(Duration::from_secs(4))).unwrap();
+            let n = ctrl.read(&mut b).expect("the shutdown FIN arrives bounded");
+            assert_eq!(n, 0, "EOF from the server's write-half shutdown");
+            ctrl
+        })
+        .await
+        .expect("mock");
+
+        // (b) the round is PARKED while the client holds.
+        tokio::time::sleep(Duration::from_millis(700)).await;
+        assert!(
+            !handle.is_finished(),
+            "#386: the refused round must park until the client closes"
+        );
+        drop(held); // client EOF → the round ends
+        let out = tokio::time::timeout(Duration::from_secs(4), handle)
+            .await
+            .expect("the round ends bounded after client EOF")
+            .expect("join");
+        // A refusal is a no-report round: Err per the #293 rule.
+        assert!(out.is_err(), "refusal has no report: {out:?}");
+    }
+
     #[tokio::test]
     async fn server_max_duration() {
         // #230: --server-max-duration is an UPFRONT param-exchange check in

--- a/riperf3/tests/integration.rs
+++ b/riperf3/tests/integration.rs
@@ -1889,6 +1889,53 @@ mod unimplemented_flags {
         assert!(out.is_err(), "refusal has no report: {out:?}");
     }
 
+    /// #386 (#429 r1 F1): the park is BOUNDED — GT's drain rides Nread,
+    /// whose front-select times out at 10 s of silence and returns 0,
+    /// failing the `> 0` drain test exactly like EOF (net.c:75, :415-436;
+    /// GT live-probed self-freeing at ~10 s against a wedged holder, doc
+    /// rendered). A client that reads the relay and HOLDS silently must
+    /// not wedge the round forever: run_once ends within the bound. ~10 s
+    /// of wall clock by design (the 41 s watchdog cell made the opposite
+    /// call; this one IS the r1 blocker, so it stays pinned).
+    #[tokio::test]
+    async fn refused_round_park_is_bounded_at_nread_idle() {
+        use std::io::{Read, Write};
+
+        let server = ServerBuilder::new()
+            .port(Some(0))
+            .server_max_duration(2)
+            .emit_output(false)
+            .build()
+            .unwrap();
+        let bound = server.bind().await.expect("bind");
+        let port = bound.local_addr().unwrap().port();
+        let handle = tokio::spawn(async move { bound.run_once().await });
+
+        let _held = tokio::task::spawn_blocking(move || {
+            let mut ctrl = std::net::TcpStream::connect(("127.0.0.1", port)).expect("ctrl");
+            ctrl.write_all(&[b'x'; 37]).unwrap();
+            let mut b = [0u8; 1];
+            ctrl.read_exact(&mut b).unwrap();
+            assert_eq!(b[0], 9, "ParamExchange");
+            let params = br#"{"tcp":true,"time":30,"parallel":1,"len":4096}"#;
+            ctrl.write_all(&(params.len() as u32).to_be_bytes())
+                .unwrap();
+            ctrl.write_all(params).unwrap();
+            let mut relay = [0u8; 9];
+            ctrl.read_exact(&mut relay).unwrap();
+            assert_eq!(relay[0], 0xfe, "SERVER_ERROR state");
+            ctrl // hold silently — never close
+        })
+        .await
+        .expect("mock");
+
+        let out = tokio::time::timeout(Duration::from_secs(14), handle)
+            .await
+            .expect("the park self-frees at ~10 s against a silent holder")
+            .expect("join");
+        assert!(out.is_err(), "refusal has no report: {out:?}");
+    }
+
     #[tokio::test]
     async fn server_max_duration() {
         // #230: --server-max-duration is an UPFRONT param-exchange check in


### PR DESCRIPTION
## Problem

riperf3's refused round (the #230/#260 upfront refusals) COMPLETED immediately after sending the SERVER_ERROR relay and printed its refusal doc. GT's refused round does not end until the client closes the ctrl: `cleanup_server` closes through `iperf_sync_close_socket` (net.c:877-886) — `shutdown(SHUT_WR)`, then **read until EOF** — and the refusal doc renders only after the `-1` return reaches main's `iperf_err`/`json_finish`. A sigend landing in that park longjmps past the unprinted doc and emits the interrupt skeleton ALONE. Probed in #385's r1 hammer (riperf3 two docs 30/30, GT skeleton-only 10/10) and re-probed live for this PR (`probe386.py`, cells A/B):

- **Cell A (EOF)**: GT renders the refusal doc (carrying `target_bitrate`) at client-close time.
- **Cell B (signal mid-park)**: GT emits exactly ONE doc — the interrupt skeleton, still carrying the parked round's `target_bitrate` (json_start was stamped at `get_parameters`).

## Fix

`negotiate_test` now returns `NegotiateOutcome` — its `Refused` arm has SENT the relay but emits nothing. `handle_one_test` owns the park (`park_refused_round`: SHUT_WR + drain-to-EOF racing the interrupt watch, unbounded like GT), and only the park's outcome picks the sink:

- EOF/RST → `emit_refusal` (the old doc/text/json-stream shapes, byte-identical);
- signal → `emit_pretest_error_doc` with the refused round's `-b` — the refusal doc is abandoned.

The park deliberately sits OUTSIDE the #361 negotiate-phase interrupt select: that select's skeleton carries no `target_bitrate` and must not win the signal race against the park. The two `refuse_*` fns fold into `emit_refusal` + module consts (GT strerror cites preserved). Conforming clients close on the relay, so the park is invisible to them — all 16 pre-existing `self_terminate` cells pass untouched, as does the lib `server_max_duration` round-trip.

riperf3's post-fix output re-probed against GT cell-for-cell: cell B is byte-shape identical (one skeleton, `target_bitrate: 1000000`), cell A renders the same two-doc sequence.

## Pins (both red-first)

- `refused_round_parks_until_client_eof` (lib, integration.rs): the mock reads the fe+37 relay, must see the server's prompt FIN (the SHUT_WR half) while `run_once` stays parked through a 700 ms hold, and the mock's close ends the round bounded.
- `sigterm_during_refusal_park_abandons_the_refusal_doc` (CLI, cfg(unix), self_terminate.rs): the park is stable state, so the signal lands deterministically — exactly ONE doc, the interrupt skeleton, `start.target_bitrate` = the refused client's `-b`. (Red today: the immediately-printed refusal doc.)

## Scope note

The auth-deny cell rides GT's same cleanup drain but different riperf3 plumbing (Err-path, AccessDenied state) — being probed separately and filed if divergent; out of #386's scope.

Closes #386
