### PR TITLE
fix: setup-kill rounds park in GT's sync-close drain before the one-off exit (#390)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,10 @@ release tags.
 - `--cport` binds `port + i` per stream like iperf3 (`-P 2` no longer dies on a source-port
   collision; 65536 wraps to ephemeral), UDP honors `--cport` at all (was silently ephemeral),
   and a failed data-stream dial reports iperf3's `unable to connect stream: …` class (#428).
+- A setup-phase kill (failed data accept, idle timeout, …) now parks the round in iperf3's
+  sync-close drain until the peer consumes the error relay — a one-off server no longer
+  closes its listener at the kill instant, which RST'd a real iperf3 client's queued data
+  socket before it could read the SERVER ERROR frame (#390).
 - `--server-bitrate-limit` breaches on iperf3's moving average — the last `rate/N` seconds
   (default 5) of one-second samples, evaluated only once the window fills — instead of a
   whole-test average at 1 Hz (breach at ~5 s like iperf3, not ~1 s; bursts age out; a quiet

--- a/riperf3-cli/tests/wire_shape.rs
+++ b/riperf3-cli/tests/wire_shape.rs
@@ -5679,6 +5679,56 @@ fn setup_data_accept_emfile_wires_iestreamconnect_with_live_errno() {
     );
 }
 
+/// #390: after a setup-kill wire-back, the round parks in GT's sync-close
+/// drain until the peer consumes/EOFs the ctrl — cleanup_server runs
+/// iperf_sync_close_socket on EVERY round exit (iperf_server_api.c:519;
+/// net.c:877-887), which is what holds a GT one-off's LISTENER open long
+/// enough for a real client's queued data socket to survive
+/// iperf_init_stream and read the fe relay (live-proven 4/4 on #387 r2).
+/// Pre-fix the one-off exit dropped ctrl+listener at the kill instant.
+#[cfg(target_os = "linux")]
+#[test]
+fn setup_kill_one_off_parks_until_peer_eof() {
+    let _serial = EMFILE_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind");
+    let port = listener.local_addr().unwrap().port();
+    drop(listener);
+    let ps = port.to_string();
+    let mut server = common::ChildGuard(
+        std::process::Command::new(env!("CARGO_BIN_EXE_riperf3"))
+            .args(["-s", "-1", "-p", &ps])
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .spawn()
+            .expect("spawn server"),
+    );
+    std::thread::sleep(std::time::Duration::from_millis(500));
+    let pid = server.0.id();
+
+    let mut ctrl = std::net::TcpStream::connect(("127.0.0.1", port)).expect("ctrl");
+    ctrl.write_all(&[b'x'; 37]).unwrap();
+    assert_eq!(read_exact(&mut ctrl, 1)[0], 9, "ParamExchange");
+    write_json_blob(&mut ctrl, INCOMPLETE_PARAMS);
+    assert_eq!(read_exact(&mut ctrl, 1)[0], 10, "CreateStreams");
+    clamp_fd_table(pid);
+    let _data = std::net::TcpStream::connect(("127.0.0.1", port)).expect("data connect");
+    let frame = read_wireback(&mut ctrl);
+    assert_eq!(frame[0], 0xfe, "the setup-kill wire-back arrived");
+
+    // HOLD the ctrl open: the server must PARK (GT's drain), not exit.
+    std::thread::sleep(std::time::Duration::from_millis(1500));
+    assert!(
+        server.0.try_wait().expect("try_wait").is_none(),
+        "the one-off parks in the sync-close drain while the peer holds ctrl (#390)"
+    );
+
+    drop(ctrl); // peer EOF → the drain ends and the one-off exits
+    let status =
+        riperf3_test_support::wait_bounded(&mut server.0, std::time::Duration::from_secs(5))
+            .expect("one-off exits after the peer EOF");
+    assert!(status.success(), "exit 0, the keep-serving class");
+}
+
 /// #383 r2 F1: the demux design's idle exemption — the both-designs
 /// convention every other #358 cell follows.
 #[test]

--- a/riperf3-cli/tests/wire_shape.rs
+++ b/riperf3-cli/tests/wire_shape.rs
@@ -5729,6 +5729,61 @@ fn setup_kill_one_off_parks_until_peer_eof() {
     assert!(status.success(), "exit 0, the keep-serving class");
 }
 
+/// #390 (#445 r1 F1): an INTERRUPT during the setup-kill park abandons the
+/// original error surface — GT's sigend longjmps out of the drain and
+/// emits ONLY `interrupt - …` (live-probed; the class line never prints).
+/// Pre-fix riperf3 printed BOTH the class line and the interrupt line.
+#[cfg(target_os = "linux")]
+#[test]
+fn setup_kill_park_interrupt_abandons_the_class_line() {
+    let _serial = EMFILE_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind");
+    let port = listener.local_addr().unwrap().port();
+    drop(listener);
+    let ps = port.to_string();
+    let mut server = common::ChildGuard(
+        std::process::Command::new(env!("CARGO_BIN_EXE_riperf3"))
+            .args(["-s", "-1", "-p", &ps])
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::piped())
+            .spawn()
+            .expect("spawn server"),
+    );
+    let se = riperf3_test_support::drain_reader(server.0.stderr.take().unwrap());
+    std::thread::sleep(std::time::Duration::from_millis(500));
+    let pid = server.0.id();
+
+    let mut ctrl = std::net::TcpStream::connect(("127.0.0.1", port)).expect("ctrl");
+    ctrl.write_all(&[b'x'; 37]).unwrap();
+    assert_eq!(read_exact(&mut ctrl, 1)[0], 9, "ParamExchange");
+    write_json_blob(&mut ctrl, INCOMPLETE_PARAMS);
+    assert_eq!(read_exact(&mut ctrl, 1)[0], 10, "CreateStreams");
+    clamp_fd_table(pid);
+    let _data = std::net::TcpStream::connect(("127.0.0.1", port)).expect("data connect");
+    let frame = read_wireback(&mut ctrl);
+    assert_eq!(frame[0], 0xfe, "the setup-kill wire-back arrived");
+
+    // Parked (the peer holds ctrl). SIGINT the server mid-park.
+    std::thread::sleep(std::time::Duration::from_millis(700));
+    let rc = unsafe { libc::kill(pid as i32, libc::SIGINT) };
+    assert_eq!(rc, 0, "SIGINT delivered");
+    let status =
+        riperf3_test_support::wait_bounded(&mut server.0, std::time::Duration::from_secs(5))
+            .expect("exits on the interrupt");
+    drop(ctrl);
+    let serr = se.join().expect("stderr");
+    assert!(
+        !serr.contains("error - unable to connect stream"),
+        "GT's sigend abandons the class line — interrupt surface only \
+         (#445 r1 F1): {serr:?}"
+    );
+    assert!(
+        serr.contains("interrupt - "),
+        "the interrupt line prints: {serr:?}"
+    );
+    assert!(status.success(), "GT's signal exit shape");
+}
+
 /// #383 r2 F1: the demux design's idle exemption — the both-designs
 /// convention every other #358 cell follows.
 #[test]

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -1226,17 +1226,37 @@ impl Server {
                         // (cleanup_server → iperf_sync_close_socket) — the
                         // bounded drain holds the round, and with it the
                         // one-off listener, open until the peer consumed
-                        // the setup-kill wire-back. An interrupt abandons
-                        // the drain (GT's sigend longjmps out the same
-                        // way); the original error propagates either way.
-                        let _ = self.park_refused_round(&mut ctx.ctrl).await;
-                        return Err(e);
+                        // the setup-kill wire-back.
+                        match self.park_refused_round(&mut ctx.ctrl).await {
+                            None => return Err(e),
+                            Some(_msg) => {
+                                // #445 r1 F1 (live-probed): GT's sigend
+                                // longjmps out of the drain and emits ONLY
+                                // the interrupt surface — the original
+                                // class line is ABANDONED. Consuming the
+                                // round here suppresses the text line (the
+                                // interrupt watcher prints its own).
+                                // RECORDED DEVIATION (-J/json-stream): the
+                                // kill site already emitted its doc with
+                                // the ORIGINAL error where GT's single doc
+                                // carries the interrupt line — deferring
+                                // that emission to post-park is the #386
+                                // refusal shape, left as a follow-up with
+                                // the pre-CreateStreams sync-close family.
+                                return Ok(None);
+                            }
+                        }
                     }
                 };
             if let SetupFlow::ClientDone = setup_flow {
                 // #356 r1 F1: GT's clean IPERF_DONE arm — the round ends
                 // with no error surface, keep-serving like a refusal
                 // (None maps to handle_one_test's Ok(None) after the gate).
+                // #445 r1 F3: GT's IPERF_DONE exit ALSO runs
+                // cleanup_server's sync-close; a conforming DONE-sender
+                // EOFs the drain instantly, so this only matters against
+                // an adversarial holder.
+                let _ = self.park_refused_round(&mut ctx.ctrl).await;
                 return Ok(None);
             }
             // #380: the full arm — every real task was already pushed at

--- a/riperf3/src/server.rs
+++ b/riperf3/src/server.rs
@@ -1217,9 +1217,23 @@ impl Server {
             // killing every bidir_intervals cell while Linux (8 MB main)
             // and worker/test threads (2 MB) never noticed. Boxing moves
             // setup's state out of the enclosing frame; behavior identical.
-            if let SetupFlow::ClientDone =
-                Box::pin(self.setup_data_streams(&mut ctx, listener, &mut abort_guard)).await?
-            {
+            let setup_flow =
+                match Box::pin(self.setup_data_streams(&mut ctx, listener, &mut abort_guard)).await
+                {
+                    Ok(flow) => flow,
+                    Err(e) => {
+                        // #390: GT sync-closes the ctrl on every round exit
+                        // (cleanup_server → iperf_sync_close_socket) — the
+                        // bounded drain holds the round, and with it the
+                        // one-off listener, open until the peer consumed
+                        // the setup-kill wire-back. An interrupt abandons
+                        // the drain (GT's sigend longjmps out the same
+                        // way); the original error propagates either way.
+                        let _ = self.park_refused_round(&mut ctx.ctrl).await;
+                        return Err(e);
+                    }
+                };
+            if let SetupFlow::ClientDone = setup_flow {
                 // #356 r1 F1: GT's clean IPERF_DONE arm — the round ends
                 // with no error surface, keep-serving like a refusal
                 // (None maps to handle_one_test's Ok(None) after the gate).
@@ -3983,6 +3997,14 @@ impl Server {
     /// GT's >0 partial return restarts a full Nread, so its tail runs up
     /// to ~2x (probed 15.2 s) — adversarial-peer-only, boundedness
     /// matches.
+    /// #390: the SAME drain runs after a setup-kill wire-back (the
+    /// handle_one_test setup-Err choke point) — GT's cleanup_server calls
+    /// iperf_sync_close_socket on EVERY round exit (iperf_server_api.c:519),
+    /// which is what holds a one-off's LISTENER open until the peer
+    /// consumed the fe relay; without it, the listener close RSTs the
+    /// client's queued data socket out of iperf_init_stream (live-proven
+    /// 4/4 on #387 r2). A dead peer EOFs the drain instantly, so the
+    /// unconditional call is self-limiting.
     async fn park_refused_round(&self, ctrl: &mut tokio::net::TcpStream) -> Option<String> {
         use tokio::io::{AsyncReadExt, AsyncWriteExt};
         let _ = ctrl.shutdown().await; // GT's SHUT_WR half-close


### PR DESCRIPTION
Fixes #390.

A one-off server exited the instant a setup-phase kill's fe wire-back was sent, dropping the ctrl and the listener together — the listener close RST'd a real GT client's queued data socket while it was still inside `iperf_init_stream`, so it died IEINITSTREAM without ever reading the SERVER ERROR relay (live-proven 4/4 on #387 r2). GT never loses that race: `cleanup_server` runs `iperf_sync_close_socket` on EVERY round exit (iperf_server_api.c:519; net.c:877-887 — shutdown(SHUT_WR) + the bounded drain), holding the round and the listener open until the peer consumed the frame.

The fix is one choke point: `handle_one_test`'s setup-phase `Err` path now runs the existing #386 sync-close drain (`park_refused_round` — GT's exact port, 10 s Nread bound, interrupt-abandonable) on the ctrl before propagating. Unconditional across serve modes like GT's cleanup_server; self-limiting — a dead peer EOFs the drain instantly, which is why the full battery (32/32) shows zero blast radius on the existing kill cells (their mocks drop sockets at the kill).

Pin (Linux, the #387 EMFILE clamp harness): drive the setup data-accept kill, read the fe frame, then HOLD the ctrl 1.5 s — the fixed server parks (pre-fix: exits within ~100 ms, red-proven); dropping the ctrl unparks it to a clean exit-0 within the bound. The drain-drop mutant reds the pin.

Non-goals (disclosed): mid-test kill classes (rate breach, unknown message) keep their current close ordering — GT's cleanup_server drains those too, but their clients actively read the ctrl (the #443 one-frame cell passes today) and none of their cells is probed for the race; a follow-up can fold them if a probe shows a live divergence. The persistent pairing already interoperated (bind-once keeps the backlog conn alive).
