### PR TITLE
fix: params blob carries repeating_payload/dont_fragment/flowlabel; server honors repeating + DF like GT (#414)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,8 +58,9 @@ release tags.
   and a failed data-stream dial reports iperf3's `unable to connect stream: …` class (#428).
 - The client's params blob carries `repeating_payload` / `dont_fragment` / `flowlabel` like
   iperf3, and the server honors the first two on its send paths: reverse/bidir TCP payload
-  fills the repeating pattern, and UDP v4 egress sets DF (iperf3's gate — UDP+IPv4 only;
-  the TCP client no longer sets DF where iperf3 never did) (#414).
+  fills the repeating pattern — now iperf3's ASCII-digit fill; the previous 0x00..0xFF ramp
+  the client sent was a wire divergence — and UDP v4 egress sets DF (iperf3's gate —
+  UDP+IPv4 only; the TCP client no longer sets DF where iperf3 never did) (#414).
 - `-w 0` is a no-op like iperf3 (0 = kernel autotuning): the window is never applied to
   data sockets — was clamping both buffers to kernel minimums, a live throughput hit — and
   the params blob omits the `"window"` key, so a `-w 0` client no longer shrinks a riperf3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,10 @@ release tags.
 - `--cport` binds `port + i` per stream like iperf3 (`-P 2` no longer dies on a source-port
   collision; 65536 wraps to ephemeral), UDP honors `--cport` at all (was silently ephemeral),
   and a failed data-stream dial reports iperf3's `unable to connect stream: …` class (#428).
+- The client's params blob carries `repeating_payload` / `dont_fragment` / `flowlabel` like
+  iperf3, and the server honors the first two on its send paths: reverse/bidir TCP payload
+  fills the repeating pattern, and UDP v4 egress sets DF (iperf3's gate — UDP+IPv4 only;
+  the TCP client no longer sets DF where iperf3 never did) (#414).
 - `-w 0` is a no-op like iperf3 (0 = kernel autotuning): the window is never applied to
   data sockets — was clamping both buffers to kernel minimums, a live throughput hit — and
   the params blob omits the `"window"` key, so a `-w 0` client no longer shrinks a riperf3

--- a/riperf3/src/client.rs
+++ b/riperf3/src/client.rs
@@ -1306,8 +1306,9 @@ impl Client {
             p.tos = Some(self.tos);
         }
         // #414: GT sends all three when set (truthy gates,
-        // iperf_api.c:2475 flowlabel / :2489 repeating_payload, literal 1 /
-        // :2494 dont_fragment) — without them the peer server can't fill
+        // iperf_api.c:2475 flowlabel / :2489 repeating_payload — the
+        // field's value, 1 for every CLI-reachable state / :2494
+        // dont_fragment) — without them the peer server can't fill
         // the repeating pattern or set DF on ITS send paths. flowlabel
         // rides for wire parity although GT's SERVER never applies it
         // (client-connect-only, iperf_tcp.c:521 in iperf_tcp_connect;
@@ -1443,7 +1444,7 @@ impl Client {
                     )?;
                     // Apply socket options (no-ops on non-Linux).
                     // #414: NO DF here — GT's gate is UDP && AF_INET only
-                    // (iperf_new_stream, iperf_api.c:4964-4975); a TCP
+                    // (iperf_init_stream, iperf_api.c:4964-4975); a TCP
                     // --dont-fragment run leaves the socket untouched.
                     // #302: GT warns and continues on a pacing failure.
                     net::apply_fq_rate(&data_stream, self.fq_rate.unwrap_or(0));
@@ -4681,7 +4682,11 @@ mod tests {
                 .build()
                 .unwrap();
             let p = c.build_params(1460);
-            assert_eq!(p.repeating_payload, Some(1), "GT sends literal 1");
+            assert_eq!(
+                p.repeating_payload,
+                Some(1),
+                "GT sends the field's value, 1 from the CLI"
+            );
             assert_eq!(p.dont_fragment, Some(1));
             assert_eq!(p.flowlabel, Some(3));
 

--- a/riperf3/src/client.rs
+++ b/riperf3/src/client.rs
@@ -1305,6 +1305,20 @@ impl Client {
         if self.tos != 0 {
             p.tos = Some(self.tos);
         }
+        // #414: GT sends all three when set (truthy gates,
+        // iperf_api.c:2475 flowlabel / :2489 repeating_payload, literal 1 /
+        // :2494 dont_fragment) — without them the peer server can't fill
+        // the repeating pattern or set DF on ITS send paths. flowlabel
+        // rides for wire parity although GT's SERVER never applies it
+        // (client-connect-only, iperf_tcp.c:521 in iperf_tcp_connect;
+        // nothing in the accept path or iperf_udp.c).
+        p.flowlabel = self.flowlabel.filter(|&l| l != 0);
+        if self.repeating_payload {
+            p.repeating_payload = Some(1);
+        }
+        if self.dont_fragment {
+            p.dont_fragment = Some(1);
+        }
         p.congestion = self.congestion.clone();
         p.title = self.title.clone();
         p.extra_data = self.extra_data.clone();
@@ -1427,10 +1441,10 @@ impl Client {
                         self.window,
                         self.congestion.as_deref(),
                     )?;
-                    // Apply socket options (no-ops on non-Linux)
-                    if self.dont_fragment {
-                        net::set_dont_fragment(&data_stream)?;
-                    }
+                    // Apply socket options (no-ops on non-Linux).
+                    // #414: NO DF here — GT's gate is UDP && AF_INET only
+                    // (iperf_new_stream, iperf_api.c:4964-4975); a TCP
+                    // --dont-fragment run leaves the socket untouched.
                     // #302: GT warns and continues on a pacing failure.
                     net::apply_fq_rate(&data_stream, self.fq_rate.unwrap_or(0));
                     if let Some(ms) = self.rcv_timeout {
@@ -1651,6 +1665,7 @@ impl Client {
                         let pt = self.pacing_timer;
                         let bu = self.burst;
                         let uw = self.window.is_some();
+                        let df = self.dont_fragment;
                         let u64bit = self.udp_counters_64bit;
                         let use_sendmmsg = self.sendmmsg;
                         let st = start.clone();
@@ -1658,11 +1673,11 @@ impl Client {
                         thread_gate.spawn(move || {
                             if use_sendmmsg {
                                 stream::run_udp_sender_sendmmsg(
-                                    std_sock, c, bs, d, rate, pt, bu, uw, u64bit, st, md,
+                                    std_sock, c, bs, d, rate, pt, bu, uw, df, u64bit, st, md,
                                 )
                             } else {
                                 stream::run_udp_sender_blocking(
-                                    std_sock, c, bs, d, rate, pt, bu, uw, u64bit, st, md,
+                                    std_sock, c, bs, d, rate, pt, bu, uw, df, u64bit, st, md,
                                 )
                             }
                         })
@@ -4650,6 +4665,31 @@ mod tests {
                 .build()
                 .unwrap();
             assert_eq!(c.build_params(1460).bandwidth, Some(5_000_000));
+        }
+
+        /// #414: GT sends all three when set (truthy gates,
+        /// iperf_api.c:2475 flowlabel / :2489 repeating_payload (value 1) /
+        /// :2494 dont_fragment) and omits them otherwise. Pre-fix riperf3
+        /// never populated them — the peer server couldn't fill the
+        /// repeating pattern or set DF on ITS send paths.
+        #[test]
+        fn build_params_sends_the_414_trio_under_gt_gates() {
+            let c = ClientBuilder::new("h")
+                .repeating_payload(true)
+                .dont_fragment(true)
+                .flowlabel(3)
+                .build()
+                .unwrap();
+            let p = c.build_params(1460);
+            assert_eq!(p.repeating_payload, Some(1), "GT sends literal 1");
+            assert_eq!(p.dont_fragment, Some(1));
+            assert_eq!(p.flowlabel, Some(3));
+
+            let c = ClientBuilder::new("h").build().unwrap();
+            let p = c.build_params(1460);
+            assert_eq!(p.repeating_payload, None, "absent when unset, like GT");
+            assert_eq!(p.dont_fragment, None);
+            assert_eq!(p.flowlabel, None);
         }
 
         // #32: iperf3 ALWAYS sends pacing_timer in the param exchange (default

--- a/riperf3/src/net.rs
+++ b/riperf3/src/net.rs
@@ -605,10 +605,20 @@ const UDP_SEND_TIMEOUT_MS: u64 = 1000;
 pub fn configure_udp_sender(
     socket: &std::net::UdpSocket,
     sndbuf_target: Option<usize>,
+    dont_fragment: bool,
 ) -> Result<()> {
     use nix::sys::socket::{self, sockopt};
     use nix::sys::time::TimeVal;
     socket.set_nonblocking(false)?;
+    // #414: GT's DF gate — iperf_new_stream sets IP-level DF only for
+    // UDP && AF_INET (iperf_api.c:4964-4975), both roles; v6 and TCP never.
+    // Applied at this egress choke point so every UDP sender (client,
+    // server recycling, server demux) carries it. (GT also stamps its
+    // RECEIVING UDP sockets — invisible on the wire, receivers don't send
+    // post-handshake — deliberately not mirrored.)
+    if dont_fragment && socket.local_addr().map(|a| a.is_ipv4()).unwrap_or(false) {
+        set_dont_fragment(socket)?;
+    }
     let sock = socket2::SockRef::from(socket);
     // GROW-ONLY, and not at all under an explicit -w (#163; callers pass
     // None then): iperf3 never sets UDP SO_SNDBUF except for -w. The
@@ -645,8 +655,13 @@ pub fn configure_udp_sender(
 pub fn configure_udp_sender(
     socket: &std::net::UdpSocket,
     _sndbuf_target: Option<usize>,
+    dont_fragment: bool,
 ) -> Result<()> {
     socket.set_nonblocking(false)?;
+    // #414: same GT gate as the unix variant — UDP && AF_INET only.
+    if dont_fragment && socket.local_addr().map(|a| a.is_ipv4()).unwrap_or(false) {
+        set_dont_fragment(socket)?;
+    }
     Ok(())
 }
 
@@ -1192,7 +1207,7 @@ mod tests {
         let s = std::net::UdpSocket::bind("127.0.0.1:0").unwrap();
         let sock = socket2::SockRef::from(&s);
         let default_buf = sock.send_buffer_size().unwrap();
-        configure_udp_sender(&s, Some(4096)).unwrap();
+        configure_udp_sender(&s, Some(4096), false).unwrap();
         assert!(
             sock.send_buffer_size().unwrap() >= default_buf,
             "a small batch target must not shrink the send buffer below the default"
@@ -1212,7 +1227,7 @@ mod tests {
         let sock = socket2::SockRef::from(&s);
         let _ = sock.set_send_buffer_size(64 * 1024);
         let before = sock.send_buffer_size().unwrap();
-        configure_udp_sender(&s, None).unwrap();
+        configure_udp_sender(&s, None, false).unwrap();
         assert_eq!(
             sock.send_buffer_size().unwrap(),
             before,
@@ -1240,7 +1255,7 @@ mod tests {
         let sock = socket2::SockRef::from(&s);
         let _ = sock.set_send_buffer_size(1024 * 1024);
         let bumped = sock.send_buffer_size().unwrap();
-        configure_udp_sender(&s, Some(11_584)).unwrap();
+        configure_udp_sender(&s, Some(11_584), false).unwrap();
         assert!(
             sock.send_buffer_size().unwrap() >= bumped,
             "-w's bump must not be clobbered down to batch x blksize"
@@ -1814,6 +1829,49 @@ mod tests {
         );
     }
 
+    /// #414: the DF gate at the UDP egress choke point — GT's
+    /// iperf_new_stream sets IP-level DF only for UDP && AF_INET
+    /// (iperf_api.c:4964-4975). Real-socket readback: IP_MTU_DISCOVER
+    /// lands PMTUDISC_DO on a v4 socket with the flag, stays default
+    /// without it, and a v6 socket passes through untouched (no error).
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn configure_udp_sender_applies_gt_df_gate() {
+        use std::os::fd::AsRawFd;
+        fn mtu_discover(s: &std::net::UdpSocket) -> libc::c_int {
+            let mut v: libc::c_int = -1;
+            let mut l = std::mem::size_of::<libc::c_int>() as libc::socklen_t;
+            let rc = unsafe {
+                libc::getsockopt(
+                    s.as_raw_fd(),
+                    libc::IPPROTO_IP,
+                    libc::IP_MTU_DISCOVER,
+                    std::ptr::from_mut(&mut v).cast(),
+                    &mut l,
+                )
+            };
+            assert_eq!(rc, 0, "getsockopt IP_MTU_DISCOVER");
+            v
+        }
+        let s = std::net::UdpSocket::bind("127.0.0.1:0").unwrap();
+        configure_udp_sender(&s, None, true).unwrap();
+        assert_eq!(
+            mtu_discover(&s),
+            libc::IP_PMTUDISC_DO,
+            "v4 + flag sets DF like GT"
+        );
+        let s = std::net::UdpSocket::bind("127.0.0.1:0").unwrap();
+        configure_udp_sender(&s, None, false).unwrap();
+        assert_ne!(
+            mtu_discover(&s),
+            libc::IP_PMTUDISC_DO,
+            "no flag leaves the socket at the kernel default"
+        );
+        let s6 = std::net::UdpSocket::bind("[::1]:0").unwrap();
+        configure_udp_sender(&s6, None, true)
+            .expect("v6 + flag is a clean no-op, GT's AF_INET gate");
+    }
+
     #[cfg(unix)]
     #[test]
     fn configure_udp_sender_switches_to_blocking() {
@@ -1828,7 +1886,7 @@ mod tests {
             "precondition: socket starts non-blocking"
         );
 
-        configure_udp_sender(&socket, Some(128 * 1460)).unwrap();
+        configure_udp_sender(&socket, Some(128 * 1460), false).unwrap();
         assert!(
             !is_nonblocking(socket.as_raw_fd()),
             "sender socket must be switched to blocking"
@@ -1843,7 +1901,7 @@ mod tests {
         // is a no-op on UDP and would leave the timeout unset (#6 review).
         use nix::sys::socket::{getsockopt, sockopt};
         let socket = std::net::UdpSocket::bind("127.0.0.1:0").unwrap();
-        configure_udp_sender(&socket, Some(128 * 1460)).unwrap();
+        configure_udp_sender(&socket, Some(128 * 1460), false).unwrap();
         let tv = getsockopt(&socket, sockopt::SendTimeout).unwrap();
         assert!(
             tv.tv_sec() > 0 || tv.tv_usec() > 0,

--- a/riperf3/src/net.rs
+++ b/riperf3/src/net.rs
@@ -610,7 +610,7 @@ pub fn configure_udp_sender(
     use nix::sys::socket::{self, sockopt};
     use nix::sys::time::TimeVal;
     socket.set_nonblocking(false)?;
-    // #414: GT's DF gate — iperf_new_stream sets IP-level DF only for
+    // #414: GT's DF gate — iperf_init_stream sets IP-level DF only for
     // UDP && AF_INET (iperf_api.c:4964-4975), both roles; v6 and TCP never.
     // Applied at this egress choke point so every UDP sender (client,
     // server recycling, server demux) carries it. (GT also stamps its
@@ -1830,7 +1830,7 @@ mod tests {
     }
 
     /// #414: the DF gate at the UDP egress choke point — GT's
-    /// iperf_new_stream sets IP-level DF only for UDP && AF_INET
+    /// iperf_init_stream sets IP-level DF only for UDP && AF_INET
     /// (iperf_api.c:4964-4975). Real-socket readback: IP_MTU_DISCOVER
     /// lands PMTUDISC_DO on a v4 socket with the flag, stays default
     /// without it, and a v6 socket passes through untouched (no error).

--- a/riperf3/src/net.rs
+++ b/riperf3/src/net.rs
@@ -1870,6 +1870,13 @@ mod tests {
         let s6 = std::net::UdpSocket::bind("[::1]:0").unwrap();
         configure_udp_sender(&s6, None, true)
             .expect("v6 + flag is a clean no-op, GT's AF_INET gate");
+        // The kernel accepts IP-level opts on v6 sockets, so no-error alone
+        // can't prove the gate skipped — read the option back.
+        assert_ne!(
+            mtu_discover(&s6),
+            libc::IP_PMTUDISC_DO,
+            "the v4-only gate must not stamp a v6 socket"
+        );
     }
 
     #[cfg(unix)]

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -38,12 +38,13 @@ pub(crate) struct TestConfig {
     pub tos: i32,
     pub congestion: Option<String>,
     pub udp_counters_64bit: bool,
-    /// #414: the client asked for the repeating 0x00..0xFF payload — GT
-    /// fills it in iperf_new_stream on BOTH roles (iperf_api.c:4891), so
-    /// the server's reverse/bidir senders honor it too. PRESENCE-triggered
-    /// on the wire (GT sets 1 whatever the value, iperf_api.c:2645-2646).
+    /// #414: the client asked for the repeating payload (GT's ASCII
+    /// '0'..'9' pattern, iperf_util.c:85-99) — GT fills it in
+    /// iperf_new_stream on BOTH roles (iperf_api.c:4891), so the server's
+    /// reverse/bidir senders honor it too. PRESENCE-triggered on the wire
+    /// (GT sets 1 whatever the value, iperf_api.c:2645-2646).
     pub repeating_payload: bool,
-    /// #414: the client's --dont-fragment — GT sets DF in iperf_new_stream
+    /// #414: the client's --dont-fragment — GT sets DF in iperf_init_stream
     /// on BOTH roles, gated UDP && AF_INET (iperf_api.c:4964-4975), so the
     /// server's UDP v4 data sockets carry it on server-sent datagrams.
     /// (The wire `flowlabel` key is deliberately NOT plumbed here: GT's

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -38,6 +38,18 @@ pub(crate) struct TestConfig {
     pub tos: i32,
     pub congestion: Option<String>,
     pub udp_counters_64bit: bool,
+    /// #414: the client asked for the repeating 0x00..0xFF payload — GT
+    /// fills it in iperf_new_stream on BOTH roles (iperf_api.c:4891), so
+    /// the server's reverse/bidir senders honor it too. PRESENCE-triggered
+    /// on the wire (GT sets 1 whatever the value, iperf_api.c:2645-2646).
+    pub repeating_payload: bool,
+    /// #414: the client's --dont-fragment — GT sets DF in iperf_new_stream
+    /// on BOTH roles, gated UDP && AF_INET (iperf_api.c:4964-4975), so the
+    /// server's UDP v4 data sockets carry it on server-sent datagrams.
+    /// (The wire `flowlabel` key is deliberately NOT plumbed here: GT's
+    /// server ingests it but never applies it to any socket — the only
+    /// apply site is the client's iperf_tcp_connect, iperf_tcp.c:521.)
+    pub dont_fragment: bool,
 }
 
 /// GT's IECTRLCLOSE read-site sentence (iperf_server_api.c:249-254,
@@ -200,6 +212,8 @@ impl TestConfig {
             tos: params.tos.unwrap_or(0),
             congestion: params.congestion.clone(),
             udp_counters_64bit: params.udp_counters_64bit.unwrap_or(0) != 0,
+            repeating_payload: params.repeating_payload.is_some(),
+            dont_fragment: params.dont_fragment.unwrap_or(0) != 0,
         })
     }
 }
@@ -1918,7 +1932,10 @@ impl Server {
                     let congestion_used = net::tcp_congestion_used(&data_stream);
 
                     let task = if is_sender {
-                        let buf = make_send_buffer(ctx.cfg.blksize, false);
+                        // #414: honor the client's wire repeating_payload —
+                        // GT fills the pattern in iperf_new_stream on BOTH
+                        // roles (iperf_api.c:4891).
+                        let buf = make_send_buffer(ctx.cfg.blksize, ctx.cfg.repeating_payload);
                         let c = counters.clone();
                         let d = ctx.done.clone();
                         // `-b` paces the sender in reverse/bidir too (negotiated
@@ -3158,11 +3175,12 @@ impl Server {
                 let u64bit = udp_counters_64bit;
                 let bu = burst;
                 let uw = window.is_some();
+                let df = ctx.cfg.dont_fragment;
                 let st = ctx.start.clone();
                 let md = max_duration;
                 let task = thread_gate.spawn(move || {
                     stream::run_udp_sender_blocking(
-                        std_sock, c, bs, d, rate, pt, bu, uw, u64bit, st, md,
+                        std_sock, c, bs, d, rate, pt, bu, uw, df, u64bit, st, md,
                     )
                 });
                 // #381 (#427 r1 F3): a running spawn_blocking task ignores
@@ -3452,6 +3470,7 @@ impl Server {
                 let d = ctx.done.clone();
                 let bu = burst;
                 let uw = window.is_some();
+                let df = ctx.cfg.dont_fragment;
                 let st = ctx.start.clone();
                 let md = max_duration;
                 let task = thread_gate.spawn(move || {
@@ -3465,6 +3484,7 @@ impl Server {
                         pt,
                         bu,
                         uw,
+                        df,
                         u64bit,
                         st,
                         md,
@@ -4640,6 +4660,33 @@ mod tests {
     /// #316: the server adopts the client's exchanged GSO/GRO request
     /// (GT iperf_api.c:2599-2619), including the zero-dg_size recompute
     /// from the negotiated blksize (:2607-2613).
+    /// #414: the wire trio's ingest semantics, per GT's get_parameters.
+    #[test]
+    fn from_params_ingests_the_414_trio_like_gt() {
+        // repeating_payload is PRESENCE-triggered (GT sets 1 whatever the
+        // value, iperf_api.c:2645-2646); dont_fragment takes the value
+        // truthily (:2650-2651).
+        let set = crate::protocol::TestParams {
+            repeating_payload: Some(0), // presence wins — GT ignores the value
+            dont_fragment: Some(1),
+            ..Default::default()
+        };
+        let cfg = TestConfig::from_params(&set).unwrap();
+        assert!(cfg.repeating_payload, "presence-triggered like GT");
+        assert!(cfg.dont_fragment);
+
+        let unset = crate::protocol::TestParams::default();
+        let cfg = TestConfig::from_params(&unset).unwrap();
+        assert!(!cfg.repeating_payload);
+        assert!(!cfg.dont_fragment);
+
+        let df_zero = crate::protocol::TestParams {
+            dont_fragment: Some(0), // falsy value → off, GT truthiness
+            ..Default::default()
+        };
+        assert!(!TestConfig::from_params(&df_zero).unwrap().dont_fragment);
+    }
+
     /// #415 (r1 F1): a wire `"window": 0` ingests as UNSET — GT's
     /// socket_bufsize 0 is the unset sentinel in EVERY consumer, including
     /// the UDP auto-increase arm (iperf_udp.c:563/:691, the GT analogue of

--- a/riperf3/src/stream.rs
+++ b/riperf3/src/stream.rs
@@ -1264,6 +1264,7 @@ pub fn run_udp_sender_sendmmsg(
     pacing_timer_us: u32,
     burst: u32,
     user_window: bool,
+    dont_fragment: bool,
     use_64bit: bool,
     start: Arc<AtomicBool>,
     max_duration: Option<Duration>,
@@ -1300,7 +1301,11 @@ pub fn run_udp_sender_sendmmsg(
     // batch and bound a wedged link with SO_SNDTIMEO (issue #6).
     // None under an explicit -w: iperf3 applies the user's window and never
     // a batch-derived size (#163 review r1 n1).
-    crate::net::configure_udp_sender(&socket, (!user_window).then_some(batch_size * blksize))?;
+    crate::net::configure_udp_sender(
+        &socket,
+        (!user_window).then_some(batch_size * blksize),
+        dont_fragment,
+    )?;
 
     let fd = socket.as_raw_fd();
 
@@ -1404,6 +1409,7 @@ pub fn run_udp_sender_sendmmsg(
     pacing_timer_us: u32,
     burst: u32,
     user_window: bool,
+    dont_fragment: bool,
     use_64bit: bool,
     start: Arc<AtomicBool>,
     max_duration: Option<Duration>,
@@ -1417,6 +1423,7 @@ pub fn run_udp_sender_sendmmsg(
         pacing_timer_us,
         burst,
         user_window,
+        dont_fragment,
         use_64bit,
         start,
         max_duration,
@@ -1522,6 +1529,7 @@ fn udp_send_loop(
     pacing_timer_us: u32,
     burst: u32,
     user_window: bool,
+    dont_fragment: bool,
     use_64bit: bool,
     start: Arc<AtomicBool>,
     max_duration: Option<Duration>,
@@ -1547,6 +1555,7 @@ fn udp_send_loop(
     crate::net::configure_udp_sender(
         socket,
         (!user_window).then_some(batch_size as usize * blksize),
+        dont_fragment,
     )?;
 
     let pacing = if rate_bits_per_sec > 0 {
@@ -1642,6 +1651,7 @@ pub fn run_udp_sender_blocking(
     pacing_timer_us: u32,
     burst: u32,
     user_window: bool,
+    dont_fragment: bool,
     use_64bit: bool,
     start: Arc<AtomicBool>,
     max_duration: Option<Duration>,
@@ -1656,6 +1666,7 @@ pub fn run_udp_sender_blocking(
         pacing_timer_us,
         burst,
         user_window,
+        dont_fragment,
         use_64bit,
         start,
         max_duration,
@@ -1678,6 +1689,7 @@ pub(crate) fn run_udp_server_demux_sender(
     pacing_timer_us: u32,
     burst: u32,
     user_window: bool,
+    dont_fragment: bool,
     use_64bit: bool,
     start: Arc<AtomicBool>,
     max_duration: Option<Duration>,
@@ -1692,6 +1704,7 @@ pub(crate) fn run_udp_server_demux_sender(
         pacing_timer_us,
         burst,
         user_window,
+        dont_fragment,
         use_64bit,
         start,
         max_duration,
@@ -2668,6 +2681,7 @@ mod tests {
                 1000,
                 false,
                 false,
+                false,
                 started(),
                 None,
             )
@@ -2826,6 +2840,7 @@ mod tests {
             0,
             false,
             false,
+            false,
             started(),
             Some(Duration::from_millis(200)),
         )
@@ -2868,6 +2883,7 @@ mod tests {
             100_000_000, // rate>0 → batched (batch_size > 1)
             1000,
             0,
+            false,
             false,
             false,
             started(),
@@ -2923,6 +2939,7 @@ mod tests {
             0,
             false,
             false,
+            false,
             started(),
             Some(Duration::from_millis(150)),
         )
@@ -2955,6 +2972,7 @@ mod tests {
             0,
             false,
             false,
+            false,
             started(),
             Some(Duration::from_millis(200)),
         )
@@ -2985,6 +3003,7 @@ mod tests {
             0,
             1000,
             0,
+            false,
             false,
             false,
             started(),
@@ -3021,6 +3040,7 @@ mod tests {
             0, // unlimited → full batch ceiling
             1000,
             0,
+            false,
             false,
             false,
             started(),
@@ -3066,6 +3086,7 @@ mod tests {
             0,
             false,
             false,
+            false,
             started(),
             None,
         )
@@ -3097,6 +3118,7 @@ mod tests {
                 0,
                 1000,
                 0,
+                false,
                 false,
                 false,
                 s2,
@@ -3142,6 +3164,7 @@ mod tests {
             0,
             false,
             false,
+            false,
             start,
             Some(Duration::from_secs(10)),
         )
@@ -3172,6 +3195,7 @@ mod tests {
                 0,
                 1000,
                 0,
+                false,
                 false,
                 false,
                 s,

--- a/riperf3/src/utils.rs
+++ b/riperf3/src/utils.rs
@@ -114,11 +114,15 @@ pub fn parse_keepalive(s: &str) -> (Option<u32>, Option<u32>, Option<u32>) {
 }
 
 /// Create a send buffer of `size` bytes.
-/// If `repeating_payload` is true, fills with a repeating 0x00..0xFF pattern (like iperf2).
-/// Otherwise returns a zero-filled buffer.
+/// If `repeating_payload` is true, fills with GT's repeating pattern —
+/// ASCII digits `'0'..'9'`, period 10 (`fill_with_repeating_pattern`,
+/// iperf_util.c:85-99; #441 r1 fixed the old 0x00..0xFF ramp, which was a
+/// wire-payload divergence live-probed against a real GT reverse round).
+/// Otherwise returns a zero-filled buffer (the zeros-vs-GT-entropy
+/// deviation is tracked in #440).
 pub fn make_send_buffer(size: usize, repeating_payload: bool) -> Vec<u8> {
     if repeating_payload {
-        (0..size).map(|i| (i % 256) as u8).collect()
+        (0..size).map(|i| b'0' + (i % 10) as u8).collect()
     } else {
         vec![0u8; size]
     }
@@ -490,13 +494,14 @@ mod tests {
 
     // -- make_send_buffer edge cases --
 
+    /// GT's pattern: ASCII '0'..'9' with period 10 from offset 0
+    /// (fill_with_repeating_pattern, iperf_util.c:85-99) — live-probed
+    /// byte-for-byte against a GT 3.21 reverse round (#441 r1).
     #[test]
-    fn make_send_buffer_wraps_at_256() {
-        let buf = make_send_buffer(512, true);
-        assert_eq!(buf[0], 0);
-        assert_eq!(buf[255], 255);
-        assert_eq!(buf[256], 0); // wraps
-        assert_eq!(buf[511], 255);
+    fn make_send_buffer_matches_gt_digit_pattern() {
+        let buf = make_send_buffer(25, true);
+        assert_eq!(&buf[..12], b"012345678901");
+        assert_eq!(buf[24], b'4');
     }
 }
 
@@ -654,9 +659,9 @@ mod implemented_flag_unit_tests {
     fn repeating_payload_buffer() {
         let buf = crate::utils::make_send_buffer(256, true);
         assert_eq!(buf.len(), 256);
-        assert_eq!(buf[0], 0);
-        assert_eq!(buf[1], 1);
-        assert_eq!(buf[255], 255);
+        assert_eq!(buf[0], b'0');
+        assert_eq!(buf[1], b'1');
+        assert_eq!(buf[255], b'5'); // 255 % 10
 
         let zeros = crate::utils::make_send_buffer(256, false);
         assert!(zeros.iter().all(|&b| b == 0));

--- a/riperf3/tests/integration.rs
+++ b/riperf3/tests/integration.rs
@@ -3214,6 +3214,61 @@ async fn cport_65535_wraps_to_ephemeral_like_gt() {
     );
 }
 
+/// #414 (server half): GT fills the repeating 0x00..0xFF pattern in
+/// iperf_new_stream on BOTH roles (iperf_api.c:4891), so a server whose
+/// client sent `"repeating_payload"` sends the pattern in reverse. The
+/// riperf3 server hardcoded `make_send_buffer(blksize, false)` (zeros),
+/// ignoring the wire key entirely. A raw mock client drives a reverse
+/// round and reads the server's first block off the data socket: it must
+/// be the repeating pattern, byte-for-byte.
+#[tokio::test]
+async fn reverse_server_honors_repeating_payload_key() {
+    let server = ServerBuilder::new()
+        .port(Some(0))
+        .emit_output(false)
+        .build()
+        .unwrap();
+    let bound = server.bind().await.expect("bind");
+    let port = bound.local_addr().unwrap().port();
+    let server_task = tokio::spawn(async move { bound.run_once().await });
+
+    let first_block = tokio::task::spawn_blocking(move || {
+        use std::io::{Read, Write};
+        let rd1 = |s: &mut std::net::TcpStream| {
+            let mut b = [0u8; 1];
+            s.read_exact(&mut b).expect("state byte");
+            b[0]
+        };
+        let cookie = [b'x'; 37];
+        let mut ctrl = std::net::TcpStream::connect(("127.0.0.1", port)).expect("ctrl");
+        ctrl.write_all(&cookie).unwrap();
+        assert_eq!(rd1(&mut ctrl), 9, "ParamExchange");
+        let p =
+            r#"{"tcp":true,"reverse":true,"time":1,"parallel":1,"len":4096,"repeating_payload":1}"#;
+        ctrl.write_all(&(p.len() as u32).to_be_bytes()).unwrap();
+        ctrl.write_all(p.as_bytes()).unwrap();
+        assert_eq!(rd1(&mut ctrl), 10, "CreateStreams");
+        let mut data = std::net::TcpStream::connect(("127.0.0.1", port)).expect("data");
+        data.write_all(&cookie).unwrap();
+        assert_eq!(rd1(&mut ctrl), 1, "TestStart");
+        assert_eq!(rd1(&mut ctrl), 2, "TestRunning");
+        let mut block = vec![0u8; 4096];
+        data.read_exact(&mut block).expect("first server block");
+        // The round ends unceremoniously — the payload is the pin.
+        drop((ctrl, data));
+        block
+    })
+    .await
+    .expect("mock");
+    let _ = tokio::time::timeout(Duration::from_secs(15), server_task).await;
+
+    let want: Vec<u8> = (0..4096usize).map(|i| (i % 256) as u8).collect();
+    assert_eq!(
+        first_block, want,
+        "the server's reverse payload is the repeating pattern when the wire key rode (#414)"
+    );
+}
+
 /// #406 (r1): the `RecvMessageFailed`↔`SendFailed` cell of the same
 /// invisibility class — the repo's first RENDERING-IDENTICAL variant pair
 /// (both print `error - {msg}` with the carried message and both errexit

--- a/riperf3/tests/integration.rs
+++ b/riperf3/tests/integration.rs
@@ -3214,13 +3214,15 @@ async fn cport_65535_wraps_to_ephemeral_like_gt() {
     );
 }
 
-/// #414 (server half): GT fills the repeating 0x00..0xFF pattern in
+/// #414 (server half): GT fills the repeating pattern — ASCII '0'..'9',
+/// period 10 (fill_with_repeating_pattern, iperf_util.c:85-99) — in
 /// iperf_new_stream on BOTH roles (iperf_api.c:4891), so a server whose
-/// client sent `"repeating_payload"` sends the pattern in reverse. The
-/// riperf3 server hardcoded `make_send_buffer(blksize, false)` (zeros),
-/// ignoring the wire key entirely. A raw mock client drives a reverse
-/// round and reads the server's first block off the data socket: it must
-/// be the repeating pattern, byte-for-byte.
+/// client sent `"repeating_payload"` sends the pattern in reverse
+/// (live-probed against GT 3.21, #441 r1). The riperf3 server hardcoded
+/// `make_send_buffer(blksize, false)` (zeros), ignoring the wire key
+/// entirely. A raw mock client drives a reverse round and reads the
+/// server's first block off the data socket: it must be GT's pattern,
+/// byte-for-byte.
 #[tokio::test]
 async fn reverse_server_honors_repeating_payload_key() {
     let server = ServerBuilder::new()
@@ -3262,7 +3264,7 @@ async fn reverse_server_honors_repeating_payload_key() {
     .expect("mock");
     let _ = tokio::time::timeout(Duration::from_secs(15), server_task).await;
 
-    let want: Vec<u8> = (0..4096usize).map(|i| (i % 256) as u8).collect();
+    let want: Vec<u8> = (0..4096usize).map(|i| b'0' + (i % 10) as u8).collect();
     assert_eq!(
         first_block, want,
         "the server's reverse payload is the repeating pattern when the wire key rode (#414)"


### PR DESCRIPTION
Fixes #414.

## The gaps (probe/source record on the issue)

1. **Wire**: the client never sent `repeating_payload` / `dont_fragment` / `flowlabel` — GT emits all three when set (truthy gates, iperf_api.c:2475/:2489/:2494), so a riperf3 client's peer server never learned them. `TestParams` already had the fields in GT's positions (#378/#413); they were just never populated.
2. **Server repeating**: GT fills the repeating pattern in `iperf_new_stream` on BOTH roles (iperf_api.c:4891); riperf3's server sender hardcoded `make_send_buffer(blksize, false)` — reverse/bidir payload was zeros even when the client asked.
3. **DF gate, everywhere**: GT's gate is `UDP && AF_INET`, both roles (iperf_api.c:4964-4975). riperf3 had it inverted: the TCP client applied DF (GT never does), the UDP client didn't, and the server never did. Now applied at the one UDP-egress choke point (`configure_udp_sender`, threaded to all four sender paths: client sendmmsg/blocking, server recycling/demux) and removed from the TCP client.
4. **flowlabel**: wire + ingest only, deliberately — GT's server ingests the key but never applies it to any socket (the only apply site is the client's `iperf_tcp_connect`, iperf_tcp.c:521; nothing in the accept path or iperf_udp.c). Recorded in the cfg rustdoc.

Ingest semantics mirror GT's `get_parameters`: `repeating_payload` is PRESENCE-triggered (value ignored, :2645-2646), `dont_fragment` value-truthy.

## Pins & mutants

Four pins red-proven (build_params trio gates; from_params ingest incl. the presence-trigger and value-0 cells; a raw-mock reverse round asserting the server's first data block IS the repeating pattern byte-for-byte; the DF gate on real sockets with IP_MTU_DISCOVER readback — v4+flag→PMTUDISC_DO, no-flag→default, v6+flag→untouched). Five mutants killed (trio dropped, ingest dropped, buffer reverted, gate no-op'd, family-gate dropped — the last needed the v6 READBACK leg: the kernel accepts IP-level opts on v6 sockets, so no-error alone couldn't discriminate).

A/B on the wire: both tools' params blobs carry identical trio key sets and values across `--repeating-payload --dont-fragment -u`, `-6 -L 42`, and bare runs (mock-server capture).

Known non-mirrors, disclosed: the call-site *threading* of the DF flag (which spawn passes what) is covered by review + the choke-point pin, not per-site mutants; GT also stamps DF on its RECEIVING UDP sockets (wire-invisible — receivers don't send post-handshake) — deliberately not mirrored, noted at the gate. Follow-up filed: #440 (UDP senders ignore repeating_payload both roles + zeros-vs-entropy payload content).

## Battery

fmt / clippy `-D warnings` / doc clean; full workspace 32/32.
