### PR TITLE
fix: --server-bitrate-limit breach is GT's moving-average window; the rate/N knob wires through (#410)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,8 +59,9 @@ release tags.
 - `--server-bitrate-limit` breaches on iperf3's moving average — the last `rate/N` seconds
   (default 5) of one-second samples, evaluated only once the window fills — instead of a
   whole-test average at 1 Hz (breach at ~5 s like iperf3, not ~1 s; bursts age out; a quiet
-  prefix no longer dilutes). The `/N` averaging-interval half now wires through; new
-  `ServerBuilder::server_bitrate_limit_interval` (#410).
+  prefix no longer dilutes). The `/N` averaging-interval half now wires through (new
+  `ServerBuilder::server_bitrate_limit_interval`), and a limit of 0 disables the check
+  like iperf3 instead of killing every test (#410).
 - The client's params blob carries `repeating_payload` / `dont_fragment` / `flowlabel` like
   iperf3, and the server honors the first two on its send paths: reverse/bidir TCP payload
   fills the repeating pattern — now iperf3's ASCII-digit fill; the previous 0x00..0xFF ramp

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,11 @@ release tags.
 - `--cport` binds `port + i` per stream like iperf3 (`-P 2` no longer dies on a source-port
   collision; 65536 wraps to ephemeral), UDP honors `--cport` at all (was silently ephemeral),
   and a failed data-stream dial reports iperf3's `unable to connect stream: …` class (#428).
+- `--server-bitrate-limit` breaches on iperf3's moving average — the last `rate/N` seconds
+  (default 5) of one-second samples, evaluated only once the window fills — instead of a
+  whole-test average at 1 Hz (breach at ~5 s like iperf3, not ~1 s; bursts age out; a quiet
+  prefix no longer dilutes). The `/N` averaging-interval half now wires through; new
+  `ServerBuilder::server_bitrate_limit_interval` (#410).
 - The client's params blob carries `repeating_payload` / `dont_fragment` / `flowlabel` like
   iperf3, and the server honors the first two on its send paths: reverse/bidir TCP payload
   fills the repeating pattern — now iperf3's ASCII-digit fill; the previous 0x00..0xFF ramp

--- a/riperf3-cli/src/cli.rs
+++ b/riperf3-cli/src/cli.rs
@@ -890,11 +890,8 @@ impl Cli {
             // #328: GT's `bitrate_limit = unit_atof_rate(rate_part)` — an
             // iperf_size_t (uint64), so a negative rate wraps huge and GT
             // proceeds (iperf_api.c:1379-1383). The IETOTALINTERVAL check
-            // on the interval part runs pre-sink in main.rs. RECORDED
-            // DEVIATION: the interval VALUE is validated like GT but not
-            // wired — riperf3's limit enforcement keeps its own averaging
-            // window (the lib has no interval knob).
-            let (rate, _interval) = split_rate_interval(s);
+            // on the interval part runs pre-sink in main.rs.
+            let (rate, interval) = split_rate_interval(s);
             let n = unit_atof_rate_like_bytes(rate).map_err(|()| {
                 format!(
                     "invalid unit value or suffix: '{}'",
@@ -902,6 +899,18 @@ impl Cli {
                 )
             })?;
             builder = builder.server_bitrate_limit(c_double_to_u64(n));
+            // #410: the `/N` averaging window rides into the lib (GT's
+            // bitrate_limit_interval, iperf_api.c:1371 — un-recording the
+            // old "validated but not wired" deviation). RECORDED DEVIATION
+            // (`/0` only): GT's interval=0 leaves its sample derivation
+            // degenerate (per_interval stays 0 → a division by zero inside
+            // iperf_check_total_rate); riperf3 reads 0 as the default 5 s
+            // window instead of reproducing the UB.
+            if let Some(iv) = interval.map(atof_like_bytes) {
+                if iv != 0.0 {
+                    builder = builder.server_bitrate_limit_interval(iv);
+                }
+            }
         }
         if let Some(secs) = self.server_max_duration {
             builder = builder.server_max_duration(u32::try_from(secs).unwrap_or(u32::MAX));
@@ -2888,9 +2897,10 @@ mod cli_tests {
         // #328: the rate part is GT's unit_atof_rate (1000-based) with the
         // /interval piece split off first (iperf_api.c:1366-1385) — junk
         // after the suffix is ignored, and a negative rate (uint64)-wraps
-        // huge like GT's iperf_size_t assignment. RECORDED DEVIATION: the
-        // interval VALUE is range-checked like GT (IETOTALINTERVAL, in
-        // main.rs) but not wired — the lib keeps its own averaging window.
+        // huge like GT's iperf_size_t assignment. #410: the `/N` interval
+        // half wires into the lib's averaging window (GT's
+        // bitrate_limit_interval); `/0` stays unwired — GT's 0 leaves its
+        // derivation degenerate (recorded at the build_server site).
         #[test]
         fn server_bitrate_limit_rate_parses_like_gt() {
             let cli = Cli::parse_from(["riperf3", "-s", "--server-bitrate-limit", "10M/2"]);
@@ -2899,8 +2909,19 @@ mod cli_tests {
                 riperf3::ServerBuilder::new()
                     .emit_output(true)
                     .server_bitrate_limit(10_000_000)
+                    .server_bitrate_limit_interval(2.0)
                     .build()
                     .unwrap()
+            );
+            let cli = Cli::parse_from(["riperf3", "-s", "--server-bitrate-limit", "10M/0"]);
+            assert_eq!(
+                build_server_from_cli(&cli),
+                riperf3::ServerBuilder::new()
+                    .emit_output(true)
+                    .server_bitrate_limit(10_000_000)
+                    .build()
+                    .unwrap(),
+                "the /0 edge keeps the default window (recorded deviation)"
             );
             let cli = Cli::parse_from(["riperf3", "-s", "--server-bitrate-limit", "10Kx"]);
             assert_eq!(

--- a/riperf3-cli/src/cli.rs
+++ b/riperf3-cli/src/cli.rs
@@ -902,10 +902,12 @@ impl Cli {
             // #410: the `/N` averaging window rides into the lib (GT's
             // bitrate_limit_interval, iperf_api.c:1371 — un-recording the
             // old "validated but not wired" deviation). RECORDED DEVIATION
-            // (`/0` only): GT's interval=0 leaves its sample derivation
-            // degenerate (per_interval stays 0 → a division by zero inside
-            // iperf_check_total_rate); riperf3 reads 0 as the default 5 s
-            // window instead of reproducing the UB.
+            // (`/0` only, r1 F5 live probe): GT's interval=0 leaves
+            // per_interval at 0 → 0.0/0.0 = NaN → uint64 conversion UB —
+            // on x86-64 that reads 2^63 bps and GT SELF-TERMINATES every
+            // test at the FIRST tick (aarch64's NaN→0 would never breach).
+            // Platform-divergent UB is not mirrorable; riperf3 reads 0 as
+            // the default 5 s window.
             if let Some(iv) = interval.map(atof_like_bytes) {
                 if iv != 0.0 {
                     builder = builder.server_bitrate_limit_interval(iv);

--- a/riperf3-cli/tests/self_terminate.rs
+++ b/riperf3-cli/tests/self_terminate.rs
@@ -1,3 +1,6 @@
+//! #410: the bitrate-breach cells run `-t 9` — GT's 5-sample moving-average
+//! gate fires at ~5 s, and a `-t 5` client races the breach at exactly the
+//! window boundary (the pre-#410 whole-test check fired at ~1 s).
 //! #224 — server self-terminate parity (--server-bitrate-limit /
 //! --server-max-duration). Ground truth (iperf 3.21, live-captured 2026-06-11
 //! on the pinned interop build): both paths use the **SERVER_ERROR (-2)**
@@ -66,7 +69,7 @@ fn bitrate_limit_text_relays_server_error_no_summaries() {
     std::thread::sleep(Duration::from_millis(300));
 
     let client = common::run_client(
-        &["-c", "127.0.0.1", "-p", &ps, "-t", "5"],
+        &["-c", "127.0.0.1", "-p", &ps, "-t", "9"],
         Duration::from_secs(40),
         "client",
     );
@@ -120,7 +123,7 @@ fn bitrate_limit_json_client_single_doc_with_relayed_error() {
     std::thread::sleep(Duration::from_millis(300));
 
     let client = common::run_client(
-        &["-c", "127.0.0.1", "-p", &ps, "-t", "5", "-J"],
+        &["-c", "127.0.0.1", "-p", &ps, "-t", "9", "-J"],
         Duration::from_secs(40),
         "client -J",
     );
@@ -172,7 +175,7 @@ fn bitrate_limit_json_server_doc_bare_end_and_prefixed_error() {
     std::thread::sleep(Duration::from_millis(300));
 
     let _client = common::run_client(
-        &["-c", "127.0.0.1", "-p", &ps, "-t", "5"],
+        &["-c", "127.0.0.1", "-p", &ps, "-t", "9"],
         Duration::from_secs(40),
         "client",
     );

--- a/riperf3-cli/tests/self_terminate.rs
+++ b/riperf3-cli/tests/self_terminate.rs
@@ -772,7 +772,7 @@ fn bitrate_limit_line_carries_the_timestamps_prefix() {
     let server = spawn_server(&["--server-bitrate-limit", "1K", "--timestamps=XTSX "], &ps);
     std::thread::sleep(Duration::from_millis(300));
     let _ = common::run_client(
-        &["-c", "127.0.0.1", "-p", &ps, "-t", "5"],
+        &["-c", "127.0.0.1", "-p", &ps, "-t", "9"],
         Duration::from_secs(40),
         "client",
     );

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -11,6 +11,52 @@ use crate::utils::*;
 /// Shared test configuration derived from the client's parameter JSON.
 /// Crate-internal (#67): retracted from the public API, so `pub(crate)` keeps a
 /// future stray `pub use` from silently re-leaking it.
+/// #410: GT's `iperf_check_total_rate` window (iperf_api.c:2142-2179) — a
+/// ring of the last N interval byte counts. `push` returns the window
+/// average in bits/s once the ring has filled (GT gates on
+/// `stats_count < bitrate_limit_stats_per_interval`, :2160), `None`
+/// before. The push cadence is the server's fixed 1 Hz rate arm —
+/// riperf3's stats_interval.
+pub(crate) struct RateLimitWindow {
+    ring: Vec<u64>,
+    idx: usize,
+    count: u64,
+}
+
+impl RateLimitWindow {
+    /// GT's parse-time sample derivation (iperf_api.c:2008-2012) with
+    /// riperf3's stats_interval pinned at 1.0 s (there is no server `-i`
+    /// knob): `interval <= 1 → 1` sample, else `round(interval)`. The
+    /// interval is `--server-bitrate-limit rate/N`'s N, default 5
+    /// (iperf_api.c:3291).
+    pub(crate) fn from_interval_secs(interval: f64) -> Self {
+        let samples = if interval <= 1.0 {
+            1
+        } else {
+            interval.round() as usize
+        };
+        Self {
+            ring: vec![0; samples],
+            idx: 0,
+            count: 0,
+        }
+    }
+
+    /// Push one interval's byte count; returns the moving average over the
+    /// window in bits/s once enough samples accumulated (GT :2153-2169:
+    /// ring insert, count gate, `sum * 8 / (stats_interval × samples)`).
+    pub(crate) fn push(&mut self, interval_bytes: u64) -> Option<f64> {
+        self.idx = (self.idx + 1) % self.ring.len();
+        self.ring[self.idx] = interval_bytes;
+        self.count += 1;
+        if self.count < self.ring.len() as u64 {
+            return None;
+        }
+        let total: u64 = self.ring.iter().sum();
+        Some(total as f64 * 8.0 / self.ring.len() as f64)
+    }
+}
+
 pub(crate) struct TestConfig {
     pub protocol: TransportProtocol,
     pub duration: u32,
@@ -406,6 +452,9 @@ pub struct Server {
     /// DEFAULT_NO_MSG_RCVD_TIMEOUT, iperf_api.h:70).
     pub(crate) rcv_timeout: Option<u64>,
     pub(crate) server_bitrate_limit: Option<u64>,
+    /// #410: `--server-bitrate-limit rate/N`'s N — the averaging window in
+    /// seconds (GT's bitrate_limit_interval, default 5, iperf_api.c:3291).
+    pub(crate) server_bitrate_limit_interval: Option<f64>,
     pub(crate) server_max_duration: Option<u32>,
     pub(crate) forceflush: bool,
     pub(crate) bind_address: Option<String>,
@@ -2184,6 +2233,13 @@ impl Server {
         let mut rate_check = tokio::time::interval(std::time::Duration::from_secs(1));
         rate_check.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
         rate_check.tick().await; // skip immediate tick
+                                 // #410: GT's breach check is a MOVING AVERAGE over the last N
+                                 // one-second samples (iperf_check_total_rate's ring), N from the
+                                 // `rate/N` interval (default 5) — never a whole-test average, and
+                                 // silent until the ring fills (GT breach at ~5 s, live-probed).
+        let mut rate_window =
+            RateLimitWindow::from_interval_secs(self.server_bitrate_limit_interval.unwrap_or(5.0));
+        let mut rate_prev_total: u64 = 0;
 
         // #237: ONE absolute deadline, pinned before the loop. A sleep()
         // recreated inside select! restarts from zero every time another arm
@@ -2343,13 +2399,18 @@ impl Server {
                     break;
                 }
                 _ = rate_check.tick(), if bitrate_limit.is_some() => {
-                    let elapsed = test_start.elapsed().as_secs_f64();
-                    if elapsed > 0.0 {
+                    {
+                        // GT sums each interval's sent+received across
+                        // streams (iperf_stats_callback, iperf_api.c:3725);
+                        // the cumulative counters here yield the same
+                        // per-tick delta.
                         let total_bytes: u64 = ctx.streams.iter().map(|s| {
                             s.meta.counters.bytes_sent() + s.meta.counters.bytes_received()
                         }).sum();
-                        let bits_per_sec = total_bytes as f64 * 8.0 / elapsed;
-                        if let Some(limit) = bitrate_limit {
+                        let interval_bytes = total_bytes.saturating_sub(rate_prev_total);
+                        rate_prev_total = total_bytes;
+                        let verdict = rate_window.push(interval_bytes);
+                        if let (Some(limit), Some(bits_per_sec)) = (bitrate_limit, verdict) {
                             if bits_per_sec > limit as f64 {
                                 // #350 RECORDED DEVIATION: GT relays this
                                 // frame TWICE — the explicit rate-path write
@@ -4340,6 +4401,7 @@ pub struct ServerBuilder {
     idle_timeout: Option<u32>,
     rcv_timeout: Option<u64>,
     server_bitrate_limit: Option<u64>,
+    server_bitrate_limit_interval: Option<f64>,
     server_max_duration: Option<u32>,
     forceflush: bool,
     bind_address: Option<String>,
@@ -4368,6 +4430,7 @@ impl Default for ServerBuilder {
             idle_timeout: None,
             rcv_timeout: None,
             server_bitrate_limit: None,
+            server_bitrate_limit_interval: None,
             server_max_duration: None,
             forceflush: false,
             bind_address: None,
@@ -4476,6 +4539,15 @@ impl ServerBuilder {
     /// exceeds `rate` bits/sec (unset: no limit).
     pub fn server_bitrate_limit(mut self, rate: u64) -> Self {
         self.server_bitrate_limit = Some(rate);
+        self
+    }
+
+    /// The `--server-bitrate-limit rate/N` averaging window in seconds —
+    /// iperf3's bitrate_limit_interval (default 5): the breach check is a
+    /// moving average over the last `round(N)` one-second samples and
+    /// evaluates only once that many have accumulated (#410).
+    pub fn server_bitrate_limit_interval(mut self, secs: f64) -> Self {
+        self.server_bitrate_limit_interval = Some(secs);
         self
     }
 
@@ -4622,6 +4694,7 @@ impl ServerBuilder {
             idle_timeout: self.idle_timeout,
             rcv_timeout: self.rcv_timeout,
             server_bitrate_limit: self.server_bitrate_limit,
+            server_bitrate_limit_interval: self.server_bitrate_limit_interval,
             server_max_duration: self.server_max_duration,
             forceflush: self.forceflush,
             bind_address: self.bind_address,
@@ -4661,6 +4734,54 @@ mod tests {
     /// #316: the server adopts the client's exchanged GSO/GRO request
     /// (GT iperf_api.c:2599-2619), including the zero-dg_size recompute
     /// from the negotiated blksize (:2607-2613).
+    /// #410: GT's iperf_check_total_rate window semantics in isolation —
+    /// the fill gate, the ring aging, the average math, and the sample
+    /// derivation formula (iperf_api.c:2142-2179 + :2008-2012).
+    #[test]
+    fn rate_limit_window_matches_gt_semantics() {
+        // Gate: silent until the ring fills (GT :2158-2161).
+        let mut w = RateLimitWindow::from_interval_secs(5.0);
+        for _ in 0..4 {
+            assert_eq!(w.push(1_000_000), None, "no verdict before 5 samples");
+        }
+        // 5th sample: 5 x 1 MB over 5 s = 8 Mbit/s.
+        assert_eq!(w.push(1_000_000), Some(8_000_000.0));
+
+        // Aging: a burst leaves the window once the ring wraps over it —
+        // the pre-#410 whole-test average never forgot.
+        let mut w = RateLimitWindow::from_interval_secs(5.0);
+        w.push(u64::from(u32::MAX)); // the burst
+        for _ in 0..3 {
+            w.push(0);
+        }
+        let with_burst = w.push(0).expect("ring full");
+        assert!(with_burst > 0.0, "burst still inside the window");
+        assert_eq!(
+            w.push(0),
+            Some(0.0),
+            "the next push overwrites the burst slot — aged out"
+        );
+
+        // Derivation (GT :2008-2012, stats_interval pinned 1.0): <= 1 s
+        // collapses to ONE sample (verdicts on the first push); fractions
+        // round like C round().
+        let mut w1 = RateLimitWindow::from_interval_secs(1.0);
+        assert_eq!(
+            w1.push(125_000),
+            Some(1_000_000.0),
+            "1-sample window verdicts immediately"
+        );
+        let mut w06 = RateLimitWindow::from_interval_secs(0.6);
+        assert!(w06.push(1).is_some(), "sub-second interval = 1 sample");
+        let mut w24 = RateLimitWindow::from_interval_secs(2.4);
+        assert!(w24.push(1).is_none());
+        assert!(w24.push(1).is_some(), "2.4 rounds to 2 samples");
+        let mut w25 = RateLimitWindow::from_interval_secs(2.5);
+        assert!(w25.push(1).is_none());
+        assert!(w25.push(1).is_none());
+        assert!(w25.push(1).is_some(), "2.5 rounds half-away to 3 samples");
+    }
+
     /// #414: the wire trio's ingest semantics, per GT's get_parameters.
     #[test]
     fn from_params_ingests_the_414_trio_like_gt() {

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -8,9 +8,6 @@ use crate::protocol::{self, TestParams, TestResultsJson, TestState, TransportPro
 use crate::stream::{self, DataStream, StreamCounters, StreamMeta, UdpRecvStats};
 use crate::utils::*;
 
-/// Shared test configuration derived from the client's parameter JSON.
-/// Crate-internal (#67): retracted from the public API, so `pub(crate)` keeps a
-/// future stray `pub use` from silently re-leaking it.
 /// #410: GT's `iperf_check_total_rate` window (iperf_api.c:2142-2179) — a
 /// ring of the last N interval byte counts. `push` returns the window
 /// average in bits/s once the ring has filled (GT gates on
@@ -28,12 +25,21 @@ impl RateLimitWindow {
     /// riperf3's stats_interval pinned at 1.0 s (there is no server `-i`
     /// knob): `interval <= 1 → 1` sample, else `round(interval)`. The
     /// interval is `--server-bitrate-limit rate/N`'s N, default 5
-    /// (iperf_api.c:3291).
+    /// (iperf_api.c:3291). HARDENED beyond GT (r1 F1 — this is a lib
+    /// surface): a non-finite or non-positive interval falls back to the
+    /// default 5, and the ring is capped at 86 400 samples (a day at 1 Hz)
+    /// so a huge value can't abort on allocation. GT's own CLI bounds the
+    /// value to 0.1..=60 before it ever reaches the math.
     pub(crate) fn from_interval_secs(interval: f64) -> Self {
+        let interval = if interval.is_finite() && interval > 0.0 {
+            interval
+        } else {
+            5.0
+        };
         let samples = if interval <= 1.0 {
             1
         } else {
-            interval.round() as usize
+            (interval.round() as usize).min(86_400)
         };
         Self {
             ring: vec![0; samples],
@@ -43,9 +49,12 @@ impl RateLimitWindow {
     }
 
     /// Push one interval's byte count; returns the moving average over the
-    /// window in bits/s once enough samples accumulated (GT :2153-2169:
-    /// ring insert, count gate, `sum * 8 / (stats_interval × samples)`).
-    pub(crate) fn push(&mut self, interval_bytes: u64) -> Option<f64> {
+    /// window once enough samples accumulated (GT :2153-2169: ring insert,
+    /// count gate, `sum * 8 / (stats_interval × samples)`). INTEGER bits/s
+    /// like GT's `uint64_t bits_per_second` (:2146/:2169 — the C double
+    /// division truncates on assignment), so a fractional average never
+    /// breaches a limit its integer part equals (r1 F4).
+    pub(crate) fn push(&mut self, interval_bytes: u64) -> Option<u64> {
         self.idx = (self.idx + 1) % self.ring.len();
         self.ring[self.idx] = interval_bytes;
         self.count += 1;
@@ -53,10 +62,13 @@ impl RateLimitWindow {
             return None;
         }
         let total: u64 = self.ring.iter().sum();
-        Some(total as f64 * 8.0 / self.ring.len() as f64)
+        Some((total as f64 * 8.0 / self.ring.len() as f64) as u64)
     }
 }
 
+/// Shared test configuration derived from the client's parameter JSON.
+/// Crate-internal (#67): retracted from the public API, so `pub(crate)` keeps a
+/// future stray `pub use` from silently re-leaking it.
 pub(crate) struct TestConfig {
     pub protocol: TransportProtocol,
     pub duration: u32,
@@ -2215,7 +2227,12 @@ impl Server {
     /// and the interrupt watch; records how the test ended in the context
     /// flags (`server_error` / `client_terminated` / `interrupted`).
     async fn await_test_end(&self, ctx: &mut TestRunCtx) -> Result<()> {
-        let bitrate_limit = self.server_bitrate_limit;
+        // #410 r1 F2: GT's first gate — a limit of 0 DISABLES the check
+        // entirely (iperf_check_total_rate, iperf_api.c:2149-2151); the
+        // upfront param check already filters `> 0`, the runtime arm must
+        // too (live-probed: GT ran `--server-bitrate-limit 0` clean where
+        // the unfiltered arm self-terminated at the window boundary).
+        let bitrate_limit = self.server_bitrate_limit.filter(|&l| l > 0);
         let test_start = ctx.report_start;
         // #230: GT's in-flight 160-watchdog (create_server_timers,
         // iperf_server_api.c:380-395) arms for EVERY test with a nonzero
@@ -2411,7 +2428,7 @@ impl Server {
                         rate_prev_total = total_bytes;
                         let verdict = rate_window.push(interval_bytes);
                         if let (Some(limit), Some(bits_per_sec)) = (bitrate_limit, verdict) {
-                            if bits_per_sec > limit as f64 {
+                            if bits_per_sec > limit {
                                 // #350 RECORDED DEVIATION: GT relays this
                                 // frame TWICE — the explicit rate-path write
                                 // (iperf_server_api.c:626-643), then
@@ -4731,9 +4748,12 @@ mod tests {
         assert_eq!(super::DEFAULT_RCV_TIMEOUT_MS, 120_000);
     }
 
-    /// #316: the server adopts the client's exchanged GSO/GRO request
-    /// (GT iperf_api.c:2599-2619), including the zero-dg_size recompute
-    /// from the negotiated blksize (:2607-2613).
+    // #316 (the from_params cluster below, generally): the server adopts
+    // the client's exchanged GSO/GRO request (GT iperf_api.c:2599-2619),
+    // including the zero-dg_size recompute from the negotiated blksize
+    // (:2607-2613). A plain comment on purpose — as a doc comment it kept
+    // re-attaching to whichever test was inserted first (#443 r1 F3).
+
     /// #410: GT's iperf_check_total_rate window semantics in isolation —
     /// the fill gate, the ring aging, the average math, and the sample
     /// derivation formula (iperf_api.c:2142-2179 + :2008-2012).
@@ -4744,8 +4764,9 @@ mod tests {
         for _ in 0..4 {
             assert_eq!(w.push(1_000_000), None, "no verdict before 5 samples");
         }
-        // 5th sample: 5 x 1 MB over 5 s = 8 Mbit/s.
-        assert_eq!(w.push(1_000_000), Some(8_000_000.0));
+        // 5th sample: 5 x 1 MB over 5 s = 8 Mbit/s. INTEGER bits/s —
+        // GT's uint64_t assignment truncates (r1 F4).
+        assert_eq!(w.push(1_000_000), Some(8_000_000));
 
         // Aging: a burst leaves the window once the ring wraps over it —
         // the pre-#410 whole-test average never forgot.
@@ -4755,10 +4776,10 @@ mod tests {
             w.push(0);
         }
         let with_burst = w.push(0).expect("ring full");
-        assert!(with_burst > 0.0, "burst still inside the window");
+        assert!(with_burst > 0, "burst still inside the window");
         assert_eq!(
             w.push(0),
-            Some(0.0),
+            Some(0),
             "the next push overwrites the burst slot — aged out"
         );
 
@@ -4768,7 +4789,7 @@ mod tests {
         let mut w1 = RateLimitWindow::from_interval_secs(1.0);
         assert_eq!(
             w1.push(125_000),
-            Some(1_000_000.0),
+            Some(1_000_000),
             "1-sample window verdicts immediately"
         );
         let mut w06 = RateLimitWindow::from_interval_secs(0.6);
@@ -4780,6 +4801,27 @@ mod tests {
         assert!(w25.push(1).is_none());
         assert!(w25.push(1).is_none());
         assert!(w25.push(1).is_some(), "2.5 rounds half-away to 3 samples");
+
+        // Truncation (r1 F4): GT's uint64_t drops the fraction — a window
+        // averaging 1001.6 bits/s reads 1001 and does NOT breach a 1001
+        // limit. 626 bytes over 5 s = 1001.6.
+        let mut wt = RateLimitWindow::from_interval_secs(5.0);
+        for _ in 0..4 {
+            wt.push(0);
+        }
+        assert_eq!(wt.push(626), Some(1001), "integer bits/s like GT");
+
+        // Hardening (r1 F1, lib surface beyond GT's CLI bounds): NaN,
+        // negatives, and zero fall back to the default window; huge
+        // intervals cap the ring instead of aborting on allocation.
+        let mut wn = RateLimitWindow::from_interval_secs(f64::NAN);
+        assert!(wn.push(1).is_none(), "NaN → default 5-sample window");
+        let mut wz = RateLimitWindow::from_interval_secs(0.0);
+        assert!(wz.push(1).is_none(), "0 → default window, not 1-sample");
+        let mut wneg = RateLimitWindow::from_interval_secs(-3.0);
+        assert!(wneg.push(1).is_none(), "negative → default window");
+        let wh = RateLimitWindow::from_interval_secs(1e30);
+        assert_eq!(wh.ring.len(), 86_400, "huge interval caps the ring");
     }
 
     /// #414: the wire trio's ingest semantics, per GT's get_parameters.

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -4562,7 +4562,10 @@ impl ServerBuilder {
     /// The `--server-bitrate-limit rate/N` averaging window in seconds —
     /// iperf3's bitrate_limit_interval (default 5): the breach check is a
     /// moving average over the last `round(N)` one-second samples and
-    /// evaluates only once that many have accumulated (#410).
+    /// evaluates only once that many have accumulated (#410). Hardened
+    /// input contract: a non-finite or non-positive value falls back to
+    /// the default 5 s window, and the sample count is capped at 86 400
+    /// (a day at 1 Hz). iperf3's own CLI bounds the value to 0.1..=60.
     pub fn server_bitrate_limit_interval(mut self, secs: f64) -> Self {
         self.server_bitrate_limit_interval = Some(secs);
         self

--- a/riperf3/tests/integration.rs
+++ b/riperf3/tests/integration.rs
@@ -2857,6 +2857,40 @@ async fn server_run_once_self_terminates_on_runtime_bitrate_breach() {
     );
 }
 
+/// #410 r1 F2: a limit of ZERO disables the check entirely — GT's first
+/// gate (`bitrate_limit == 0 → return`, iperf_api.c:2149-2151;
+/// live-probed: GT ran `--server-bitrate-limit 0` for a full 7 s where an
+/// unfiltered runtime arm self-terminated at the window boundary).
+#[tokio::test]
+async fn zero_bitrate_limit_disables_the_check() {
+    let server = ServerBuilder::new()
+        .port(Some(0))
+        .server_bitrate_limit(0)
+        .emit_output(false)
+        .build()
+        .unwrap();
+    let bound = server.bind().await.expect("bind");
+    let port = bound.local_addr().unwrap().port();
+    let server_task = tokio::spawn(async move { bound.run_once().await });
+    let client = ClientBuilder::new("127.0.0.1")
+        .port(Some(port))
+        .duration(7)
+        .emit_output(false)
+        .build()
+        .unwrap();
+    let cli = tokio::time::timeout(Duration::from_secs(20), client.run())
+        .await
+        .expect("client hung")
+        .expect("client run");
+    assert_eq!(
+        cli.termination,
+        riperf3::Termination::Completed,
+        "limit 0 = no limit, like GT (#410 r1 F2)"
+    );
+    let srv = server_task.await.expect("join").expect("server run_once");
+    assert_eq!(srv.termination, riperf3::Termination::Completed);
+}
+
 /// #410 (M2 discriminator): a COMPLIANT steady sender must never breach —
 /// the moving window drains as traffic flows at a sub-limit rate, where a
 /// cumulative feed (the pre-#410 whole-test shape smuggled into the ring)

--- a/riperf3/tests/integration.rs
+++ b/riperf3/tests/integration.rs
@@ -2004,9 +2004,11 @@ mod unimplemented_flags {
         let start = std::time::Instant::now();
         let result = client.run().await;
         let elapsed = start.elapsed();
-        // Should terminate well before 10 seconds
+        // Terminates before the 10 s duration — at ~5 s, GT's 5-sample
+        // moving-average gate (#410; the precise timing window is pinned in
+        // server_run_once_self_terminates_on_runtime_bitrate_breach).
         assert!(
-            elapsed.as_secs() < 5,
+            elapsed.as_secs() < 8,
             "bitrate limit didn't cut test: {elapsed:?}"
         );
         // #224 ground truth (iperf 3.21): SERVER_ERROR + IETOTALRATE, the

--- a/riperf3/tests/integration.rs
+++ b/riperf3/tests/integration.rs
@@ -2855,6 +2855,84 @@ async fn server_run_once_self_terminates_on_runtime_bitrate_breach() {
     );
 }
 
+/// #410 (M2 discriminator): a COMPLIANT steady sender must never breach —
+/// the moving window drains as traffic flows at a sub-limit rate, where a
+/// cumulative feed (the pre-#410 whole-test shape smuggled into the ring)
+/// keeps growing and false-breaches within ~5 ticks. 400 Kbit/s against a
+/// 1 Mbit/s limit, 8 s, SMALL blksize — the default 128 KiB block is one
+/// whole burst above the per-tick budget and legitimately trips the
+/// window on both tools (the #260 "controls need small blksize" lesson).
+#[tokio::test]
+async fn compliant_steady_rate_never_breaches_the_window() {
+    let server = ServerBuilder::new()
+        .port(Some(0))
+        .server_bitrate_limit(1_000_000)
+        .emit_output(false)
+        .build()
+        .unwrap();
+    let bound = server.bind().await.expect("bind");
+    let port = bound.local_addr().unwrap().port();
+    let server_task = tokio::spawn(async move { bound.run_once().await });
+    let client = ClientBuilder::new("127.0.0.1")
+        .port(Some(port))
+        .duration(8)
+        .bandwidth(400_000)
+        .blksize(1_400)
+        .emit_output(false)
+        .build()
+        .unwrap();
+    let cli = tokio::time::timeout(Duration::from_secs(20), client.run())
+        .await
+        .expect("client hung")
+        .expect("client run");
+    assert_eq!(
+        cli.termination,
+        riperf3::Termination::Completed,
+        "a sub-limit steady rate never trips GT's moving window (#410)"
+    );
+    let srv = server_task.await.expect("join").expect("server run_once");
+    assert_eq!(srv.termination, riperf3::Termination::Completed);
+}
+
+/// #410 (the `/N` knob): `--server-bitrate-limit rate/2` shrinks the
+/// window to 2 samples — GT breaches at 2.0 s (live-probed; `/10` at
+/// 10.0 s). An unwired knob leaves the default 5-sample gate and fires
+/// ~5 s, red here.
+#[tokio::test]
+async fn rate_window_interval_knob_scales_the_gate() {
+    const MSG: &str = "total required bandwidth is larger than server limit";
+    let server = ServerBuilder::new()
+        .port(Some(0))
+        .server_bitrate_limit(1_000)
+        .server_bitrate_limit_interval(2.0)
+        .emit_output(false)
+        .build()
+        .unwrap();
+    let bound = server.bind().await.expect("bind");
+    let port = bound.local_addr().unwrap().port();
+    let server_task = tokio::spawn(async move { bound.run_once().await });
+    let t0 = std::time::Instant::now();
+    let client = ClientBuilder::new("127.0.0.1")
+        .port(Some(port))
+        .duration(8)
+        .emit_output(false)
+        .build()
+        .unwrap();
+    let _ = tokio::time::timeout(Duration::from_secs(20), client.run())
+        .await
+        .expect("client hung");
+    let breach_at = t0.elapsed();
+    assert!(
+        (Duration::from_millis(1500)..=Duration::from_millis(4000)).contains(&breach_at),
+        "a 2 s window breaches at ~2 s like GT (#410): {breach_at:?}"
+    );
+    let srv = server_task.await.expect("join").expect("server run_once");
+    assert_eq!(
+        srv.termination,
+        riperf3::Termination::SelfTerminated(MSG.to_string())
+    );
+}
+
 /// #392: GT renders a NEGATIVE requested window verbatim — `-w -1` is
 /// real-client-reachable (unit_atof keeps the sign; only the upper bound
 /// is range-checked, iperf_api.c:1446) and BOTH roles' `-J` docs carry

--- a/riperf3/tests/integration.rs
+++ b/riperf3/tests/integration.rs
@@ -2798,7 +2798,7 @@ async fn server_run_once_self_terminates_on_runtime_bitrate_breach() {
     const MSG: &str = "total required bandwidth is larger than server limit";
     let server = ServerBuilder::new()
         .port(Some(0))
-        .server_bitrate_limit(1_000) // 1 Kbit/s: any real transfer trips the 1 Hz check
+        .server_bitrate_limit(1_000) // 1 Kbit/s: any real transfer breaches
         .emit_output(false)
         .build()
         .unwrap();
@@ -2810,15 +2810,29 @@ async fn server_run_once_self_terminates_on_runtime_bitrate_breach() {
     // (total = 0) lets the test START, then loopback throughput blows past
     // 1 Kbit/s and the RUNTIME breach fires. An explicit `-b 2M` would instead
     // be refused UPFRONT (no server report — the other tests' path).
+    // #410: the duration must OUTLIVE GT's 5-sample moving-average gate
+    // (iperf_check_total_rate needs bitrate_limit_stats_per_interval = 5
+    // interval samples before it evaluates; live-probed GT breach = 5.0 s).
+    let t0 = std::time::Instant::now();
     let client = ClientBuilder::new("127.0.0.1")
         .port(Some(port))
-        .duration(2)
+        .duration(10)
         .emit_output(false)
         .build()
         .unwrap();
-    let result = tokio::time::timeout(Duration::from_secs(15), client.run())
+    let result = tokio::time::timeout(Duration::from_secs(20), client.run())
         .await
         .expect("client hung");
+    let breach_at = t0.elapsed();
+    assert!(
+        breach_at >= Duration::from_millis(4500),
+        "the breach must wait for GT's 5-sample window, not fire on a \
+         whole-test average at the first tick (#410): fired at {breach_at:?}"
+    );
+    assert!(
+        breach_at <= Duration::from_millis(8000),
+        "the breach fires at the window boundary, ~5 s (#410): {breach_at:?}"
+    );
     let server_result = server_task.await.expect("server task");
 
     // Server: the runtime breach produced a report → Ok (an Err here is exactly


### PR DESCRIPTION
Fixes #410.

riperf3's `--server-bitrate-limit` breach check was a whole-test average evaluated at every 1 Hz tick; GT's `iperf_check_total_rate` (iperf_api.c:2142-2179) is a **moving average over the last N one-second interval samples** — a ring buffer that stays silent until it fills. Live divergence (probe record on the issue): GT breaches an unthrottled client at exactly the window boundary — 5.0 s default, 2.0 s with `rate/2`, 10.0 s with `rate/10` — riperf3 at 1.1 s. Beyond timing: bursts never aged out of the whole-test average (false positives forever) and a long quiet prefix diluted fresh breaches (false negatives).

Now: a `RateLimitWindow` with GT's exact semantics (ring insert, fill gate, `sum × 8 / (1 s × samples)`, strict `>`), fed per-tick deltas of the cumulative stream counters (GT's per-interval sent+received sum). The sample count derives with GT's parse-time formula (iperf_api.c:2008-2012, stats_interval pinned at riperf3's fixed 1 Hz tick): `≤ 1 s → 1`, else `round(N)`. The `rate/N` CLI half — previously validated but recorded as unwired — now rides into the lib via new `ServerBuilder::server_bitrate_limit_interval` (default 5, GT's :3291). Recorded deviation: GT's `/0` leaves its derivation degenerate (per_interval 0 → division by zero); riperf3 reads 0 as the default window. The breach plumbing itself (SERVER_ERROR + IETOTALRATE relay, bare end, SelfTerminated) was already faithful and is untouched.

**Post-fix A/B**: riperf3 breaches at 5.1 / 2.1 / 10.1 s across the same three cells.

**Pins & mutants**: unit (fill gate, ring aging, average math, the derivation formula incl. the ≤1 s and round-half cells); e2e timing (breach in [4.5, 8] s, red pre-fix at 1.10 s); the compliant-steady cell (sub-limit paced client never breaches — kills the cumulative-feed mutant, and needed a small blksize: the default 128 KiB block is one whole burst above a low per-tick budget and legitimately trips the window on both tools); the `/2` knob cell (breach ~2 s — kills the knob-unwired mutant); CLI glue compare incl. the `/0` edge. The old smoke test's `< 5 s` bound updated to the GT gate.

Battery: fmt / clippy `-D warnings` / doc clean; full workspace 32/32.
