### PR TITLE
test: de-flake the #415 TCP actuals pin on macOS (floor assertion instead of cross-run equality)

### DIFF
--- a/riperf3/tests/integration.rs
+++ b/riperf3/tests/integration.rs
@@ -2924,28 +2924,56 @@ async fn run_round_actuals(
 
 /// #415: an explicit `-w 0` is a NO-OP in GT — the buffer-apply guard is C
 /// truthiness (`if ((opt = test->settings->socket_bufsize))`,
-/// iperf_tcp.c:257/:434), so `socket_bufsize = 0` never reaches setsockopt
-/// and the w=0 cell equals the unset cell exactly (the #391 equality-pin
-/// pattern, extended from the setup-doc to the live data path). Pre-fix
-/// riperf3 applied 0 to BOTH roles' data sockets — the client's directly,
-/// the server's via the params blob's `"window": 0` (GT omits the key,
-/// iperf_api.c:2451) — and the kernel clamped the buffers to its minimums
-/// (live-probed: 4608/2304 vs 3939840/131072 untouched), a real throughput
-/// divergence, not just a doc one.
+/// iperf_tcp.c:257/:434), so `socket_bufsize = 0` never reaches setsockopt.
+/// Pre-fix riperf3 applied 0 to BOTH roles' data sockets — the client's
+/// directly, the server's via the params blob's `"window": 0` (GT omits the
+/// key, iperf_api.c:2451) — and the kernel clamped the buffers to its
+/// minimums (live-probed: 4608/2304 vs 3939840/131072 untouched), a real
+/// throughput divergence, not just a doc one.
+///
+/// The regression signature is therefore "actuals collapse to the kernel
+/// clamp floor", asserted directly. Cross-run EQUALITY with an unset cell
+/// (the #391 pattern, as first merged) proved flaky on macOS, whose TCP
+/// receive-buffer autosizing lands run-dependently (observed rcvbuf_actual
+/// 881928 vs 1045248 for identical settings, CI run 29135962755).
+/// `sock_bufsize` is riperf3's own rendering, not a kernel readback, so it
+/// stays an exact equality; the unset cell remains as the control that the
+/// floor fits the environment.
 #[tokio::test]
-async fn tcp_window_zero_equals_unset_cell_both_roles() {
+async fn tcp_window_zero_leaves_buffers_untouched_both_roles() {
+    // Above the kernel clamp minimums (Linux SOCK_MIN_SNDBUF 4608 /
+    // SOCK_MIN_RCVBUF 2304), below every CI platform's untouched default
+    // (>= 16 KiB).
+    const CLAMP_FLOOR: i64 = 8192;
     let unset = run_round_actuals(None, false).await;
     let zero = run_round_actuals(Some(0), false).await;
     for (role, i) in [("client", 0), ("server", 1)] {
-        assert_eq!(
-            zero[i], unset[i],
-            "the {role}'s -w 0 actuals trio must equal the unset cell (#415)"
-        );
         assert_eq!(
             zero[i].0,
             Some(0),
             "the {role}'s sock_bufsize renders 0 for -w 0, like GT's verbatim 0"
         );
+        assert_eq!(
+            zero[i].0, unset[i].0,
+            "the {role}'s -w 0 sock_bufsize must equal the unset cell (#415)"
+        );
+        for (name, z, u) in [
+            ("sndbuf_actual", zero[i].1, unset[i].1),
+            ("rcvbuf_actual", zero[i].2, unset[i].2),
+        ] {
+            let u = u.expect("unset actual present");
+            assert!(
+                u > CLAMP_FLOOR,
+                "control: the {role}'s unset {name} ({u}) sits under the floor — \
+                 the floor misfits this environment, not the code"
+            );
+            let z = z.expect("w=0 actual present");
+            assert!(
+                z > CLAMP_FLOOR,
+                "the {role}'s -w 0 {name} ({z}) collapsed toward the kernel \
+                 clamp floor — 0 reached setsockopt (#415)"
+            );
+        }
     }
 }
 

--- a/riperf3/tests/integration.rs
+++ b/riperf3/tests/integration.rs
@@ -2935,10 +2935,14 @@ async fn run_round_actuals(
 /// clamp floor", asserted directly. Cross-run EQUALITY with an unset cell
 /// (the #391 pattern, as first merged) proved flaky on macOS, whose TCP
 /// receive-buffer autosizing lands run-dependently (observed rcvbuf_actual
-/// 881928 vs 1045248 for identical settings, CI run 29135962755).
-/// `sock_bufsize` is riperf3's own rendering, not a kernel readback, so it
-/// stays an exact equality; the unset cell remains as the control that the
-/// floor fits the environment.
+/// 881928 vs 1045248 for identical settings, CI run 29135962755); FreeBSD's
+/// TCP rcvbuf autotuning made it latent-flaky there too. `sock_bufsize` is
+/// riperf3's own rendering, not a kernel readback, so it stays an exact
+/// equality; the unset cell remains as the control that the floor fits the
+/// environment. On the BSD kernels (macOS/FreeBSD, sbreserve hiwat=0) a real
+/// regression may instead wedge the round and surface as the harness's 15s
+/// "client hung" panic rather than the floor message — still red, just
+/// hang-shaped.
 #[tokio::test]
 async fn tcp_window_zero_leaves_buffers_untouched_both_roles() {
     // Above the kernel clamp minimums (Linux SOCK_MIN_SNDBUF 4608 /
@@ -2955,7 +2959,8 @@ async fn tcp_window_zero_leaves_buffers_untouched_both_roles() {
         );
         assert_eq!(
             zero[i].0, unset[i].0,
-            "the {role}'s -w 0 sock_bufsize must equal the unset cell (#415)"
+            "the {role}'s UNSET-cell sock_bufsize must also render GT's verbatim 0 \
+             (this arm pins the unset render; the w=0 render is pinned above)"
         );
         for (name, z, u) in [
             ("sndbuf_actual", zero[i].1, unset[i].1),
@@ -2981,7 +2986,10 @@ async fn tcp_window_zero_leaves_buffers_untouched_both_roles() {
 /// (apply_window=true, the #59 path), distinct from TCP's
 /// `configure_tcp_stream_full` — GT's guard is the same truthiness in
 /// `iperf_udp_buffercheck` (iperf_udp.c:384). Client doc only: the server's
-/// UDP start block carries no actuals (#383).
+/// UDP start block carries no actuals (#383). Cross-run equality stays safe
+/// here where the TCP sibling had to drop it: UDP buffers are not autotuned
+/// on any CI platform (static defaults), and the #163 sndbuf bump is
+/// deterministic across both cells.
 #[tokio::test]
 async fn udp_window_zero_equals_unset_cell() {
     let unset = run_round_actuals(None, true).await;


### PR DESCRIPTION
## What

De-flakes `tcp_window_zero_equals_unset_cell_both_roles` (added in #432 for #415), renamed to `tcp_window_zero_leaves_buffers_untouched_both_roles`. Test-only diff; no library or CLI behavior change.

## Why

The pin asserted cross-run equality of the kernel-reported actuals trio between a `-w 0` round and an unset round. On macOS that is inherently racy: TCP receive-buffer autosizing lands run-dependently for identical settings. First observed on PR #435's CI (run 29135962755, `Native test (macos-latest)`):

```
  left: (Some(0), Some(146988), Some(881928))
 right: (Some(0), Some(146988), Some(1045248))
```

Both values are healthy autotuned sizes — the runs differ only in where `rcvbuf_actual` settled. #432's own CI and main's post-merge run passed by luck.

## How

The regression the pin exists to catch is "0 reached setsockopt", whose signature is actuals collapsing to the kernel clamp minimums (live-probed pre-fix: 4608/2304). The rewrite asserts that signature directly:

- `sock_bufsize` (riperf3's own rendering, not a kernel readback) keeps exact equality with the unset cell, and `== Some(0)`.
- `sndbuf_actual` / `rcvbuf_actual` move from cross-run equality to a floor assertion (`> 8192` — above the Linux clamp minimums, below every CI platform's untouched default).
- The unset cell stays as a control: if *it* sits under the floor, the failure message says the floor misfits the environment rather than blaming the code.

The UDP flavor (`udp_window_zero_equals_unset_cell`) is untouched — UDP buffers are not autosized on any CI platform and the flake has never been observed there.

## Discrimination

The floor pin is still load-bearing, with a subtlety worth recording: **no single-layer mutant of the #415 fix can red this e2e**, because the three normalization points (apply-site guard, client `build()` filter, server `from_params` filter) are deliberately redundant — any one layer alone stops the bug. Single-layer mutants are killed by their dedicated unit/blob/ingest pins (the #432 discrimination record). This e2e is the whole-stack backstop, so its honest mutant is the full three-layer revert — applied here, it reds with exactly the pre-fix signature:

```
the client's -w 0 sndbuf_actual (4608) collapsed toward the kernel clamp floor — 0 reached setsockopt (#415)
```

Verified single-layer mutants (apply-site guard dropped; `build()` filter dropped) leave the e2e green as expected, then reverted.

## Battery

fmt / clippy `-D warnings` / doc clean; full workspace suite 32/32 green binaries.
