### PR TITLE
fix: --cport increments per stream like GT; UDP honors --cport; stream dials fold to IESTREAMCONNECT (#428)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,9 @@ release tags.
   byte — 0xFF is the busy-server signal only), no "Accepted connection" block, and the
   unstamped `error - no error` line/doc string. A client receiving 0xFF reports iperf3's
   IEACCESSDENIED text; new lib variant `RiperfError::ServerBusy` (#395).
+- `--cport` binds `port + i` per stream like iperf3 (`-P 2` no longer dies on a source-port
+  collision; 65536 wraps to ephemeral), UDP honors `--cport` at all (was silently ephemeral),
+  and a failed data-stream dial reports iperf3's `unable to connect stream: …` class (#428).
 - `-w 0` is a no-op like iperf3 (0 = kernel autotuning): the window is never applied to
   data sockets — was clamping both buffers to kernel minimums, a live throughput hit — and
   the params blob omits the `"window"` key, so a `-w 0` client no longer shrinks a riperf3

--- a/riperf3-cli/tests/error_format.rs
+++ b/riperf3-cli/tests/error_format.rs
@@ -1830,3 +1830,76 @@ fn auth_param_valid_combos_pass_parse() {
         "the fully-configured auth server reaches its banner: {stdout:?}"
     );
 }
+
+/// #428: a data-stream dial failure is GT's IESTREAMCONNECT — "unable to
+/// connect stream: " + the errno text (stamped at both netdial sites,
+/// iperf_tcp.c:404 / iperf_udp.c:670-672), exit 1, same string in the -J
+/// error key (live-probed: a held port inside the `--cport + i` range →
+/// "unable to connect stream: Address already in use"). Pre-fix riperf3
+/// leaked the raw bind wrapper ("protocol violation: failed to bind local
+/// address …"). Prefix-only asserts: the errno rendering is
+/// platform-varied and the `(os error N)` suffix is the recorded
+/// deviation.
+#[test]
+fn stream_connect_failure_renders_gt_class() {
+    for json in [false, true] {
+        let sport = common::free_port().to_string();
+        let mut server = std::process::Command::new(env!("CARGO_BIN_EXE_riperf3"))
+            .args(["-s", "-1", "-p", &sport])
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .spawn()
+            .unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(400));
+        // Hold cport+1 so stream 2's bind collides deterministically.
+        let base = common::free_port();
+        let _holder = loop {
+            match std::net::TcpListener::bind(("0.0.0.0", base + 1)) {
+                Ok(l) => break l,
+                Err(_) => std::thread::sleep(std::time::Duration::from_millis(50)),
+            }
+        };
+        let cport = base.to_string();
+        let mut args = vec![
+            "-c",
+            "127.0.0.1",
+            "-p",
+            &sport,
+            "--cport",
+            &cport,
+            "-P",
+            "2",
+            "-t",
+            "1",
+        ];
+        if json {
+            args.push("-J");
+        }
+        let run = common::run_client(&args, std::time::Duration::from_secs(15), "collide client");
+        assert_eq!(
+            run.status.code(),
+            Some(1),
+            "IESTREAMCONNECT exits 1 like GT (json={json}): {err}",
+            err = run.stderr
+        );
+        if json {
+            let doc: serde_json::Value = serde_json::from_str(run.stdout.trim())
+                .unwrap_or_else(|e| panic!("one -J doc ({e}): {out}", out = run.stdout));
+            let msg = doc["error"].as_str().expect("error key");
+            assert!(
+                msg.starts_with("unable to connect stream: "),
+                "GT's IESTREAMCONNECT prefix in -J (#428): {doc}"
+            );
+        } else {
+            assert!(
+                run.stderr
+                    .contains("riperf3: error - unable to connect stream: "),
+                "GT's IESTREAMCONNECT text line (#428): {err}",
+                err = run.stderr
+            );
+        }
+        let _ = server.kill();
+        let _ = server.wait();
+    }
+}

--- a/riperf3-cli/tests/error_format.rs
+++ b/riperf3-cli/tests/error_format.rs
@@ -1853,12 +1853,25 @@ fn stream_connect_failure_renders_gt_class() {
             .unwrap();
         std::thread::sleep(std::time::Duration::from_millis(400));
         // Hold cport+1 so stream 2's bind collides deterministically.
-        let base = common::free_port();
-        let _holder = loop {
-            match std::net::TcpListener::bind(("0.0.0.0", base + 1)) {
-                Ok(l) => break l,
-                Err(_) => std::thread::sleep(std::time::Duration::from_millis(50)),
+        // r1 F2: the pair comes from its OWN window OUTSIDE free_port()'s
+        // 7000-32000 range — holding an in-window port for the test's
+        // lifetime steals a parallel test's probe-claimed port — and the
+        // hunt is bounded, not an unbounded spin.
+        let (base, _holder) = {
+            let window = 33000u16 + (std::process::id() % 60) as u16 * 40;
+            let mut found = None;
+            for slot in 0..20u16 {
+                let b = window + slot * 2;
+                let Ok(probe) = std::net::TcpListener::bind(("0.0.0.0", b)) else {
+                    continue;
+                };
+                drop(probe);
+                if let Ok(h) = std::net::TcpListener::bind(("0.0.0.0", b + 1)) {
+                    found = Some((b, h));
+                    break;
+                }
             }
+            found.expect("no free cport pair in the test window")
         };
         let cport = base.to_string();
         let mut args = vec![

--- a/riperf3/src/client.rs
+++ b/riperf3/src/client.rs
@@ -3315,10 +3315,12 @@ impl ClientBuilder {
     /// `--cport`: the local source port for the DATA streams — stream `i`
     /// binds `port + i` over creation order like iperf3
     /// (iperf_client_api.c:113-124; bidir's receive half follows the send
-    /// half, so a `-P n --bidir` run spans `port..port+2n`). Wraps at
-    /// 65536 to an ephemeral port (iperf3's htons truncation), and 0 is
-    /// iperf3's unset sentinel: no stream binds a fixed port (#428). The
-    /// CONTROL connection is always ephemeral, both tools.
+    /// half, so a `-P n --bidir` run spans `port..port+2n`). Wraps at the
+    /// 16-bit boundary like iperf3's htons truncation — exactly 65536
+    /// lands ephemeral, deeper wraps bind explicit low (typically
+    /// privileged) ports — and 0 is iperf3's unset sentinel: no stream
+    /// binds a fixed port (#428). The CONTROL connection is always
+    /// ephemeral, both tools.
     pub fn cport(mut self, port: u16) -> Self {
         self.cport = Some(port);
         self

--- a/riperf3/src/client.rs
+++ b/riperf3/src/client.rs
@@ -157,7 +157,6 @@ fn peer_half_summary(
     }
 }
 
-/// Bytes transferred so far against an `-n`/`-k` limit. Faithful to iperf3's
 /// #428: fold a DATA-stream dial failure into GT's `IESTREAMCONNECT`
 /// class — GT stamps it for the whole netdial (bind + connect alike,
 /// iperf_tcp.c:404 / iperf_udp.c:670-672), the same class the server side
@@ -181,9 +180,10 @@ fn stream_dial_error(e: RiperfError) -> RiperfError {
 /// #428: GT's per-stream source port — `bind_port + i` over creation order
 /// behind the `if (orig_bind_port)` ZERO-GATE (iperf_client_api.c:117): a
 /// cport of 0 NEVER increments (every stream ephemeral, GT's no-bind path
-/// → None here). A nonzero cport wraps like GT's htons truncation
-/// (65535 + 1 → int 65536, still truthy → explicit bind of port 0 =
-/// ephemeral), so the wrap result stays Some.
+/// → None here). A nonzero cport wraps like GT's htons truncation at the
+/// 16-bit boundary (65535 + 1 → int 65536, still truthy → explicit bind of
+/// port 0 = ephemeral; deeper wraps land on low explicit ports, both
+/// tools), so the wrap result stays Some.
 fn stream_cport(cport: Option<u16>, i: u32) -> Option<u16> {
     match cport {
         Some(0) => None,
@@ -192,6 +192,7 @@ fn stream_cport(cport: Option<u16>, i: u32) -> Option<u16> {
     }
 }
 
+/// Bytes transferred so far against an `-n`/`-k` limit. Faithful to iperf3's
 /// `bytes_sent >= N || bytes_received >= N` end check (`iperf_client_api.c`):
 /// the client's senders accumulate in forward, its receivers in reverse, and in
 /// bidir whichever direction reaches the limit first ends the test. Counting

--- a/riperf3/src/client.rs
+++ b/riperf3/src/client.rs
@@ -95,26 +95,6 @@ pub struct Client {
 /// subtract for the post-omit summary (#31) — this also reads a real iperf3
 /// server's omit results correctly. `is_udp` gates the datagram columns so a
 /// TCP pair line stays a plain byte line.
-/// #428: fold a DATA-stream dial failure into GT's `IESTREAMCONNECT`
-/// class — GT stamps it for the whole netdial (bind + connect alike,
-/// iperf_tcp.c:404 / iperf_udp.c:670-672), the same class the server side
-/// stamps on a setup accept() failure (the shared variant). The io
-/// rendering keeps the recorded `(os error N)` suffix; a local-bind
-/// failure keeps riperf3's bind-context message (recorded extra context vs
-/// GT's bare strerror); the timeout rendering matches the control-connect
-/// fold's recorded text.
-fn stream_dial_error(e: RiperfError) -> RiperfError {
-    let io = match e {
-        RiperfError::Io(io) => io,
-        RiperfError::ConnectionTimeout => {
-            std::io::Error::new(std::io::ErrorKind::TimedOut, "Connection timed out")
-        }
-        RiperfError::Protocol(msg) => std::io::Error::other(msg),
-        other => std::io::Error::other(other.to_string()),
-    };
-    RiperfError::StreamConnectFailed(io)
-}
-
 /// This host's own omitted count for a stream (#271): omitted SENT
 /// datagrams on sending streams, omitted RECEIVED datagrams on receiving
 /// ones — the local estimate the old-peer resolution nets with. 0 without
@@ -178,6 +158,40 @@ fn peer_half_summary(
 }
 
 /// Bytes transferred so far against an `-n`/`-k` limit. Faithful to iperf3's
+/// #428: fold a DATA-stream dial failure into GT's `IESTREAMCONNECT`
+/// class — GT stamps it for the whole netdial (bind + connect alike,
+/// iperf_tcp.c:404 / iperf_udp.c:670-672), the same class the server side
+/// stamps on a setup accept() failure (the shared variant). The io
+/// rendering keeps the recorded `(os error N)` suffix; a local-bind
+/// failure keeps riperf3's bind-context message (recorded extra context vs
+/// GT's bare strerror); the timeout rendering matches the control-connect
+/// fold's recorded text.
+fn stream_dial_error(e: RiperfError) -> RiperfError {
+    let io = match e {
+        RiperfError::Io(io) => io,
+        RiperfError::ConnectionTimeout => {
+            std::io::Error::new(std::io::ErrorKind::TimedOut, "Connection timed out")
+        }
+        RiperfError::Protocol(msg) => std::io::Error::other(msg),
+        other => std::io::Error::other(other.to_string()),
+    };
+    RiperfError::StreamConnectFailed(io)
+}
+
+/// #428: GT's per-stream source port — `bind_port + i` over creation order
+/// behind the `if (orig_bind_port)` ZERO-GATE (iperf_client_api.c:117): a
+/// cport of 0 NEVER increments (every stream ephemeral, GT's no-bind path
+/// → None here). A nonzero cport wraps like GT's htons truncation
+/// (65535 + 1 → int 65536, still truthy → explicit bind of port 0 =
+/// ephemeral), so the wrap result stays Some.
+fn stream_cport(cport: Option<u16>, i: u32) -> Option<u16> {
+    match cport {
+        Some(0) => None,
+        Some(p) => Some(p.wrapping_add(i as u16)),
+        None => None,
+    }
+}
+
 /// `bytes_sent >= N || bytes_received >= N` end check (`iperf_client_api.c`):
 /// the client's senders accumulate in forward, its receivers in reverse, and in
 /// bidir whichever direction reaches the limit first ends the test. Counting
@@ -1391,13 +1405,12 @@ impl Client {
                     // order (iperf_create_streams, iperf_client_api.c:113-124
                     // — the bidir receive half's `+ num_streams` collapses
                     // into the flat index because senders are created first,
-                    // both tools). wrapping_add mirrors GT's htons truncation
-                    // at 65536 → 0 = ephemeral (live-probed).
+                    // both tools). Zero-gate + wrap semantics on the helper.
                     let mut data_stream = net::tcp_connect(
                         &self.host,
                         self.port,
                         self.connect_timeout,
-                        self.cport.map(|p| p.wrapping_add(i as u16)),
+                        stream_cport(self.cport, i),
                         self.bind_address.as_deref(),
                         self.bind_dev.as_deref(),
                         self.mptcp,
@@ -1570,7 +1583,7 @@ impl Client {
                     // passed a literal 0 and --cport was a UDP no-op. The
                     // whole dial (bind/dev/connect) folds into GT's
                     // IESTREAMCONNECT like netdial's.
-                    let cport = self.cport.map_or(0, |p| p.wrapping_add(i as u16));
+                    let cport = stream_cport(self.cport, i).unwrap_or(0);
                     let udp_sock = net::udp_bind(bind_ip.as_deref(), cport, remote.is_ipv6())
                         .await
                         .map_err(stream_dial_error)?;
@@ -3298,7 +3311,13 @@ impl ClientBuilder {
         self
     }
 
-    /// `--cport`: bind to a specific local client port (default: ephemeral).
+    /// `--cport`: the local source port for the DATA streams — stream `i`
+    /// binds `port + i` over creation order like iperf3
+    /// (iperf_client_api.c:113-124; bidir's receive half follows the send
+    /// half, so a `-P n --bidir` run spans `port..port+2n`). Wraps at
+    /// 65536 to an ephemeral port (iperf3's htons truncation), and 0 is
+    /// iperf3's unset sentinel: no stream binds a fixed port (#428). The
+    /// CONTROL connection is always ephemeral, both tools.
     pub fn cport(mut self, port: u16) -> Self {
         self.cport = Some(port);
         self

--- a/riperf3/src/client.rs
+++ b/riperf3/src/client.rs
@@ -95,6 +95,26 @@ pub struct Client {
 /// subtract for the post-omit summary (#31) — this also reads a real iperf3
 /// server's omit results correctly. `is_udp` gates the datagram columns so a
 /// TCP pair line stays a plain byte line.
+/// #428: fold a DATA-stream dial failure into GT's `IESTREAMCONNECT`
+/// class — GT stamps it for the whole netdial (bind + connect alike,
+/// iperf_tcp.c:404 / iperf_udp.c:670-672), the same class the server side
+/// stamps on a setup accept() failure (the shared variant). The io
+/// rendering keeps the recorded `(os error N)` suffix; a local-bind
+/// failure keeps riperf3's bind-context message (recorded extra context vs
+/// GT's bare strerror); the timeout rendering matches the control-connect
+/// fold's recorded text.
+fn stream_dial_error(e: RiperfError) -> RiperfError {
+    let io = match e {
+        RiperfError::Io(io) => io,
+        RiperfError::ConnectionTimeout => {
+            std::io::Error::new(std::io::ErrorKind::TimedOut, "Connection timed out")
+        }
+        RiperfError::Protocol(msg) => std::io::Error::other(msg),
+        other => std::io::Error::other(other.to_string()),
+    };
+    RiperfError::StreamConnectFailed(io)
+}
+
 /// This host's own omitted count for a stream (#271): omitted SENT
 /// datagrams on sending streams, omitted RECEIVED datagrams on receiving
 /// ones — the local estimate the old-peer resolution nets with. 0 without
@@ -1367,17 +1387,24 @@ impl Client {
         match self.protocol {
             TransportProtocol::Tcp => {
                 for i in 0..total {
+                    // #428: GT binds `cport + i` per stream over creation
+                    // order (iperf_create_streams, iperf_client_api.c:113-124
+                    // — the bidir receive half's `+ num_streams` collapses
+                    // into the flat index because senders are created first,
+                    // both tools). wrapping_add mirrors GT's htons truncation
+                    // at 65536 → 0 = ephemeral (live-probed).
                     let mut data_stream = net::tcp_connect(
                         &self.host,
                         self.port,
                         self.connect_timeout,
-                        self.cport,
+                        self.cport.map(|p| p.wrapping_add(i as u16)),
                         self.bind_address.as_deref(),
                         self.bind_dev.as_deref(),
                         self.mptcp,
                         self.ip_version,
                     )
-                    .await?;
+                    .await
+                    .map_err(stream_dial_error)?;
                     protocol::send_cookie(&mut data_stream, cookie).await?;
                     net::configure_tcp_stream_full(
                         &data_stream,
@@ -1538,11 +1565,23 @@ impl Client {
                 // (iperf_udp.c:459-515), and the report echoes POST-probe.
                 let (mut gso_on, mut gro_on) = (self.gsro, self.gsro);
                 for i in 0..total {
-                    let udp_sock = net::udp_bind(bind_ip.as_deref(), 0, remote.is_ipv6()).await?;
+                    // #428: GT binds `cport + i` here too (netdial gets
+                    // test->bind_port, iperf_udp.c:670) — pre-fix riperf3
+                    // passed a literal 0 and --cport was a UDP no-op. The
+                    // whole dial (bind/dev/connect) folds into GT's
+                    // IESTREAMCONNECT like netdial's.
+                    let cport = self.cport.map_or(0, |p| p.wrapping_add(i as u16));
+                    let udp_sock = net::udp_bind(bind_ip.as_deref(), cport, remote.is_ipv6())
+                        .await
+                        .map_err(stream_dial_error)?;
                     if let Some(ref dev) = self.bind_dev {
-                        net::set_bind_dev(&udp_sock, dev, remote.is_ipv6())?;
+                        net::set_bind_dev(&udp_sock, dev, remote.is_ipv6())
+                            .map_err(stream_dial_error)?;
                     }
-                    udp_sock.connect(remote).await?;
+                    udp_sock
+                        .connect(remote)
+                        .await
+                        .map_err(|e| stream_dial_error(RiperfError::Io(e)))?;
                     protocol::udp_connect_client(&udp_sock).await?;
                     // #302: GT paces its UDP connect path too
                     // (iperf_udp.c:704-718); fq-qdisc dependent, warn-only.

--- a/riperf3/src/error.rs
+++ b/riperf3/src/error.rs
@@ -165,12 +165,17 @@ pub enum RiperfError {
     #[error("unable to accept connection from client: {0}")]
     AcceptFailed(std::io::Error),
 
-    /// iperf3's IESTREAMCONNECT(203): the SETUP data-stream accept()
-    /// failed (iperf_tcp.c:134-135) — GT's cleanup_server round-kill with
-    /// the fe+203+LIVE-errno wire-back and the populated setup doc (#362,
-    /// the PR #384 r2 F4 cell). The site-captured errno rides text and
-    /// wire (GT's TEXT surface prints the clobbered post-cleanup errno
-    /// but WIRES the live one — #387 r1 F2/F6).
+    /// iperf3's IESTREAMCONNECT(203), BOTH sides of the data plane. Server:
+    /// the SETUP data-stream accept() failed (iperf_tcp.c:134-135) — GT's
+    /// cleanup_server round-kill with the fe+203+LIVE-errno wire-back and
+    /// the populated setup doc (#362, the PR #384 r2 F4 cell). The
+    /// site-captured errno rides text and wire (GT's TEXT surface prints
+    /// the clobbered post-cleanup errno but WIRES the live one — #387 r1
+    /// F2/F6). Client (#428): a data-stream DIAL failed — GT stamps the
+    /// same class for the whole netdial (bind + connect alike,
+    /// iperf_tcp.c:404 / iperf_udp.c:670-672); a local-bind failure carries
+    /// riperf3's bind-context message (recorded extra context vs GT's bare
+    /// strerror). The CONTROL connect is the separate IECONNECT class.
     #[error("unable to connect stream: {0}")]
     StreamConnectFailed(std::io::Error),
 

--- a/riperf3/tests/integration.rs
+++ b/riperf3/tests/integration.rs
@@ -3067,7 +3067,9 @@ async fn params_blob_omits_window_zero_like_gt() {
 fn free_cport_base(span: u16) -> u16 {
     use std::sync::atomic::{AtomicU16, Ordering};
     static NEXT: AtomicU16 = AtomicU16::new(0);
-    let window = 36000 + (std::process::id() % 450) as u16 * 64;
+    // Window stride 512 covers the full claim range (64 claims × 8) so
+    // adjacent pid windows can't overlap (r2 F2).
+    let window = 36000 + (std::process::id() % 57) as u16 * 512;
     'outer: for _ in 0..64 {
         let base = window + NEXT.fetch_add(1, Ordering::Relaxed) % 64 * 8;
         let mut holds = Vec::new();

--- a/riperf3/tests/integration.rs
+++ b/riperf3/tests/integration.rs
@@ -3055,6 +3055,142 @@ async fn params_blob_omits_window_zero_like_gt() {
     );
 }
 
+/// #428 harness: find a base with `span` CONSECUTIVE free ports. NOT
+/// `free_port()`-derived: that allocator hands out consecutive values, so
+/// one test's `base + 1` is a parallel test's base (live collision in this
+/// very suite). Own pid-keyed window (36000+, clear of the #176 7000-32000
+/// windows) with a stride of 8 per claim, full-span bind-probed.
+fn free_cport_base(span: u16) -> u16 {
+    use std::sync::atomic::{AtomicU16, Ordering};
+    static NEXT: AtomicU16 = AtomicU16::new(0);
+    let window = 36000 + (std::process::id() % 450) as u16 * 64;
+    'outer: for _ in 0..64 {
+        let base = window + NEXT.fetch_add(1, Ordering::Relaxed) % 64 * 8;
+        let mut holds = Vec::new();
+        for off in 0..span {
+            let Some(p) = base.checked_add(off) else {
+                continue 'outer;
+            };
+            match std::net::TcpListener::bind(("0.0.0.0", p)) {
+                Ok(l) => holds.push(l),
+                Err(_) => continue 'outer,
+            }
+        }
+        drop(holds);
+        return base;
+    }
+    panic!("no {span}-wide free port range found");
+}
+
+/// #428 harness: one full round with `--cport`, returning the client
+/// report's `start.connected[i].local_port` in creation order. A CONCRETE
+/// server port because of #431 (the UDP data socket binds the CONFIGURED
+/// port).
+async fn run_round_cport_ports(cport: u16, streams: u32, bidir: bool, udp: bool) -> Vec<u16> {
+    let port = next_port();
+    let server = ServerBuilder::new()
+        .port(Some(port))
+        .emit_output(false)
+        .build()
+        .unwrap();
+    let bound = server.bind().await.expect("bind");
+    let server_task = tokio::spawn(async move { bound.run_once().await });
+    let mut builder = ClientBuilder::new("127.0.0.1")
+        .port(Some(port))
+        .duration(1)
+        .num_streams(streams)
+        .cport(cport)
+        .emit_output(false);
+    if bidir {
+        builder = builder.bidir(true);
+    }
+    if udp {
+        builder = builder.protocol(TransportProtocol::Udp);
+    }
+    let client = builder.build().unwrap();
+    let outcome = tokio::time::timeout(Duration::from_secs(20), client.run())
+        .await
+        .expect("client hung")
+        .expect("client run");
+    server_task.await.expect("join").expect("server run_once");
+    let v = serde_json::to_value(&outcome.report).unwrap();
+    v["start"]["connected"]
+        .as_array()
+        .expect("connected block")
+        .iter()
+        .map(|c| c["local_port"].as_u64().expect("local_port") as u16)
+        .collect()
+}
+
+/// #428: GT increments the bound source port per stream —
+/// `bind_port + i` over creation order (iperf_create_streams,
+/// iperf_client_api.c:113-124; live-probed fwd/rev: N, N+1). Pre-fix
+/// riperf3 reused the FIXED cport for every TCP stream, so `-P 2` died
+/// EADDRNOTAVAIL/EADDRINUSE on the second dial. The control connect stays
+/// EPHEMERAL on both tools (netdial's literal 0 + "using an ephemeral
+/// port" comment, iperf_client_api.c:437-439 — riperf3 passes None).
+#[tokio::test]
+async fn tcp_cport_increments_per_stream_like_gt() {
+    let base = free_cport_base(2);
+    let ports = run_round_cport_ports(base, 2, false, false).await;
+    assert_eq!(
+        ports,
+        vec![base, base + 1],
+        "TCP -P 2 --cport binds N, N+1 in creation order (#428)"
+    );
+}
+
+/// #428, bidir flavor: GT's receive half adds `+ num_streams`
+/// (iperf_client_api.c:119-121), and GT creates the send half first — so
+/// the mapping is still `cport + creation_index` over riperf3's flat
+/// sender-first loop. Live-probed: bidir -P 2 --cport N uses N..N+3 (the
+/// server saw all four).
+#[tokio::test]
+async fn tcp_bidir_cport_covers_both_halves_like_gt() {
+    let base = free_cport_base(4);
+    let ports = run_round_cport_ports(base, 2, true, false).await;
+    assert_eq!(
+        ports,
+        vec![base, base + 1, base + 2, base + 3],
+        "bidir -P 2 --cport binds N..N+3, senders first (#428)"
+    );
+}
+
+/// #428, the second bug: riperf3's UDP arm IGNORED `--cport` outright
+/// (udp_bind got a literal 0) — every UDP stream was ephemeral where GT
+/// binds N, N+1, … (netdial(test->bind_port), iperf_udp.c:670;
+/// live-probed).
+#[tokio::test]
+async fn udp_cport_increments_per_stream_like_gt() {
+    let base = free_cport_base(2);
+    let ports = run_round_cport_ports(base, 2, false, true).await;
+    assert_eq!(
+        ports,
+        vec![base, base + 1],
+        "UDP -P 2 --cport binds N, N+1 like GT (#428)"
+    );
+}
+
+/// #428, the wrap edge: GT's `bind_port + i` passes 65536 through
+/// getaddrinfo/htons where it truncates to 0 = EPHEMERAL (live-probed:
+/// `--cport 65535 -P 2` → stream 1 on 65535, stream 2 ephemeral, exit 0).
+/// riperf3 mirrors with `u16::wrapping_add` + the existing 0-is-ephemeral
+/// dial path. A saturating mutant re-collides on 65535 and reds here.
+#[tokio::test]
+async fn cport_65535_wraps_to_ephemeral_like_gt() {
+    if std::net::TcpListener::bind(("0.0.0.0", 65535)).is_err() {
+        eprintln!("SKIP: port 65535 busy in this environment");
+        return;
+    }
+    let ports = run_round_cport_ports(65535, 2, false, false).await;
+    assert_eq!(ports.len(), 2, "both streams connected");
+    assert_eq!(ports[0], 65535, "stream 1 keeps the requested port");
+    assert_ne!(
+        ports[1], 65535,
+        "stream 2 wrapped to ephemeral, not a re-collision (#428)"
+    );
+}
+
 /// #406 (r1): the `RecvMessageFailed`↔`SendFailed` cell of the same
 /// invisibility class — the repo's first RENDERING-IDENTICAL variant pair
 /// (both print `error - {msg}` with the carried message and both errexit

--- a/riperf3/tests/integration.rs
+++ b/riperf3/tests/integration.rs
@@ -3059,7 +3059,11 @@ async fn params_blob_omits_window_zero_like_gt() {
 /// `free_port()`-derived: that allocator hands out consecutive values, so
 /// one test's `base + 1` is a parallel test's base (live collision in this
 /// very suite). Own pid-keyed window (36000+, clear of the #176 7000-32000
-/// windows) with a stride of 8 per claim, full-span bind-probed.
+/// windows) with a stride of 8 per claim, full-span bind-probed. Recorded
+/// residual (r1 F5): the window sits inside Linux's default ephemeral
+/// range (32768-60999), so a kernel ephemeral allocation landing in a
+/// claimed span between probe-drop and bind can red an exact-equality pin
+/// (~0.01-0.1%/run); no port range is clear of every allocator.
 fn free_cport_base(span: u16) -> u16 {
     use std::sync::atomic::{AtomicU16, Ordering};
     static NEXT: AtomicU16 = AtomicU16::new(0);
@@ -3171,9 +3175,26 @@ async fn udp_cport_increments_per_stream_like_gt() {
     );
 }
 
+/// #428 r1 F1: GT's `if (orig_bind_port)` ZERO-GATE
+/// (iperf_client_api.c:117) — a cport of 0 never increments; every stream
+/// dials ephemeral (GT's no-bind path). Without the gate, stream 2 binds
+/// port 0+1 = 1: EACCES for a non-root run (the run errors and the length
+/// assert reds), a wrong explicit port under root (the != 1 assert reds).
+#[tokio::test]
+async fn cport_zero_never_increments() {
+    let ports = run_round_cport_ports(0, 2, false, false).await;
+    assert_eq!(ports.len(), 2, "both streams connected");
+    assert!(
+        ports.iter().all(|&p| p != 1),
+        "no stream lands on port 1 — GT's zero-gate (#428 r1): {ports:?}"
+    );
+}
+
 /// #428, the wrap edge: GT's `bind_port + i` passes 65536 through
 /// getaddrinfo/htons where it truncates to 0 = EPHEMERAL (live-probed:
-/// `--cport 65535 -P 2` → stream 1 on 65535, stream 2 ephemeral, exit 0).
+/// `--cport 65535 -P 2` → stream 1 on 65535, stream 2 ephemeral, exit 0;
+/// the int 65536 stays truthy through GT's zero-gate, so this is the
+/// EXPLICIT-bind-0 path, distinct from cport-0's no-bind path).
 /// riperf3 mirrors with `u16::wrapping_add` + the existing 0-is-ephemeral
 /// dial path. A saturating mutant re-collides on 65535 and reds here.
 #[tokio::test]


### PR DESCRIPTION
Fixes #428.

## The bugs (both live-probed, record on the issue)

1. **TCP**: every data stream dialed with the FIXED `--cport`, so `-P 2` died deterministically on the second stream's source-port collision. GT binds `cport + i` per stream (iperf_create_streams, iperf_client_api.c:113-124).
2. **UDP**: `--cport` was a complete no-op — the UDP arm passed a literal 0 to `udp_bind`, every stream ephemeral, where GT binds `cport + i` (netdial, iperf_udp.c:670).

## The mapping (GT source + live probes)

- Control connect: EPHEMERAL on both tools (`netdial(..., 0, ...)` + GT's literal "using an ephemeral port" comment; riperf3 already passed `None`).
- Data streams: `cport + creation_index` — GT's bidir receive-half `+ num_streams` offset collapses into the flat index because both tools create senders first (live-probed: fwd/rev = N, N+1; bidir P2 = N..N+3; UDP = N, N+1).
- Overflow: GT's 65536 truncates through htons to 0 = ephemeral (live-probed `--cport 65535 -P 2`); mirrored with `u16::wrapping_add` + the existing 0-is-ephemeral dial path.

## Error class

A failed data-stream dial now folds into the existing `RiperfError::StreamConnectFailed` — GT's IESTREAMCONNECT, which it stamps for the whole netdial on BOTH sides (the variant already covered the server's setup-accept side, #362). Probed collision cell: GT `unable to connect stream: Address already in use`, exit 1, same string in `-J` — riperf3 previously leaked the raw bind wrapper (`protocol violation: failed to bind local address …`). The `(os error N)` suffix and bind-context detail ride as recorded deviations.

## Pins & mutants

Five pins, red-proven pre-fix: TCP fwd P2 / bidir P2 / UDP P2 connected-block `local_port` mappings, the 65535 wrap cell (skips if 65535 is busy), and the held-port collision CLI cell (text + `-J`, exit 1, GT prefix). Four mutants (increment dropped, UDP revert to 0, saturating-instead-of-wrapping, fold dropped) each killed by a dedicated pin. The pin harness allocates cport bases from its own pid-keyed stride-8 window — `free_port()`'s consecutive values collide with multi-port spans under parallel tests (hit live during development).

Post-fix A/B: riperf3 client vs GT server, all four modes, port sequences identical.

## Battery

fmt / clippy `-D warnings` / doc clean; full workspace 32/32 green binaries.
