### PR TITLE
fix: -w 0 is a no-op like GT — never applied, never on the wire (#415)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,10 @@ release tags.
 
 ### Fixed
 
+- `-w 0` is a no-op like iperf3 (0 = kernel autotuning): the window is never applied to
+  data sockets — was clamping both buffers to kernel minimums, a live throughput hit — and
+  the params blob omits the `"window"` key, so a `-w 0` client no longer shrinks a riperf3
+  server's buffers either (#415).
 - Rate-set server documents place `target_bitrate` at iperf3's get_parameters slot (right
   after `system_info`, shifting the TCP trio); the duplicate on_connect emission is a
   recorded deviation (#377).

--- a/riperf3-cli/src/cli.rs
+++ b/riperf3-cli/src/cli.rs
@@ -657,10 +657,13 @@ impl Cli {
             // out-of-i32-range negative (`-w -3G`) saturates to i32::MIN on
             // both (GT's cvttsd2si also yields INT_MIN); positive overflow is
             // unreachable (IEBUFSIZE catches anything > MAX_TCP_BUFFER first).
-            // RECORDED DEVIATION (unobservable): the sole literal that
-            // diverges is `-w nan` — `nan as i32` = 0, GT's `(int)nan` =
-            // INT_MIN. socket_bufsize is not a wire/output field and `-w nan`
-            // never connects, so the value is never observable; not worth a
+            // RECORDED DEVIATION: the sole literal that diverges is `-w nan`
+            // — `nan as i32` = 0, GT's `(int)nan` = INT_MIN. Both tools DO
+            // connect and complete (#432 r2 probe): GT renders
+            // `sock_bufsize: -2147483648` with the negative applied (the
+            // kernel max-clamps it), riperf3 renders 0 and runs fully unset
+            // (#415 normalizes the 0 to kernel autotuning). Observable in
+            // `-J`, tolerated: a NaN-cast literal is not worth a
             // special-case for an absurd input.
             let farg = unit_atoi_os(s)?;
             builder = builder.window(farg as i32);

--- a/riperf3/src/client.rs
+++ b/riperf3/src/client.rs
@@ -3062,7 +3062,11 @@ impl ClientBuilder {
     }
 
     /// `-w/--window`: socket buffer size in bytes (indirectly sets the TCP
-    /// window size).
+    /// window size). `0` normalizes to unset at `build()` — kernel autotuning,
+    /// never applied, never sent on the wire — mirroring iperf3, whose
+    /// `socket_bufsize` 0 is the unset sentinel behind C truthiness guards
+    /// (#415). Negatives pass through verbatim like iperf3 (only the upper
+    /// bound is range-checked there); the kernel decides what they mean.
     pub fn window(mut self, window: i32) -> Self {
         self.window = Some(window);
         self

--- a/riperf3/src/client.rs
+++ b/riperf3/src/client.rs
@@ -3438,7 +3438,12 @@ impl ClientBuilder {
     }
 
     /// Like [`Self::window`], accepting a KMG-suffixed size string
-    /// (`-w 4M`; binary, 1024-based).
+    /// (`-w 4M`; binary, 1024-based). The parsed value is cast to `i32`
+    /// without a range check (like iperf3's `(int) unit_atof(optarg)`), so an
+    /// out-of-range size wraps — `"4G"` wraps to 0, which [`Self::window`]
+    /// then treats as unset (#432 r2 F4). iperf3's CLI rejects anything over
+    /// 512M (IEBUFSIZE) before its cast; callers wanting that guard should
+    /// range-check before calling, as riperf3's own CLI does.
     pub fn window_str(self, s: &str) -> std::result::Result<Self, ConfigError> {
         Ok(self.window(parse_kmg(s)? as i32))
     }

--- a/riperf3/src/client.rs
+++ b/riperf3/src/client.rs
@@ -3649,7 +3649,15 @@ impl ClientBuilder {
             omit: self.omit,
             no_delay: self.no_delay,
             mss: self.mss,
-            window: self.window,
+            // #415: an explicit 0 IS "unset" — GT's socket_bufsize uses 0 as
+            // the unset sentinel and truthiness-gates every consumer (the
+            // apply sites, iperf_tcp.c:257/:434; the params-blob key,
+            // iperf_api.c:2451), so `-w 0` must ride every unset arm: no
+            // setsockopt, no "window" key on the wire, and the #163 UDP
+            // batch sizing treats the buffer as untouched. Normalizing here
+            // covers them all; the `start.sock_bufsize` render is unchanged
+            // (`unwrap_or(0)` — GT renders the verbatim 0 either way).
+            window: self.window.filter(|&w| w != 0),
             // Resolve the rate default now (UDP unset → 1 Mbit/s, like iperf3);
             // an explicit -b (incl. 0 = unlimited) is honored. TCP default is
             // unlimited (0). After this, bandwidth==0 unambiguously = unlimited.

--- a/riperf3/src/net.rs
+++ b/riperf3/src/net.rs
@@ -383,9 +383,10 @@ pub fn configure_tcp_stream(stream: &TcpStream, no_delay: bool) -> Result<()> {
 /// iperf_tcp.c:257/:434, iperf_udp.c:384), so an explicit `-w 0` never reaches
 /// setsockopt. Pre-#415 riperf3 applied the 0 and the kernel clamped both
 /// buffers to its minimums — a live throughput divergence. The guard sits HERE,
-/// not only at the client boundary, because a server can be handed
-/// `"window": 0` on the wire by older riperf3 clients (≤0.9.0 sent the key
-/// where GT omits it).
+/// not only at the boundaries, because a server can be handed `"window": 0`
+/// on the wire by pre-0.9.0 riperf3 clients (they sent the key where GT omits
+/// it) — the server's param ingest normalizes that 0 to unset (`from_params`,
+/// r1 F1), and this guard is the defense-in-depth layer behind it.
 pub(crate) fn apply_socket_window(sock: &socket2::SockRef<'_>, window: Option<i32>) {
     if let Some(size) = window {
         if size != 0 {

--- a/riperf3/src/net.rs
+++ b/riperf3/src/net.rs
@@ -369,15 +369,29 @@ pub fn configure_tcp_stream(stream: &TcpStream, no_delay: bool) -> Result<()> {
 /// Apply the requested socket buffer size (`-w/--window`) to a socket's send and
 /// receive buffers (`SO_SNDBUF` / `SO_RCVBUF`).
 ///
-/// Best-effort: a kernel that clamps or rejects the size is not fatal — iperf3
-/// likewise proceeds, and the realized size is read back separately for the
-/// `sndbuf_actual` / `rcvbuf_actual` report. Used for both TCP and UDP data
-/// sockets so `-w` is honored on UDP too (#59), matching iperf3's
-/// `iperf_udp_buffercheck`. `None` is a no-op (kernel default).
+/// Best-effort at the syscall: a kernel that clamps the size is not fatal here —
+/// the realized size is read back separately for the `sndbuf_actual` /
+/// `rcvbuf_actual` report, and [`check_socket_window`] enforces GT's clamp abort
+/// (IESETBUF2). (An outright setsockopt REJECTION is IESETBUF in GT; Linux
+/// clamps rather than rejects — `-w -1` live-probes to identical max-size
+/// buffers on both tools — so the arm is not mirrored.) Used for both TCP and
+/// UDP data sockets so `-w` is honored on UDP too (#59), matching iperf3's
+/// `iperf_udp_buffercheck`.
+///
+/// `None` AND `Some(0)` are no-ops (kernel default): GT's apply guard is C
+/// truthiness on `socket_bufsize` (`if ((opt = test->settings->socket_bufsize))`,
+/// iperf_tcp.c:257/:434, iperf_udp.c:384), so an explicit `-w 0` never reaches
+/// setsockopt. Pre-#415 riperf3 applied the 0 and the kernel clamped both
+/// buffers to its minimums — a live throughput divergence. The guard sits HERE,
+/// not only at the client boundary, because a server can be handed
+/// `"window": 0` on the wire by older riperf3 clients (≤0.9.0 sent the key
+/// where GT omits it).
 pub(crate) fn apply_socket_window(sock: &socket2::SockRef<'_>, window: Option<i32>) {
     if let Some(size) = window {
-        let _ = sock.set_recv_buffer_size(size as usize);
-        let _ = sock.set_send_buffer_size(size as usize);
+        if size != 0 {
+            let _ = sock.set_recv_buffer_size(size as usize);
+            let _ = sock.set_send_buffer_size(size as usize);
+        }
     }
 }
 
@@ -1262,6 +1276,30 @@ mod tests {
         let before = s2.send_buffer_size().unwrap();
         apply_socket_window(&s2, None);
         assert_eq!(s2.send_buffer_size().unwrap(), before);
+    }
+
+    /// #415: `Some(0)` must be a no-op like `None` — GT's buffer-apply guard is
+    /// C truthiness (`if ((opt = test->settings->socket_bufsize))`,
+    /// iperf_tcp.c:257/:434, iperf_udp.c:384), so `-w 0` never reaches
+    /// setsockopt. Pre-fix riperf3 applied 0 and the kernel clamped both
+    /// buffers to its minimums (live-probed: 4608/2304 vs untouched defaults).
+    #[test]
+    fn apply_socket_window_zero_is_a_noop() {
+        let sock = std::net::UdpSocket::bind("127.0.0.1:0").unwrap();
+        let s = socket2::SockRef::from(&sock);
+        let snd_before = s.send_buffer_size().unwrap();
+        let rcv_before = s.recv_buffer_size().unwrap();
+        apply_socket_window(&s, Some(0));
+        assert_eq!(
+            s.send_buffer_size().unwrap(),
+            snd_before,
+            "SO_SNDBUF must be untouched by -w 0 (GT truthiness skip)"
+        );
+        assert_eq!(
+            s.recv_buffer_size().unwrap(),
+            rcv_before,
+            "SO_RCVBUF must be untouched by -w 0 (GT truthiness skip)"
+        );
     }
 
     // #149: the server's listener and UDP socket honor --bind-dev pre-bind

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -159,7 +159,12 @@ impl TestConfig {
             omit: params.omit.unwrap_or(0) as u32,
             no_delay: params.nodelay.unwrap_or(false),
             mss: params.mss,
-            window: params.window,
+            // #415 (r1 F1): a wire `"window": 0` (pre-0.9.0 riperf3 clients
+            // sent the key; GT omits it, iperf_api.c:2451) is GT's unset
+            // sentinel — normalize here so every consumer rides the unset
+            // arm, the UDP senders' `uw` gates included. Nonzero values,
+            // negatives included (#392), ingest verbatim.
+            window: params.window.filter(|&w| w != 0),
             // A present rate (incl. 0 = unlimited) is used verbatim. An ABSENT
             // rate means unlimited (0), matching iperf3: it omits the param only
             // for -b 0 and sends it explicitly otherwise (incl. its 1 Mbit/s UDP
@@ -4623,6 +4628,43 @@ mod tests {
     /// #316: the server adopts the client's exchanged GSO/GRO request
     /// (GT iperf_api.c:2599-2619), including the zero-dg_size recompute
     /// from the negotiated blksize (:2607-2613).
+    /// #415 (r1 F1): a wire `"window": 0` ingests as UNSET — GT's
+    /// socket_bufsize 0 is the unset sentinel in EVERY consumer, including
+    /// the UDP auto-increase arm (iperf_udp.c:563/:691, the GT analogue of
+    /// the #163 sndbuf bump). Pre-fix the two UDP-sender arms'
+    /// `uw = window.is_some()` treated a pre-0.9.0 client's `"window": 0`
+    /// as user-set and suppressed the bump. Nonzero values — negatives
+    /// included (#392) — ingest verbatim.
+    #[test]
+    fn from_params_window_zero_ingests_as_unset() {
+        let zero = crate::protocol::TestParams {
+            window: Some(0),
+            ..Default::default()
+        };
+        assert_eq!(
+            TestConfig::from_params(&zero).unwrap().window,
+            None,
+            "wire window 0 must ride every unset arm, like GT's 0 sentinel"
+        );
+        let explicit = crate::protocol::TestParams {
+            window: Some(65536),
+            ..Default::default()
+        };
+        assert_eq!(
+            TestConfig::from_params(&explicit).unwrap().window,
+            Some(65536)
+        );
+        let negative = crate::protocol::TestParams {
+            window: Some(-1),
+            ..Default::default()
+        };
+        assert_eq!(
+            TestConfig::from_params(&negative).unwrap().window,
+            Some(-1),
+            "negatives stay verbatim (#392) — GT applies them and lets the kernel decide"
+        );
+    }
+
     #[test]
     fn test_config_adopts_the_gsro_block() {
         let params = crate::protocol::TestParams {

--- a/riperf3/tests/integration.rs
+++ b/riperf3/tests/integration.rs
@@ -2879,6 +2879,146 @@ async fn negative_window_renders_minus_one_like_gt() {
     }
 }
 
+/// Run one full round and return both roles' `start` docs as
+/// `(sock_bufsize, sndbuf_actual, rcvbuf_actual)` trios — the #415 probes'
+/// actuals trio, client then server. A CONCRETE port (not `Some(0)`): a UDP
+/// round's data socket binds the CONFIGURED port, so an ephemeral control
+/// bind strands it on a random port and the round wedges (#431).
+async fn run_round_actuals(
+    window: Option<i32>,
+    udp: bool,
+) -> [(Option<i64>, Option<i64>, Option<i64>); 2] {
+    let port = next_port();
+    let server = ServerBuilder::new()
+        .port(Some(port))
+        .emit_output(false)
+        .build()
+        .unwrap();
+    let bound = server.bind().await.expect("bind");
+    let server_task = tokio::spawn(async move { bound.run_once().await });
+    let mut builder = ClientBuilder::new("127.0.0.1")
+        .port(Some(port))
+        .duration(1)
+        .emit_output(false);
+    if udp {
+        builder = builder.protocol(TransportProtocol::Udp);
+    }
+    if let Some(w) = window {
+        builder = builder.window(w);
+    }
+    let client = builder.build().unwrap();
+    let cli = tokio::time::timeout(Duration::from_secs(15), client.run())
+        .await
+        .expect("client hung")
+        .expect("client run");
+    let srv = server_task.await.expect("join").expect("server run_once");
+    [&cli, &srv].map(|outcome| {
+        let v = serde_json::to_value(&outcome.report).unwrap();
+        (
+            v["start"]["sock_bufsize"].as_i64(),
+            v["start"]["sndbuf_actual"].as_i64(),
+            v["start"]["rcvbuf_actual"].as_i64(),
+        )
+    })
+}
+
+/// #415: an explicit `-w 0` is a NO-OP in GT — the buffer-apply guard is C
+/// truthiness (`if ((opt = test->settings->socket_bufsize))`,
+/// iperf_tcp.c:257/:434), so `socket_bufsize = 0` never reaches setsockopt
+/// and the w=0 cell equals the unset cell exactly (the #391 equality-pin
+/// pattern, extended from the setup-doc to the live data path). Pre-fix
+/// riperf3 applied 0 to BOTH roles' data sockets — the client's directly,
+/// the server's via the params blob's `"window": 0` (GT omits the key,
+/// iperf_api.c:2451) — and the kernel clamped the buffers to its minimums
+/// (live-probed: 4608/2304 vs 3939840/131072 untouched), a real throughput
+/// divergence, not just a doc one.
+#[tokio::test]
+async fn tcp_window_zero_equals_unset_cell_both_roles() {
+    let unset = run_round_actuals(None, false).await;
+    let zero = run_round_actuals(Some(0), false).await;
+    for (role, i) in [("client", 0), ("server", 1)] {
+        assert_eq!(
+            zero[i], unset[i],
+            "the {role}'s -w 0 actuals trio must equal the unset cell (#415)"
+        );
+        assert_eq!(
+            zero[i].0,
+            Some(0),
+            "the {role}'s sock_bufsize renders 0 for -w 0, like GT's verbatim 0"
+        );
+    }
+}
+
+/// #415, UDP flavor: the UDP apply site is `capture_stream_meta`
+/// (apply_window=true, the #59 path), distinct from TCP's
+/// `configure_tcp_stream_full` — GT's guard is the same truthiness in
+/// `iperf_udp_buffercheck` (iperf_udp.c:384). Client doc only: the server's
+/// UDP start block carries no actuals (#383).
+#[tokio::test]
+async fn udp_window_zero_equals_unset_cell() {
+    let unset = run_round_actuals(None, true).await;
+    let zero = run_round_actuals(Some(0), true).await;
+    assert_eq!(
+        zero[0], unset[0],
+        "the client's UDP -w 0 actuals trio must equal the unset cell (#415)"
+    );
+}
+
+/// #415 (wire half): GT gates the params blob's `"window"` key on the same
+/// truthiness (`if (test->settings->socket_bufsize)` — iperf_api.c:2451), so
+/// a `-w 0` client sends NO window key. Pre-fix riperf3 sent `"window": 0`,
+/// which a pre-fix riperf3 server applied to its data sockets (the server
+/// half of the live bug; a GT server ingests 0 harmlessly but the wire bytes
+/// still diverge). A `-w 65536` control cell keeps the positive path pinned.
+#[tokio::test]
+async fn params_blob_omits_window_zero_like_gt() {
+    use std::io::{Read, Write};
+
+    async fn capture_params_blob(window: i32) -> serde_json::Value {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind mock");
+        let port = listener.local_addr().unwrap().port();
+        let mock = tokio::task::spawn_blocking(move || {
+            let (mut ctrl, _) = listener.accept().expect("ctrl accept");
+            let mut cookie = [0u8; 37];
+            ctrl.read_exact(&mut cookie).unwrap();
+            ctrl.write_all(&[9u8]).unwrap(); // ParamExchange
+            let mut len = [0u8; 4];
+            ctrl.read_exact(&mut len).unwrap();
+            let mut blob = vec![0u8; u32::from_be_bytes(len) as usize];
+            ctrl.read_exact(&mut blob).unwrap();
+            blob
+            // ctrl drops here — the client errors out of the round promptly.
+        });
+        let client = ClientBuilder::new("127.0.0.1")
+            .port(Some(port))
+            .duration(1)
+            .window(window)
+            .emit_output(false)
+            .build()
+            .unwrap();
+        let run = tokio::spawn(async move { client.run().await });
+        let blob = tokio::time::timeout(Duration::from_secs(10), mock)
+            .await
+            .expect("mock hung")
+            .expect("mock join");
+        // Reap the erroring client; its outcome is not this pin's business.
+        let _ = tokio::time::timeout(Duration::from_secs(10), run).await;
+        serde_json::from_slice(&blob).expect("params blob is JSON")
+    }
+
+    let zero = capture_params_blob(0).await;
+    assert!(
+        zero.get("window").is_none(),
+        "-w 0 must omit the params blob's window key like GT (iperf_api.c:2451): {zero}"
+    );
+    let explicit = capture_params_blob(65536).await;
+    assert_eq!(
+        explicit["window"].as_i64(),
+        Some(65536),
+        "a nonzero -w still carries the window key: {explicit}"
+    );
+}
+
 /// #406 (r1): the `RecvMessageFailed`↔`SendFailed` cell of the same
 /// invisibility class — the repo's first RENDERING-IDENTICAL variant pair
 /// (both print `error - {msg}` with the carried message and both errexit


### PR DESCRIPTION
Fixes #415.

## The bug

An explicit `-w 0` is a NO-OP in GT — the buffer-apply guard is C truthiness (`if ((opt = test->settings->socket_bufsize))`, iperf_tcp.c:257/:434, iperf_udp.c:384), so `socket_bufsize = 0` never reaches setsockopt. riperf3 applied the 0 to its data sockets and the kernel clamped both buffers to its minimums — live-probed on the exact cells:

| cell | GT | riperf3 pre-fix |
|---|---|---|
| TCP client `-w 0` | `(0, 16384, 131072)` | `(0, 4608, 2304)` |
| UDP client `-w 0` | `(0, 212992, 212992)` | `(0, 4608, 2304)` |
| RP client `-w 0` → RP server (server trio) | n/a | `(0, 4608, 2304)` |

(trio = `sock_bufsize, sndbuf_actual, rcvbuf_actual`.) ~4 KB socket buffers are a real throughput divergence, not a doc one.

The wire half: GT gates the params-blob `"window"` key on the same truthiness (iperf_api.c:2451). riperf3 sent `"window": 0`, which a riperf3 server applied to ITS data sockets too (a GT server ingests the 0 harmlessly, but the wire bytes diverge).

## The fix

- `net::apply_socket_window` skips `Some(0)` — the GT apply-site truthiness. Kept at the shared site (not only the client boundary) because servers can be fed `"window": 0` on the wire by riperf3 clients ≤0.9.0.
- `ClientBuilder::build()` normalizes `window(0)` to `None`, so `-w 0` rides every unset arm: no setsockopt, no params-blob key, and the #163 UDP batch sizing treats the buffer as untouched. `start.sock_bufsize` still renders the verbatim 0 (`unwrap_or(0)`), like GT.

## Pins (all red-proven pre-fix, each fix half mutant-discriminated)

- `apply_socket_window_zero_is_a_noop` (unit) — kills the apply-guard revert.
- `tcp_window_zero_equals_unset_cell_both_roles` — both roles' actuals trio, w=0 == unset (the #391 equality-pin pattern extended to the live data path); red pre-fix with the exact probed values above.
- `udp_window_zero_equals_unset_cell` — the UDP apply site (`capture_stream_meta`) is distinct from TCP's (`configure_tcp_stream_full`).
- `params_blob_omits_window_zero_like_gt` — raw mock server captures the blob; `-w 0` omits the key, `-w 65536` positive control carries it. Kills the build()-filter revert.

## Post-fix parity

Re-probed the full matrix (w ∈ {unset, 0, 65536, -1} × both roles × TCP/UDP × cross-tool): w=0 cells equal the unset cells on both tools, all other cells unchanged. `-w -1` was probed at parity pre- and post-fix (Linux clamps the negative to max for both tools; sock_bufsize renders -1 verbatim per #392).

## Filed along the way

- #431 — UDP rounds wedge on the `bind()` surface with `port(Some(0))`: the UDP data socket binds the CONFIGURED port, not the listener's realized one (found by the UDP pin's harness; worked around here with a concrete `next_port()`).
